### PR TITLE
Update rules to use ml.logo_detect

### DIFF
--- a/detection-rules/attachment_adobe_image_lure_fts.yml
+++ b/detection-rules/attachment_adobe_image_lure_fts.yml
@@ -9,7 +9,7 @@ source: |
   and length(body.links) >0
   and all(body.links, .display_text is null)
   and any(attachments,
-      any(beta.logo_detect(.).brands, .name == "Adobe" and .confidence in ("high")) 
+      any(ml.logo_detect(.).brands, .name == "Adobe" and .confidence in ("high")) 
       and any(file.explode(.),
             any(.scan.strings.strings, strings.ilike(.,
                 "*review*", "*sign*", "*view*", "*completed document*", "*open agreement*"))

--- a/detection-rules/attachment_docusign_image_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_image_suspicious_links.yml
@@ -7,7 +7,7 @@ source: |
   and length(filter(attachments, .file_type not in~ ('png', 'jpeg', 'jpg', 'bmp'))) == 0 
   and any(body.links, not strings.ilike(.href_url.domain.root_domain, "docusign.*"))
   and any(attachments,
-       any(beta.logo_detect(.).brands, .name == "DocuSign" and .confidence in ("medium", "high"))
+       any(ml.logo_detect(.).brands, .name == "DocuSign" and .confidence in ("medium", "high"))
        and any(file.explode(.),
             any(.scan.strings.strings, regex.icontains(.,
                  "review", "[^d][^o][^c][^u]sign", "important edocs", "completed document"))

--- a/detection-rules/attachment_microsoft_image_lure_qr_code.yml
+++ b/detection-rules/attachment_microsoft_image_lure_qr_code.yml
@@ -9,7 +9,7 @@ source: |
   and any(attachments, .file_type  in~ ('png', 'jpeg', 'jpg', 'bmp'))
   and any(attachments, 
           .file_type in~ ('bmp', 'png', 'jpg', 'jpeg')
-          and any(beta.logo_detect(.).brands, .name in~ ("Microsoft", "Office365"))
+          and any(ml.logo_detect(.).brands, .name in~ ("Microsoft", "Office365"))
   )
   and any(attachments,
       .file_type in~ ('bmp', 'png', 'jpg', 'jpeg')

--- a/detection-rules/attachment_office365_image.yml
+++ b/detection-rules/attachment_office365_image.yml
@@ -9,7 +9,7 @@ source: |
   and (
       any(attachments, 
           .file_type in~ ('bmp', 'png', 'jpg', 'jpeg')
-          and any(beta.logo_detect(.).brands, .name in~ ("Microsoft", "Office365"))
+          and any(ml.logo_detect(.).brands, .name in~ ("Microsoft", "Office365"))
       )
       or any(attachments, 
           .file_type in~ ('bmp', 'png', 'jpg', 'jpeg')

--- a/detection-rules/impersonation_paypal.yml
+++ b/detection-rules/impersonation_paypal.yml
@@ -13,7 +13,7 @@ source: |
       or strings.ilike(sender.email.domain.domain, '*paypal*')
 
       or any(attachments, .file_type == "pdf"
-          and any(beta.logo_detect(.).brands, .name == "PayPal")
+          and any(ml.logo_detect(.).brands, .name == "PayPal")
           and any(file.explode(.),
               any(.scan.strings.strings, strings.ilike(., "*PayPal*"))
               and any(.scan.strings.strings,

--- a/detection-rules/impersonation_sharepoint_body_credential_theft.yml
+++ b/detection-rules/impersonation_sharepoint_body_credential_theft.yml
@@ -8,7 +8,7 @@ source: |
   and length(body.links) > 0
   and any(attachments,
       .file_type in ('png', 'jpeg', 'jpg', 'bmp')
-      and any(beta.logo_detect(.).brands, .name == "Microsoft SharePoint")
+      and any(ml.logo_detect(.).brands, .name == "Microsoft SharePoint")
   )
   and any(ml.nlu_classifier(coalesce(body.html.display_text, body.plain.raw)).intents, .name == "cred_theft")
 tags: 

--- a/detection-rules/impersonation_sharepoint_image_credential_theft.yml
+++ b/detection-rules/impersonation_sharepoint_image_credential_theft.yml
@@ -8,7 +8,7 @@ source: |
   and length(body.links) > 0
   and any(attachments,
       .file_type in ('png', 'jpeg', 'jpg', 'bmp')
-      and any(beta.logo_detect(.).brands, .name == "Microsoft SharePoint")
+      and any(ml.logo_detect(.).brands, .name == "Microsoft SharePoint")
 
       and any(file.explode(.),
           any(ml.nlu_classifier(.scan.ocr.raw).intents,

--- a/detection-rules/link_microsoft_low_reputation.yml
+++ b/detection-rules/link_microsoft_low_reputation.yml
@@ -33,7 +33,7 @@ source: |
   // Microsoft logo
   and any(attachments,
       .file_type in ('png', 'jpeg', 'jpg', 'bmp')
-      and any(beta.logo_detect(.).brands, .name in ("Microsoft", "Office365", "Outlook"))
+      and any(ml.logo_detect(.).brands, .name in ("Microsoft", "Office365", "Outlook"))
   )
 
   // suspicious content


### PR DESCRIPTION
Renaming this function from beta. Still keeping the old name around for backwards compatibility.