### PR TITLE
Revert "Change validation workflow to run on branches"

### DIFF
--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -2,7 +2,7 @@ name: Rules PR CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "test-rules" ]
   pull_request:
     branches: [ "**" ]
   workflow_dispatch: {}

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -2,6 +2,8 @@ name: Rules PR CI
 
 on:
   push:
+    branches: [ "main" ]
+  pull_request:
     branches: [ "**" ]
   workflow_dispatch: {}
 


### PR DESCRIPTION
Reverts sublime-security/sublime-rules#530

This was running actions in the context of the source repository, but we need to run those in the context of this repository. I think this'll fix some issues we're running to.

And if I'm wrong, we can revert again.