### PR TITLE
Fixing FN:  attachment_html_recipient_in_javascript_identifiers.yml

### DIFF
--- a/detection-rules/attachment_html_recipient_in_javascript_identifiers.yml
+++ b/detection-rules/attachment_html_recipient_in_javascript_identifiers.yml
@@ -7,7 +7,7 @@ source: |
   type.inbound
   and any(attachments,
           (
-            .file_extension in~ ("html", "htm", "shtml", "dhtml")
+            .file_extension in~ ("html", "htm", "shtml", "dhtml", "xhtml")
             or (
               .file_extension is null
               and .file_type == "unknown"
@@ -16,13 +16,18 @@ source: |
             )
             or .file_extension in~ $file_extensions_common_archives
             or .file_type == "html"
+            or .content_type == "text/html"
           )
           and any(file.explode(.),
                   // suspicious identifiers
-                  any(.scan.javascript.identifiers, strings.like(., "atob", "decrypt"))
+                  any([.scan.strings.strings, .scan.javascript.identifiers],
+                      any(., strings.like(., "*atob*", "*decrypt*"))
+                  )
                   // Recipients address found in javascript
-                  and any(recipients.to,
-                          any(..scan.javascript.strings, strings.icontains(., ..email.email))
+                  and any(file.explode(..),
+                          any(recipients.to,
+                              any(..scan.javascript.strings, strings.icontains(., ..email.email))
+                          )
                   )
           )
   ) 

--- a/detection-rules/attachment_html_recipient_in_javascript_identifiers.yml
+++ b/detection-rules/attachment_html_recipient_in_javascript_identifiers.yml
@@ -12,7 +12,6 @@ source: |
               .file_extension is null
               and .file_type == "unknown"
               and .content_type == "application/octet-stream"
-              and .size < 100000000
             )
             or .file_extension in~ $file_extensions_common_archives
             or .file_type == "html"
@@ -23,14 +22,14 @@ source: |
                   any([.scan.strings.strings, .scan.javascript.identifiers],
                       any(., strings.like(., "*atob*", "*decrypt*"))
                   )
-                  // Recipients address found in javascript
-                  and any(file.explode(..),
-                          any(recipients.to,
-                              any(..scan.javascript.strings, strings.icontains(., ..email.email))
-                          )
+          )
+          // Recipients address found in javascript
+          and any(file.explode(.),
+                  any(recipients.to,
+                      any(..scan.javascript.strings, strings.icontains(., ..email.email))
                   )
           )
-  ) 
+  )
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
Fixing issue where the rule would fail to flag if the recipient and the javascript terms were found in separate exploded pieces of the same file.