### PR TITLE
Updated Rule: HTML smuggling with eval and atob

### DIFF
--- a/detection-rules/attachment_html_smuggling_eval_atob.yml
+++ b/detection-rules/attachment_html_smuggling_eval_atob.yml
@@ -13,7 +13,7 @@ source: |
       )
       and any(beta.binexplode(.),
           // usage: onerror="eval(atob('
-          any(.scan.strings.strings, strings.ilike(., "*onerror*eval*atob*"))
+          any(.scan.strings.strings, regex.imatch(., ".*eval.{1,4}atob.*"))
       )
   )
 tags:


### PR DESCRIPTION
Proposing a small change to detect more `eval*atob` activity.
Current detection requires `onerror` to precede `eval(atob` which is not found in all of these smuggling attacks I have detected.

Let me know your thoughts.

Thanks!