### PR TITLE
Update rules to use .credphish.confidence instead of .brand.confidence

### DIFF
--- a/detection-rules/link_credential_phishing.yml
+++ b/detection-rules/link_credential_phishing.yml
@@ -7,7 +7,7 @@ source: |
   type.inbound 
   and any(body.links, 
       beta.linkanalysis(.).credphish.disposition == "phishing"
-      and beta.linkanalysis(.).credphish.brand.confidence in ("medium", "high")
+      and beta.linkanalysis(.).credphish.confidence in ("medium", "high")
   ) 
   // first-time sender
   and (

--- a/detection-rules/recipients_undisclosed_compauth_check.yml
+++ b/detection-rules/recipients_undisclosed_compauth_check.yml
@@ -28,7 +28,7 @@ source: |
           any(body.links, 
               any([beta.linkanalysis(.)],
               .credphish.disposition == "phishing"
-              and .credphish.brand.confidence in ("high")
+              and .credphish.confidence in ("high")
               )   
           )
       )


### PR DESCRIPTION
Looks like a couple rules were using .brand.confidence to inspect a credphish.disposition. If we're inspecting a disposition it should be using .confidence, and if we're inspecting a brand it should use .brand.confidence
