### PR TITLE
Update link analysis logic for EML attachment

### DIFF
--- a/detection-rules/attachment_eml_cred_theft.yml
+++ b/detection-rules/attachment_eml_cred_theft.yml
@@ -10,11 +10,13 @@ source: |
           .content_type == "message/rfc822"
           and any(file.explode(.),
                   any(.scan.url.urls,
-                      .domain.root_domain in $free_subdomain_hosts
-                      or .domain.root_domain in ("sharepoint.com")
-                      or .domain.root_domain not in $tranco_1m
+                      (
+                        .domain.root_domain in $free_subdomain_hosts
+                        or .domain.root_domain in ("sharepoint.com")
+                        or .domain.root_domain not in $tranco_1m
+                      )
+                      and beta.linkanalysis(.).credphish.disposition == "phishing"
                   )
-                  and any(.scan.url.urls, beta.linkanalysis(.).credphish.disposition == "phishing")
           )
   )
 


### PR DESCRIPTION
Before this we did:
"if any of the URLs found in the scan match X criteria"
"then click *all* of the URLs found in the scan"

Now it's: "only click the URLs that match"