### PR TITLE
Adjust github.ref to head_ref

### DIFF
--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   tests:
@@ -22,6 +22,9 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Validate Rules
         run: |


### PR DESCRIPTION
<img width="747" alt="Screenshot 2023-07-26 at 4 49 22 PM" src="https://github.com/sublime-security/sublime-rules/assets/88673576/46373401-0eb7-47a4-88ca-95eba761ce0a">

In `pull_request_target` workflows the `github.ref` is the base branch, [see here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target).

The effects of it can be seen here:
* https://github.com/sublime-security/sublime-rules/pull/622
   * Rule validation should have failed
* https://github.com/sublime-security/sublime-rules/pull/621
   * https://github.com/sublime-security/sublime-rules/actions/runs/5674758230
   * CI cancelled because both competed for `main`