### PR TITLE
Updating Rule: Brand impersonation: Github

### DIFF
--- a/detection-rules/impersonation_github.yml
+++ b/detection-rules/impersonation_github.yml
@@ -12,7 +12,7 @@ source: |
       or strings.ilike(sender.email.email, '*github*')
       or strings.ilevenshtein(sender.email.domain.sld, 'github') <= 1
   )
-  and sender.email.domain.root_domain not in ('github.com', 'gitlab.com', 'itthub.net', 'githubsupport.com', 'gtmhub.com')
+  and sender.email.domain.root_domain not in ('github.com', 'gitlab.com', 'itthub.net', 'githubsupport.com', 'gtmhub.com', 'githubstatus.com')
   and (
         (
             sender.email.domain.root_domain in $free_email_providers


### PR DESCRIPTION
[githubstatus.com](https://githubstatus.com) is a legit domain used by GitHub to send out operational status updates. 
Adding it to the legit domain list to prevent status update emails from creating false alerts.