### PR TITLE
Update Sharepoint credential phishing rule to use attachments

### DIFF
--- a/detection-rules/link_microsoft_sharepoint_logo_credential_phish.yml
+++ b/detection-rules/link_microsoft_sharepoint_logo_credential_phish.yml
@@ -6,11 +6,11 @@ severity: "medium"
 source: |
   type.inbound
   and length(body.links) > 0
-  and any(beta.logo_detect(beta.message_screenshot()).brands,
+  and any(attachments, beta.logo_detect(.).brands,
         .name == "Microsoft SharePoint" and .confidence == "high")
   
   and (
-        any(file.explode(beta.message_screenshot()),
+        any(attachments, file.explode(.),
           any(ml.nlu_classifier(.scan.ocr.raw).intents,
             .name == "cred_theft" and
             .confidence == "high"))

--- a/detection-rules/link_microsoft_sharepoint_logo_credential_phish.yml
+++ b/detection-rules/link_microsoft_sharepoint_logo_credential_phish.yml
@@ -10,10 +10,10 @@ source: |
         .name == "Microsoft SharePoint" and .confidence == "high")
   
   and (
-        any(attachments, file.explode(.),
+        any(attachments, any(file.explode(.),
           any(ml.nlu_classifier(.scan.ocr.raw).intents,
             .name == "cred_theft" and
-            .confidence == "high"))
+            .confidence == "high")))
   
      or any(ml.nlu_classifier(coalesce(body.html.display_text, body.plain.raw)).intents,
           .name == "cred_theft" and


### PR DESCRIPTION
Our Sharepoint rule uses `beta.message_screenshot()`, but let's pull that out for now while we continue to evaluate the function.