### PR TITLE
FP tune: impersonation_venmo.yml

### DIFF
--- a/detection-rules/impersonation_venmo.yml
+++ b/detection-rules/impersonation_venmo.yml
@@ -14,6 +14,15 @@ source: |
   )
   and sender.email.domain.root_domain not in~ ('venmo.com', 'synchronybank.com')
   and sender.email.email not in $recipient_emails
+  
+  // and not if the sender.display.name contains "via" and dmarc pass from venmo.com
+  and not (
+    any(distinct(headers.hops, .authentication_results.dmarc is not null),
+        strings.ilike(.authentication_results.dmarc, "pass")
+        and .authentication_results.dmarc_details.from.domain == "venmo.com"
+    )
+    and strings.contains(sender.display_name, "via")
+  )
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
Venmo will send emails on your behalf as a receipt. 

This change negates the condition when the display name contains "via" yet the emails are still passing dmarc as authenticated by venmo.com