### PR TITLE
add insertAdjacentHTML to HTML Smuggling atob rule

### DIFF
--- a/detection-rules/attachment_html_smuggling_atob.yml
+++ b/detection-rules/attachment_html_smuggling_atob.yml
@@ -5,7 +5,7 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and any(attachments, .size <= 15000 and
+  and any(attachments, .size <= 60000 and
       (
           .file_extension in~ ("html", "htm", "shtml", "dhtml") or
           .file_extension in~ $file_extensions_common_archives or
@@ -17,7 +17,11 @@ source: |
               all(["document", "write", "atob"], . in ..scan.javascript.identifiers)
               
               // usage: document['write'](atob)
-              or any(.scan.strings.strings, strings.ilike(., "*document*write*atob*"))
+              // usage: document.head.insertAdjacentHTML("beforeend", atob(...
+              or 
+                  any(.scan.strings.strings, strings.ilike(.,
+                      "*document*write*atob*",
+                      "*document*insertAdjacentHTML*atob*"))
           )
       )
   )


### PR DESCRIPTION
Example:  `document.head.insertAdjacentHTML("beforeend", atob(...`