### PR TITLE
New rule - Impersonation using recipient domain (first-time sender)

### DIFF
--- a/detection-rules/impersonation_recipient_domain.yml
+++ b/detection-rules/impersonation_recipient_domain.yml
@@ -1,0 +1,35 @@
+name: "Impersonation using recipient domain (first-time sender)"
+description: |
+  The recipient's domain is used in the sender's display name
+  in order to impersonate the organization. The impersonation has been 
+  observed to use both the recipient's full email address, as well as 
+  just the domain.
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+
+  // only 1 To: recipient
+  and length(recipients.to) + length(recipients.bcc) == 1
+  and length(recipients.cc) == 0
+
+  and any(recipients.to,
+      // custom domains only
+      sender.email.domain.domain not in $free_email_providers
+
+      // recipient's domain is in the sender's display name
+      and strings.icontains(sender.display_name, .email.domain.root_domain))
+
+  // first-time sender
+  and (
+            (
+                sender.email.domain.root_domain in $free_email_providers
+                and sender.email.email not in $sender_emails
+            )
+            or (
+                sender.email.domain.root_domain not in $free_email_providers
+                and sender.email.domain.domain not in $sender_domains
+            )
+  )
+tags:
+  - "Suspicious sender"

--- a/detection-rules/impersonation_recipient_domain.yml
+++ b/detection-rules/impersonation_recipient_domain.yml
@@ -10,8 +10,7 @@ source: |
   type.inbound
 
   // only 1 To: recipient
-  and length(recipients.to) + length(recipients.bcc) == 1
-  and length(recipients.cc) == 0
+  and length(recipients.to) + length(recipients.bcc) + length(recipients.cc) == 1
 
   and any(recipients.to,
       // custom domains only


### PR DESCRIPTION
This rule is wildly effective. `strings.icontains` has opened up so many killer detections.
