### PR TITLE
Replace tabs with spaces in attachment_suspicious_macro.yml

### DIFF
--- a/discovery-rules/attachment_suspicious_macro.yml
+++ b/discovery-rules/attachment_suspicious_macro.yml
@@ -5,8 +5,8 @@ type: "rule"
 source: |
   type.inbound
   and any(attachments, .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm")
-		and beta.ml_macro_classifier(.).malicious
-		and beta.ml_macro_classifier(.).confidence in ("low", "medium", "high")
+    and beta.ml_macro_classifier(.).malicious
+    and beta.ml_macro_classifier(.).confidence in ("low", "medium", "high")
   )
 tags:
   - "Suspicious attachment"


### PR DESCRIPTION
## Context

Tabs are invalid in MQL and cause the CI to fail. Simply replaced the tabs with spaces.