### PR TITLE
Update Rule: Brand impersonation: Facebook

### DIFF
--- a/detection-rules/impersonation_facebook.yml
+++ b/detection-rules/impersonation_facebook.yml
@@ -13,7 +13,7 @@ source: |
       or strings.ilevenshtein(sender.display_name, 'facebook business') <= 2
       or strings.ilike(sender.email.domain.domain, '*facebook*')
   )
-  and sender.email.domain.root_domain not in~ ('facebook.com','facebookmail.com', 'eventsatfacebook.com')
+  and sender.email.domain.root_domain not in~ ('facebook.com','facebookmail.com', 'eventsatfacebook.com', 'facebookenterprise.com')
   and sender.email.email not in $recipient_emails
 tags:
   - "Brand impersonation"


### PR DESCRIPTION
facebookenterprise.com is a domain owned by Meta that they use for enterprise related communications.
Whitelisting it in the brand protection rule for Facebook to prevent it from triggering false alert.

https://www.whois.com/whois/facebookenterprise.com
<img width="722" alt="Screenshot 2023-03-17 at 2 14 05 PM" src="https://user-images.githubusercontent.com/17494876/226052318-8e9f1587-4d64-41b2-8a84-e862d172f913.png">
