### PR TITLE
Bump MQL mimic test timeout

### DIFF
--- a/.github/workflows/mql-mimic-tests.yml
+++ b/.github/workflows/mql-mimic-tests.yml
@@ -37,4 +37,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: "MQL Mimic Tests"
           ref: ${{ github.sha }}
-          timeoutSeconds: 1800
+          timeoutSeconds: 3600


### PR DESCRIPTION
Generally 30 minutes is fine but if a bunch of new external function calls are introduced then the tests can be slower.