### PR TITLE
Simplify docusign logic

### DIFF
--- a/detection-rules/attachment_docusign_image_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_image_suspicious_links.yml
@@ -6,7 +6,7 @@ source: |
   type.inbound
   and all(attachments, .file_type in~ ('png', 'jpeg', 'jpg', 'bmp'))
   and any(body.links, not strings.ilike(.href_url.domain.root_domain, "docusign.*"))
-  and any(attachments, .file_type in~ ('png','jpg','jpeg','bmp')
+  and any(attachments,
       and any(file.explode(.),
       any(.scan.strings.strings, strings.ilike(., "*docusign*"))
        and any(.scan.strings.strings, strings.ilike(., "*review*", "*sign*"))

--- a/detection-rules/attachment_docusign_image_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_image_suspicious_links.yml
@@ -4,7 +4,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and all(attachments, .file_type is null or .file_type in~ ('png', 'jpeg', 'jpg', 'bmp'))
+  and all(attachments, .file_type in~ ('png', 'jpeg', 'jpg', 'bmp'))
   and any(body.links, not strings.ilike(.href_url.domain.root_domain, "docusign.*"))
   and any(attachments, .file_type in~ ('png','jpg','jpeg','bmp')
       and any(file.explode(.),

--- a/detection-rules/attachment_docusign_image_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_image_suspicious_links.yml
@@ -4,7 +4,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and all(attachments, .file_type in~ ('png', 'jpeg', 'jpg', 'bmp'))
+  and all(attachments, .file_type is null or .file_type in~ ('png', 'jpeg', 'jpg', 'bmp'))
   and any(body.links, not strings.ilike(.href_url.domain.root_domain, "docusign.*"))
   and any(attachments, .file_type in~ ('png','jpg','jpeg','bmp')
       and any(file.explode(.),

--- a/detection-rules/attachment_docusign_image_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_image_suspicious_links.yml
@@ -4,9 +4,8 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(filter(attachments, .file_type not in~ ('png', 'jpeg', 'jpg', 'bmp'))) == 0 
+  and all(attachments, .file_type in~ ('png', 'jpeg', 'jpg', 'bmp'))
   and any(body.links, not strings.ilike(.href_url.domain.root_domain, "docusign.*"))
-  
   and any(attachments, .file_type in~ ('png','jpg','jpeg','bmp')
       and any(file.explode(.),
       any(.scan.strings.strings, strings.ilike(., "*docusign*"))

--- a/detection-rules/attachment_docusign_image_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_image_suspicious_links.yml
@@ -7,7 +7,7 @@ source: |
   and all(attachments, .file_type in~ ('png', 'jpeg', 'jpg', 'bmp'))
   and any(body.links, not strings.ilike(.href_url.domain.root_domain, "docusign.*"))
   and any(attachments,
-      and any(file.explode(.),
+      any(file.explode(.),
       any(.scan.strings.strings, strings.ilike(., "*docusign*"))
        and any(.scan.strings.strings, strings.ilike(., "*review*", "*sign*"))
       )


### PR DESCRIPTION
The `length(filter(x)) == 0` is the same thing as `not any(x)`. If we also require that `file_type` is not null, then we can go a step further: `all(not x)`

All these optimizations happen under the hood anyway, so the rule is still logically identical. This seems simpler to me though, and I think it's more readable (although this might be triggering for anyone with some `all` trauma). We can add a `length` check if we'd like but it's already combined with the `any` so it's redundant