### PR TITLE
Update wells fargo rule to use ilike instead of iregex_search

### DIFF
--- a/detection-rules/impersonation_wells_fargo.yml
+++ b/detection-rules/impersonation_wells_fargo.yml
@@ -11,8 +11,8 @@ source: |
       or iedit_distance(sender.display_name, 'wells fargo') <= 1
       or ilike(sender.email.domain.domain, '*wellsfargo*')
       or ilike(subject.subject, '*wells fargo security*')
-      or iregex_search(body.plain.raw, '.*wells fargo security team.*')
-      or iregex_search(body.html.raw, '.*wells fargo security team.*')
+      or ilike(body.plain.raw, '*wells fargo security team*')
+      or ilike(body.html.raw, '*wells fargo security team*')
   )
   and sender.email.domain.root_domain not in~ ('wellsfargo.com', 'wellsfargoadvisors.com', 'transunion.com', 'wellsfargoemail.com')
   and sender.email.email not in $recipient_emails


### PR DESCRIPTION
Straightforward change, noticed an `iregex_search` call that could just be `ilike`.
