### PR TITLE
New Rule: Link to auto-downloaded file with Google Drive branding

### DIFF
--- a/detection-rules/link_html_smuggling_with_googledrive_branding.yml
+++ b/detection-rules/link_html_smuggling_with_googledrive_branding.yml
@@ -1,0 +1,43 @@
+name: "Link to auto-downloaded file with Google Drive branding"
+description: |
+  A link in the body of the email downloads a file from a site that uses Google Drive branding as employed by threat actors, such as Qakbot.
+type: "rule"
+references:
+  - "https://delivr.to/payloads?id=bd455258-af43-4a4e-ab0f-601960cfc3a5"
+  - "https://github.com/sublime-security/sublime-rules/blob/main/detection-rules/link_html_smuggling_with_adobe_branding.yml"
+severity: "high"
+source: |
+  type.inbound
+  and any(body.links,
+      // There are files downloaded
+      length(beta.linkanalysis(.).files_downloaded) > 0 and 
+      
+      // Google Drive branding
+      beta.linkanalysis(.).credphish.brand.name == "GoogleDrive" and 
+      beta.linkanalysis(.).credphish.brand.confidence == "high" and 
+      
+      // Qakbot text for user coercion
+      any(beta.binexplode(beta.linkanalysis(.).screenshot),
+          all([
+              "the file is not displayed correctly",
+              "document password"
+          ], strings.icontains(..scan.ocr.raw, .))
+      )
+  )
+  // unsolicited
+  and (
+          (
+              sender.email.domain.root_domain in $free_email_providers
+              and sender.email.email not in $recipient_emails
+          )
+          or (
+              sender.email.domain.root_domain not in $free_email_providers
+              and sender.email.domain.domain not in $recipient_domains
+          )
+  ) 
+tags:
+  - "HTML smuggling"
+  - "Suspicious link"
+  - "Brand impersonation"
+  - "Malware"
+  - "Qakbot"


### PR DESCRIPTION
Heavily inspired by https://github.com/sublime-security/sublime-rules/blob/main/detection-rules/link_html_smuggling_with_adobe_branding.yml (thanks @ajpc500!)