### PR TITLE
Require an Financial Entity be present in Extortion Intents

### DIFF
--- a/detection-rules/body_extortion.yml
+++ b/detection-rules/body_extortion.yml
@@ -9,6 +9,9 @@ source: |
   any(beta.ml_nlu_classifier(.).intents,
         .name == "extortion" and .confidence == "high"
       )
+      and (
+        any(beta.ml_nlu_classifier(.).entities, .name == "financial")
+      )
   )
 
   and (
@@ -23,6 +26,7 @@ source: |
           // many extortion emails spoof sender domains and fail sender authentication
           or any(headers.hops, .authentication_results.dmarc == "fail")
   )
+
 tags:
   - "Machine Learning"
   - "Natural Language Understanding"


### PR DESCRIPTION
Adding additional logic to decrease FPs associated with the `extortion` intent classification. 