### PR TITLE
Update Rule: Impersonation Github to negate 3rd party training

### DIFF
--- a/detection-rules/impersonation_github.yml
+++ b/detection-rules/impersonation_github.yml
@@ -7,6 +7,7 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
+  and not strings.ilike(sender.display_name, '*course*', '*bootcamp*', '*training*')
   and (
       strings.ilike(sender.display_name, '*github*')
       or strings.ilike(sender.email.email, '*github*')


### PR DESCRIPTION
Several FP reports have been submitted for 3rd party training Git/Github training courses. Adding keyword negation to sender.display_name which resolves all known samples. 