### PR TITLE
Update CVE-2022-30190 rule to support RTF files

### DIFF
--- a/detection-rules/office_remote_html_template.yml
+++ b/detection-rules/office_remote_html_template.yml
@@ -18,6 +18,8 @@ references:
   - "https://twitter.com/Ledtech3/status/1530979998416441347"
   - "https://twitter.com/gentilkiwi/status/1531384447219781634"
   - "https://twitter.com/jkamdjou/status/1531387025533943809"
+  - "https://sandbox.sublimesecurity.com/?id=95cb0bd2-7c6c-488d-a591-9bb3e1d66101"
+  - "https://sandbox.sublimesecurity.com/?id=85c23b23-3db5-45bf-ad90-3f65597da861"
 type: "rule"
 severity: "high"
 source: |

--- a/detection-rules/office_remote_html_template.yml
+++ b/detection-rules/office_remote_html_template.yml
@@ -53,9 +53,9 @@ source: |
                     // office files
                     .flavors.mime == "text/xml" and
                     any(.scan.strings.strings, iregex_search(., "oleObject.*html?!"))
-                )
-                // rtf files
-                or (
+                ) or
+                (
+                    // rtf files
                     .flavors.mime == "text/rtf" and
                     any(.scan.strings.strings, iregex_search(., "objclass.*htm.?"))
                 )

--- a/detection-rules/office_remote_html_template.yml
+++ b/detection-rules/office_remote_html_template.yml
@@ -63,3 +63,4 @@ source: |
 tags:
   - "Suspicious attachment"
   - "Office exploit"
+  - "CVE-2022-30190"

--- a/detection-rules/office_remote_html_template.yml
+++ b/detection-rules/office_remote_html_template.yml
@@ -17,6 +17,7 @@ references:
   - "https://twitter.com/sans_isc/status/1531321260784898050"
   - "https://twitter.com/Ledtech3/status/1530979998416441347"
   - "https://twitter.com/gentilkiwi/status/1531384447219781634"
+  - "https://twitter.com/jkamdjou/status/1531387025533943809"
 type: "rule"
 severity: "high"
 source: |
@@ -24,7 +25,8 @@ source: |
   and any(attachments,
       (
           (
-              .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm", "rtf")
+              // office files
+              .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm")
 
               // detect files without an extension
               or .file_type in ("docx")
@@ -33,14 +35,28 @@ source: |
       )
       or (
           (
+              // explode archives
               .file_extension in~ ("7z","bz2","gz","rar","tar","zip","zipx","iso","img")
 
               // detect files without an extension
               or .file_type in ("7z")
+
+              or .file_extension in~ ("rtf")
           )
-          and any(beta.binexplode(.),
-              .flavors.mime == "text/xml" and
-              any(.scan.strings.strings, iregex_search(., "oleObject.*html?!"))
+
+          and (
+
+              // office files
+              any(beta.binexplode(.),
+                  .flavors.mime == "text/xml" and
+                  any(.scan.strings.strings, iregex_search(., "oleObject.*html?!"))
+              )
+
+              // rtf files
+              or any(beta.binexplode(.),
+                  .flavors.mime == "text/rtf" and
+                  any(.scan.strings.strings, iregex_search(., "objclass.*htm.?"))
+              )
           )
       )
   )

--- a/detection-rules/office_remote_html_template.yml
+++ b/detection-rules/office_remote_html_template.yml
@@ -43,22 +43,23 @@ source: |
               // detect files without an extension
               or .file_type in ("7z")
 
+              // rtf files
               or .file_extension in~ ("rtf")
           )
 
           and (
-
-              // office files
-              any(beta.binexplode(.),
-                  .flavors.mime == "text/xml" and
-                  any(.scan.strings.strings, iregex_search(., "oleObject.*html?!"))
-              )
-
-              // rtf files
-              or any(beta.binexplode(.),
-                  .flavors.mime == "text/rtf" and
-                  any(.scan.strings.strings, iregex_search(., "objclass.*htm.?"))
-              )
+            any(beta.binexplode(.),
+                (
+                    // office files
+                    .flavors.mime == "text/xml" and
+                    any(.scan.strings.strings, iregex_search(., "oleObject.*html?!"))
+                )
+                // rtf files
+                or (
+                    .flavors.mime == "text/rtf" and
+                    any(.scan.strings.strings, iregex_search(., "objclass.*htm.?"))
+                )
+            )
           )
       )
   )


### PR DESCRIPTION
h/t @vector-sec for [pointing out](https://sublimecommunity.slack.com/archives/C02N1F7FP7C/p1654526539143209) the original version did not have proper coverage for RTFs