### PR TITLE
Fix `or` -> `and` in Github Sawfish rule

### DIFF
--- a/detection-rules/impersonation_github_sawfish.yml
+++ b/detection-rules/impersonation_github_sawfish.yml
@@ -21,7 +21,7 @@ source: |
     ilike(sender.email.email, '*github*'),
     ilike(subject.subject, '*github*')
   )  
-  or any(body.links, .href_url.domain.root_domain in 
+  and any(body.links, .href_url.domain.root_domain in 
       ('secure-git.org',
       'auth-glthub.com',
       'secure-glthub.com',


### PR DESCRIPTION
I'm not sure where this `or` is supposed to be. I stumbled on this rule and noticed that it looks incorrect.