### PR TITLE
Switch rules to use $file_types_images

### DIFF
--- a/detection-rules/attachment_adobe_image_lure_fts.yml
+++ b/detection-rules/attachment_adobe_image_lure_fts.yml
@@ -4,7 +4,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(filter(attachments, .file_type not in~ ('png', 'jpeg', 'jpg', 'bmp'))) == 0
+  and length(filter(attachments, .file_type not in $file_types_images)) == 0
   and length(body.links) > 0
   and all(body.links, .display_text is null)
   and any(attachments,

--- a/detection-rules/attachment_callback_phish_with_img.yml
+++ b/detection-rules/attachment_callback_phish_with_img.yml
@@ -21,7 +21,7 @@ source: |
   )
   and sender.email.domain.root_domain in $free_email_providers
   and any(attachments,
-          .file_extension in~ ('png', 'jpg', 'jpeg')
+          .file_extension in $file_types_images
           and any(file.explode(.),
                   length(filter(.scan.strings.strings,
                                 strings.ilike(.,

--- a/detection-rules/attachment_docusign_image_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_image_suspicious_links.yml
@@ -4,7 +4,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(filter(attachments, .file_type not in~ ('png', 'jpeg', 'jpg', 'bmp', 'gif'))) == 0
+  and length(filter(attachments, .file_type not in $file_types_images)) == 0
   and any(body.links, not strings.ilike(.href_url.domain.root_domain, "docusign.*"))
   and any(attachments,
           (

--- a/detection-rules/attachment_dropbox_image_suspicious_links.yml
+++ b/detection-rules/attachment_dropbox_image_suspicious_links.yml
@@ -4,10 +4,10 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(filter(attachments, .file_type not in~ ('png', 'jpeg', 'jpg', 'bmp'))) == 0
+  and length(filter(attachments, .file_type not in $file_types_images)) == 0
   and any(body.links, not strings.ilike(.href_url.domain.root_domain, "dropbox.*"))
   and any(attachments,
-          .file_type in~ ('png', 'jpg', 'jpeg', 'bmp')
+          .file_type in $file_types_images
           and any(file.explode(.),
                   any(.scan.strings.strings, strings.ilike(., "*dropbox*"))
                   and any(.scan.strings.strings, strings.ilike(., "*review*", "*sign*"))

--- a/detection-rules/attachment_microsoft_image_lure_qr_code.yml
+++ b/detection-rules/attachment_microsoft_image_lure_qr_code.yml
@@ -7,13 +7,13 @@ source: |
   type.inbound
   and (
     any(attachments,
-        .file_type in~ ('bmp', 'png', 'jpg', 'jpeg')
+        .file_type in $file_types_images
         and any(ml.logo_detect(.).brands, strings.starts_with(.name, "Microsoft"))
     )
     or any(ml.logo_detect(beta.message_screenshot()).brands, strings.starts_with(.name, "Microsoft"))
   )
   and any(attachments,
-          .file_type in~ ('bmp', 'png', 'jpg', 'jpeg')
+          .file_type in $file_types_images
           and (
             any(file.explode(.),
                 any(.scan.strings.strings, regex.icontains(., 'scan|camera'))

--- a/detection-rules/attachment_office365_image.yml
+++ b/detection-rules/attachment_office365_image.yml
@@ -5,19 +5,19 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(filter(attachments, .file_type not in~ ('png', 'jpeg', 'jpg', 'bmp'))) == 0
+  and length(filter(attachments, .file_type not in $file_types_images)) == 0
   and (
     any(attachments,
-        .file_type in~ ('bmp', 'png', 'jpg', 'jpeg')
+        .file_type in $file_types_images
         and any(ml.logo_detect(.).brands, strings.starts_with(.name, "Microsoft"))
     )
     or any(attachments,
-           .file_type in~ ('bmp', 'png', 'jpg', 'jpeg')
+           .file_type in $file_types_images
            and any(file.explode(.), strings.ilike(.scan.ocr.raw, "*microsoft*", "*office"))
     )
   )
   and any(attachments,
-          .file_type in~ ('bmp', 'png', 'jpg', 'jpeg')
+          .file_type in $file_types_images
           and (
             any(file.explode(.),
                 length(filter(.scan.strings.strings,

--- a/detection-rules/attachment_uncommon_compressed.yml
+++ b/detection-rules/attachment_uncommon_compressed.yml
@@ -8,7 +8,8 @@ references:
 type: "rule"
 severity: "low"
 source: |
-  type.inbound and any(attachments, .file_extension in ('tar', 'iso', 'img', 'cab', 'gadget', 'uue'))
+  type.inbound
+  and any(attachments, .file_extension in ('tar', 'iso', 'img', 'cab', 'gadget', 'uue'))
 tags:
   - "Attack surface reduction"
 attack_types:

--- a/detection-rules/body_microsoft_logo_bing_redirect.yml
+++ b/detection-rules/body_microsoft_logo_bing_redirect.yml
@@ -9,11 +9,11 @@ source: |
   // Microsoft logo
   and (
     any(attachments,
-        .file_type in ('png', 'jpeg', 'jpg', 'bmp')
+        .file_type in $file_types_images
         and any(ml.logo_detect(.).brands, strings.starts_with(.name, "Microsoft"))
     )
     or any(attachments,
-           .file_type in~ ('bmp', 'png', 'jpg', 'jpeg')
+           .file_type in $file_types_images
            and (
              any(file.explode(.),
                  length(filter(.scan.strings.strings,

--- a/detection-rules/callback_phishing_nlu_body_or_attachments.yml
+++ b/detection-rules/callback_phishing_nlu_body_or_attachments.yml
@@ -7,7 +7,7 @@ source: |
   type.inbound
   and (
     any(attachments,
-        .file_type in ("png", "jpg", "pdf")
+        (.file_type in $file_types_images or .file_type == "pdf")
         and any(file.explode(.),
                 any(ml.nlu_classifier(.scan.ocr.raw).intents,
                     .name == "callback_scam" and .confidence == "high"

--- a/detection-rules/headers_replyto_new_domain_nlu_request.yml
+++ b/detection-rules/headers_replyto_new_domain_nlu_request.yml
@@ -8,8 +8,7 @@ source: |
   type.inbound
   and any(headers.reply_to,
           // mismatched reply-to and sender domain
-          .email.domain.root_domain
-          != sender.email.domain.root_domain
+          .email.domain.root_domain != sender.email.domain.root_domain
 
           // newly registered reply-to domain
           and beta.whois(.email.domain).days_old <= 30

--- a/detection-rules/impersonation_amazon_suspicious_text.yml
+++ b/detection-rules/impersonation_amazon_suspicious_text.yml
@@ -11,7 +11,7 @@ source: |
   type.inbound
   and strings.ilike(sender.display_name, "amazon*")
   and any(attachments,
-          .file_type in ("pdf", "jpg", "jpeg", "png")
+          (.file_type in $file_types_images or .file_type == "pdf")
           and any(ml.logo_detect(.).brands, .name == "Amazon" and .confidence in~ ("medium", "high"))
           and (
             any(file.explode(.),

--- a/detection-rules/impersonation_dropbox.yml
+++ b/detection-rules/impersonation_dropbox.yml
@@ -12,7 +12,7 @@ source: |
   )
   and sender.email.domain.root_domain !~ 'dropbox.com'
   and any(attachments,
-          .file_type in~ ('png', 'jpg', 'jpeg', 'bmp')
+          .file_type in $file_types_images
           and any(file.explode(.), any(.scan.strings.strings, strings.ilike(., "*dropbox*")))
   )
   and sender.email.email not in $recipient_emails

--- a/detection-rules/impersonation_microsoft_fake_sign_in_alert.yml
+++ b/detection-rules/impersonation_microsoft_fake_sign_in_alert.yml
@@ -16,7 +16,7 @@ source: |
 
       // or Microsoft Brand logo
       any(attachments,
-          .file_type in ('png', 'jpeg', 'jpg', 'bmp')
+          .file_type in $file_types_images
           and any(ml.logo_detect(.).brands, strings.starts_with(.name, "Microsoft"))
       )
     )

--- a/detection-rules/impersonation_microsoft_quarantine.yml
+++ b/detection-rules/impersonation_microsoft_quarantine.yml
@@ -5,7 +5,7 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and length(filter(attachments, .file_type not in~ ('png', 'jpeg', 'jpg', 'bmp', 'gif'))) == 0
+  and length(filter(attachments, .file_type not in $file_types_images)) == 0
   and any(attachments,
           any(file.explode(.),
               any(ml.nlu_classifier(.scan.ocr.raw).intents,

--- a/detection-rules/impersonation_microsoft_teams.yml
+++ b/detection-rules/impersonation_microsoft_teams.yml
@@ -6,7 +6,7 @@ severity: "high"
 source: |
   type.inbound
   and any(attachments,
-          .file_type in ("pdf", "jpg", "jpeg", "png")
+           (.file_type in $file_types_images or .file_type == "pdf")
           and any(file.explode(.),
                   regex.icontains(.scan.ocr.raw, "trying to reach you.*microsoft teams")
           )

--- a/detection-rules/impersonation_norton_lifelock.yml
+++ b/detection-rules/impersonation_norton_lifelock.yml
@@ -12,7 +12,7 @@ source: |
   type.inbound
   and sender.email.domain.domain != "norton.com"
   and any(attachments,
-          .file_extension in~ ('pdf', 'jpg', 'jpeg', 'png')
+           (.file_type in $file_types_images or .file_type == "pdf")
           and (
             strings.ilike(.file_name, "*norton*")
             or any(file.explode(.),

--- a/detection-rules/impersonation_paypal.yml
+++ b/detection-rules/impersonation_paypal.yml
@@ -12,7 +12,7 @@ source: |
     or strings.ilevenshtein(sender.display_name, 'paypal') <= 1
     or strings.ilike(sender.email.domain.domain, '*paypal*')
     or any(attachments,
-           .file_type in ("pdf", "jpg", "jpeg", "png")
+           (.file_type in $file_types_images or .file_type == "pdf")
            and any(ml.logo_detect(.).brands, .name == "PayPal")
            and any(file.explode(.),
                    any(.scan.strings.strings, strings.ilike(., "*PayPal*"))

--- a/detection-rules/impersonation_sharepoint_body_credential_theft.yml
+++ b/detection-rules/impersonation_sharepoint_body_credential_theft.yml
@@ -7,7 +7,7 @@ source: |
   type.inbound
   and length(body.links) > 0
   and any(attachments,
-          .file_type in ('png', 'jpeg', 'jpg', 'bmp')
+           (.file_type in $file_types_images or .file_type == "pdf")
           and any(ml.logo_detect(.).brands, .name == "Microsoft SharePoint")
   )
   and any(ml.nlu_classifier(coalesce(body.html.display_text, body.plain.raw)).intents,

--- a/detection-rules/impersonation_sharepoint_image_credential_theft.yml
+++ b/detection-rules/impersonation_sharepoint_image_credential_theft.yml
@@ -7,7 +7,7 @@ source: |
   type.inbound
   and length(body.links) > 0
   and any(attachments,
-          .file_type in ('png', 'jpeg', 'jpg', 'bmp')
+          .file_type in $file_types_images
           and any(ml.logo_detect(.).brands, .name == "Microsoft SharePoint")
           and any(file.explode(.),
                   any(ml.nlu_classifier(.scan.ocr.raw).intents,

--- a/detection-rules/impersonation_ukr_net.yml
+++ b/detection-rules/impersonation_ukr_net.yml
@@ -22,8 +22,7 @@ source: |
     )
     or (
       // IOCs
-      subject.subject
-      == "Увага"
+      subject.subject == "Увага"
       and (
         sender.email.email in (
           "muthuprakash.b@tvsrubber.com",

--- a/detection-rules/inline_image_as_message.yml
+++ b/detection-rules/inline_image_as_message.yml
@@ -17,7 +17,7 @@ source: |
       and any(body.links, not strings.ilike(.href_url.url, "*.png"))
     )
     // cid images are treated as attachments, so we're looking for more than 1
-    or (length(attachments) > 1 and any(attachments, .file_type not in file_types_images))
+    or (length(attachments) > 1 and any(attachments, .file_type not in $file_types_images))
   )
   and strings.ilike(body.html.raw, "*img*cid*")
   and sender.email.email not in $recipient_emails

--- a/detection-rules/inline_image_as_message.yml
+++ b/detection-rules/inline_image_as_message.yml
@@ -17,7 +17,7 @@ source: |
       and any(body.links, not strings.ilike(.href_url.url, "*.png"))
     )
     // cid images are treated as attachments, so we're looking for more than 1
-    or (length(attachments) > 1 and any(attachments, .file_type not in ("jpg", "png", "gif")))
+    or (length(attachments) > 1 and any(attachments, .file_type not in file_types_images))
   )
   and strings.ilike(body.html.raw, "*img*cid*")
   and sender.email.email not in $recipient_emails

--- a/detection-rules/link_coinbase_low_rep_or_shortened.yml
+++ b/detection-rules/link_coinbase_low_rep_or_shortened.yml
@@ -39,8 +39,7 @@ source: |
   // Coinbase logo
   and (
     any(attachments,
-        .file_type in ('png', 'jpeg', 'jpg', 'bmp')
-        and any(ml.logo_detect(.).brands, .name == "Coinbase")
+        .file_type in $file_types_images and any(ml.logo_detect(.).brands, .name == "Coinbase")
     )
     or any(ml.logo_detect(beta.message_screenshot()).brands, .name == "Coinbase")
   )

--- a/detection-rules/link_credential_phishing_suspicious_sender_tld_and_signals.yml
+++ b/detection-rules/link_credential_phishing_suspicious_sender_tld_and_signals.yml
@@ -30,7 +30,7 @@ source: |
 
     // suspicious image that's most likely cred_theft
     any(attachments,
-        .file_type in~ ('bmp', 'png', 'jpg', 'jpeg')
+        .file_type in $file_types_images
         and any(file.explode(.),
                 any(ml.nlu_classifier(.scan.ocr.raw).intents, .name == "cred_theft")
                 or any(ml.nlu_classifier(.scan.ocr.raw).entities, .name == "financial")

--- a/detection-rules/link_fake_fax_low_reputation.yml
+++ b/detection-rules/link_fake_fax_low_reputation.yml
@@ -25,8 +25,7 @@ source: |
   // any brand logo detected
   and (
     any(attachments,
-        .file_type in ('png', 'jpeg', 'jpg', 'bmp')
-        and any(ml.logo_detect(.).brands, .name is not null)
+        .file_type in $file_types_images and any(ml.logo_detect(.).brands, .name is not null)
     )
     or any(ml.logo_detect(beta.message_screenshot()).brands, .name is not null)
   )
@@ -39,7 +38,7 @@ source: |
     strings.ilike(body.plain.raw, "*fax*")
     or (
       any(attachments,
-          .file_type in ('png', 'jpeg', 'jpg', 'bmp')
+          .file_type in $file_types_images
           and any(file.explode(.), strings.ilike(.scan.ocr.raw, "*fax*"))
       )
     )

--- a/detection-rules/link_google_fake_sign_in_image_lure.yml
+++ b/detection-rules/link_google_fake_sign_in_image_lure.yml
@@ -9,11 +9,10 @@ source: |
 
   // Google Logo in Attachment
   and any(attachments,
-          .file_type in ('png', 'jpeg', 'jpg', 'bmp')
-          and any(ml.logo_detect(.).brands, .name in ("Google"))
+          .file_type in $file_types_images and any(ml.logo_detect(.).brands, .name in ("Google"))
   )
   and any(attachments,
-          .file_type in~ ('bmp', 'png', 'jpg', 'jpeg')
+          .file_type in $file_types_images
           and (
             any(file.explode(.),
                 // Fake activity warning

--- a/detection-rules/link_google_open_redirect_with_suspicious_indicators.yml
+++ b/detection-rules/link_google_open_redirect_with_suspicious_indicators.yml
@@ -8,7 +8,7 @@ source: |
   type.inbound
   // All attachments are images
   and length(attachments) > 0
-  and all(attachments, .file_type in ('png', 'jpg', 'bmp'))
+  and all(attachments, .file_type in $file_types_images)
   and sender.email.domain.root_domain not in $org_domains
 
   // not a reply
@@ -25,7 +25,7 @@ source: |
   and 2 of (
     // Not a google logo
     any(attachments,
-        .file_type in ('png', 'jpg', 'bmp')
+        .file_type in $file_types_images
         and (
           any(ml.logo_detect(.).brands, not strings.starts_with(.name, "Google"))
           or any(ml.logo_detect(beta.message_screenshot()).brands,
@@ -42,7 +42,7 @@ source: |
     // Image analysis - NLU - Credential theft language
     (
       any(attachments,
-          .file_type in ('png', 'jpg', 'bmp')
+          .file_type in $file_types_images
           and any(file.explode(.),
                   any(ml.nlu_classifier(.scan.ocr.raw).intents, .name == "cred_theft")
           )

--- a/detection-rules/link_html_smuggling_with_google_drive_branding.yml
+++ b/detection-rules/link_html_smuggling_with_google_drive_branding.yml
@@ -10,8 +10,7 @@ source: |
   type.inbound
   and any(body.links,
           // This isn't a Google Drive link
-          .href_url.domain.root_domain
-          != "google.com"
+          .href_url.domain.root_domain != "google.com"
           and 
 
           // There are files downloaded

--- a/detection-rules/link_microsoft_low_reputation.yml
+++ b/detection-rules/link_microsoft_low_reputation.yml
@@ -35,7 +35,7 @@ source: |
   // Microsoft logo
   and (
     any(attachments,
-        .file_type in ('png', 'jpeg', 'jpg', 'bmp')
+        .file_type in $file_types_images
         and any(ml.logo_detect(.).brands, strings.starts_with(.name, "Microsoft"))
     )
     or any(ml.logo_detect(beta.message_screenshot()).brands, strings.starts_with(.name, "Microsoft"))
@@ -69,7 +69,7 @@ source: |
     )
     or (
       any(attachments,
-          .file_type in ('png', 'jpeg', 'jpg', 'bmp')
+          .file_type in $file_types_images
           and any(file.explode(.),
                   strings.ilike(.scan.ocr.raw,
                                 "*password*",
@@ -102,7 +102,7 @@ source: |
         .name == "cred_theft" and .confidence in~ ("medium", "high")
     )
     or any(attachments,
-           .file_type in ('png', 'jpeg', 'jpg', 'bmp')
+           .file_type in $file_types_images
            and any(file.explode(.),
                    any(ml.nlu_classifier(.scan.ocr.raw).intents, .name == "cred_theft")
            )

--- a/detection-rules/link_qr_code_suspicious_language_fts.yml
+++ b/detection-rules/link_qr_code_suspicious_language_fts.yml
@@ -10,7 +10,7 @@ source: |
 
   // check image attachments for QR code, will want to add message.screenshot functionality here when it's ready
   and any(attachments,
-          .file_type in~ ('bmp', 'png', 'jpg', 'jpeg', 'gif')
+          .file_type in $file_types_images
           and any(file.explode(.),
                   .scan.qr.type == "url"
 
@@ -29,7 +29,7 @@ source: |
     // the attachment contains suspicious strings
     (
       any(attachments,
-          .file_type in~ ('bmp', 'png', 'jpg', 'jpeg', 'gif', 'pdf')
+          (.file_type in $file_types_images or .file_type == "pdf")
           and any(file.explode(.),
                   any(.scan.strings.strings,
                       regex.icontains(.,

--- a/detection-rules/punycode_sender_domain.yml
+++ b/detection-rules/punycode_sender_domain.yml
@@ -9,7 +9,8 @@ references:
 type: "rule"
 severity: "high"
 source: |
-  type.inbound and strings.ilike(sender.email.domain.domain, "*xn--*")
+  type.inbound
+  and strings.ilike(sender.email.domain.domain, "*xn--*")
 attack_types:
   - "Credential Phishing"
   - "Malware/Ransomware"

--- a/detection-rules/suspicious_request_for_quote_html_smuggling.yml
+++ b/detection-rules/suspicious_request_for_quote_html_smuggling.yml
@@ -10,19 +10,14 @@ source: |
   // RFP/RFQ language
   and 1 of (
     regex.icontains(coalesce(body.html.display_text, body.plain.raw),
-                   '(discuss.{0,15}purchas(e|ing))'
+                    '(discuss.{0,15}purchas(e|ing))'
     ),
-
     regex.icontains(coalesce(body.html.display_text, body.plain.raw),
                     '(sign(ed?)|view).{0,10}(purchase order)|Request for a Quot(e|ation)'
     ),
-
     regex.icontains(coalesce(body.html.display_text, body.plain.raw), '(please|kindly).{0,30}quote'),
-
     regex.icontains(subject.subject, '(request for (purchase|quot(e|ation))|\bRFQ\b|\bRFP\b)'),
-
     any(attachments, regex.icontains(.file_name, "(purchase.?order|Quot(e|ation))")),
-
     any(ml.nlu_classifier(coalesce(body.html.display_text, body.plain.raw)).entities,
         .name == "request"
     )


### PR DESCRIPTION
There are a few cases where we want image OR `pdf`. Does it make sense to add PDF to that list? I think a case could be made either way, I don't have strong opinions.

I also replaced `in~` with `in` because these will always match the case exactly anyway (unlike a file extension)