### PR TITLE
New Rule: Netflix Impersonation

### DIFF
--- a/detection-rules/impersonation_netflix.yml
+++ b/detection-rules/impersonation_netflix.yml
@@ -5,6 +5,8 @@ references:
   - "https://news.trendmicro.com/2023/01/18/netflix-scams-2023-job-text-email/"
 type: "rule"
 severity: "low"
+authors:
+  - name: "min0k"
 source: |
   type.inbound
   and (

--- a/detection-rules/impersonation_netflix.yml
+++ b/detection-rules/impersonation_netflix.yml
@@ -12,7 +12,7 @@ source: |
       or strings.ilevenshtein(sender.display_name, 'netflix') <= 1
       or strings.ilike(sender.email.domain.domain, '*netflix*')
   )
-  and sender.email.domain.domain not !~ 'netflix.com'
+  and sender.email.domain.domain !~ 'netflix.com'
   and sender.email.email not in $recipient_emails
 tags:
   - "Brand impersonation"

--- a/detection-rules/impersonation_netflix.yml
+++ b/detection-rules/impersonation_netflix.yml
@@ -1,0 +1,19 @@
+name: "Brand impersonation: Netflix"
+description: |
+  Impersonation of Netflix.
+references:
+  - "https://news.trendmicro.com/2023/01/18/netflix-scams-2023-job-text-email/"
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and (
+      strings.ilike(sender.display_name, '*netflix*')
+      or strings.ilevenshtein(sender.display_name, 'netflix') <= 1
+      or strings.ilike(sender.email.domain.domain, '*netflix*')
+  )
+  and sender.email.domain.domain not !~ 'netflix.com'
+  and sender.email.email not in $recipient_emails
+tags:
+  - "Brand impersonation"
+  - "Suspicious sender"

--- a/detection-rules/impersonation_netflix.yml
+++ b/detection-rules/impersonation_netflix.yml
@@ -17,3 +17,5 @@ source: |
 tags:
   - "Brand impersonation"
   - "Suspicious sender"
+authors:
+  - name: "min0k"

--- a/detection-rules/impersonation_netflix.yml
+++ b/detection-rules/impersonation_netflix.yml
@@ -12,7 +12,7 @@ source: |
       or strings.ilevenshtein(sender.display_name, 'netflix') <= 1
       or strings.ilike(sender.email.domain.domain, '*netflix*')
   )
-  and sender.email.domain.domain !~ 'netflix.com'
+  and sender.email.domain.root_domain !~ 'netflix.com'
   and sender.email.email not in $recipient_emails
 tags:
   - "Brand impersonation"

--- a/detection-rules/impersonation_netflix.yml
+++ b/detection-rules/impersonation_netflix.yml
@@ -19,5 +19,3 @@ source: |
 tags:
   - "Brand impersonation"
   - "Suspicious sender"
-authors:
-  - name: "min0k"


### PR DESCRIPTION
New Detection Rule to address Netflix impersonation emails. Netflix is a streaming service, the brand is commonly used in phishing attacks.

- https://news.trendmicro.com/2023/01/18/netflix-scams-2023-job-text-email/
- https://blog.knowbe4.com/scam-of-the-week-netflix-phishing-attack