### PR TITLE
New Rule: Office document loads remote document template

### DIFF
--- a/detection-rules/attachment_office_remote_doc_template.yml
+++ b/detection-rules/attachment_office_remote_doc_template.yml
@@ -14,7 +14,7 @@ source: |
               .file_extension in~ $file_extensions_macros
               or .file_extension in~ $file_extensions_common_archives
           )
-          and any(beta.binexplode(.),
+          and any(file.explode(.),
               .flavors.mime == "text/xml" and
               any(.scan.strings.strings, regex.icontains(., ".*Target.*http.*dotm.*"))
           )

--- a/detection-rules/attachment_office_remote_doc_template.yml
+++ b/detection-rules/attachment_office_remote_doc_template.yml
@@ -11,7 +11,7 @@ source: |
       (
           (
               // office files
-              .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm")
+              .file_extension in~ $file_extensions_macros
               or .file_extension in~ $file_extensions_common_archives
           )
           and any(beta.binexplode(.),

--- a/detection-rules/attachment_office_remote_doc_template.yml
+++ b/detection-rules/attachment_office_remote_doc_template.yml
@@ -10,8 +10,9 @@ source: |
   and any(attachments,
       (
           (
-          .file_extension in~ $file_extensions_macros 
-          or .file_extension in~ $file_extensions_common_archives
+              // office files
+              .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsb", "xlsm", "xlt", "xltm")
+              or .file_extension in~ $file_extensions_common_archives
           )
           and any(beta.binexplode(.),
               .flavors.mime == "text/xml" and

--- a/detection-rules/attachment_office_remote_doc_template.yml
+++ b/detection-rules/attachment_office_remote_doc_template.yml
@@ -4,7 +4,7 @@ description: |
 references:
   - "https://delivr.to/payloads?id=c7a7195e-0de3-428d-a32c-5fd59a3012da"
 type: "rule"
-severity: "high"
+severity: "medium"
 source: |
   type.inbound
   and any(attachments,

--- a/detection-rules/attachment_office_remote_doc_template.yml
+++ b/detection-rules/attachment_office_remote_doc_template.yml
@@ -1,0 +1,24 @@
+name: "Attachment: Office document loads remote document template"
+description: |
+  Recursively scans archives and Office documents to detect remote document template injection.
+references:
+  - "https://delivr.to/payloads?id=c7a7195e-0de3-428d-a32c-5fd59a3012da"
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(attachments,
+      (
+          (
+          .file_extension in~ $file_extensions_macros 
+          or .file_extension in~ $file_extensions_common_archives
+          )
+          and any(beta.binexplode(.),
+              .flavors.mime == "text/xml" and
+              any(.scan.strings.strings, regex.icontains(., ".*Target.*http.*dotm.*"))
+          )
+      )
+  )
+tags:
+  - "Suspicious attachment"
+  - "Office exploit"


### PR DESCRIPTION
Similar to https://github.com/sublime-security/sublime-rules/blob/main/detection-rules/attachment_office_remote_html_template.yml, however I don't believe they should be combined (this is a different method of attack, and not zero-click)