### PR TITLE
Use body.html.inner_text when possible (requires v0.24.5+)

### DIFF
--- a/detection-rules/impersonation_github_sawfish.yml
+++ b/detection-rules/impersonation_github_sawfish.yml
@@ -13,7 +13,7 @@ source: |
   )
   and 2 of (
     iregex_search(body.plain.raw, '.*account activity.*', '.*your activity.*', '.*suspicious api call.*'),
-    iregex_search(body.html.raw, '.*account activity.*', '.*your activity.*', '.*suspicious api call.*'),
+    iregex_search(body.html.inner_text, '.*account activity.*', '.*your activity.*', '.*suspicious api call.*'),
     iregex_search(subject.subject, '.*account activity.*', '.*your activity.*', '.*suspicious api call.*')
   )
   and 1 of (

--- a/detection-rules/impersonation_microsoft.yml
+++ b/detection-rules/impersonation_microsoft.yml
@@ -14,7 +14,7 @@ source: |
       ilike(subject.subject, '*Microsoft 365*') 
       and ilike(subject.subject, '*is expired*')
     )
-    or iregex_search(body.html.raw, ".*reach you.*microsoft teams")
+    or iregex_search(body.html.inner_text, ".*reach you.*microsoft teams")
     or ilike(sender.display_name, '*new activity in Teams*')
     or subject.subject =~ 'Offline Message in Teams'
     or ilike(subject.subject, '*Teams Sent A Message')

--- a/detection-rules/impersonation_wells_fargo.yml
+++ b/detection-rules/impersonation_wells_fargo.yml
@@ -12,7 +12,7 @@ source: |
       or ilike(sender.email.domain.domain, '*wellsfargo*')
       or ilike(subject.subject, '*wells fargo security*')
       or ilike(body.plain.raw, '*wells fargo security team*')
-      or ilike(body.html.raw, '*wells fargo security team*')
+      or ilike(body.html.inner_text, '*wells fargo security team*')
   )
   and sender.email.domain.root_domain not in~ ('wellsfargo.com', 'wellsfargoadvisors.com', 'transunion.com', 'wellsfargoemail.com')
   and sender.email.email not in $recipient_emails

--- a/detection-rules/inline_image_as_message.yml
+++ b/detection-rules/inline_image_as_message.yml
@@ -22,7 +22,7 @@ source: |
           and any(attachments, .file_type not in ("jpg", "png", "gif"))
       )
   )
-  and iregex_search(body.html.raw, ".*img.*cid.*")
+  and ilike(body.html.raw, "*img*cid*")
   and sender.email.email not in $recipient_emails
 tags:
   - "Malware"

--- a/queries/content/zero_width_spaces.yml
+++ b/queries/content/zero_width_spaces.yml
@@ -1,9 +1,9 @@
-name: "Zero-width spaces"
+name: "Zero-width spaces in a URL"
 references:
   - "https://www.securityweek.com/phishers-use-zero-width-spaces-bypass-office-365-protections"
 type: "query"
 source: |
-  iregex_search(body.html.raw, "&#65279", "&#8204")
+  any(body.links, regex_search(.href_url.url, '[\x{200B}\x{200C}\x{200D}\x{FEFF}\x{FF10}]'))
 severity: "low"
 tags:
   - "Suspicious content"

--- a/tutorial-files/3-write/office365_covid_phish.yml
+++ b/tutorial-files/3-write/office365_covid_phish.yml
@@ -12,6 +12,6 @@ source: |
     any(headers.hops, any(.fields, .name =~ "replyto" and .value == "")),
     like(sender.display_name, "*HR*"),
     iregex_search(subject.subject, "file was shared", "covid-19"),
-    iregex_search(body.html.raw, "file was shared", "scanned", "virus")
+    iregex_search(body.html.inner_text, "file was shared", "scanned", "virus")
   )
 type: rule


### PR DESCRIPTION
Update rules to use the new `body.html.inner_text` field when they are searching for strings inside of HTML. Some guidance is on the docs [here](https://docs.sublimesecurity.com/docs/how-to-detect-keywords-or-phrases-in-the-body)

This field is new as of 0.24.5