### PR TITLE
New Rule (Link): PDF file with embedded content

### DIFF
--- a/detection-rules/link_pdf_file_with_embedded_content.yml
+++ b/detection-rules/link_pdf_file_with_embedded_content.yml
@@ -17,8 +17,8 @@ source: |
           and sender.email.domain.domain not in $recipient_domains
       )
   )
-  and any(body.links, 
-      any(beta.linkanalysis(.).files_downloaded, .file_extension == "pdf"
+  and any(body.links, strings.icontains(.display_url.url, ".pdf")
+      and any(beta.linkanalysis(.).files_downloaded, .file_extension == "pdf"
              and any(file.explode(.),
                  any(.flavors.yara, . in (
                       "iso_file",

--- a/detection-rules/link_pdf_file_with_embedded_content.yml
+++ b/detection-rules/link_pdf_file_with_embedded_content.yml
@@ -1,8 +1,6 @@
 name: "Link: PDF file with embedded content"
 description: |
   Threat actors may embed files within PDF documents, including macro-enabled documents, in an attempt to bypass security controls and social engineer a recipient into running malicious code.
-references:
-  
 type: "rule"
 severity: "high"
 source: |

--- a/detection-rules/link_pdf_file_with_embedded_content.yml
+++ b/detection-rules/link_pdf_file_with_embedded_content.yml
@@ -1,0 +1,49 @@
+name: "Link: PDF file with embedded content"
+description: |
+  Threat actors may embed files within PDF documents, including macro-enabled documents, in an attempt to bypass security controls and social engineer a recipient into running malicious code.
+references:
+  
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and (
+      (
+          sender.email.domain.root_domain in $free_email_providers
+          and sender.email.email not in $recipient_emails
+      )
+      or (
+          sender.email.domain.root_domain not in $free_email_providers
+          and sender.email.domain.domain not in $recipient_domains
+      )
+  )
+  and any(body.links, 
+      any(beta.linkanalysis(.).files_downloaded, .file_extension == "pdf"
+             and any(file.explode(.),
+                 any(.flavors.yara, . in (
+                      "iso_file",
+                      "vb_file",
+                      "base64_pe", 
+                      "encrypted_word_document",
+                      "olecf_file",
+                      "ooxml_file",
+                      "encrypted_zip",
+                      "mhtml_file",
+                      "rar_file",
+                      "tar_file",
+                      "xar_file",
+                      "bzip2_file",
+                      "gzip_file",
+                      "lzma_file",
+                      "xz_file",
+                      "zlib_file",
+                      "elf_file", 
+                      "batch_file",
+                      "hta_file"
+                  )
+              )
+          )
+      )
+  )
+tags: 
+  - "Suspicious link"


### PR DESCRIPTION
Thank you to @ajpc500 for the original logic! This is the link equivalent to the attachment rule: https://github.com/sublime-security/sublime-rules/blob/main/detection-rules/attachment_pdf_file_with_embedded_content.yml