### PR TITLE
Updating Rule: Adjusting HTML detection

### DIFF
--- a/detection-rules/attachment_html_attachment_login_page.yml
+++ b/detection-rules/attachment_html_attachment_login_page.yml
@@ -26,7 +26,7 @@ source: |
           ))) >= 3 or 
           (
               // suspicious strings found outside of javascript, but binexplode'd file still of HTML type
-              .flavors.mime == "text/html" and 
+              .flavors.mime in~ ("text/html", "text/plain") and 
               length(filter(.scan.strings.strings, strings.ilike(.,
                   "*password*", "*username*", "*login-form*", "*email-form*", "*Incorrect password. Please try again.*", "*Password Incomplete, please try again*"
               ))) >= 3


### PR DESCRIPTION
Sometimes, HTML files come up as plain text. Added plain text detector to solve this.
![image](https://github.com/sublime-security/sublime-rules/assets/30846409/09a1dcca-f4f1-4a61-af8d-d7cb2248a0ab)
