### PR TITLE
Add CI validation for signals + insights

### DIFF
--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -37,6 +37,20 @@ jobs:
             fi
           done
 
+      - name: Validate Insights and Signals
+        run: |
+          for f in {insights,signals}/**/*.yml
+          do
+            echo "Processing $f"
+            http_code=$(yq eval 'del(.type) | .source = "length([\n\n" + .source + "\n]) >= 0"' "$f" -o=json | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
+            echo '' >> response.txt
+            cat response.txt
+            if [[ "$http_code" != "200" ]]; then
+              echo "Unexpected response $http_code"
+              exit 1
+            fi
+          done
+
       - name: Verify no .yaml files exist
         run: |
           ! /bin/sh -c 'ls **/*.yaml'

--- a/signals/links/link_url_shortener.yml
+++ b/signals/links/link_url_shortener.yml
@@ -1,4 +1,4 @@
 name: "Link: URL Shortener"
 type: "query"
 source: |
-  length(filter(body.links, href_url.domain.root_domain in $url_shorteners))
+  length(filter(body.links, .href_url.domain.root_domain in $url_shorteners))

--- a/signals/links/link_url_shortener_distinct.yml
+++ b/signals/links/link_url_shortener_distinct.yml
@@ -1,4 +1,4 @@
 'name': "Link: URL Shortener Unique Count"
 'type': "query"
 'source': |
-  length(distinct(body.links, href_url.domain.root_domain in $url_shorteners))
+  length(distinct(body.links, .href_url.domain.root_domain in $url_shorteners))


### PR DESCRIPTION
In CI, we'll just turn an insight into a rule and hit the existing API. This will be enough to catch errors that we're most interested in.