### PR TITLE
Updating Rule: Twitter impersonation

### DIFF
--- a/detection-rules/impersonation_twitter.yml
+++ b/detection-rules/impersonation_twitter.yml
@@ -12,7 +12,7 @@ source: |
       or strings.ilevenshtein(sender.display_name, 'twitter') <= 1
       or strings.ilike(sender.email.domain.domain, '*twitter*')
   )
-  and sender.email.domain.domain not in~ ('twitter.com', 'privaterelay.appleid.com')
+  and sender.email.domain.domain not in~ ('twitter.com', 'privaterelay.appleid.com', 'stripe.com')
   and sender.email.email not in $recipient_emails
 tags:
   - "Brand impersonation"


### PR DESCRIPTION
Twitter uses Stripe to send invoices, which did flag this rule.