### PR TITLE
Fixing typo in rule

### DIFF
--- a/detection-rules/attachment_html_smuggling_embedded_b64_pe.yml
+++ b/detection-rules/attachment_html_smuggling_embedded_b64_pe.yml
@@ -1,6 +1,6 @@
 name: "Attachment: HTML smuggling with embedded base64-encoded executable"
 description: |
-  HTML attachmemt contains a base-64 encoded executable.
+  HTML attachment contains a base-64 encoded executable.
 type: "rule"
 severity: "high"
 source: |


### PR DESCRIPTION
My bad! Fixing typo in my "Attachment: HTML smuggling with embedded base64-encoded executable" rule!