### PR TITLE
Use new lists: $file_extensions_common_archives and $file_extensions_macros

### DIFF
--- a/detection-rules/attachment_any_html_in_archive_unsolicited.yml
+++ b/detection-rules/attachment_any_html_in_archive_unsolicited.yml
@@ -10,7 +10,7 @@ severity: "medium"
 source: |
   type.inbound
   and any(attachments,
-      .file_extension in~ ( "7z", "bz2", "gz", "rar", "tar", "zip", "zipx", "iso", "img")
+      .file_extension in~ $file_extensions_common_archives
       and any(beta.binexplode(.), .depth > 0
           and .extension in~ ("html", "htm"))
   )

--- a/detection-rules/attachment_archive_with_chm.yml
+++ b/detection-rules/attachment_archive_with_chm.yml
@@ -11,17 +11,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and any(attachments, .file_extension in (
-      "7z",
-      "bz2",
-      "gz",
-      "rar",
-      "tar",
-      "zip",
-      "zipx",
-      "iso",
-      "img"
-      )
+  and any(attachments, .file_extension in~ $file_extensions_common_archives
       and any(beta.binexplode(.), .extension =~ "chm")
   )
 tags:

--- a/detection-rules/attachment_archive_with_exe.yml
+++ b/detection-rules/attachment_archive_with_exe.yml
@@ -14,17 +14,7 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and any(attachments, .file_extension in (
-      "7z",
-      "bz2",
-      "gz",
-      "rar",
-      "tar",
-      "zip",
-      "zipx",
-      "iso",
-      "img"
-      )
+  and any(attachments, .file_extension in~ $file_extensions_common_archives
       and any(beta.binexplode(.),
           any(.flavors.yara, . == "mz_file")
       )

--- a/detection-rules/attachment_disallowed_file_type_in_archive.yml
+++ b/detection-rules/attachment_disallowed_file_type_in_archive.yml
@@ -11,7 +11,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and any(attachments, .file_extension in~ ( "7z", "bz2", "gz", "rar", "tar", "zip", "zipx", "iso", "img")
+  and any(attachments, .file_extension in~ $file_extensions_common_archives
       and any(beta.binexplode(.), .extension in~ (
               // File types blocked by Gmail by default
               // https://support.google.com/mail/answer/6590?hl=en#zippy=%2Cmessages-that-have-attachments

--- a/detection-rules/attachment_encrypted_ole_unsolicited.yml
+++ b/detection-rules/attachment_encrypted_ole_unsolicited.yml
@@ -8,11 +8,20 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and any(attachments, 
-    .file_extension in~ ("doc", "dot", "docm", "dotm", "docx", "xlm", "xls", "xlsb", "xlsm", "pptm", "ppsm")
-    and beta.oletools(.).indicators.encryption.exists
+  and any(attachments,
+      .file_extension in~ $file_extensions_macros
+      and beta.oletools(.).indicators.encryption.exists
   )
-  and sender.email.email not in $recipient_emails
+  and (
+      (
+          sender.email.domain.root_domain in $free_email_providers
+          and sender.email.email not in $recipient_emails
+      )
+      or (
+          sender.email.domain.root_domain not in $free_email_providers
+          and sender.email.domain.domain not in $recipient_domains
+      )
+  )
 tags:
   - "Suspicious attachment"
   - "Encrypted attachment"

--- a/detection-rules/attachment_excel_web_query_file_iqy.yml
+++ b/detection-rules/attachment_excel_web_query_file_iqy.yml
@@ -10,21 +10,11 @@ authors:
   - twitter: "jkcoote"
 severity: "high"
 source: |
-  type.inbound 
+  type.inbound
   and (
-      any(attachments, .file_extension == "iqy")
+      any(attachments, .file_extension =~ "iqy")
       or (
-          any(attachments, .file_extension in (
-              "7z",
-              "bz2",
-              "gz",
-              "rar",
-              "tar",
-              "zip",
-              "zipx",
-              "iso",
-              "img"
-              )
+          any(attachments, .file_extension in~ $file_extensions_common_archives
               and any(beta.binexplode(.), .extension =~ "iqy")
           )
       )

--- a/detection-rules/attachment_filename_with_unicode_rtlo.yml
+++ b/detection-rules/attachment_filename_with_unicode_rtlo.yml
@@ -12,7 +12,7 @@ source: |
   type.inbound
   and any(attachments,
           regex.icontains(.file_name, '\x{202E}', '\x{202D}') or (
-              .file_extension in~ ("7z","bz2","gz","rar","tar","zip","zipx","iso","img")
+              .file_extension in~ $file_extensions_common_archives
               and any(beta.binexplode(.),
                   regex.icontains(.name, '\x{202E}', '\x{202D}')
               )

--- a/detection-rules/attachment_html_smuggling_atob.yml
+++ b/detection-rules/attachment_html_smuggling_atob.yml
@@ -7,7 +7,8 @@ source: |
   type.inbound
   and any(attachments, .size <= 15000 and
       (
-          .file_extension in~ ("html", "htm", "7z","bz2","gz","rar","tar","zip","zipx","iso","img") or
+          .file_extension in~ ("html", "htm") or
+          .file_extension in~ $file_extensions_common_archives or
           .file_type == "html"
       )
       and any(beta.binexplode(.),

--- a/detection-rules/attachment_html_smuggling_entropy.yml
+++ b/detection-rules/attachment_html_smuggling_entropy.yml
@@ -9,7 +9,8 @@ source: |
   type.inbound 
   and any(attachments,
       (
-          .file_extension in~ ("html", "htm", "7z","bz2","gz","rar","tar","zip","zipx","iso","img") or
+          .file_extension in~ ("html", "htm") or
+          .file_extension in~ $file_extensions_common_archives or
           .file_type == "html"
       )
       and any(beta.binexplode(.), 

--- a/detection-rules/attachment_html_smuggling_fromcharcode_and_others.yml
+++ b/detection-rules/attachment_html_smuggling_fromcharcode_and_others.yml
@@ -9,8 +9,8 @@ source: |
   type.inbound
   and any(attachments,
         (
-            .file_extension in~ ("html", "htm", 
-                                 "7z","bz2","gz","rar","tar","zip","zipx","iso","img") or
+            .file_extension in~ ("html", "htm") or
+            .file_extension in~ $file_extensions_common_archives or
             .file_type == "html"
         )
         and any(beta.binexplode(.),

--- a/detection-rules/attachment_html_smuggling_location.yml
+++ b/detection-rules/attachment_html_smuggling_location.yml
@@ -9,8 +9,8 @@ source: |
   type.inbound and
   any(attachments,
         (
-            .file_extension in~ ("html", "htm", 
-                                 "7z","bz2","gz","rar","tar","zip","zipx","iso","img") or
+            .file_extension in~ ("html", "htm") or
+            .file_extension in~ $file_extensions_common_archives or
             .file_type == "html"
         )
         and .size <= 5000

--- a/detection-rules/attachment_html_smuggling_microsoft_signin.yml
+++ b/detection-rules/attachment_html_smuggling_microsoft_signin.yml
@@ -8,6 +8,7 @@ source: |
   and any(attachments,
       (
           .file_extension in~ ("html", "htm") or
+          .file_extension in~ $file_extensions_common_archives or
           .file_type == "html"
       )
       and any(beta.binexplode(.),

--- a/detection-rules/attachment_html_smuggling_rot13.yml
+++ b/detection-rules/attachment_html_smuggling_rot13.yml
@@ -1,4 +1,4 @@
-name: "Attachment: Any HTML file with suspicious JavaScript identifiers"
+name: "Attachment: HTML smuggling with ROT13"
 description: |
   Potential HTML obfuscation attack based on suspicious JavaScript identifiers.
   Some attackers may use obfuscation techniques such as ROT13 to bypass email security filters.
@@ -11,15 +11,15 @@ severity: "high"
 source: |
   type.inbound and
   any(attachments,
-        (
-            .file_extension in~ ("html", "htm", 
-                                 "7z","bz2","gz","rar","tar","zip","zipx","iso","img") or
-            .file_type == "html"
-        )
-        and any(beta.binexplode(.),
-            any(.scan.javascript.identifiers, . in~ ("rot13"))
-            and length(.scan.javascript.identifiers) < 100
-        )
+      (
+          .file_extension in~ ("html", "htm") or
+          .file_extension in~ $file_extensions_common_archives or
+          .file_type == "html"
+      )
+      and any(beta.binexplode(.),
+          any(.scan.javascript.identifiers, . in~ ("rot13"))
+          and length(.scan.javascript.identifiers) < 100
+      )
   )
 tags:
   - "Suspicious attachment"

--- a/detection-rules/attachment_html_smuggling_rot13.yml
+++ b/detection-rules/attachment_html_smuggling_rot13.yml
@@ -24,3 +24,4 @@ source: |
 tags:
   - "Suspicious attachment"
   - "HTML smuggling"
+id: "6eacc4cf-9357-5441-9380-b561fa630d65"

--- a/detection-rules/attachment_html_smuggling_settimeout.yml
+++ b/detection-rules/attachment_html_smuggling_settimeout.yml
@@ -7,7 +7,8 @@ source: |
   type.inbound
   and any(attachments, .size <= 400 and
       (
-          .file_extension in~ ("html", "htm", "7z","bz2","gz","rar","tar","zip","zipx","iso","img") or
+          .file_extension in~ ("html", "htm") or
+          .file_extension in~ $file_extensions_common_archives or
           .file_type == "html"
       )
       and any(beta.binexplode(.),

--- a/detection-rules/attachment_html_smuggling_unescape.yml
+++ b/detection-rules/attachment_html_smuggling_unescape.yml
@@ -19,3 +19,4 @@ source: |
 tags:
   - "Suspicious attachment"
   - "HTML smuggling"
+id: "0b0fed36-735a-50f1-bf10-6673237a4623"

--- a/detection-rules/attachment_html_smuggling_unescape.yml
+++ b/detection-rules/attachment_html_smuggling_unescape.yml
@@ -1,4 +1,4 @@
-name: "Attachment with HTML smuggling"
+name: "Attachment: HTML smuggling with unescape"
 description: |
   Recursively scans files and archives to detect HTML smuggling techniques.
 references:
@@ -9,8 +9,8 @@ source: |
   type.inbound and
   any(attachments,
         (
-            .file_extension in~ ("html", "htm", 
-                                 "7z","bz2","gz","rar","tar","zip","zipx","iso","img") or
+            .file_extension in~ ("html", "htm") or
+            .file_extension in~ $file_extensions_common_archives or
             .file_type == "html"
         )
         and any(beta.binexplode(.),

--- a/detection-rules/attachment_lnk_file.yml
+++ b/detection-rules/attachment_lnk_file.yml
@@ -11,8 +11,8 @@ authors:
 severity: "high"
 source: |
   type.inbound 
-  and any(attachments, .file_extension == "lnk" or  (
-        .file_extension in ( "7z", "bz2", "gz", "rar", "tar", "zip", "zipx", "iso", "img")
+  and any(attachments, .file_extension =~ "lnk" or  (
+        .file_extension in~ $file_extensions_common_archives
         and any(beta.binexplode(.), .extension =~ "lnk")
       )
   )

--- a/detection-rules/attachment_malicious_vba_macro.yml
+++ b/detection-rules/attachment_malicious_vba_macro.yml
@@ -5,7 +5,7 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and any(attachments, .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm")
+  and any(attachments, .file_extension in~ $file_extensions_macros
       and beta.ml_macro_classifier(.).malicious
       and beta.ml_macro_classifier(.).confidence == "high"
   )

--- a/detection-rules/attachment_msi_installer.yml
+++ b/detection-rules/attachment_msi_installer.yml
@@ -13,21 +13,11 @@ authors:
   - twitter: "ajpc500"
 severity: "medium"
 source: |
-  type.inbound 
+  type.inbound
   and (
-      any(attachments, .file_extension == "msi")
+      any(attachments, .file_extension =~ "msi")
       or (
-          any(attachments, .file_extension in (
-              "7z",
-              "bz2",
-              "gz",
-              "rar",
-              "tar",
-              "zip",
-              "zipx",
-              "iso",
-              "img"
-              )
+          any(attachments, .file_extension in~ $file_extensions_common_archives
               and any(beta.binexplode(.), .extension =~ "msi")
           )
       )

--- a/detection-rules/attachment_office_file_with_vsto.yml
+++ b/detection-rules/attachment_office_file_with_vsto.yml
@@ -9,8 +9,7 @@ authors:
   - twitter: "vector_sec"
 source: |
   type.inbound
-  and any(attachments, .file_extension in~ ("doc","docm","docx","dot","dotm","xls","xlsx","xlsm","xlm","xlsb","xlt","xltm","ppt","pptx","pptm","ppsm",
-                                            "7z","bz2","gz","rar","tar","zip","zipx","iso","img")
+  and any(attachments, (.file_extension in~ $file_extensions_macros or .file_extension in $file_extensions_common_archives)
       and any(beta.binexplode(.),
           .extension in~ ("doc","docm","docx","dot","dotm","xls","xlsx","xlsm","xlm","xlsb","xlt","xltm","ppt","pptx","pptm","ppsm")
           and any(.scan.exiftool.fields, .key == "Tag_AssemblyLocation"

--- a/detection-rules/attachment_office_file_with_vsto.yml
+++ b/detection-rules/attachment_office_file_with_vsto.yml
@@ -9,7 +9,7 @@ authors:
   - twitter: "vector_sec"
 source: |
   type.inbound
-  and any(attachments, (.file_extension in~ $file_extensions_macros or .file_extension in $file_extensions_common_archives)
+  and any(attachments, (.file_extension in~ $file_extensions_macros or .file_extension in~ $file_extensions_common_archives)
       and any(beta.binexplode(.),
           .extension in~ ("doc","docm","docx","dot","dotm","xls","xlsx","xlsm","xlm","xlsb","xlt","xltm","ppt","pptx","pptm","ppsm")
           and any(.scan.exiftool.fields, .key == "Tag_AssemblyLocation"

--- a/detection-rules/attachment_office_remote_html_template.yml
+++ b/detection-rules/attachment_office_remote_html_template.yml
@@ -67,3 +67,4 @@ tags:
   - "Suspicious attachment"
   - "Office exploit"
   - "CVE-2022-30190"
+id: "cfb7544d-4010-5da9-b334-61e114f31a00"

--- a/detection-rules/attachment_office_remote_html_template.yml
+++ b/detection-rules/attachment_office_remote_html_template.yml
@@ -38,7 +38,7 @@ source: |
       or (
           (
               // explode archives
-              .file_extension in~ ("7z","bz2","gz","rar","tar","zip","zipx","iso","img")
+              .file_extension in~ $file_extensions_common_archives
 
               // detect files without an extension
               or .file_type in ("7z")

--- a/detection-rules/attachment_potential_sandbox_evasion_in_office_file.yml
+++ b/detection-rules/attachment_potential_sandbox_evasion_in_office_file.yml
@@ -10,23 +10,17 @@ authors:
   - twitter: "ajpc500"
 severity: "high"
 source: |
-  type.inbound 
-  and any(attachments, .file_extension in (
-      // MS Word
-      "doc", "docm", "docx", "dot", "dotm",
-      // MS Excel
-      "xls", "xlsx", "xlsm", "xlm", "xlsb", "xlt", "xltm",
-      // MS PowerPoint
-      "ppt", "pptx", "pptm", "ppsm"
-      ) and any(beta.binexplode(.), 
-          length(filter(.scan.strings.strings, strings.ilike(.,
-              "*Win32_Processor*",
-              "*Win32_LogicalDisk*",
-              "*Win32_ComputerSystem*",
-              "*Win32_Process*",
-              "*LDAP://RootDSE*"
-          ))) >= 1
-      )
+  type.inbound
+  and any(attachments, .file_extension in~ $file_extensions_macros
+      and any(beta.binexplode(.),
+            length(filter(.scan.strings.strings, strings.ilike(.,
+                "*Win32_Processor*",
+                "*Win32_LogicalDisk*",
+                "*Win32_ComputerSystem*",
+                "*Win32_Process*",
+                "*LDAP://RootDSE*"
+            ))) >= 1
+        )
   )
 tags:
   - "Suspicious attachment"

--- a/detection-rules/attachment_potential_sandbox_evasion_in_office_file.yml
+++ b/detection-rules/attachment_potential_sandbox_evasion_in_office_file.yml
@@ -10,17 +10,23 @@ authors:
   - twitter: "ajpc500"
 severity: "high"
 source: |
-  type.inbound
-  and any(attachments, .file_extension in~ $file_extensions_macros
-      and any(beta.binexplode(.),
-            length(filter(.scan.strings.strings, strings.ilike(.,
-                "*Win32_Processor*",
-                "*Win32_LogicalDisk*",
-                "*Win32_ComputerSystem*",
-                "*Win32_Process*",
-                "*LDAP://RootDSE*"
-            ))) >= 1
-        )
+  type.inbound 
+  and any(attachments, .file_extension in~ (
+      // MS Word
+      "doc", "docm", "docx", "dot", "dotm",
+      // MS Excel
+      "xls", "xlsx", "xlsm", "xlm", "xlsb", "xlt", "xltm",
+      // MS PowerPoint
+      "ppt", "pptx", "pptm", "ppsm"
+      ) and any(beta.binexplode(.), 
+          length(filter(.scan.strings.strings, strings.ilike(.,
+              "*Win32_Processor*",
+              "*Win32_LogicalDisk*",
+              "*Win32_ComputerSystem*",
+              "*Win32_Process*",
+              "*LDAP://RootDSE*"
+          ))) >= 1
+      )
   )
 tags:
   - "Suspicious attachment"

--- a/detection-rules/attachment_powershell_content.yml
+++ b/detection-rules/attachment_powershell_content.yml
@@ -11,13 +11,14 @@ authors:
   - twitter: "ajpc500"
 severity: "high"
 source: |
-  type.inbound and
-  any(attachments,
-      .file_extension in~ (
-          // PowerShell related file extensions
-          "ps1", "ps1xml", "psm1", "psd1", "pssc", "psrc", "cdxml", "ps2", "ps2xml", "psc2",
-          // Archive file formats 
-          "7z","bz2","gz","rar","tar","zip","zipx","iso","img"
+  type.inbound
+  and any(attachments,
+      (
+          .file_extension in~ (
+              // PowerShell related file extensions
+              "ps1", "ps1xml", "psm1", "psd1", "pssc", "psrc", "cdxml", "ps2", "ps2xml", "psc2",
+          )
+          or .file_extension in~ $file_extensions_common_archives
       )
       and any(beta.binexplode(.), .extension in~
           ("ps1", "ps1xml", "psm1", "psd1", "pssc", "psrc", "cdxml", "ps2", "ps2xml", "psc2",)

--- a/detection-rules/attachment_rdp_connection_file.yml
+++ b/detection-rules/attachment_rdp_connection_file.yml
@@ -8,23 +8,13 @@ references:
 type: "rule"
 authors:
   - twitter: "ajpc500"
-severity: "high"
+severity: "medium"
 source: |
-  type.inbound 
+  type.inbound
   and (
-      any(attachments, .file_extension == "rdp")
+      any(attachments, .file_extension =~ "rdp")
       or (
-          any(attachments, .file_extension in (
-              "7z",
-              "bz2",
-              "gz",
-              "rar",
-              "tar",
-              "zip",
-              "zipx",
-              "iso",
-              "img"
-              )
+          any(attachments, .file_extension in~ $file_extensions_common_archives
               and any(beta.binexplode(.), .extension =~ "rdp")
           )
       )

--- a/detection-rules/attachment_shellbrowserwindow_com_object_in_macro.yml
+++ b/detection-rules/attachment_shellbrowserwindow_com_object_in_macro.yml
@@ -8,17 +8,11 @@ authors:
   - twitter: "ajpc500"
 severity: "high"
 source: |
-  type.inbound 
-  and any(attachments, .file_extension in (
-      // MS Word
-      "doc", "docm", "docx", "dot", "dotm",
-      // MS Excel
-      "xls", "xlsx", "xlsm", "xlm", "xlsb", "xlt", "xltm",
-      // MS PowerPoint
-      "ppt", "pptx", "pptm", "ppsm"
-      ) and any(beta.binexplode(.), 
+  type.inbound
+  and any(attachments, .file_extension in~ $file_extensions_macros
+      and any(beta.binexplode(.),
           any(.scan.strings.strings, strings.ilike(.,
-            "*new:C08AFD90-F2A1-11D1-8455-00A0C91F3880*"
+          "*new:C08AFD90-F2A1-11D1-8455-00A0C91F3880*"
           ))
       )
   )

--- a/detection-rules/attachment_shellbrowserwindow_com_object_in_macro.yml
+++ b/detection-rules/attachment_shellbrowserwindow_com_object_in_macro.yml
@@ -8,11 +8,17 @@ authors:
   - twitter: "ajpc500"
 severity: "high"
 source: |
-  type.inbound
-  and any(attachments, .file_extension in~ $file_extensions_macros
-      and any(beta.binexplode(.),
+  type.inbound 
+  and any(attachments, .file_extension in~ (
+      // MS Word
+      "doc", "docm", "docx", "dot", "dotm",
+      // MS Excel
+      "xls", "xlsx", "xlsm", "xlm", "xlsb", "xlt", "xltm",
+      // MS PowerPoint
+      "ppt", "pptx", "pptm", "ppsm"
+      ) and any(beta.binexplode(.), 
           any(.scan.strings.strings, strings.ilike(.,
-          "*new:C08AFD90-F2A1-11D1-8455-00A0C91F3880*"
+            "*new:C08AFD90-F2A1-11D1-8455-00A0C91F3880*"
           ))
       )
   )

--- a/detection-rules/attachment_soliciting_enable_macros.yml
+++ b/detection-rules/attachment_soliciting_enable_macros.yml
@@ -8,11 +8,16 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and any(attachments, .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm", "zip")
-         and any(beta.binexplode(.), 
-           strings.ilike(.scan.ocr.raw, "*please*enable*macros")
-           or any(.scan.strings.strings, strings.ilike(., "*please enable macros*"))
-        ))
+  and any(attachments,
+      (
+          .file_extension in~ $file_extensions_macros
+          or .file_extension in~ $file_extensions_common_archives
+      )
+      and any(beta.binexplode(.),
+          strings.ilike(.scan.ocr.raw, "*please*enable*macros")
+          or any(.scan.strings.strings, strings.ilike(., "*please enable macros*"))
+      )
+  )
   and (
       (
           sender.email.domain.root_domain in $free_email_providers

--- a/detection-rules/attachment_suspicious_vba_macro_first_time_sender.yml
+++ b/detection-rules/attachment_suspicious_vba_macro_first_time_sender.yml
@@ -5,7 +5,7 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and any(attachments, .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm")
+  and any(attachments, .file_extension in~ $file_extensions_macros
       and beta.ml_macro_classifier(.).malicious
       and beta.ml_macro_classifier(.).confidence in ("medium", "high")
   )

--- a/detection-rules/attachment_vba_macro_auto_exec_unsolicited.yml
+++ b/detection-rules/attachment_vba_macro_auto_exec_unsolicited.yml
@@ -10,7 +10,7 @@ severity: "medium"
 source: |
   type.inbound 
   and any(attachments, 
-    .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm")
+    .file_extension in~ $file_extensions_macros
     and any(beta.oletools(.).macros.keywords, .type =~ "autoexec")
   )
   and (

--- a/detection-rules/attachment_vba_macro_auto_open_unsolicited.yml
+++ b/detection-rules/attachment_vba_macro_auto_open_unsolicited.yml
@@ -7,10 +7,14 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and any(attachments, .file_extension in~ ("doc", "dot", "docm", "dotm", "docx", "xlm", "xls", "xlsb", "xlsm", "pptm", "ppsm", "zip")
-        and any(beta.binexplode(.),
-          any(.scan.vba.auto_exec, . == "AutoOpen")
-  		)
+  and any(attachments,
+    (
+        .file_extension in~ $file_extensions_macros
+        or .file_extension in~ $file_extensions_common_archives
+    )
+    and any(beta.binexplode(.),
+        any(.scan.vba.auto_exec, . == "AutoOpen")
+    )
   )
   and (
         (

--- a/detection-rules/attachment_vba_macro_calling_executable.yml
+++ b/detection-rules/attachment_vba_macro_calling_executable.yml
@@ -9,7 +9,7 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and any(attachments, .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm", "zip")
+  and any(attachments, (.file_extension in~ $file_extensions_macros or .file_extension in~ $file_extensions_common_archives)
         and any(beta.binexplode(.),
           any(.scan.vba.hex, strings.ilike(., "*exe*")))
   )

--- a/detection-rules/attachment_vba_macro_employee_impersonation.yml
+++ b/detection-rules/attachment_vba_macro_employee_impersonation.yml
@@ -1,4 +1,4 @@
-name: "Attachment with VBA macros from employee impersonation"
+name: "Attachment with VBA macros from employee impersonation (unsolicited)"
 description: |
   Attachment contains a VBA macro from a sender your organization has never sent an email to.
   
@@ -13,15 +13,20 @@ severity: "high"
 source: |
   type.inbound
   and sender.display_name in $org_display_names
-  and any(attachments, 
-          .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", 
-                               "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm")
-          and beta.oletools(.).indicators.vba_macros.exists
-      )
-  and (sender.email.domain.root_domain in $free_email_providers
-    or sender.email.domain.root_domain not in $tranco_1m
+  and any(attachments,
+      (.file_extension in~ $file_extensions_macros or .file_extension in~ $file_extensions_common_archives)
+      and beta.oletools(.).indicators.vba_macros.exists
   )
-  and sender.email.email not in $recipient_emails
+  and (
+          (
+              sender.email.domain.root_domain in $free_email_providers
+              and sender.email.email not in $recipient_emails
+          )
+          or (
+              sender.email.domain.root_domain not in $free_email_providers
+              and sender.email.domain.domain not in $recipient_domains
+          )
+  )
 tags:
   - "Suspicious attachment"
   - "Macros"

--- a/detection-rules/attachment_vba_macro_high_risk.yml
+++ b/detection-rules/attachment_vba_macro_high_risk.yml
@@ -8,7 +8,7 @@ severity: "high"
 source: |
   type.inbound
   and any(attachments, 
-    .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm")
+    .file_extension in~ $file_extensions_macros
     and beta.oletools(.).indicators.vba_macros.risk == "high"
   )
   and (

--- a/detection-rules/attachment_with_suspicious_author_unsolicited.yml
+++ b/detection-rules/attachment_with_suspicious_author_unsolicited.yml
@@ -5,7 +5,7 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and any(attachments, .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "zip")
+  and any(attachments, (.file_extension in~ ("doc", "docm", "docx", "dot", "dotm") or .file_extension in~ $file_extensions_common_archives)
         and any(beta.binexplode(.), strings.ilike(.scan.docx.author, "root")
   	)
   )

--- a/detection-rules/cve_2021_40444_external_relationship.yml
+++ b/detection-rules/cve_2021_40444_external_relationship.yml
@@ -18,10 +18,10 @@ source: |
   type.inbound
   and any(attachments,
       (
-          .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm", "rtf")
+          (.file_extension in~ $file_extensions_macros or .file_extension =~ "rtf")
           and any(beta.oletools(.).relationships, regex.icontains(.target, ".*html:http.*"))
       ) or (
-          .file_extension in~ ("7z","bz2","gz","rar","tar","zip","zipx","iso","img")
+          .file_extension in~ $file_extensions_common_archives
           and any(beta.binexplode(.),
               .flavors.mime == "text/xml" and
               any(.scan.strings.strings, regex.icontains(., ".*oleObject.*mhtml.*http.*"))

--- a/detection-rules/impersonation_wells_fargo.yml
+++ b/detection-rules/impersonation_wells_fargo.yml
@@ -9,7 +9,7 @@ severity: "high"
 source: |
   type.inbound
   and (
-      strings.ilike(sender.display_name, '*wells fargo*')
+      sender.display_name =~ 'wells fargo'
       or strings.ilevenshtein(sender.display_name, 'wells fargo') <= 1
       or strings.ilike(sender.email.domain.domain, '*wellsfargo*')
       or strings.ilike(subject.subject, '*wells fargo security*')

--- a/queries/attachments/vba_macros.yml
+++ b/queries/attachments/vba_macros.yml
@@ -1,7 +1,7 @@
 name: "Attachments with VBA macros"
 type: "query"
 source: |
-  map(filter(attachments, .file_extension in~ ("doc", "dot", "docm", "dotm", "docx", "xlm", "xls", "xlsb", "xlsm", "pptm", "ppsm")
+  map(filter(attachments, .file_extension in~ $file_extensions_macros
     and beta.oletools(.).indicators.vba_macros.exists), .file_name)
 severity: "medium"
 tags:


### PR DESCRIPTION
Also in this PR:

- Updated some legacy Unsolicited snippets
- Updated the RDP file rule severity to medium (h/t @ajpc500)
- Renamed 3 files for consistency (below for reference): @rw-access should we add the feed ID so they don't show up as deleted/new rules when viewing the Feed? That would also keep historically flagged data on these rules in tact. If yes, I could use a reminder on how to do that
- Small FP update

```
 rename detection-rules/{attachment_any_html_suspicious_javascript_identifiers.yml => attachment_html_smuggling_rot13.yml}
 rename detection-rules/{attachment_html_smuggling.yml => attachment_html_smuggling_unescape.yml}
 rename detection-rules/{office_remote_html_template.yml => attachment_office_remote_html_template.yml}
```