### PR TITLE
Validate CI Failures for Redirect

### DIFF
--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -28,5 +28,10 @@ jobs:
           for f in *-rules/*.yml
           do
             echo "Processing $f"
-            yq -o=json eval 'del(.type)' "$f" | curl -H "Content-Type: application/json" -X POST --data-binary @- --fail --silent https://sandbox.sublimesecurity.com/v1/rules/validate
+            http_code=$(yq -o=json eval 'del(.type)' "$f" | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://sandbox.sublimesecurity.com/v1/rules/validate)
+            cat response.txt
+            if [[ "$http_code" != "200" ]]; then
+              echo "Unexpected response $http_code"
+              exit 1
+            fi
           done

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -28,7 +28,7 @@ jobs:
           for f in *-rules/*.yml
           do
             echo "Processing $f"
-            http_code=$(yq -o=json eval 'del(.type)' "$f" | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://sandbox.sublimesecurity.com/v1/rules/validate)
+            http_code=$(yq -o=json eval 'del(.type)' "$f" | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
             cat response.txt
             if [[ "$http_code" != "200" ]]; then
               echo "Unexpected response $http_code"

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -28,5 +28,5 @@ jobs:
           for f in *-rules/*.yml
           do
             echo "Processing $f"
-            yq -o=json eval 'del(.type)' "$f" | curl -H "Content-Type: application/json" -X POST --data-binary @- --fail --silent https://playground.sublimesecurity.com/v1/rules/validate
+            yq -o=json eval 'del(.type)' "$f" | curl -H "Content-Type: application/json" -X POST --data-binary @- --fail --silent https://sandbox.sublimesecurity.com/v1/rules/validate
           done

--- a/detection-rules/attachment_any_html_in_archive_unsolicited.yml
+++ b/detection-rules/attachment_any_html_in_archive_unsolicited.yml
@@ -16,8 +16,7 @@ source: |
   )
   and (
           (
-              sender.email.domain.root_domain in $free_email_providers
-              and sender.email.email not in $recipient_emails
+              invalid!?!
           )
           or (
               sender.email.domain.root_domain not in $free_email_providers

--- a/detection-rules/attachment_any_html_in_archive_unsolicited.yml
+++ b/detection-rules/attachment_any_html_in_archive_unsolicited.yml
@@ -16,7 +16,8 @@ source: |
   )
   and (
           (
-              invalid!?!
+              sender.email.domain.root_domain in $free_email_providers
+              and sender.email.email not in $recipient_emails
           )
           or (
               sender.email.domain.root_domain not in $free_email_providers


### PR DESCRIPTION
Following up on https://github.com/sublime-security/sublime-rules/pull/211 -- I didn't think CI was behaving correctly because we were only seeing the redirect text, not analysis response.

```
Processing detection-rules/attachment_any_html_in_archive_unsolicited.yml
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>302 Moved</TITLE></HEAD><BODY>
<H1>302 Moved</H1>
The document has moved
<A HREF="https://playground.sublimesecurity.com/v1/rules/validate">here</A>.
</BODY></HTML>
```

curl `--fail` isn't sufficient and we were not actually validating these rules.

https://github.com/sublime-security/sublime-rules/pull/212/commits/a872f28067aefa102f47b8a1a996a2eee644e0fe shows that we're succeeding even with invalid MQL. 
https://github.com/sublime-security/sublime-rules/pull/212/commits/9c1d1e9d5dedb3a77bb493b1f4a2fb9419809a21 validate the HTTP code (fails on the redirect, not the invalid MQL).
https://github.com/sublime-security/sublime-rules/pull/212/commits/2b1465439adf502b65b39fa68e6c1513e2ad3fe0 with correct URL we'll fail on the invalid MQL
https://github.com/sublime-security/sublime-rules/pull/212/commits/b04cd8eeb15bdb28beec573c46a2643c6aa0205c with correct MQL to show success case

We could also add `--post302 -L` the `curl` command so that it will follow redirects. We don't expect to change our redirects often though, so I don't think keeping this up to date should be an issue.

```
yq -o=json eval 'del(.type)' "detection-rules/attachment_any_html_new_sender.yml" | curl --post302 -L -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://sandbox.sublimesecurity.com/v1/rules/validate
200%
```