### PR TITLE
Updating Rule: Adding nextdoor.com to negate neighborhood alerts

### DIFF
--- a/detection-rules/impersonation_southwest.yml
+++ b/detection-rules/impersonation_southwest.yml
@@ -10,7 +10,7 @@ source: |
       or strings.ilike(sender.email.email, '*southwest*')
       or strings.ilevenshtein(sender.email.domain.sld, 'southwest') <= 1
   )
-  and sender.email.domain.root_domain not in ('southwest.com', 'southwestvacations.com', 'southwesthotels.com', 'swathestore.com', 'swamedia.com', 'southwestairlinesinvestorrelations.com', 'southwest.fm', 'southwestair.com', 'wnco.com')
+  and sender.email.domain.root_domain not in ('southwest.com', 'southwestvacations.com', 'southwesthotels.com', 'swathestore.com', 'swamedia.com', 'southwestairlinesinvestorrelations.com', 'southwest.fm', 'southwestair.com', 'wnco.com', 'nextdoor.com')
   and (
       (
           sender.email.domain.root_domain in $free_email_providers


### PR DESCRIPTION
Multiple reports from nextdoor are triggering this rule.

---
Example
Sender:Your Southwest Oakville neighbours <reply@rs.ca.nextdoor.com>