### PR TITLE
Add Test rule

### DIFF
--- a/detection-rules/test_rule.yml
+++ b/detection-rules/test_rule.yml
@@ -1,0 +1,10 @@
+name: "Test rule"
+description: |
+  The Sublime standard test rule will flag on any message that contains the string "Sublime-Standard-Test-String" anywhere in the subject or body. The purpose of this rule is to confirm that the Sublime system is operating correctly.
+references:
+  - "https://en.wikipedia.org/wiki/EICAR_test_file"
+type: "rule"
+source: |
+  ilike(subject.subject, "*Sublime-Standard-Test-String*")
+  or iregex_search(body.html.raw, ".*Sublime-Standard-Test-String.*")
+  or iregex_search(body.plain.raw, ".*Sublime-Standard-Test-String.*")


### PR DESCRIPTION
Instead of auto-creating the "Test rule" when setting up your first message source like we do today, it can be auto-installed and auto-activated from the Feed. I think it would be cooler to see a Feed Rule in your Dashboard when you first sign in, opposed to just a regular one.

We'd need to standardize Feed rule IDs across all deployments for that to work.

There is an argument for not having "test rules" in the feed at all so I am a bit torn tbh, lmk if you feel strongly either way @rw-access
