### PR TITLE
Update rules to use .scan.ocr.raw

### DIFF
--- a/detection-rules/attachment_invoice_fake_customer_service_freemail_sender.yml
+++ b/detection-rules/attachment_invoice_fake_customer_service_freemail_sender.yml
@@ -9,10 +9,10 @@ source: |
   and sender.email.domain.root_domain in $free_email_providers
   and any(attachments, .file_extension in~ ('pdf', 'png', 'jpg', 'jpeg')
       and any(beta.binexplode(.),
-          any(.scan.ocr.text, ilike(., "*order*", "*invoice*", "*receipt*")) and 
-          any(.scan.ocr.text, ilike(., "*call*", "*contact*", "*connect*")) and 
-          any(.scan.ocr.text, ilike(., "*help*", "*support*", "*cancel*")) 
-          // and not any(.scan.ocr.text, ilike(., "*your keyword here*", "*your second keyword here*"))
+          ilike(.scan.ocr.raw, "*order*", "*invoice*", "*receipt*") and 
+          ilike(.scan.ocr.raw, "*call*", "*contact*", "*connect*") and 
+          ilike(.scan.ocr.raw, "*help*", "*support*", "*cancel*") 
+          // and not ilike(.scan.ocr.text, "*your keyword here*", "*your second keyword here*"))
           // uncomment the line above to add keywords specific to your org that may filter out legitimate messages
       )
   )

--- a/detection-rules/attachment_office365_image.yml
+++ b/detection-rules/attachment_office365_image.yml
@@ -17,8 +17,8 @@ source: |
               )
           or
               (
-                  any(.scan.ocr.text, ilike(., "*microsoft*", "*office365*", "*office*")) and
-                  any(.scan.ocr.text, ilike(., "*password*", "*expire*", "*expiry*"))
+                  ilike(.scan.ocr.raw, "*microsoft*", "*office365*", "*office*") and
+                  ilike(.scan.ocr.raw, "*password*", "*expire*", "*expiry*")
               )
           )
       )

--- a/detection-rules/attachment_soliciting_enable_macros.yml
+++ b/detection-rules/attachment_soliciting_enable_macros.yml
@@ -9,9 +9,9 @@ source: |
   type.inbound
   and any(attachments, .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm", "zip")
          and any(beta.binexplode(.), 
-           (any(.scan.ocr.text, ilike(., "*please*")) and any(.scan.ocr.text, ilike(., "*enable*")) and any(.scan.ocr.text, ilike(., "*macros*"))
-           or any(.scan.strings.strings, ilike(., "*please enable macros*"))))
-        )
+           ilike(.scan.ocr.raw, "*please*enable*macros")
+           or any(.scan.strings.strings, ilike(., "*please enable macros*"))
+        ))
   and (
       (
           sender.email.domain.root_domain in $free_email_providers


### PR DESCRIPTION
Now that the simpler `.scan.ocr.raw` is available and `.scan.ocr.text` is deprecated, the rules should use the newer, simpler field.