### PR TITLE
New Rule: Open Redirect (go2.aspx) leading to Microsoft credential phish

### DIFF
--- a/detection-rules/link_microsoft_go2_open_redirect_phish.yml
+++ b/detection-rules/link_microsoft_go2_open_redirect_phish.yml
@@ -1,4 +1,4 @@
-name: "Open Redirect (go2.aspx) leading to Microsoft crendential phishing"
+name: "Open Redirect (go2.aspx) leading to Microsoft credential phishing"
 description: |
   This rule is designed to detect credential phishing attacks that exploit go2.aspx redirects and masquerade as
   Microsoft-related emails.

--- a/detection-rules/link_microsoft_go2_open_redirect_phish.yml
+++ b/detection-rules/link_microsoft_go2_open_redirect_phish.yml
@@ -11,7 +11,7 @@ source: |
 
   and any(body.links, strings.ends_with(.href_url.path, "go2.aspx")
 
-  // query params from hhref_url or beta.linkanalysis contain a redirection string ending with a base64
+  // query params from href_url or beta.linkanalysis contain a redirection string ending with a base64
   // pattern intended to capture an encoded email passed as an additional parameter
 
   and (regex.contains(.href_url.query_params,

--- a/detection-rules/link_microsoft_go2_open_redirect_phish.yml
+++ b/detection-rules/link_microsoft_go2_open_redirect_phish.yml
@@ -1,0 +1,28 @@
+name: "Open Redirect (go2.aspx) leading to Microsoft crendetial phishing"
+description: |
+  This rule is designed to detect credential phishing attacks that exploit go2.aspx redirects and masquerade as
+  Microsoft-related emails.
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+
+  // url path ends with go2.aspx
+
+  and any(body.links, strings.ends_with(.href_url.path, "go2.aspx")
+
+  // query params from hhref_url or beta.linkanalysis contain a redirection string ending with a base64
+  // pattern intended to capture an encoded email passed as an additional parameter
+
+  and (regex.contains(.href_url.query_params,
+     '[a-z]=[a-z0-9-]+\.[a-z]{2,3}.+[A-Za-z0-9+/=]$|=[^=]$|={3,}$')
+  or regex.icontains(beta.linkanalysis(.).effective_url.query_params,
+     '[a-z]=[a-z0-9-]+\.[a-z]{2,3}.+[A-Za-z0-9+/=]$|=[^=]$|={3,}$'))
+  )
+  and headers.mailer is null
+  and regex.icontains(body.html.inner_text,
+      '(i͏c͏r͏os͏of͏|icrosof)|(office|o)\s?365')
+tags:
+  - "Suspicious link"
+  - "Credential phishing"
+  - "Open redirect"

--- a/detection-rules/link_microsoft_go2_open_redirect_phish.yml
+++ b/detection-rules/link_microsoft_go2_open_redirect_phish.yml
@@ -1,4 +1,4 @@
-name: "Open Redirect (go2.aspx) leading to Microsoft crendetial phishing"
+name: "Open Redirect (go2.aspx) leading to Microsoft crendential phishing"
 description: |
   This rule is designed to detect credential phishing attacks that exploit go2.aspx redirects and masquerade as
   Microsoft-related emails.


### PR DESCRIPTION
This was surfaced as a result of researching reported credential phishing emails from edu domains. During the investigation it became apparent that the first redirect was occurring on trusted domains, which seemed abnormal....

Further examination revealed that the first subdomain host, hosting the redirection resolves to an IP hosted by Cheetah Mail. 

```
host [l.service01.email-allstate.com](http://l.service01.email-allstate.com/) >> 63.148.46.72 >> org:
"AS53316 CHEETAHMAIL"
```


This appears to be being abused to send credential phishing. However this is also a legitimate service, thus the rule requires both unicode confusable "icrosoft" or ascii "icrosof" strings or "office", "o" followed by 365 as well as a null mailer. (legitimate messages were observed with a mailer)

------------------------
7d Hunt (No FP's)
32 messages found 2 Already Flagged

14d Hunt (No FP's)
32 messages found 2 Already Flagged