### PR TITLE
Update Rule: Docusign "via" in sender display name negation

### DIFF
--- a/detection-rules/impersonation_docusign.yml
+++ b/detection-rules/impersonation_docusign.yml
@@ -32,16 +32,6 @@ source: |
         or strings.contains(.display_text, "document")
     )
     and .href_url.domain.root_domain not in ("docusign.com","docusign.net")
-    // Adding a negation if the sender displayname contains via
-    // Checking to ensure it was spawned from docusigns api
-    and not (
-        any(headers.hops,
-            any(.fields, .name == "X-Api-Host" and
-                strings.ends_with(.value, "docusign.net")
-            )
-        ) 
-        and strings.contains(sender.display_name, "via")
-    )
   )
 
   and (
@@ -51,6 +41,14 @@ source: |
             strings.ilike(.authentication_results.dmarc, "*fail")
         )
       )
+  and not (
+        any(headers.hops,
+            any(.fields, .name == "X-Api-Host" and
+                strings.ends_with(.value, "docusign.net")
+            )
+        ) 
+        and strings.contains(sender.display_name, "via")
+    )
   // unsolicited
   and (
         (

--- a/detection-rules/impersonation_docusign.yml
+++ b/detection-rules/impersonation_docusign.yml
@@ -32,6 +32,16 @@ source: |
         or strings.contains(.display_text, "document")
     )
     and .href_url.domain.root_domain not in ("docusign.com","docusign.net")
+    // Adding a negation if the sender displayname contains via
+    // Checking to ensure it was spawned from docusigns api
+    and not (
+        any(headers.hops,
+            any(.fields, .name == "X-Api-Host" and
+                strings.ends_with(.value, "docusign.net")
+            )
+        ) 
+        and strings.contains(sender.display_name, "via")
+    )
   )
 
   and (

--- a/detection-rules/impersonation_docusign.yml
+++ b/detection-rules/impersonation_docusign.yml
@@ -41,6 +41,8 @@ source: |
             strings.ilike(.authentication_results.dmarc, "*fail")
         )
       )
+  // adding negation for messages originating from docusigns api
+  // and the sender.display.name contains "via"
   and not (
         any(headers.hops,
             any(.fields, .name == "X-Api-Host" and


### PR DESCRIPTION
Added logic to prevent emails sent "via Docusign" from firing by ensuring that if the sender display name contains via,  that a hop field exists for X-Api-Host and ends with a value of docusign.net.

I have only observed docusign.net in this value but it's possible we may have to update to include docusigns other tlds. 