### PR TITLE
New rule: Attachment archive with embedded CHM file

### DIFF
--- a/detection-rules/attachment_archive_with_chm.yml
+++ b/detection-rules/attachment_archive_with_chm.yml
@@ -1,0 +1,28 @@
+name: "Attachment: Archive with embedded CHM file"
+description: |
+  Recursively scans files and archives to detect embedded CHM (Microsoft Compiled HTML Help) files.
+
+  According to CERT-UA, on March 7, 2022, phishing attacks targeted state organizations of Ukraine
+  using Zip files with embedded CHM documents, which themselves contained malicious VBScript inside a .htm file.
+  The activity is associated with UNC1151, according to CERT-UA.
+references:
+  - "https://cert.gov.ua/article/37626"
+type: "rule"
+source: |
+  type.inbound
+  and any(attachments, .file_extension in (
+      "7z",
+      "bz2",
+      "gz",
+      "rar",
+      "tar",
+      "zip",
+      "zipx",
+      "iso",
+      "img"
+      )
+      and any(beta.binexplode(.), .extension =~ "chm")
+  )
+tags:
+  - "Suspicious attachment"
+  - "Malware"


### PR DESCRIPTION
Sandbox: https://sandbox.sublimesecurity.com?id=610ee1d6-f7ff-4f6a-abdf-9af6e20074ff

Google translate of advisory:

![image](https://user-images.githubusercontent.com/11003450/157104884-87f9b9db-0da9-47b7-ab0a-f6d436001fb3.png)
