### PR TITLE
Updating Rule: Exempting legitimate Google Maps shortener

### DIFF
--- a/discovery-rules/url_shortener_from_suspicious_sender_tld.yml
+++ b/discovery-rules/url_shortener_from_suspicious_sender_tld.yml
@@ -6,7 +6,11 @@ severity: "low"
 source: |
   type.inbound
   and sender.email.domain.tld in $suspicious_tlds
-  and any(body.links, .href_url.domain.domain in $url_shorteners)
+  and any(body.links, 
+    .href_url.domain.domain in $url_shorteners
+    // exempting legitimate Google Maps shortener
+    and not strings.ilike(.href_url.url, "http?://goo.gl/maps*")
+  )
   and sender.email.email not in $recipient_emails
 tags:
   - "URL shortener"


### PR DESCRIPTION
This shortener _in this usecase (for Google Maps)_ shouldn't be treated as suspicious.