### PR TITLE
WIP test rules workflow -- use fork to get source repo

### DIFF
--- a/.github/workflows/update-test-rules.yml
+++ b/.github/workflows/update-test-rules.yml
@@ -19,13 +19,15 @@ jobs:
 
     steps:
       - name: Get PR branch
-        uses: xt0rted/pull-request-comment-branch@v2
+        uses: alessbell/pull-request-comment-branch@v1.1 # Fork of xt0rted/pull-request-comment-branch, see https://github.com/xt0rted/pull-request-comment-branch/issues/322
         id: comment-branch
 
       - name: Checkout PR branch
         uses: actions/checkout@v3
         with:
+          repository: ${{ steps.comment-branch.outputs.head_owner }}/${{ steps.comment-branch.outputs.head_repo }}
           ref: ${{ steps.comment-branch.outputs.head_ref }}
+          fetch-depth: 0
 
       - name: Wait for Rule Validation Succeed
         uses: lewagon/wait-on-check-action@v1.3.1


### PR DESCRIPTION
I figured the last change would have issues, and sure enough it couldn't get the branch from a forked repo. Looks like this is doable using a fork which supports the behavior.