### PR TITLE
New Rule (Brand impersonation): Dropbox

### DIFF
--- a/detection-rules/impersonation_dropbox.yml
+++ b/detection-rules/impersonation_dropbox.yml
@@ -1,0 +1,22 @@
+name: "Brand impersonation: Dropbox"
+description: |
+  Impersonation of Dropbox, a file sharing service.
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+      strings.ilike(sender.display_name, '*dropbox*')
+      or strings.ilevenshtein(sender.display_name, 'dropbox') <= 1
+      or strings.ilike(sender.email.domain.domain, '*dropbox*')
+  )
+  and sender.email.domain.root_domain !~ 'dropbox.com'
+  and any(attachments, .file_type in~ ('png','jpg','jpeg','bmp')
+      and any(file.explode(.),
+          any(.scan.strings.strings, strings.ilike(., "*dropbox*"))
+      )
+  )
+  and sender.email.email not in $recipient_emails
+tags: 
+  - "Brand impersonation"
+  - "Suspicious sender"


### PR DESCRIPTION
NOT a spoof, but a solid impersonation.