### PR TITLE
Update Rule: Attachment Docusign image to use file type/widen coverage

### DIFF
--- a/detection-rules/attachment_docusign_image_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_image_suspicious_links.yml
@@ -4,11 +4,10 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(attachments) == 1
-  and length(body.links) < 5
+  and length(filter(attachments, .file_type not in~ ('png', 'jpeg', 'jpg', 'bmp'))) == 0 
   and any(body.links, not strings.ilike(.href_url.domain.root_domain, "docusign.*"))
   
-  and any(attachments, .file_extension in~ ('png','jpg','jpeg','bmp')
+  and any(attachments, .file_type in~ ('png','jpg','jpeg','bmp')
       and any(file.explode(.),
       any(.scan.strings.strings, strings.ilike(., "*docusign*"))
        and any(.scan.strings.strings, strings.ilike(., "*review*", "*sign*"))


### PR DESCRIPTION
Update rule to use file type rather than extension to capture files with no extension. 
Also found misses where more than 1 image was included. This matches known FN's and increased TP counts by 20% in testing