### PR TITLE
Updating Rule: office365 image with customer feedback

### DIFF
--- a/detection-rules/attachment_office365_image.yml
+++ b/detection-rules/attachment_office365_image.yml
@@ -5,7 +5,7 @@ type: "rule"
 severity: "medium"
 source: |
    type.inbound
-   and length(body.html.inner_text) < 1000
+   and length(attachments) == 1
    and any(attachments,
        .file_extension in~ ('bmp', 'png', 'jpg', 'jpeg')
        and any(file.explode(.),
@@ -23,7 +23,8 @@ source: |
            "*renew*",
            "*review",
            "*emails failed*",
-           "*kicked out*"
+           "*kicked out*",
+           "*prevented*"
          ))) >= 2     
        ) 
    )


### PR DESCRIPTION
Following in the docusign image lure footsteps.
________________

- Migrated from inner_text length to attachments == 1
- Added "prevented" to list of terms


134 Messages Found in Old version
159 Messages Found in New version. 

No FP's were introduced. 
