### PR TITLE
HTML link smuggling update: s/exe/vba

### DIFF
--- a/detection-rules/link_download_disk_image_in_encrypted_zip.yml
+++ b/detection-rules/link_download_disk_image_in_encrypted_zip.yml
@@ -11,18 +11,8 @@ severity: "medium"
 authors:
   - twitter: "ajpc500"
 source: |
-  type.inbound and 
-  (
-      (
-          sender.email.domain.root_domain in $free_email_providers
-          and sender.email.email not in $sender_emails
-      )
-      or (
-          sender.email.domain.root_domain not in $free_email_providers
-          and sender.email.domain.domain not in $sender_domains
-      )
-  ) and
-  any(body.links, 
+  type.inbound 
+  and any(body.links, 
       any(beta.linkanalysis(.).files_downloaded, 
           any(
               beta.binexplode(.), (
@@ -30,6 +20,17 @@ source: |
                   any(.scan.zip.all_paths, any([".img", ".iso", ".vhd"], strings.ends_with(.., .)))
               )
           )
+      )
+  )
+  // first-time sender
+  and (
+      (
+          sender.email.domain.root_domain in $free_email_providers
+          and sender.email.email not in $sender_emails
+      )
+      or (
+          sender.email.domain.root_domain not in $free_email_providers
+          and sender.email.domain.domain not in $sender_domains
       )
   )
 tags:

--- a/detection-rules/link_download_suspicious_file.yml
+++ b/detection-rules/link_download_suspicious_file.yml
@@ -1,6 +1,6 @@
 name: "Link to auto-download of a suspicious file type (unsolicited)"
 description: |
-  A link in the body of the email downloads a suspicious file type (or embedded file) such as an EXE, LNK, or JS file.
+  A link in the body of the email downloads a suspicious file type (or embedded file) such as an LNK, JS, or VBA.
 
   Recursively explodes auto-downloaded files within archives to detect these file types.
 
@@ -25,12 +25,12 @@ source: |
                   "encrypted_zip" in .flavors.yara
 
                   and any(.scan.zip.attempted_files,
-                      strings.ilike(., "*.lnk", "*.exe", "*.js")
+                      strings.ilike(., "*.lnk", "*.js", "*.vba")
                   )
               )
               // for both non-encrypted zips and encrypted zips
               // that were successfully cracked
-              or .extension in ("lnk", "exe", "js")
+              or .extension in ("lnk", "js", "vba")
           )
       )
   )


### PR DESCRIPTION
EXE link downloads happen too commonly, eg links to the Zoom binary.
