### PR TITLE
Improve usage of OCR in rules and switch more to `of`

### DIFF
--- a/detection-rules/attachment_adobe_image_lure_fts.yml
+++ b/detection-rules/attachment_adobe_image_lure_fts.yml
@@ -10,14 +10,12 @@ source: |
   and any(attachments,
           any(ml.logo_detect(.).brands, .name == "Adobe" and .confidence in ("high"))
           and any(file.explode(.),
-                  any(.scan.strings.strings,
-                      strings.ilike(.,
-                                    "*review*",
-                                    "*sign*",
-                                    "*view*",
-                                    "*completed document*",
-                                    "*open agreement*"
-                      )
+                  strings.ilike(.scan.ocr.raw,
+                                "*review*",
+                                "*sign*",
+                                "*view*",
+                                "*completed document*",
+                                "*open agreement*"
                   )
           )
   )

--- a/detection-rules/attachment_callback_phish_with_img.yml
+++ b/detection-rules/attachment_callback_phish_with_img.yml
@@ -21,42 +21,35 @@ source: |
   )
   and sender.email.domain.root_domain in $free_email_providers
   and any(attachments,
-          .file_extension in $file_types_images
+          .file_type in $file_types_images
           and any(file.explode(.),
-                  length(filter(.scan.strings.strings,
-                                strings.ilike(.,
-                                              "*purchase*",
-                                              "*subscription*",
-                                              "*antivirus*",
-                                              "*order*",
-                                              "*support*",
-                                              "*receipt*",
-                                              "*amount*",
-                                              "*charged*",
-                                              "*invoice*",
-                                              "*call*",
-                                              "*cancel*",
-                                              "*renew*",
-                                              "*refund*",
-                                              "*+1*"
-                                )
-                         )
-                  ) >= 4
+                  4 of (
+                    strings.icontains(.scan.ocr.raw, "purchase"),
+                    strings.icontains(.scan.ocr.raw, "subscription"),
+                    strings.icontains(.scan.ocr.raw, "antivirus"),
+                    strings.icontains(.scan.ocr.raw, "order"),
+                    strings.icontains(.scan.ocr.raw, "support"),
+                    strings.icontains(.scan.ocr.raw, "receipt"),
+                    strings.icontains(.scan.ocr.raw, "amount"),
+                    strings.icontains(.scan.ocr.raw, "charged"),
+                    strings.icontains(.scan.ocr.raw, "invoice"),
+                    strings.icontains(.scan.ocr.raw, "call"),
+                    strings.icontains(.scan.ocr.raw, "cancel"),
+                    strings.icontains(.scan.ocr.raw, "renew"),
+                    strings.icontains(.scan.ocr.raw, "refund"),
+                  )
           )
           and any(file.explode(.),
-                  length(filter(.scan.strings.strings,
-                                strings.ilike(.,
-                                              "*geek squad*",
-                                              "*lifelock*",
-                                              "*best buy*",
-                                              "*mcafee*",
-                                              "*norton*",
-                                              "*ebay*",
-                                              "*paypal*",
-                                              "*secure anywhere*"
-                                )
-                         )
-                  ) >= 1
+                  strings.ilike(.scan.ocr.raw,
+                                "*geek squad*",
+                                "*lifelock*",
+                                "*best buy*",
+                                "*mcafee*",
+                                "*norton*",
+                                "*ebay*",
+                                "*paypal*",
+                                "*secure anywhere*"
+                  )
           )
   )
 attack_types:

