### PR TITLE
Debug organization member check + tolerate no test rules

### DIFF
--- a/.github/workflows/clear-test-rules.yml
+++ b/.github/workflows/clear-test-rules.yml
@@ -33,7 +33,7 @@ jobs:
           echo "" >> message.txt
           
           cd destination
-          files=$(ls **/*.yml)
+          files=$(ls **/*.yml) || true
           for file in $files; do
             file_pr_num=$(yq '.testing_pr' $file)
             if [[ "$pr_num" = "$file_pr_num" ]]; then

--- a/.github/workflows/update-test-rules.yml
+++ b/.github/workflows/update-test-rules.yml
@@ -29,9 +29,13 @@ jobs:
           username: ${{ github.event.comment.user.login }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Echo organization member
+        run: |
+          echo "[${{ steps.is_organization_member.outputs.result }}]"
+
       - name: Fail if not organization member
         if: |
-          steps.is_organization_member.outputs.result == false
+          steps.is_organization_member.outputs.result != 'true'
         run: exit 1
 
       - name: Fail if PR closed
@@ -91,7 +95,7 @@ jobs:
           
           # Delete any files already referencing this PR. If they're no longer included in the PR this will remove them,
           # if they're still included we'll add them back below.
-          files=$(ls destination/**/*.yml)
+          files=$(ls destination/**/*.yml) || true
           for file in $files; do
             file_pr_num=$(yq '.testing_pr' $file)
             if [[ "$pr_num" = "$file_pr_num" ]]; then


### PR DESCRIPTION
A couple of follow ups.

1. The organization member check didn't work as expected.
   * I can only test the negative case on the public repo so more iteration could be required, but hopefully this does it.
2. I missed the test case of starting with no rules in test when I added the behavior that uses `ls` and missed that it would cause the workflow to fail when there are no matching files yet.