### PR TITLE
Update impersonation_recipient_domain.yml

### DIFF
--- a/detection-rules/impersonation_recipient_domain.yml
+++ b/detection-rules/impersonation_recipient_domain.yml
@@ -15,8 +15,8 @@ source: |
           // custom domains only
           sender.email.domain.domain not in $free_email_providers
 
-          // recipient's domain is in the sender's display name
-          and strings.icontains(sender.display_name, .email.domain.root_domain)
+          // mailbox recipient's domain is in the sender's display name
+          and strings.icontains(sender.display_name, mailbox.email.domain.root_domain)
   )
   
   and not (


### PR DESCRIPTION
Changing recipient domain to use mailbox.email.domain.root_domain to negate instances where the recipient is the sender, and delivery is accomplished via BCC's.