### PR TITLE
Switch from logo_detect().brand to brands

### DIFF
--- a/detection-rules/attachment_adobe_image_lure_fts.yml
+++ b/detection-rules/attachment_adobe_image_lure_fts.yml
@@ -9,8 +9,7 @@ source: |
   and length(body.links) >0
   and all(body.links, .display_text is null)
   and any(attachments,
-      beta.logo_detect(.).brand.confidence in ("high")
-      and beta.logo_detect(.).brand.name == "Adobe"
+      any(beta.logo_detect(.).brands, .name == "Adobe" and .confidence in ("high")) 
       and any(file.explode(.),
             any(.scan.strings.strings, strings.ilike(.,
                 "*review*", "*sign*", "*view*", "*completed document*", "*open agreement*"))

--- a/detection-rules/attachment_docusign_image_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_image_suspicious_links.yml
@@ -7,8 +7,7 @@ source: |
   and length(filter(attachments, .file_type not in~ ('png', 'jpeg', 'jpg', 'bmp'))) == 0 
   and any(body.links, not strings.ilike(.href_url.domain.root_domain, "docusign.*"))
   and any(attachments,
-       beta.logo_detect(.).brand.confidence in ("medium", "high")
-       and beta.logo_detect(.).brand.name == "DocuSign"
+       any(beta.logo_detect(.).brands, .name == "DocuSign" and .confidence in ("medium", "high"))
        and any(file.explode(.),
             any(.scan.strings.strings, regex.icontains(.,
                  "review", "[^d][^o][^c][^u]sign", "important edocs", "completed document"))

--- a/detection-rules/attachment_office365_image.yml
+++ b/detection-rules/attachment_office365_image.yml
@@ -9,7 +9,7 @@ source: |
   and (
       any(attachments, 
           .file_type in~ ('bmp', 'png', 'jpg', 'jpeg')
-          and beta.logo_detect(.).brand.name in~ ("Microsoft", "Office365")
+          and any(beta.logo_detect(.).brands, .name in~ ("Microsoft", "Office365"))
       )
       or any(attachments, 
           .file_type in~ ('bmp', 'png', 'jpg', 'jpeg')

--- a/detection-rules/impersonation_paypal.yml
+++ b/detection-rules/impersonation_paypal.yml
@@ -13,7 +13,7 @@ source: |
       or strings.ilike(sender.email.domain.domain, '*paypal*')
 
       or any(attachments, .file_type == "pdf"
-          and beta.logo_detect(.).brand.name == "PayPal"
+          and any(beta.logo_detect(.).brands, .name == "PayPal")
           and any(file.explode(.),
               any(.scan.strings.strings, strings.ilike(., "*PayPal*"))
               and any(.scan.strings.strings,

--- a/detection-rules/link_microsoft_low_reputation.yml
+++ b/detection-rules/link_microsoft_low_reputation.yml
@@ -29,7 +29,7 @@ source: |
   // Microsoft logo
   and any(attachments,
       .file_type in ('png', 'jpeg', 'jpg', 'bmp')
-      and beta.logo_detect(.).brand.name in ("Microsoft", "Office365", "Outlook")
+      and any(beta.logo_detect(.).brands, .name in ("Microsoft", "Office365", "Outlook"))
   )
 
   // suspicious content


### PR DESCRIPTION
We're updating `logo_detect` to always return `brands` and stop returning `brand`.