### PR TITLE
Authentication updates, and New DMARC +  credphish rule

### DIFF
--- a/detection-rules/impersonation_dmarc_failure_high_cred_phish_conclusion.yml
+++ b/detection-rules/impersonation_dmarc_failure_high_cred_phish_conclusion.yml
@@ -1,0 +1,16 @@
+name: "DMARC failure with high confidence credential theft intent"
+description: "Detects DMARC failures and messages with a high confidence of credential theft"
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(distinct(headers.hops, .authentication_results.dmarc is not null), strings.ilike(.authentication_results.dmarc, "*fail"))
+  and any([body.plain.raw, body.html.inner_text], 
+    any(ml.nlu_classifier(.).intents,
+      .name in ("cred_theft")
+      and .confidence == "high"
+    )
+  )
+tags:
+  - "DMARC failure"
+  - "Credential theft intent"

--- a/detection-rules/impersonation_dmarc_failure_high_cred_phish_conclusion.yml
+++ b/detection-rules/impersonation_dmarc_failure_high_cred_phish_conclusion.yml
@@ -1,4 +1,4 @@
-name: "DMARC failure with high confidence credential theft intent"
+name: "Impersonation: DMARC failure with high confidence credential theft intent"
 description: "Detects DMARC failures and messages with a high confidence of credential theft"
 type: "rule"
 severity: "high"
@@ -12,5 +12,5 @@ source: |
     )
   )
 tags:
-  - "DMARC failure"
-  - "Credential theft intent"
+  - "Brand impersonation"
+  - "Credential phishing"

--- a/detection-rules/impersonation_dmarc_failure_high_cred_phish_conclusion.yml
+++ b/detection-rules/impersonation_dmarc_failure_high_cred_phish_conclusion.yml
@@ -5,11 +5,10 @@ severity: "high"
 source: |
   type.inbound
   and any(distinct(headers.hops, .authentication_results.dmarc is not null), strings.ilike(.authentication_results.dmarc, "*fail"))
-  and any([body.plain.raw, body.html.inner_text], 
-    any(ml.nlu_classifier(.).intents,
-      .name in ("cred_theft")
-      and .confidence == "high"
-    )
+  and any(ml.nlu_classifier(coalesce(
+    body.html.display_text, body.plain.raw)).intents, 
+    .name in ("cred_theft")
+    and .confidence == "high"
   )
 tags:
   - "Brand impersonation"

--- a/detection-rules/impersonation_docusign.yml
+++ b/detection-rules/impersonation_docusign.yml
@@ -34,8 +34,11 @@ source: |
     and .href_url.domain.root_domain not in ("docusign.com","docusign.net")
   )
 
-  and sender.email.domain.root_domain not in ('docusign.net', 'docusign.com')
-
+  and (
+        sender.email.domain.root_domain not in ('docusign.net', 'docusign.com')
+      or any(distinct(headers.hops, .authentication_results.dmarc is not null),
+        strings.ilike(.authentication_results.dmarc, "*fail"))
+      )
   // unsolicited
   and (
         (

--- a/detection-rules/impersonation_docusign.yml
+++ b/detection-rules/impersonation_docusign.yml
@@ -36,8 +36,10 @@ source: |
 
   and (
         sender.email.domain.root_domain not in ('docusign.net', 'docusign.com')
-      or any(distinct(headers.hops, .authentication_results.dmarc is not null),
-        strings.ilike(.authentication_results.dmarc, "*fail"))
+        // check for DMARC fail for spoofs
+        or any(distinct(headers.hops, .authentication_results.dmarc is not null),
+            strings.ilike(.authentication_results.dmarc, "*fail")
+        )
       )
   // unsolicited
   and (

--- a/queries/authentication/dkim_any_fail.yml
+++ b/queries/authentication/dkim_any_fail.yml
@@ -1,7 +1,7 @@
 name: "DKIM: Fail"
 type: "query"
 source: |
-  any(distinct(headers.hops, .authentication_results.dkim is not null), strings.like(.authentication_results.dkim, "*fail"))
+  any(distinct(headers.hops, .authentication_results.dkim is not null), strings.ilike(.authentication_results.dkim, "*fail"))
 severity: "medium"
 tags:
   - "Sender authentication"

--- a/queries/authentication/dmarc_any_fail.yml
+++ b/queries/authentication/dmarc_any_fail.yml
@@ -1,7 +1,7 @@
 name: "DMARC: Fail"
 type: "query"
 source: |
-  any(distinct(headers.hops, .authentication_results.dmarc is not null), strings.like(.authentication_results.dmarc, "*fail"))
+  any(distinct(headers.hops, .authentication_results.dmarc is not null), strings.ilike(.authentication_results.dmarc, "*fail"))
 severity: "medium"
 tags:
   - "Sender authentication"

--- a/queries/authentication/spf_any_fail.yml
+++ b/queries/authentication/spf_any_fail.yml
@@ -1,7 +1,7 @@
 name: "SPF: Fail"
 type: "query"
 source: |
-  any(distinct(headers.hops, .received_spf.verdict is not null), strings.like(.received_spf.verdict, "*fail"))
+  any(distinct(headers.hops, .received_spf.verdict is not null), strings.ilike(.received_spf.verdict, "*fail"))
 severity: "medium"
 tags:
   - "Sender authentication"


### PR DESCRIPTION
Updates: 

- Queries: Authentication queries like to ilike to account for casing
- Rule: Impersonation_Docusign to account for DMARC failures

New Rule: 

- impersonation_dmarc_failure_high_cred_phish_conclusion.yml
