### PR TITLE
Attack surface reduction: EML attachment with HTML file

### DIFF
--- a/detection-rules/attachment_eml_with_html_attachment.yml
+++ b/detection-rules/attachment_eml_with_html_attachment.yml
@@ -1,8 +1,6 @@
 name: "Attachment: EML file with HTML attachment"
 description: |
-  Detects HTML files in EML attachments from unsolicited senders.
-
-  Reduces attack surface against HTML smuggling.
+  Detects HTML files in EML attachments to reduce HTML smuggling attack surface.
 type: "rule"
 severity: "medium"
 source: |
@@ -42,17 +40,7 @@ source: |
       strings.contains(body.html.display_text, .)
   )
 
-  // unsolicited
-  and (
-          (
-              sender.email.domain.root_domain in $free_email_providers
-              and sender.email.email not in $recipient_emails
-          )
-          or (
-              sender.email.domain.root_domain not in $free_email_providers
-              and sender.email.domain.domain not in $recipient_domains
-          )
-  )
+  // to add later - high risk sender
 tags:
   - "Suspicious attachment"
   - "HTML smuggling"

--- a/detection-rules/attachment_eml_with_html_attachment.yml
+++ b/detection-rules/attachment_eml_with_html_attachment.yml
@@ -1,0 +1,59 @@
+name: "Attachment: EML file with HTML attachment"
+description: |
+  Detects HTML files in EML attachments from unsolicited senders.
+
+  Reduces attack surface against HTML smuggling.
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+
+  // has EML attachment
+  and any(attachments, .content_type == "message/rfc822"
+      and any(file.explode(.),
+
+          // HTML file inside EML attachment
+          // we've seen files named ".htm.", which results in an empty
+          // .file_extension, so instead we look at .file_name
+          // they should be rare enough in EML attachments to not cause
+          // extraneous FPs
+          strings.ilike(.file_name, "*htm*")
+
+          // optional: we can add additional signals here if necessary
+          // identify at least one additional suspicious signal in the message
+          // and (
+          //     // html smuggling signals
+          //     any(.scan.javascript.identifiers, . == "unescape") or
+          //     any(.scan.strings.strings, regex.icontains(., "eval")) or
+          //     // more signals here if needed
+
+          //     // commonly abused sender TLD
+          //     strings.ilike(sender.email.domain.tld, "*.jp")
+          // )
+        )
+  )
+
+  // exclude bounce backs & read receipts
+  and not strings.like(sender.email.local_part, "*postmaster*", "*mailer-daemon*", "*administrator*")
+  and not regex.icontains(subject.subject, "^(undeliverable|read:)")
+  and not any(attachments, .content_type == "message/delivery-status")
+  // if the "References" is in the body of the message, it's probably a bounce
+  and not any(headers.references,
+      strings.contains(body.html.display_text, .)
+  )
+
+  // unsolicited
+  and (
+          (
+              sender.email.domain.root_domain in $free_email_providers
+              and sender.email.email not in $recipient_emails
+          )
+          or (
+              sender.email.domain.root_domain not in $free_email_providers
+              and sender.email.domain.domain not in $recipient_domains
+          )
+  )
+tags:
+  - "Suspicious attachment"
+  - "HTML smuggling"
+  - "Attack surface reduction"

--- a/detection-rules/attachment_eml_with_html_attachment.yml
+++ b/detection-rules/attachment_eml_with_html_attachment.yml
@@ -1,6 +1,8 @@
 name: "Attachment: EML file with HTML attachment"
 description: |
-  Detects HTML files in EML attachments to reduce HTML smuggling attack surface.
+  Detects HTML files in EML attachments from unsolicited senders.
+
+  Reduces attack surface against HTML smuggling.
 type: "rule"
 severity: "medium"
 source: |
@@ -40,7 +42,17 @@ source: |
       strings.contains(body.html.display_text, .)
   )
 
-  // to add later - high risk sender
+  // unsolicited
+  and (
+          (
+              sender.email.domain.root_domain in $free_email_providers
+              and sender.email.email not in $recipient_emails
+          )
+          or (
+              sender.email.domain.root_domain not in $free_email_providers
+              and sender.email.domain.domain not in $recipient_domains
+          )
+  )
 tags:
   - "Suspicious attachment"
   - "HTML smuggling"

--- a/detection-rules/attachment_eml_with_html_attachment.yml
+++ b/detection-rules/attachment_eml_with_html_attachment.yml
@@ -1,4 +1,4 @@
-name: "Attachment: EML file with HTML attachment"
+name: "Attachment: EML file with HTML attachment (unsolicited)"
 description: |
   Detects HTML files in EML attachments from unsolicited senders.
 


### PR DESCRIPTION
We discovered that the reason https://github.com/sublime-security/sublime-rules/pull/433/files was FPing was because in the following snippet:

```
and any(file.explode(.),
          .flavors.mime == "text/html"
          or .file_extension in ("htm", "html")
          or "html_file" in .flavors.yara
          or any(.scan.strings.strings, regex.contains(., "Content-Type: text/html"))
      )
```

these 2 lines are not only true for HTML attachments, but also EMLs with HTML sections:
```
          or "html_file" in .flavors.yara
          or any(.scan.strings.strings, regex.contains(., "Content-Type: text/html"))
```

this mitigates those FPs and also includes protections against bouncebacks. if we do discover FPs in testing, i've left some placeholders where we can look for additional suspicious signals
