### PR TITLE
New Rule: Headers: Zimbra mailer from a non-supported OS version

### DIFF
--- a/detection-rules/headers_zimbra_mailer_unsupported_os_versions.yml
+++ b/detection-rules/headers_zimbra_mailer_unsupported_os_versions.yml
@@ -1,0 +1,11 @@
+name: "Headers: Zimbra mailer from a non-supported OS version"
+description: |
+  Detects Zimbra originated emails sent from non-supported Windows versions. 
+  Observed in widespread HTML credential phishing campaigns.
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and regex.icontains(headers.mailer, '\b(5\.1|6\.1)\.\d{4}\b')
+tags:
+  - "Suspicious sender"

--- a/detection-rules/headers_zimbra_mailer_unsupported_os_versions.yml
+++ b/detection-rules/headers_zimbra_mailer_unsupported_os_versions.yml
@@ -6,6 +6,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
+  and strings.starts_with(headers.mailer, "Zimbra")
   and regex.icontains(headers.mailer, '\b(5\.1|6\.1)\.\d{4}\b')
 tags:
   - "Suspicious sender"


### PR DESCRIPTION
- New Rule: Zimbra mailer from non-supported OS version
- Adding strings.startswith Zimbra
