### PR TITLE
Update Rule: Notion suspicious file share

### DIFF
--- a/detection-rules/impersonation_github.yml
+++ b/detection-rules/impersonation_github.yml
@@ -12,7 +12,7 @@ source: |
       or strings.ilike(sender.email.email, '*github*')
       or strings.ilevenshtein(sender.email.domain.sld, 'github') <= 1
   )
-  and sender.email.domain.root_domain not in ('github.com', 'gitlab.com', 'itthub.net', 'githubsupport.com', 'gtmhub.com')
+  and sender.email.domain.root_domain not in ('github.com', 'gitlab.com', 'itthub.net', 'githubsupport.com', 'gtmhub.com', 'githubstatus.com')
   and (
         (
             sender.email.domain.root_domain in $free_email_providers

--- a/detection-rules/link_notion_file_share.yml
+++ b/detection-rules/link_notion_file_share.yml
@@ -1,13 +1,14 @@
 name: "Notion suspicious file share"
 description: |
-  Message contains a notion link that contains suspicious terms. You 
-  may need to deactivate or fork this rule if your organization uses 
-  Notion.
+  Message contains a notion link that contains suspicious terms. If 
+  your organization uses Notion, you can fork and modify the 
+  YOUR_COMPANY_SLUG variable in the rule to prevent internal Notion 
+  links from triggering the alert.
 type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and any(body.links, .href_url.domain.root_domain =~ 'notion.so'
+  and any(body.links, (.href_url.domain.root_domain =~ 'notion.so' and not strings.starts_with(.href_url.path,'/YOUR_COMPANY_SLUG/'))
       and (strings.ilike(.href_url.url, '*shared*', '*document*', '*secure*', '*office*', '*important*', '*wants-to*', '*share*', '*statement*')
            or strings.ilike(.display_url.url, '*shared*', '*document*', '*secure*', '*office*', '*important*', '*wants-to*', '*share*', '*statement*')
            or strings.ilike(.display_text, '*shared*', '*document*', '*secure*', '*office*', '*important*', '*wants-to*', '*share*', '*statement*')))


### PR DESCRIPTION
Notion supports customizing slug for each organization.
![Notion screenshot](https://user-images.githubusercontent.com/17494876/223578624-af7f33f3-ac71-4c87-b54c-10ee3d5d857c.png)

By providing the option to exclude your organization slug in the detection rule, we can prevent internal Notion links from triggering the alert and cause false positives.

Reference: [Public pages & web publishing](https://www.notion.so/help/public-pages-and-web-publishing)