### PR TITLE
Add Rule validation GitHub Action

### DIFF
--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -1,0 +1,30 @@
+name: Rules PR CI
+
+on:
+  push:
+    branches: [ "**" ]
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  tests:
+    name: Run Rule Validation
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Set up yq
+        uses: mikefarah/yq@v4.27.3
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Validate Rules
+        run: |
+          for f in *-rules/*.yml
+          do
+            echo "Processing $f"
+            yq -o=json eval 'del(.type)' "$f" | curl -H "Content-Type: application/json" -X POST --data-binary @- --fail --silent https://sandbox.sublimesecurity.com/v1/rules/validate
+          done


### PR DESCRIPTION
## Context

Currently, no rules were being validated before being merged which could result in feeds being broken due to malformed rules. The `/v1/rules/validate` endpoint was updated to validate an entire rule (not just the MQL) and is now accessible via the sandbox.

Now that there is a publicly available way to validate a rule, we can now add CI that checks rules on each PR in this repo.

## Changes

* Sends all rules in `detection-rules` and `discovery-rules` to `sandbox.sublimesecurity.com/v1/rules/validate`
  * We may want to consider throttling or adding a speed limit parameter to curl in the future if this action is run often

## Tests

* Updated the MQL to be invalid and the action failed as expected
  * https://github.com/sublime-security/sublime-rules/runs/8279876838?check_suite_focus=true
* Ran the action on existing rules with no changes
  * https://github.com/sublime-security/sublime-rules/runs/8280161624?check_suite_focus=true