### PR TITLE
Split up detection rules to prevent false positives for Github sawfish campaign

### DIFF
--- a/detection-rules/impersonation_github_sawfish.yml
+++ b/detection-rules/impersonation_github_sawfish.yml
@@ -11,10 +11,12 @@ source: |
     sender.email.domain.domain != 'github.com'
     or headers.return_path.domain.root_domain != 'github.com'
   )
-  and 3 of (
+  and 2 of (
     iregex_search(body.plain.raw, '.*account activity.*', '.*github.*', '.*your activity.*', '.*suspicious api call.*'),
     iregex_search(body.html.raw, '.*account activity.*', '.*github.*', '.*your activity.*', '.*suspicious api call.*'),
-    iregex_search(subject.subject, '.*account activity.*', '.*your activity.*', '.*suspicious api call.*'),
+    iregex_search(subject.subject, '.*account activity.*', '.*your activity.*', '.*suspicious api call.*')
+  )
+  and 1 of (
     ilike(sender.display_name, '*github*'),
     ilike(sender.email.email, '*github*'),
     ilike(subject.subject, '*github*')


### PR DESCRIPTION
This PR will essentially make sure that there must be a mention of the word github before it triggers the rule.