### PR TITLE
Expand rule to include archives to match description

### DIFF
--- a/detection-rules/attachment_html_smuggling.yml
+++ b/detection-rules/attachment_html_smuggling.yml
@@ -7,7 +7,8 @@ type: "rule"
 source: |
   type.inbound and
   any(attachments,
-      .file_extension in~ ('html', 'htm')
+      .file_extension in~ ("html", "htm",
+                           "7z","bz2","gz","rar","tar","zip","zipx","iso","img")
          and any(beta.binexplode(.),
                any(.scan.javascript.identifiers, . == "unescape"))
   )


### PR DESCRIPTION
h/t @vector-sec for pointing this out in #118
