### PR TITLE
New Insight - URLhaus link domain

### DIFF
--- a/insights/links/urlhaus_domain.yml
+++ b/insights/links/urlhaus_domain.yml
@@ -3,7 +3,7 @@ type: "query"
 source: |
   distinct(map(filter(body.links, 
                .href_url.domain.root_domain in $abuse_ch_urlhaus_domains_trusted_reporters
-               and .href_url.domain.root_domain not in $alexa1m), 
+               and .href_url.domain.root_domain not in $alexa_1m), 
   .href_url.domain.root_domain), .)
 severity: "medium"
 tags:

--- a/insights/links/urlhaus_domain.yml
+++ b/insights/links/urlhaus_domain.yml
@@ -2,7 +2,8 @@ name: "URLhaus link domain"
 type: "query"
 source: |
   distinct(map(filter(body.links, 
-               .href_url.domain.root_domain in $abuse_ch_urlhaus_domains_trusted_reporters), 
+               .href_url.domain.root_domain in $abuse_ch_urlhaus_domains_trusted_reporters
+               and .href_url.domain.root_domain not in $alexa1m), 
   .href_url.domain.root_domain), .)
 severity: "medium"
 tags:

--- a/insights/links/urlhaus_domain.yml
+++ b/insights/links/urlhaus_domain.yml
@@ -1,0 +1,9 @@
+name: "URLhaus link domain"
+type: "query"
+source: |
+  distinct(map(filter(body.links, 
+               .href_url.domain.root_domain in~ $abuse_ch_urlhaus_domains_trusted_reporters), 
+  .href_url.domain.root_domain), .)
+severity: "medium"
+tags:
+  - "Suspicious links"

--- a/insights/links/urlhaus_domain.yml
+++ b/insights/links/urlhaus_domain.yml
@@ -2,7 +2,7 @@ name: "URLhaus link domain"
 type: "query"
 source: |
   distinct(map(filter(body.links, 
-               .href_url.domain.root_domain in~ $abuse_ch_urlhaus_domains_trusted_reporters), 
+               .href_url.domain.root_domain in $abuse_ch_urlhaus_domains_trusted_reporters), 
   .href_url.domain.root_domain), .)
 severity: "medium"
 tags:


### PR DESCRIPTION
This insight surfaces any link domains that are in $abuse_ch_urlhaus_domains_trusted_reporters but not in $alexa_1m
$alexa_1m negation needed as popular domains such as dropbox were found in the list in testing. 

![image](https://github.com/sublime-security/sublime-rules/assets/6809735/5cecfe6a-b4d8-4b35-8de5-2188f327370a)
