### PR TITLE
Delete any rules/queries with references to .received

### DIFF
--- a/queries/headers_from_russia.yml
+++ b/queries/headers_from_russia.yml
@@ -1,9 +1,0 @@
-name: "Headers from Russia"
-source: |
-  type.inbound
-  and (
-    headers.return_path.domain.tld == 'ru'
-    or any(headers.hops, ilike(.received, ".ru"))
-    or ilike(headers.message_id, ".ru")
-  )
-type: "query"

--- a/queries/localhost_in_headers.yml
+++ b/queries/localhost_in_headers.yml
@@ -1,6 +1,0 @@
-name: "Localhost in headers"
-source: |
-  type.inbound
-  and any(headers.hops, ilike(.received, "localhost"))
-  and any(headers.hops, ilike(.received, "127.0.0.1"))
-type: "query"

--- a/queries/root_in_headers.yml
+++ b/queries/root_in_headers.yml
@@ -1,5 +1,0 @@
-name: "Root in headers"
-source: |
-  type.inbound
-  and any(headers.hops, ilike(.received, "root@"))
-type: "query"


### PR DESCRIPTION
They no longer work since clearing out that field from Hops
