### PR TITLE
Fix duplicate attachment/binexplode loops

### DIFF
--- a/detection-rules/attachment_soliciting_enable_macros.yml
+++ b/detection-rules/attachment_soliciting_enable_macros.yml
@@ -7,17 +7,11 @@ references:
 type: "rule"
 source: |
   type.inbound
-  and (any(attachments, .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm", "zip")
+  and any(attachments, .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm", "zip")
          and any(beta.binexplode(.), 
-           any(.scan.ocr.text, ilike(., "*please*"))
-           and any(.scan.ocr.text, ilike(., "*enable*"))
-           and any(.scan.ocr.text, ilike(., "*macros*")))
-    )
-    or (any(attachments, .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm", "zip")
-         and any(beta.binexplode(.), 
-          any(.scan.strings.strings, ilike(., "*please enable macros*"))))
-    )
-  )
+           (any(.scan.ocr.text, ilike(., "*please*")) and any(.scan.ocr.text, ilike(., "*enable*")) and any(.scan.ocr.text, ilike(., "*macros*"))
+           or any(.scan.strings.strings, ilike(., "*please enable macros*"))))
+        )
   and (
       (
           sender.email.domain.root_domain in $free_email_providers


### PR DESCRIPTION
Found duplicate loops in the "Please Enable Macros" rule that can be merged together.