### PR TITLE
New Rule: PDF with embedded executable

### DIFF
--- a/detection-rules/attachment_pdf_embedded_exec.yml
+++ b/detection-rules/attachment_pdf_embedded_exec.yml
@@ -1,0 +1,18 @@
+name: "Attachment: PDF with embedded executable"
+description: |
+  PDF attachmemt contains an executable.
+references:
+   - "https://delivr.to/payloads?id=d4dab160-0437-4f84-9294-db0348364b31"
+   - "https://playground.sublimesecurity.com?id=1eb72565-e53a-4c4d-9a89-b82f7f14eb7e"
+type: "rule"
+severity: "high"
+source: |
+  type.inbound 
+      and any(attachments, .file_extension == "pdf"
+          and any(beta.binexplode(.), 
+              .flavors.mime in~ ("application/x-dosexec", "text/x-msdos-batch")
+              or any(.flavors.yara, . == 'base64_pe')
+      )
+  )
+tags:
+  - "Suspicious attachment"


### PR DESCRIPTION
Similar to #193, but I believe a separate detection for PDF files makes sense.