### PR TITLE
Adding another Spotify domain to their impersonation rule

### DIFF
--- a/detection-rules/impersonation_spotify.yml
+++ b/detection-rules/impersonation_spotify.yml
@@ -11,7 +11,7 @@ source: |
       or iedit_distance(sender.display_name, 'spotify') <= 1
       or ilike(sender.email.domain.domain, '*spotify*')
   )
-  and sender.email.domain.root_domain not in~ ('spotify.com', 'byspotify.com', 'echosign.com')
+  and sender.email.domain.root_domain not in~ ('spotify.com', 'byspotify.com', 'echosign.com', 'fromspotify.com')
   and sender.email.domain.domain not in~ ('privaterelay.appleid.com')
   and sender.email.email not in $recipient_emails
 tags:


### PR DESCRIPTION
Ordered a Car Thing from Spotify and the order confirmation came from no-reply@fromspotify.com