### PR TITLE
Update attachment_html_smuggling_unescape.yml

### DIFF
--- a/detection-rules/attachment_html_smuggling_unescape.yml
+++ b/detection-rules/attachment_html_smuggling_unescape.yml
@@ -13,7 +13,10 @@ source: |
             or .file_extension in~ $file_extensions_common_archives
             or .file_type == "html"
           )
-          and any(file.explode(.), any(.scan.javascript.identifiers, . == "unescape"))
+          and any(file.explode(.),
+                  any(.scan.javascript.identifiers, . == "unescape")
+                  or any(.scan.strings.strings, regex.contains(., "document.write.{0,10}unescape"))
+          )
   )
 attack_types:
   - "Credential Phishing"


### PR DESCRIPTION
Depending on how the HTML is structured javascript identifiers never populates and this is present in strings only. Updating to accommodate.