### PR TITLE
Skip CI instead of fail

### DIFF
--- a/.github/workflows/clear-old-test-rules.yml
+++ b/.github/workflows/clear-old-test-rules.yml
@@ -21,13 +21,6 @@ jobs:
           ref: "test-rules"
           path: destination
 
-      - name: Check if forked repository
-        run: |
-          if [[ "${{ github.repository }}" != "sublime-security/sublime-rules" ]]; then
-            echo "This is a forked repository. Skipping the job."
-            exit 1
-          fi
-
       - name: Get Open PRs
         id: open_prs
         uses: actions/github-script@v4
@@ -46,6 +39,11 @@ jobs:
         env:
           OPEN_PRS: ${{ steps.open_prs.outputs.open_prs }}
         run: |
+          if [[ "${{ github.repository }}" != "sublime-security/sublime-rules" ]]; then
+            echo "This is a forked repository. Skipping the job."
+            exit 0
+          fi
+
           echo "Scheduled cleanup" > message.txt
           echo "" >> message.txt
           


### PR DESCRIPTION
We don't want this CI job to fail. Instead, we should just exit the final step gracefully.