### PR TITLE
Use updated CI check name

### DIFF
--- a/.github/workflows/update-test-rules.yml
+++ b/.github/workflows/update-test-rules.yml
@@ -51,7 +51,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: ${{ steps.comment-branch.outputs.head_sha }}
-          check-name: 'Run Rule Validation'
+          check-name: 'Rule Tests and ID Generation'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
 


### PR DESCRIPTION
Last weeks changes involved changing the name of our CI check, and the test rules CI depend on the exact name here.

I'll test post release!