### PR TITLE
FP: Adding FTS Proper

### DIFF
--- a/detection-rules/inline_image_as_message.yml
+++ b/detection-rules/inline_image_as_message.yml
@@ -20,7 +20,16 @@ source: |
     or (length(attachments) > 1 and any(attachments, .file_type not in $file_types_images))
   )
   and strings.ilike(body.html.raw, "*img*cid*")
-  and sender.email.email not in $recipient_emails
+  and (
+    (
+      sender.email.domain.root_domain in $free_email_providers
+      and sender.email.email not in $sender_emails
+    )
+    or (
+      sender.email.domain.root_domain not in $free_email_providers
+      and sender.email.domain.domain not in $sender_domains
+    )
+  )
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
This rule  has a precision of .68% debated retiring it as I feel our capabilities are better now, but adding proper FTS as the FN is from a listserv and likely won't be the only message from that sender.