### PR TITLE
Update link_microsoft_low_reputation.yml

### DIFF
--- a/detection-rules/link_microsoft_low_reputation.yml
+++ b/detection-rules/link_microsoft_low_reputation.yml
@@ -4,10 +4,9 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-
   // suspicious link
   and any(body.links,
-      .href_url.domain.domain not in $tranco_1m or
+      (.href_url.domain.domain not in $tranco_1m and .href_url.domain.root_domain != "svc.ms" and .href_url.domain.root_domain != "sharepoint.com") or
       .href_url.domain.domain in $free_file_hosts or
       .href_url.domain.root_domain in $free_subdomain_hosts or
       .href_url.domain.domain in $url_shorteners or

--- a/detection-rules/link_microsoft_low_reputation.yml
+++ b/detection-rules/link_microsoft_low_reputation.yml
@@ -6,17 +6,22 @@ source: |
   type.inbound
   // suspicious link
   and any(body.links,
-      (.href_url.domain.domain not in $tranco_1m and .href_url.domain.root_domain != "svc.ms" and .href_url.domain.root_domain != "sharepoint.com") or
-      .href_url.domain.domain in $free_file_hosts or
-      .href_url.domain.root_domain in $free_subdomain_hosts or
-      .href_url.domain.domain in $url_shorteners or
+      (
+          .href_url.domain.domain not in $tranco_1m or
+          .href_url.domain.domain in $free_file_hosts or
+          .href_url.domain.root_domain in $free_subdomain_hosts or
+          .href_url.domain.domain in $url_shorteners or
 
-      // mass mailer link, masks the actual URL
-      .href_url.domain.root_domain in (
-          "hubspotlinks.com",
-          "mandrillapp.com",
-          "sendgrid.net",
+          // mass mailer link, masks the actual URL
+          .href_url.domain.root_domain in (
+              "hubspotlinks.com",
+              "mandrillapp.com",
+              "sendgrid.net",
+          )
       )
+      
+      // exclude sources of potential FPs
+      and .href_url.domain.root_domain not in ("svc.ms", "sharepoint.com")
   )
 
   // not a reply


### PR DESCRIPTION
Excluded commonly seen root domains in legitimate Onedrive emails from tranco_1m check