### PR TITLE
New Rule: Undisclosed Recipients with link to free subdomain host

### DIFF
--- a/detection-rules/recipients_undisclosed_free_subdomain_host.yml
+++ b/detection-rules/recipients_undisclosed_free_subdomain_host.yml
@@ -1,4 +1,4 @@
-name: "Suspicious Link: Free Subdomain host with undisclosed recipients"
+name: "Link: Free Subdomain host with undisclosed recipients"
 description: |
   Detects messages with undisclosed recipients, containing links to free subdomain hosts
 type: "rule"

--- a/detection-rules/recipients_undisclosed_free_subdomain_host.yml
+++ b/detection-rules/recipients_undisclosed_free_subdomain_host.yml
@@ -1,8 +1,6 @@
 name: "Suspicious Link: Free Subdomain host with undisclosed recipients"
 description: |
   Detects messages with undisclosed recipients, containing links to free subdomain hosts
-references:
-  
 type: "rule"
 severity: "medium"
 source: |

--- a/detection-rules/recipients_undisclosed_free_subdomain_host.yml
+++ b/detection-rules/recipients_undisclosed_free_subdomain_host.yml
@@ -1,0 +1,24 @@
+name: "Suspicious Link: Free Subdomain host with undisclosed recipients"
+description: |
+  Detects messages with undisclosed recipients, containing links to free subdomain hosts
+references:
+  
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  
+  and any(body.links, 
+      .href_url.domain.root_domain in $free_subdomain_hosts
+      and .href_url.domain.subdomain is not null
+      and .href_url.domain.subdomain != "www"
+  )
+  and (
+      length(recipients.to) == 0
+      or all(recipients.to, .display_name == "Undisclosed recipients")
+  )
+  and length(recipients.cc) == 0
+  and length(recipients.bcc) == 0
+tags: 
+  - "Suspicious link"
+  - "Suspicious headers"


### PR DESCRIPTION
This FP's only on Sharepoint examples. 
Before approval I'd recommend merging https://github.com/sublime-security/static-files/pull/80 
to remove sharepoint from the $freesubdomain_hosts list. 