### PR TITLE
New Rule: MSFT Forms Google Impersonation

### DIFF
--- a/detection-rules/impersonation_google.yml
+++ b/detection-rules/impersonation_google.yml
@@ -1,0 +1,24 @@
+name: "Brand impersonation: Google"
+description: |
+  Impersonation of Google.
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and (
+  (
+      strings.ilike(subject.subject, '*urgent*') 
+      or strings.ilike(subject.subject, '*alert*')
+  )
+  or
+      (
+      strings.ilike(body.html.display_text, "*google*")
+      and strings.ilike(body.html.display_text, "*suspicious*")
+      and strings.ilike(body.html.display_text, "*secure*")
+      )
+  )
+  and sender.email.domain.domain == 'email.formspro.microsoft.com'
+
+tags:
+  - "Brand impersonation"
+  - "Suspicious sender"

--- a/detection-rules/impersonation_google.yml
+++ b/detection-rules/impersonation_google.yml
@@ -1,6 +1,6 @@
-name: "Brand impersonation: Google"
+name: "Brand impersonation: Google using Microsoft Forms"
 description: |
-  Impersonation of Google.
+  Abuses Microsoft Forms to impersonate Google.
 type: "rule"
 severity: "high"
 source: |

--- a/detection-rules/impersonation_google_via_msft_forms.yml
+++ b/detection-rules/impersonation_google_via_msft_forms.yml
@@ -6,19 +6,20 @@ severity: "high"
 source: |
   type.inbound
   and (
-    (
-      strings.ilike(subject.subject, '*urgent*') 
-      and strings.ilike(subject.subject, '*alert*')
-    )
-  and
       (
-        strings.ilike(body.html.display_text, "*google*")
-        and strings.ilike(body.html.display_text, "*suspicious*")
-        and strings.ilike(body.html.display_text, "*secure*")
+          strings.ilike(subject.subject, '*urgent*')
+          and strings.ilike(subject.subject, '*alert*')
+      )
+      // we could change this to an 'or' to make a more generic impersonation
+      // via MSFT Forms rule
+      and
+      (
+          strings.ilike(body.html.display_text, "*google*")
+          and strings.ilike(body.html.display_text, "*suspicious*")
+          and strings.ilike(body.html.display_text, "*secure*")
       )
   )
   and sender.email.domain.domain == 'email.formspro.microsoft.com'
-
 tags:
   - "Brand impersonation"
   - "Suspicious sender"

--- a/detection-rules/impersonation_google_via_msft_forms.yml
+++ b/detection-rules/impersonation_google_via_msft_forms.yml
@@ -6,15 +6,15 @@ severity: "high"
 source: |
   type.inbound
   and (
-  (
+    (
       strings.ilike(subject.subject, '*urgent*') 
-      or strings.ilike(subject.subject, '*alert*')
-  )
-  or
+      and strings.ilike(subject.subject, '*alert*')
+    )
+  and
       (
-      strings.ilike(body.html.display_text, "*google*")
-      and strings.ilike(body.html.display_text, "*suspicious*")
-      and strings.ilike(body.html.display_text, "*secure*")
+        strings.ilike(body.html.display_text, "*google*")
+        and strings.ilike(body.html.display_text, "*suspicious*")
+        and strings.ilike(body.html.display_text, "*secure*")
       )
   )
   and sender.email.domain.domain == 'email.formspro.microsoft.com'


### PR DESCRIPTION
### Overview
Some attacks impersonate Google, where users are urged to secure their accounts. All emails come from the same sender domain: `email[.]formspro[.]microsoft[.]com`. 

### Example
<img width="538" alt="Screenshot 2023-01-26 at 11 43 12 AM" src="https://user-images.githubusercontent.com/29960025/214909657-627123b4-d104-484d-a380-37a166722826.png">
