### PR TITLE
Skip Remove Stale CI on forks

### DIFF
--- a/.github/workflows/clear-old-test-rules.yml
+++ b/.github/workflows/clear-old-test-rules.yml
@@ -21,6 +21,13 @@ jobs:
           ref: "test-rules"
           path: destination
 
+      - name: Check if forked repository
+        run: |
+          if [[ "${{ github.repository }}" != "sublime-security/sublime-rules" ]]; then
+            echo "This is a forked repository. Skipping the job."
+            exit 1
+          fi
+
       - name: Get Open PRs
         id: open_prs
         uses: actions/github-script@v4


### PR DESCRIPTION
We only want to run `Remove Stale from test-rules Branch` on the main repo instead of on forks.