### PR TITLE
delivr.to references

### DIFF
--- a/detection-rules/attachment_double_encoded_zip_in_html_smuggle.yml
+++ b/detection-rules/attachment_double_encoded_zip_in_html_smuggle.yml
@@ -5,6 +5,7 @@ references:
   - "https://twitter.com/pr0xylife/status/1593325734004768770"
   - "https://github.com/Neo23x0/signature-base/blob/master/yara/mal_qbot_payloads.yar"
   - "https://delivr.to/payloads?id=0e04949a-24f3-4acd-b77c-bbffc4cb3cb9"
+  - "https://delivr.to/payloads?id=ef39f124-6766-491c-a46c-00f2b60aa7a7"
 type: "rule"
 severity: "high"
 authors:

--- a/detection-rules/attachment_double_encoded_zip_in_html_smuggle.yml
+++ b/detection-rules/attachment_double_encoded_zip_in_html_smuggle.yml
@@ -4,6 +4,7 @@ description: |
 references:
   - "https://twitter.com/pr0xylife/status/1593325734004768770"
   - "https://github.com/Neo23x0/signature-base/blob/master/yara/mal_qbot_payloads.yar"
+  - "https://delivr.to/payloads?id=0e04949a-24f3-4acd-b77c-bbffc4cb3cb9"
 type: "rule"
 severity: "high"
 authors:

--- a/detection-rules/attachment_excel_web_query_file_iqy.yml
+++ b/detection-rules/attachment_excel_web_query_file_iqy.yml
@@ -5,6 +5,7 @@ description: |
   Coercing a target user into providing credentials to an attacker-controlled web server, or for SMB relaying.
 references:
   - "http://www.labofapenetrationtester.com/2015/08/abusing-web-query-iqy-files.html"
+  - "https://delivr.to/payloads?id=c8c6c2dd-f882-48c1-9d3c-d338c45f95fe"
 type: "rule"
 authors:
   - twitter: "jkcoote"

--- a/detection-rules/attachment_lnk_file.yml
+++ b/detection-rules/attachment_lnk_file.yml
@@ -5,6 +5,8 @@ description: |
   LNK files can be weaponised to execute arbitrary commands including unpacking and running executable content embedded within the file itself.
 references:
   - "https://forensicitguy.github.io/shortcut-to-emotet-ttp-change/"
+  - "https://delivr.to/payloads?id=a9f91563-a31f-49f4-9e6c-c6a9fe8095c4"
+  - "https://delivr.to/payloads?id=db034beb-1909-421f-85d0-98fdc37da5f3"
 type: "rule"
 authors:
   - twitter: "ajpc500"

--- a/detection-rules/attachment_msi_installer.yml
+++ b/detection-rules/attachment_msi_installer.yml
@@ -8,6 +8,8 @@ description: |
 references:
   - "https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1218.007/T1218.007.md"
   - "https://www.trendmicro.com/en_us/research/19/d/analysis-abuse-of-custom-actions-in-windows-installer-msi-to-run-malicious-javascript-vbscript-and-powershell-scripts.html"
+  - "https://delivr.to/payloads?id=9f7d3318-5072-4ba6-a7e2-14b4b2470a09"
+  - "https://delivr.to/payloads?id=24b2db63-60f0-4948-bec4-163e038bf402"
 type: "rule"
 authors:
   - twitter: "ajpc500"

--- a/detection-rules/attachment_pdf_file_with_embedded_content.yml
+++ b/detection-rules/attachment_pdf_file_with_embedded_content.yml
@@ -4,6 +4,7 @@ description: |
 references:
   - "https://www.bleepingcomputer.com/news/security/pdf-smuggles-microsoft-word-doc-to-drop-snake-keylogger-malware/"
   - "https://blog.didierstevens.com/2009/07/01/embedding-and-hiding-files-in-pdf-documents/"
+  - "https://delivr.to/payloads?id=6cc3a70e-f832-425e-ae45-5f735d3f1efe"
 type: "rule"
 authors:
   - twitter: "ajpc500"

--- a/detection-rules/attachment_potential_sandbox_evasion_in_office_file.yml
+++ b/detection-rules/attachment_potential_sandbox_evasion_in_office_file.yml
@@ -5,6 +5,7 @@ description: |
   Malicious code may carry out checks against the local host (e.g. running processes, disk size, domain-joined status) before running its final payload.
 references:
   - "https://github.com/S3cur3Th1sSh1t/OffensiveVBA/tree/main/src/SandBoxEvasion"
+  - "https://delivr.to/payloads?id=6e8d282b-7608-4720-9277-fd4ba750aa9c"
 type: "rule"
 authors:
   - twitter: "ajpc500"

--- a/detection-rules/attachment_powershell_content.yml
+++ b/detection-rules/attachment_powershell_content.yml
@@ -6,6 +6,7 @@ description: |
 references:
   - https://stackoverflow.com/questions/62604621/what-are-the-different-powershell-file-types
   - https://en.wikipedia.org/wiki/PowerShell#:~:text=named%20native%20commands.-,Filename%20extensions,-%5Bedit%5D
+  - https://delivr.to/payloads?id=2d2a0629-7cbd-46f7-979a-e69d5dbd57c1
 type: "rule"
 authors:
   - twitter: "ajpc500"

--- a/detection-rules/attachment_rdp_connection_file.yml
+++ b/detection-rules/attachment_rdp_connection_file.yml
@@ -5,6 +5,7 @@ description: |
   Coercing a target user into connecting to an attacker-owned RDP server can expose elements of their host and potentially lead to compromise.
 references:
   - "https://www.blackhillsinfosec.com/rogue-rdp-revisiting-initial-access-methods/"
+  - "https://delivr.to/payloads?id=64f2d144-0060-472e-989c-3b331f6fb095"
 type: "rule"
 authors:
   - twitter: "ajpc500"

--- a/detection-rules/attachment_shellbrowserwindow_com_object_in_macro.yml
+++ b/detection-rules/attachment_shellbrowserwindow_com_object_in_macro.yml
@@ -3,6 +3,7 @@ description: |
   Macro references the ShellBrowserWindow COM object which can be used to spawn new processes from Explorer.exe rather than as a child process of the Office application. This can be useful for a threat actor attempting to evade security controls.
 references:
   - "https://blog.f-secure.com/dechaining-macros-and-evading-edr/"
+  - "https://delivr.to/payloads?id=0db5ac46-b59d-4bec-8252-59a40a0d9dec"
 type: "rule"
 authors:
   - twitter: "ajpc500"

--- a/detection-rules/download_link_to_disk_image_in_encrypted_zip.yml
+++ b/detection-rules/download_link_to_disk_image_in_encrypted_zip.yml
@@ -4,6 +4,7 @@ description: |
 type: "rule"
 references:
   - "https://twitter.com/pr0xylife/status/1592502966409654272"
+  - "https://delivr.to/payloads?id=ca00292e-d5a2-43f9-b638-6c0b01b73353"
 severity: "medium"
 authors:
   - twitter: "ajpc500"


### PR DESCRIPTION
Opted to add 1-2 examples per rule, rather than all permutations (e.g. an lnk in a zip, iso, img etc.)