### PR TITLE
Ignore YARA files for repo language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.yar linguist-detectable=false


### PR DESCRIPTION
I think this is a bit misleading:

<img width="513" alt="image" src="https://user-images.githubusercontent.com/11003450/212445254-06f966e6-8e26-496f-9629-c86ed7d21f53.png">

<img width="377" alt="image" src="https://user-images.githubusercontent.com/11003450/212445259-766caddd-597b-4745-9f2f-e91a8b433b1d.png">

I tested this on my own fork and this will hide YARA from the language stats.