--- a/detection-rules/attachment_callback_phish_with_pdf.yml
+++ b/detection-rules/attachment_callback_phish_with_pdf.yml
@@ -32,39 +32,32 @@ source: |
 
           // 4 of the following strings are found        
           and any(file.explode(.),
-                  length(filter(.scan.strings.strings,
-                                strings.ilike(.,
-                                              "*purchase*",
-                                              "*subscription*",
-                                              "*antivirus*",
-                                              "*order*",
-                                              "*support*",
-                                              "*receipt*",
-                                              "*invoice*",
-                                              "*call*",
-                                              "*cancel*",
-                                              "*renew*",
-                                              "*refund*",
-                                              "*+1*"
-                                )
-                         )
-                  ) >= 4
+                  4 of (
+                    strings.icontains(.scan.ocr.raw, "purchase"),
+                    strings.icontains(.scan.ocr.raw, "subscription"),
+                    strings.icontains(.scan.ocr.raw, "antivirus"),
+                    strings.icontains(.scan.ocr.raw, "order"),
+                    strings.icontains(.scan.ocr.raw, "support"),
+                    strings.icontains(.scan.ocr.raw, "receipt"),
+                    strings.icontains(.scan.ocr.raw, "invoice"),
+                    strings.icontains(.scan.ocr.raw, "call"),
+                    strings.icontains(.scan.ocr.raw, "cancel"),
+                    strings.icontains(.scan.ocr.raw, "renew"),
+                    strings.icontains(.scan.ocr.raw, "refund"),
+                  )
           )
 
           // 1 of the following strings is found, representing common Callback brands          
           and any(file.explode(.),
-                  length(filter(.scan.strings.strings,
-                                strings.ilike(.,
-                                              "*geek squad*",
-                                              "*lifelock*",
-                                              "*best buy*",
-                                              "*mcafee*",
-                                              "*norton*",
-                                              "*ebay*",
-                                              "*paypal*",
-                                )
-                         )
-                  ) >= 1
+                  1 of (
+                    strings.icontains(.scan.ocr.raw, "geek squad"),
+                    strings.icontains(.scan.ocr.raw, "lifelock"),
+                    strings.icontains(.scan.ocr.raw, "best buy"),
+                    strings.icontains(.scan.ocr.raw, "mcafee"),
+                    strings.icontains(.scan.ocr.raw, "norton"),
+                    strings.icontains(.scan.ocr.raw, "ebay"),
+                    strings.icontains(.scan.ocr.raw, "paypal"),
+                  )
           )
   )
 attack_types:

--- a/detection-rules/attachment_docusign_image_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_image_suspicious_links.yml
@@ -16,13 +16,11 @@ source: |
             )
           )
           and any(file.explode(.),
-                  any(.scan.strings.strings,
-                      regex.icontains(.,
-                                      "review document",
-                                      "[^d][^o][^c][^u]sign",
-                                      "important edocs",
-                                      "completed document"
-                      )
+                  regex.icontains(.scan.ocr.raw,
+                                  "review document",
+                                  "[^d][^o][^c][^u]sign",
+                                  "important edocs",
+                                  "completed document"
                   )
           )
   )

