### PR TITLE
Remove attachment file sizes signal

### DIFF
--- a/signals/attachment_filesizes.yml
+++ b/signals/attachment_filesizes.yml
@@ -1,4 +1,0 @@
-name: "Attachments File Sizes"
-type: "query"
-source: |
-  map(attachments, .size)


### PR DESCRIPTION
There's an issue in the consumer which will cause this signal to generate some noise. I'll follow up, but temporarily removing this signal to prevent issues.