### PR TITLE
FP fix: Update link_credential_phishing_intent_and_other_indicators.yml

### DIFF
--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -279,7 +279,8 @@ source: |
           // this is common in link tracking, both for
           // benign marketing traffic but also attackers
           any(recipients.to,
-              strings.icontains(..href_url.url, .email.local_part)
+              .email.domain.valid
+              and strings.icontains(..href_url.url, .email.local_part)
               and strings.icontains(..href_url.url, .email.domain.domain)
           )
   )
@@ -290,12 +291,12 @@ source: |
   and (
     // freemail providers should never be sending this type of email
     sender.email.domain.domain in $free_email_providers
-
+  
     // if not freemail, it's suspicious if the sender's root domain
     // doesn't match any links in the body
     or all(body.links, .href_url.domain.root_domain != sender.email.domain.root_domain)
   )
-
+  
   // first-time sender
   and (
     (


### PR DESCRIPTION
Falsely returns true if recipient is null. Adding a valid check