### PR TITLE
Updating rule: attachment_office365_image.yml

### DIFF
--- a/detection-rules/attachment_office365_image.yml
+++ b/detection-rules/attachment_office365_image.yml
@@ -37,10 +37,36 @@ source: |
               "*prevented*",
               "*storage quota*",
               "*required now",
-              "*cache*"
+              "*cache*",
+              "*qr code*",
+              "*security update*"
               ))) >= 2     
       ) 
-  ))
+  )
+  or (
+          any(file.explode(.),
+              length(filter(["password",
+              "unread messages",
+              "Shared Documents",
+              "expiration",
+              "office",
+              "expire",
+              "expiring",
+              "kindly",
+              "renew",
+              "review",
+              "emails failed",
+              "kicked out",
+              "prevented",
+              "storage quota",
+              "required now",
+              "cache",
+              "qr code",
+              "security update"], strings.icontains(..scan.ocr.raw, .))) >= 2   
+      )
+  )    
+
+  )
   and (
       not any(headers.hops, .authentication_results.compauth.verdict is not null
       and .authentication_results.compauth.verdict == "pass"


### PR DESCRIPTION
Missing some detecting using strings, added OCR check as well.