### PR TITLE
Update impersonation_paypal.yml

### DIFF
--- a/detection-rules/impersonation_paypal.yml
+++ b/detection-rules/impersonation_paypal.yml
@@ -47,7 +47,8 @@ source: |
       'synchronyfinancial.com',
       'synchronybank.com',
       'xoom.com',
-      'paypal-experience.com'
+      'paypal-experience.com',
+      'paypalcorp.com'
   )
 
   // unsolicited


### PR DESCRIPTION
Excluded paypalcorp.com which is used by Paypal to communicate DMARC reports