### PR TITLE
Update body_callback_phishing_no_attachment.yml

### DIFF
--- a/detection-rules/body_callback_phishing_no_attachment.yml
+++ b/detection-rules/body_callback_phishing_no_attachment.yml
@@ -29,6 +29,7 @@ source: |
                     "*best buy*",
                     "*lifelock*"
   )
+  and length(body.current_thread.text) < 1500
   and 3 of (
     strings.ilike(body.current_thread.text, '*purchase*'),
     strings.ilike(body.current_thread.text, '*payment*'),
@@ -46,7 +47,7 @@ source: |
     strings.ilike(body.current_thread.text, '*refund*')
   )
   // phone number regex
-  and regex.icontains(body.current_thread.text, '\+?(\d{1}.)?\d{3}.\d{3,}')
+  and regex.icontains(body.current_thread.text, '\+?(\d{1}.)?\(?\d{3}?\)?.\d{3}.?\d{4}')
   and sender.email.domain.root_domain not in (
     // paypal domain
     "xoom.com"


### PR DESCRIPTION
Expanding regex and gating with a char limiter, in review malicious evaluations are less than 1500 chars. Where as most of our FP's are all longer by significant margins