### PR TITLE
Add file_type check to any_html_attachment rules to be more resilient

### DIFF
--- a/detection-rules/attachment_any_html_new_sender.yml
+++ b/detection-rules/attachment_any_html_new_sender.yml
@@ -9,7 +9,12 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and any(attachments, .file_extension in~ ('htm', 'html'))
+  and any(attachments,
+      .file_extension in~ ('htm', 'html') or
+      .file_type == "html"
+  )
+
+  // first-time sender
   and (
           (
               sender.email.domain.root_domain in $free_email_providers

--- a/detection-rules/attachment_any_html_new_sender.yml
+++ b/detection-rules/attachment_any_html_new_sender.yml
@@ -5,6 +5,7 @@ description: |
   This rule may be expanded to inspect HTML attachments for suspicious code.
 references:
   - "https://ired.team/offensive-security/defense-evasion/file-smuggling-with-html-and-javascript"
+  - "https://sandbox.sublimesecurity.com?id=106315e9-166a-4e0f-946e-88ff6fd5f9fd"
 type: "rule"
 severity: "medium"
 source: |

--- a/detection-rules/attachment_any_html_unsolicited.yml
+++ b/detection-rules/attachment_any_html_unsolicited.yml
@@ -9,20 +9,21 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and any(attachments, .file_extension in~ ('htm', 'html'))
+  and any(attachments,
+      .file_extension in~ ('htm', 'html') or
+      .file_type == "html"
+  )
+
+  // unsolicited
   and (
-          // if this comes from a free email provider,
-          // flag if org has never sent an email to sender's email before
-          (
-              sender.email.domain.root_domain in $free_email_providers
-              and sender.email.email not in $recipient_emails
-          )
-          // if this comes from a custom domain,
-          // flag if org has never sent an email to sender's domain before
-          or (
-              sender.email.domain.root_domain not in $free_email_providers
-              and sender.email.domain.domain not in $recipient_domains
-          )
+      (
+          sender.email.domain.root_domain in $free_email_providers
+          and sender.email.email not in $recipient_emails
+      )
+      or (
+          sender.email.domain.root_domain not in $free_email_providers
+          and sender.email.domain.domain not in $recipient_domains
+      )
   )
 tags:
   - "Suspicious attachment"

--- a/detection-rules/attachment_any_html_unsolicited.yml
+++ b/detection-rules/attachment_any_html_unsolicited.yml
@@ -5,6 +5,7 @@ description: |
   This rule may be expanded to inspect HTML attachments for suspicious code.
 references:
   - "https://ired.team/offensive-security/defense-evasion/file-smuggling-with-html-and-javascript"
+  - "https://sandbox.sublimesecurity.com?id=106315e9-166a-4e0f-946e-88ff6fd5f9fd"
 type: "rule"
 severity: "medium"
 source: |


### PR DESCRIPTION
This will flag attacks with .shtml extensions, or attachments missing an extension.
