### PR TITLE
Update Rule: Office365 Image lure with different attachment criteria

### DIFF
--- a/detection-rules/attachment_office365_image.yml
+++ b/detection-rules/attachment_office365_image.yml
@@ -5,7 +5,7 @@ type: "rule"
 severity: "medium"
 source: |
    type.inbound
-   and length(attachments) == 1
+   and length(filter(attachments, .file_extension not in~ ('png', 'jpeg', 'jpg', 'bmp'))) == 0
    and any(attachments,
        .file_extension in~ ('bmp', 'png', 'jpg', 'jpeg')
        and any(file.explode(.),


### PR DESCRIPTION
Removing the single image attachment restriction and ensuring all attachments are an image type
`and length(filter(attachments, .file_extension not in~ ('png', 'jpeg', 'jpg', 'bmp'))) == 0`

We have observed instances of multiple images causing the previous logic to FN. 