### PR TITLE
Tune: Update attachment_html_smuggling_atob.yml

### DIFF
--- a/detection-rules/attachment_html_smuggling_atob.yml
+++ b/detection-rules/attachment_html_smuggling_atob.yml
@@ -8,8 +8,7 @@ severity: "high"
 source: |
   type.inbound
   and any(attachments,
-          .size <= 60000
-          and (
+          (
             .file_extension in~ ("html", "htm", "shtml", "dhtml")
             or .file_extension in~ $file_extensions_common_archives
             or .file_type == "html"


### PR DESCRIPTION
Removing size requirement, as we're missing ATOB samples.