### PR TITLE
Accounted for byte strings in raw buffer rule

### DIFF
--- a/detection-rules/attachment_html_smuggling_raw_buffer.yml
+++ b/detection-rules/attachment_html_smuggling_raw_buffer.yml
@@ -2,7 +2,7 @@ name: "Attachment: HTML smuggling with raw array buffer"
 description: |
   Recursively scans files and archives to detect HTML smuggling techniques.
 references:
-  - "https://playground.sublimesecurity.com?id=a6a72d97-39c7-4b12-af4d-370b654944c0"
+  - "https://playground.sublimesecurity.com?id=1c9531ea-f25b-41dc-9aeb-848a211293fb"
 type: "rule"
 severity: "high"
 source: |

--- a/detection-rules/attachment_html_smuggling_raw_buffer.yml
+++ b/detection-rules/attachment_html_smuggling_raw_buffer.yml
@@ -17,14 +17,13 @@ source: |
                 any(.scan.strings.strings,
                     // arrayBuffer, eg repetition:
                     // [0xa0,0x8e,0xd0,0x60,...]
-                    regex.icontains(., '(.*0x[a-zA-Z0-9]{2}.*,\s*){100}')
+                    regex.icontains(., '(\W?0x[a-zA-Z0-9]{2}\W?,\s*){100}')
                 )
                 and any(.scan.strings.strings,
                     strings.contains(., ".map")
                 )
         )
   )
-
 tags:
   - "Suspicious attachment"
   - "HTML smuggling"

--- a/detection-rules/attachment_html_smuggling_raw_buffer.yml
+++ b/detection-rules/attachment_html_smuggling_raw_buffer.yml
@@ -17,13 +17,14 @@ source: |
                 any(.scan.strings.strings,
                     // arrayBuffer, eg repetition:
                     // [0xa0,0x8e,0xd0,0x60,...]
-                    regex.icontains(., '(0x[a-zA-Z0-9]{2},\s*){100}')
+                    regex.icontains(., '(.*0x[a-zA-Z0-9]{2}.*,\s*){100}')
                 )
                 and any(.scan.strings.strings,
                     strings.contains(., ".map")
                 )
         )
   )
+
 tags:
   - "Suspicious attachment"
   - "HTML smuggling"


### PR DESCRIPTION
These raw buffer arrays could be in the form `0x1a` or `'0x1a'`. Added an optional character to the regex to account for that 