### PR TITLE
Drop legacy function names

### DIFF
--- a/detection-rules/mass_campaign_recipient_address_new_sender.yml
+++ b/detection-rules/mass_campaign_recipient_address_new_sender.yml
@@ -42,7 +42,7 @@ source: |
       any(recipients.to, strings.icontains(..href_url.query_params, .email.email))
   )
 
-  and any(beta.ml_nlu_classifier(coalesce(
+  and any(ml._nlu_classifier(coalesce(
     body.html.display_text, body.plain.raw)).intents,
     .name in ("cred_theft") and .confidence == "high"
   ) 

--- a/detection-rules/mass_campaign_recipient_address_new_sender.yml
+++ b/detection-rules/mass_campaign_recipient_address_new_sender.yml
@@ -42,7 +42,7 @@ source: |
       any(recipients.to, strings.icontains(..href_url.query_params, .email.email))
   )
 
-  and any(ml._nlu_classifier(coalesce(
+  and any(ml.nlu_classifier(coalesce(
     body.html.display_text, body.plain.raw)).intents,
     .name in ("cred_theft") and .confidence == "high"
   ) 


### PR DESCRIPTION
I think this is the only one that slipped through the cracks.