--- a/detection-rules/attachment_dropbox_image_suspicious_links.yml
+++ b/detection-rules/attachment_dropbox_image_suspicious_links.yml
@@ -9,8 +9,8 @@ source: |
   and any(attachments,
           .file_type in $file_types_images
           and any(file.explode(.),
-                  any(.scan.strings.strings, strings.ilike(., "*dropbox*"))
-                  and any(.scan.strings.strings, strings.ilike(., "*review*", "*sign*"))
+                  strings.ilike(.scan.ocr.raw, "*dropbox*")
+                  and strings.ilike(.scan.ocr.raw, "*review*", "*sign*")
           )
   )
   and (

--- a/detection-rules/attachment_eml_html_attachment_portal.yml
+++ b/detection-rules/attachment_eml_html_attachment_portal.yml
@@ -24,49 +24,53 @@ source: |
   and any(attachments,
           .content_type == "message/rfc822"
           and any(file.explode(.),
-                  (
-                    // suspicious strings found in javascript
-                    length(filter(.scan.javascript.strings,
-                                  strings.ilike(.,
-                                                "*username*",
-                                                "*login-form*",
-                                                "*email-form*",
-                                                "*Incorrect password. Please try again.*",
-                                                "*Password Incomplete, please try again*"
-                                  )
-                           )
-                    ) >= 3
-                    or (
+                  // suspicious strings found in javascript
+                  length(filter(.scan.javascript.strings,
+                                strings.ilike(.,
+                                              "*username*",
+                                              "*login-form*",
+                                              "*email-form*",
+                                              "*Incorrect password. Please try again.*",
+                                              "*Password Incomplete, please try again*"
+                                )
+                         )
+                  ) >= 3
+                  or (
 
-                      // suspicious strings found outside of javascript, but binexplode'd file still of HTML type
-                      .flavors.mime in~ ("text/html", "text/plain")
-                      and length(filter(.scan.strings.strings,
-                                        strings.ilike(.,
-                                                      "*username*",
-                                                      "*login-form*",
-                                                      "*email-form*",
-                                                      "*Incorrect password. Please try again.*",
-                                                      "*Password Incomplete, please try again*"
-                                        )
-                                 )
-                      ) >= 3
+                    // suspicious strings found outside of javascript, but binexplode'd file still of HTML type
+                    .flavors.mime in~ ("text/html", "text/plain")
+                    and 3 of (
+                      any(.scan.strings.strings, strings.ilike(., "*username*")),
+                      any(.scan.strings.strings, strings.ilike(., "*login-form*")),
+                      any(.scan.strings.strings, strings.ilike(., "*email-form*")),
+                      any(.scan.strings.strings,
+                          strings.ilike(., "*Incorrect password. Please try again.*")
+                      ),
+                      any(.scan.strings.strings,
+                          strings.ilike(., "*Password Incomplete, please try again*")
+                      )
                     )
                   )
                   or 
 
                   //Known phishing obfuscation
-                  (
-                    length(filter(.scan.strings.strings,
-                                  strings.ilike(.,
-                                                //Enter password  
-                                                "*&#69;&#110;&#116;&#101;&#114;&#32;&#112;&#97;&#115;&#115;&#119;&#111;&#114;&#100*",
-                                                //Forgotten my password
-                                                "*&#70;&#111;&#114;&#103;&#111;&#116;&#116;&#101;&#110;&#32;&#109;&#121;&#32;&#112;&#97;&#115;&#115;&#119;&#111;&#114;&#100*",
-                                                //Sign in
-                                                "*&#83;&#105;&#103;&#110;&#32;&#105;&#110*"
-                                  )
-                           )
-                    ) >= 2
+                  2 of (
+                    // Enter password
+                    any(.scan.strings.strings,
+                        strings.ilike(.,
+                                      "*&#69;&#110;&#116;&#101;&#114;&#32;&#112;&#97;&#115;&#115;&#119;&#111;&#114;&#100*"
+                        )
+                    ),
+                    // Forgotten my password
+                    any(.scan.strings.strings,
+                        strings.ilike(.,
+                                      "*&#70;&#111;&#114;&#103;&#111;&#116;&#116;&#101;&#110;&#32;&#109;&#121;&#32;&#112;&#97;&#115;&#115;&#119;&#111;&#114;&#100*"
+                        )
+                    ),
+                    // Sign in
+                    any(.scan.strings.strings,
+                        strings.ilike(., "*&#83;&#105;&#103;&#110;&#32;&#105;&#110*")
+                    )
                   )
           )
   )

--- a/detection-rules/attachment_html_attachment_login_page.yml
+++ b/detection-rules/attachment_html_attachment_login_page.yml
@@ -18,34 +18,32 @@ source: |
             or .file_type == "html"
           )
           and any(file.explode(.),
-                  (
-                    // suspicious strings found in javascript
-                    3 of (
-                      any(.scan.javascript.strings, strings.ilike(., "*password*")),
-                      any(.scan.javascript.strings, strings.ilike(., "*username*")),
-                      any(.scan.javascript.strings, strings.ilike(., "*login-form*")),
-                      any(.scan.javascript.strings, strings.ilike(., "*email-form*")),
-                      any(.scan.javascript.strings,
+                  // suspicious strings found in javascript
+                  3 of (
+                    any(.scan.javascript.strings, strings.ilike(., "*password*")),
+                    any(.scan.javascript.strings, strings.ilike(., "*username*")),
+                    any(.scan.javascript.strings, strings.ilike(., "*login-form*")),
+                    any(.scan.javascript.strings, strings.ilike(., "*email-form*")),
+                    any(.scan.javascript.strings,
+                        strings.ilike(., "*Incorrect password. Please try again.*")
+                    ),
+                    any(.scan.javascript.strings,
+                        strings.ilike(., "*Password Incomplete, please try again*")
+                    )
+                  )
+                  or (
+                    // suspicious strings found outside of javascript, but binexplode'd file still of HTML type
+                    .flavors.mime in~ ("text/html", "text/plain")
+                    and 3 of (
+                      any(.scan.strings.strings, strings.ilike(., "*password*")),
+                      any(.scan.strings.strings, strings.ilike(., "*username*")),
+                      any(.scan.strings.strings, strings.ilike(., "*login-form*")),
+                      any(.scan.strings.strings, strings.ilike(., "*email-form*")),
+                      any(.scan.strings.strings,
                           strings.ilike(., "*Incorrect password. Please try again.*")
                       ),
-                      any(.scan.javascript.strings,
+                      any(.scan.strings.strings,
                           strings.ilike(., "*Password Incomplete, please try again*")
-                      )
-                    )
-                    or (
-                      // suspicious strings found outside of javascript, but binexplode'd file still of HTML type
-                      .flavors.mime in~ ("text/html", "text/plain")
-                      and 3 of (
-                        any(.scan.strings.strings, strings.ilike(., "*password*")),
-                        any(.scan.strings.strings, strings.ilike(., "*username*")),
-                        any(.scan.strings.strings, strings.ilike(., "*login-form*")),
-                        any(.scan.strings.strings, strings.ilike(., "*email-form*")),
-                        any(.scan.strings.strings,
-                            strings.ilike(., "*Incorrect password. Please try again.*")
-                        ),
-                        any(.scan.strings.strings,
-                            strings.ilike(., "*Password Incomplete, please try again*")
-                        )
                       )
                     )
                   )

--- a/detection-rules/attachment_html_attachment_login_page.yml
+++ b/detection-rules/attachment_html_attachment_login_page.yml
@@ -20,47 +20,56 @@ source: |
           and any(file.explode(.),
                   (
                     // suspicious strings found in javascript
-                    length(filter(.scan.javascript.strings,
-                                  strings.ilike(.,
-                                                "*password*",
-                                                "*username*",
-                                                "*login-form*",
-                                                "*email-form*",
-                                                "*Incorrect password. Please try again.*",
-                                                "*Password Incomplete, please try again*"
-                                  )
-                           )
-                    ) >= 3
+                    3 of (
+                      any(.scan.javascript.strings, strings.ilike(., "*password*")),
+                      any(.scan.javascript.strings, strings.ilike(., "*username*")),
+                      any(.scan.javascript.strings, strings.ilike(., "*login-form*")),
+                      any(.scan.javascript.strings, strings.ilike(., "*email-form*")),
+                      any(.scan.javascript.strings,
+                          strings.ilike(., "*Incorrect password. Please try again.*")
+                      ),
+                      any(.scan.javascript.strings,
+                          strings.ilike(., "*Password Incomplete, please try again*")
+                      )
+                    )
                     or (
                       // suspicious strings found outside of javascript, but binexplode'd file still of HTML type
                       .flavors.mime in~ ("text/html", "text/plain")
-                      and length(filter(.scan.strings.strings,
-                                        strings.ilike(.,
-                                                      "*password*",
-                                                      "*username*",
-                                                      "*login-form*",
-                                                      "*email-form*",
-                                                      "*Incorrect password. Please try again.*",
-                                                      "*Password Incomplete, please try again*"
-                                        )
-                                 )
-                      ) >= 3
+                      and 3 of (
+                        any(.scan.strings.strings, strings.ilike(., "*password*")),
+                        any(.scan.strings.strings, strings.ilike(., "*username*")),
+                        any(.scan.strings.strings, strings.ilike(., "*login-form*")),
+                        any(.scan.strings.strings, strings.ilike(., "*email-form*")),
+                        any(.scan.strings.strings,
+                            strings.ilike(., "*Incorrect password. Please try again.*")
+                        ),
+                        any(.scan.strings.strings,
+                            strings.ilike(., "*Password Incomplete, please try again*")
+                        )
+                      )
                     )
                   )
                   or 
                   //Known phishing obfuscation
-                  (
-                    length(filter(.scan.strings.strings,
-                                  strings.ilike(.,
-                                                //Enter password  
-                                                "*&#69;&#110;&#116;&#101;&#114;&#32;&#112;&#97;&#115;&#115;&#119;&#111;&#114;&#100*",
-                                                //Forgotten my password
-                                                "*&#70;&#111;&#114;&#103;&#111;&#116;&#116;&#101;&#110;&#32;&#109;&#121;&#32;&#112;&#97;&#115;&#115;&#119;&#111;&#114;&#100*",
-                                                //Sign in
-                                                "*&#83;&#105;&#103;&#110;&#32;&#105;&#110*"
-                                  )
-                           )
-                    ) >= 2
+                  2 of (
+                    // Enter password
+                    any(.scan.strings.strings,
+                        strings.ilike(.,
+                                      "*&#69;&#110;&#116;&#101;&#114;&#32;&#112;&#97;&#115;&#115;&#119;&#111;&#114;&#100*"
+                        )
+                    ),
+
+                    // Forgotten my password
+                    any(.scan.strings.strings,
+                        strings.ilike(.,
+                                      "*&#70;&#111;&#114;&#103;&#111;&#116;&#116;&#101;&#110;&#32;&#109;&#121;&#32;&#112;&#97;&#115;&#115;&#119;&#111;&#114;&#100*"
+                        )
+                    ),
+
+                    // Sign in
+                    any(.scan.strings.strings,
+                        strings.ilike(., "*&#83;&#105;&#103;&#110;&#32;&#105;&#110*")
+                    )
                   )
           )
   )

--- a/detection-rules/attachment_malicious_onenote_commands.yml
+++ b/detection-rules/attachment_malicious_onenote_commands.yml
@@ -14,22 +14,20 @@ source: |
   and any(attachments,
           (.file_extension in~ ("one") or .file_extension in~ $file_extensions_common_archives)
           and any(file.explode(.),
-                  any(.flavors.yara,
-                      . == "onenote_file"
-                      and any(..scan.strings.strings,
-                              strings.ilike(.,
-                                            "*WshShell*",
-                                            "*ExecuteCmdAsync*",
-                                            "*CreateObject*",
-                                            "*Wscript.Shell*",
-                                            "*schtasks*",
-                                            "*CreateProcess*",
-                                            "*winmgmts*",
-                                            "*SetEnvironmentVariable*",
-                                            "*powershell*",
-                                            "*echo off*"
-                              )
-                      )
+                  "onenote_file" in .flavors.yara
+                  and any(.scan.strings.strings,
+                          strings.ilike(.,
+                                        "*WshShell*",
+                                        "*ExecuteCmdAsync*",
+                                        "*CreateObject*",
+                                        "*Wscript.Shell*",
+                                        "*schtasks*",
+                                        "*CreateProcess*",
+                                        "*winmgmts*",
+                                        "*SetEnvironmentVariable*",
+                                        "*powershell*",
+                                        "*echo off*"
+                          )
                   )
           )
   )

--- a/detection-rules/attachment_microsoft_image_lure_qr_code.yml
+++ b/detection-rules/attachment_microsoft_image_lure_qr_code.yml
@@ -16,15 +16,15 @@ source: |
           .file_type in $file_types_images
           and (
             any(file.explode(.),
-                any(.scan.strings.strings, regex.icontains(., 'scan|camera'))
-                and any(.scan.strings.strings, regex.icontains(., '\bQR\b|Q\.R\.|barcode'))
+                regex.icontains(.scan.ocr.raw, 'scan|camera')
+                and regex.icontains(.scan.ocr.raw, '\bQR\b|Q\.R\.|barcode')
             )
-            or (
-              any(file.explode(.),
-                  .scan.qr.type == "url"
-                  // recipient email address is present in the URL, a common tactic used in credential phishing attacks 
-                  and any(recipients.to, strings.icontains(..scan.qr.data, .email.email))
-              )
+          )
+          or (
+            any(file.explode(.),
+                .scan.qr.type == "url"
+                // recipient email address is present in the URL, a common tactic used in credential phishing attacks 
+                and any(recipients.to, strings.icontains(..scan.qr.data, .email.email))
             )
           )
   )

--- a/detection-rules/attachment_office365_image.yml
+++ b/detection-rules/attachment_office365_image.yml
@@ -18,60 +18,30 @@ source: |
   )
   and any(attachments,
           .file_type in $file_types_images
-          and (
-            any(file.explode(.),
-                length(filter(.scan.strings.strings,
-                              strings.ilike(.,
-                                            "*password*",
-                                            "*unread messages*",
-                                            "*Shared Documents*",
-                                            "*expiration*",
-                                            "*office*",
-                                            "*expire*",
-                                            "*expiring*",
-                                            "*kindly*",
-                                            "*renew*",
-                                            "*review",
-                                            "*emails failed*",
-                                            "*kicked out*",
-                                            "*prevented*",
-                                            "*storage quota*",
-                                            "*required now",
-                                            "*cache*",
-                                            "*qr code*",
-                                            "*barcode*",
-                                            "*security update*"
-                              )
-                       )
-                ) >= 2
-            )
-          )
-          or (
-            any(file.explode(.),
-                length(filter([
-                                "password",
-                                "unread messages",
-                                "Shared Documents",
-                                "expiration",
-                                "office",
-                                "expire",
-                                "expiring",
-                                "kindly",
-                                "renew",
-                                "review",
-                                "emails failed",
-                                "kicked out",
-                                "prevented",
-                                "storage quota",
-                                "required now",
-                                "cache",
-                                "qr code",
-                                "security update"
-                              ],
-                              strings.icontains(..scan.ocr.raw, .)
-                       )
-                ) >= 2
-            )
+          and any(file.explode(.),
+                  length(filter([
+                                  "password",
+                                  "unread messages",
+                                  "Shared Documents",
+                                  "expiration",
+                                  "office",
+                                  "expire",
+                                  "expiring",
+                                  "kindly",
+                                  "renew",
+                                  "review",
+                                  "emails failed",
+                                  "kicked out",
+                                  "prevented",
+                                  "storage quota",
+                                  "required now",
+                                  "cache",
+                                  "qr code",
+                                  "security update"
+                                ],
+                                strings.icontains(..scan.ocr.raw, .)
+                         )
+                  ) >= 2
           )
   )
   and (

--- a/detection-rules/attachment_potential_sandbox_evasion_in_office_file.yml
+++ b/detection-rules/attachment_potential_sandbox_evasion_in_office_file.yml
@@ -15,16 +15,13 @@ source: |
   and any(attachments,
           .file_extension in~ $file_extensions_macros
           and any(file.explode(.),
-                  length(filter(.scan.strings.strings,
-                                strings.ilike(.,
-                                              "*Win32_Processor*",
-                                              "*Win32_LogicalDisk*",
-                                              "*Win32_ComputerSystem*",
-                                              "*Win32_Process*",
-                                              "*LDAP://RootDSE*"
-                                )
-                         )
-                  ) >= 1
+                  1 of (
+                    any(.scan.strings.strings, strings.ilike(., "*Win32_Processor*")),
+                    any(.scan.strings.strings, strings.ilike(., "*Win32_LogicalDisk*")),
+                    any(.scan.strings.strings, strings.ilike(., "*Win32_ComputerSystem*")),
+                    any(.scan.strings.strings, strings.ilike(., "*Win32_Process*")),
+                    any(.scan.strings.strings, strings.ilike(., "*LDAP://RootDSE*"))
+                  )
           )
   )
 attack_types:

--- a/detection-rules/attachment_svg_embedded_js.yml
+++ b/detection-rules/attachment_svg_embedded_js.yml
@@ -14,7 +14,7 @@ source: |
           (.file_extension =~ "svg" or .file_extension in $file_extensions_common_archives)
           and any(file.explode(.),
                   .file_extension == "svg"
-                  and any(.scan.xml.tags, . =~ "script")
+                  and "script" in~ .scan.xml.tags
                   // unclear if this is necessary, but it's been observed
                   // in all payloads we've seen, so we'll include it
                   // as an extra FP precaution

--- a/detection-rules/body_microsoft_logo_bing_redirect.yml
+++ b/detection-rules/body_microsoft_logo_bing_redirect.yml
@@ -16,31 +16,28 @@ source: |
            .file_type in $file_types_images
            and (
              any(file.explode(.),
-                 length(filter(.scan.strings.strings,
-                               strings.ilike(.,
-                                             "*password*",
-                                             "*unread messages*",
-                                             "*Shared Documents*",
-                                             "*expiration*",
-                                             "*office*",
-                                             "*expire*",
-                                             "*expiring*",
-                                             "*kindly*",
-                                             "*renew*",
-                                             "*review",
-                                             "*emails failed*",
-                                             "*kicked out*",
-                                             "*prevented*",
-                                             "*storage quota*",
-                                             "*required now",
-                                             "*cache*",
-                                             "*qr code*",
-                                             "*barcode*",
-                                             "*security update*",
-                                             "*quarantine*"
-                               )
-                        )
-                 ) >= 2
+                 2 of (
+                   strings.ilike(.scan.ocr.raw, "*password*"),
+                   strings.ilike(.scan.ocr.raw, "*unread messages*"),
+                   strings.ilike(.scan.ocr.raw, "*Shared Documents*"),
+                   strings.ilike(.scan.ocr.raw, "*expiration*"),
+                   strings.ilike(.scan.ocr.raw, "*office*"),
+                   strings.ilike(.scan.ocr.raw, "*expire*"),
+                   strings.ilike(.scan.ocr.raw, "*expiring*"),
+                   strings.ilike(.scan.ocr.raw, "*kindly*"),
+                   strings.ilike(.scan.ocr.raw, "*renew*"),
+                   strings.ilike(.scan.ocr.raw, "*review"),
+                   strings.ilike(.scan.ocr.raw, "*emails failed*"),
+                   strings.ilike(.scan.ocr.raw, "*kicked out*"),
+                   strings.ilike(.scan.ocr.raw, "*prevented*"),
+                   strings.ilike(.scan.ocr.raw, "*storage quota*"),
+                   strings.ilike(.scan.ocr.raw, "*required now"),
+                   strings.ilike(.scan.ocr.raw, "*cache*"),
+                   strings.ilike(.scan.ocr.raw, "*qr code*"),
+                   strings.ilike(.scan.ocr.raw, "*barcode*"),
+                   strings.ilike(.scan.ocr.raw, "*security update*"),
+                   strings.ilike(.scan.ocr.raw, "*quarantine*")
+                 )
              )
            )
     )

--- a/detection-rules/impersonation_dropbox.yml
+++ b/detection-rules/impersonation_dropbox.yml
@@ -13,7 +13,7 @@ source: |
   and sender.email.domain.root_domain !~ 'dropbox.com'
   and any(attachments,
           .file_type in $file_types_images
-          and any(file.explode(.), any(.scan.strings.strings, strings.ilike(., "*dropbox*")))
+          and any(file.explode(.), strings.ilike(.scan.ocr.raw, "*dropbox*"))
   )
   and sender.email.email not in $recipient_emails
 attack_types:

--- a/detection-rules/impersonation_microsoft_quarantine.yml
+++ b/detection-rules/impersonation_microsoft_quarantine.yml
@@ -15,10 +15,10 @@ source: |
           )
           and any(file.explode(.),
                   3 of (
-                    any(.scan.strings.strings, strings.icontains(., "review")),
-                    any(.scan.strings.strings, strings.icontains(., "release")),
-                    any(.scan.strings.strings, strings.icontains(., "quarantine")),
-                    any(.scan.strings.strings, strings.icontains(., "messages")),
+                    strings.icontains(.scan.ocr.raw, "review"),
+                    strings.icontains(.scan.ocr.raw, "release"),
+                    strings.icontains(.scan.ocr.raw, "quarantine"),
+                    strings.icontains(.scan.ocr.raw, "messages"),
                     any(ml.logo_detect(..).brands, strings.starts_with(.name, "Microsoft"))
                   )
           )

--- a/detection-rules/impersonation_microsoft_teams.yml
+++ b/detection-rules/impersonation_microsoft_teams.yml
@@ -6,7 +6,7 @@ severity: "high"
 source: |
   type.inbound
   and any(attachments,
-           (.file_type in $file_types_images or .file_type == "pdf")
+          (.file_type in $file_types_images or .file_type == "pdf")
           and any(file.explode(.),
                   regex.icontains(.scan.ocr.raw, "trying to reach you.*microsoft teams")
           )

--- a/detection-rules/impersonation_norton_lifelock.yml
+++ b/detection-rules/impersonation_norton_lifelock.yml
@@ -12,12 +12,14 @@ source: |
   type.inbound
   and sender.email.domain.domain != "norton.com"
   and any(attachments,
-           (.file_type in $file_types_images or .file_type == "pdf")
+          (.file_type in $file_types_images or .file_type == "pdf")
           and (
             strings.ilike(.file_name, "*norton*")
             or any(file.explode(.),
-                   any(.scan.strings.strings,
-                       regex.icontains(., ".*norton.?60.*", ".*lifelock.*", ".*norton.?security.*")
+                   regex.icontains(.scan.ocr.raw,
+                                   ".*norton.?60.*",
+                                   ".*lifelock.*",
+                                   ".*norton.?security.*"
                    )
             )
           )

--- a/detection-rules/impersonation_paypal.yml
+++ b/detection-rules/impersonation_paypal.yml
@@ -15,14 +15,12 @@ source: |
            (.file_type in $file_types_images or .file_type == "pdf")
            and any(ml.logo_detect(.).brands, .name == "PayPal")
            and any(file.explode(.),
-                   any(.scan.strings.strings, strings.ilike(., "*PayPal*"))
-                   and any(.scan.strings.strings,
-                           strings.ilike(.,
-                                         "*invoice*",
-                                         "*transaction*",
-                                         "*bitcoin*",
-                                         "*dear customer*",
-                           )
+                   strings.ilike(.scan.ocr.raw, "*PayPal*")
+                   and strings.ilike(.scan.ocr.raw,
+                                     "*invoice*",
+                                     "*transaction*",
+                                     "*bitcoin*",
+                                     "*dear customer*",
                    )
            )
     )

--- a/detection-rules/impersonation_sharepoint_body_credential_theft.yml
+++ b/detection-rules/impersonation_sharepoint_body_credential_theft.yml
@@ -7,7 +7,7 @@ source: |
   type.inbound
   and length(body.links) > 0
   and any(attachments,
-           (.file_type in $file_types_images or .file_type == "pdf")
+          (.file_type in $file_types_images or .file_type == "pdf")
           and any(ml.logo_detect(.).brands, .name == "Microsoft SharePoint")
   )
   and any(ml.nlu_classifier(coalesce(body.html.display_text, body.plain.raw)).intents,

--- a/detection-rules/link_google_fake_sign_in_image_lure.yml
+++ b/detection-rules/link_google_fake_sign_in_image_lure.yml
@@ -16,15 +16,12 @@ source: |
           and (
             any(file.explode(.),
                 // Fake activity warning
-                length(filter(.scan.strings.strings,
-                              strings.ilike(.,
-                                            "*new sign-in*",
-                                            "*google account*",
-                                            "*secure your account*",
-                                            "*check activity*"
-                              )
-                       )
-                ) >= 3
+                3 of (
+                  strings.ilike(.scan.ocr.raw, "*new sign-in*"),
+                  strings.ilike(.scan.ocr.raw, "*google account*"),
+                  strings.ilike(.scan.ocr.raw, "*secure your account*"),
+                  strings.ilike(.scan.ocr.raw, "*check activity*"),
+                )
             )
           )
   )

--- a/detection-rules/paypal_invoice_abuse.yml
+++ b/detection-rules/paypal_invoice_abuse.yml
@@ -15,7 +15,7 @@ source: |
   and strings.ilike(body.html.display_text, "*seller note*")
   and (
     (
-      //phone number but not 800 number
+      // phone number but not 800 number
       regex.contains(body.html.inner_text,
                      '[\s:,-]\+?\d{1,2}[\s:,-]\(?([2-7][0-9]{2}|80[1-9]|8[1-9][0-9])\)?[\s:,-]\d{3}[\s:,-]\d{4}\b'
       )
@@ -38,7 +38,7 @@ source: |
       )
     )
     or (
-      //Unicode confusables words obfuscated in note
+      // Unicode confusables words obfuscated in note
       regex.contains(body.html.inner_text, '\+𝟭|𝗽𝗮𝘆𝗺𝗲𝗻𝘁|𝗛𝗲𝗹𝗽 𝗗𝗲𝘀𝗸|𝗿𝗲𝗳𝘂𝗻𝗱|𝗮𝗻𝘁𝗶𝘃𝗶𝗿𝘂𝘀|𝗰𝗮𝗹𝗹|𝗰𝗮𝗻𝗰𝗲𝗹')
     )
   )

--- a/detection-rules/stripe_invoice_abuse.yml
+++ b/detection-rules/stripe_invoice_abuse.yml
@@ -13,17 +13,14 @@ source: |
   and any(attachments,
           .file_extension == "pdf"
           and any(file.explode(.),
-                  length(filter(.scan.strings.strings,
-                                strings.ilike(.,
-                                              "*Btc Purchase*",
-                                              "*suspicious activity*",
-                                              "*get in touch with us straight once*",
-                                              "*your phone number*",
-                                              "*due deducted*",
-                                              "*merchant security service center*",
-                                )
-                         )
-                  ) >= 4
+                  4 of (
+                    strings.ilike(.scan.ocr.raw, "*Btc Purchase*"),
+                    strings.ilike(.scan.ocr.raw, "*suspicious activity*"),
+                    strings.ilike(.scan.ocr.raw, "*get in touch with us straight once*"),
+                    strings.ilike(.scan.ocr.raw, "*your phone number*"),
+                    strings.ilike(.scan.ocr.raw, "*due deducted*"),
+                    strings.ilike(.scan.ocr.raw, "*merchant security service center*"),
+                  )
           )
   )
 attack_types:

--- a/discovery-rules/attachment_any_eml.yml
+++ b/discovery-rules/attachment_any_eml.yml
@@ -8,3 +8,4 @@ authors:
 source: |
   type.inbound
   and any(attachments, .file_extension =~ 'eml')
+


### PR DESCRIPTION
This is basically #671 but after the other refactors to keep it from being as overwhelming.
I tried to keep concerns here focused to one of these two things:

- Manually updated rules to use `.scan.ocr.raw` when it makes sense
- Switch from `length(filter.scan.strings.strings, ...)` to `of` when it makes more sense
- Fixed or simplified logic in a few places in these files when I encountered them