### PR TITLE
Update VIP impersonation rule to ignore org_domains

### DIFF
--- a/detection-rules/vip_impersonation_attack_surface_reduction.yml
+++ b/detection-rules/vip_impersonation_attack_surface_reduction.yml
@@ -22,7 +22,7 @@ source: |
   )
 
   and (
-    profile.by_sender().prevalence in ("new", "outlier")
+    profile.by_sender().prevalence == "new"
     or (
       profile.by_sender().any_messages_malicious_or_spam
       and not profile.by_sender().any_false_positives

--- a/detection-rules/vip_impersonation_attack_surface_reduction.yml
+++ b/detection-rules/vip_impersonation_attack_surface_reduction.yml
@@ -36,9 +36,6 @@ source: |
       and not profile.by_sender().any_false_positives
     )
   )
-
-  // handle cases where type.inbound is incorrectly set
-  and sender.email.domain.domain not in $org_domains
 tags:
   - "Attack surface reduction"
 attack_types:

--- a/detection-rules/vip_impersonation_attack_surface_reduction.yml
+++ b/detection-rules/vip_impersonation_attack_surface_reduction.yml
@@ -38,7 +38,7 @@ source: |
   )
 
   // handle cases where type.inbound is incorrectly set
-  and sender.domain.domain not in $org_domains
+  and sender.email.domain.domain not in $org_domains
 tags:
   - "Attack surface reduction"
 attack_types:

--- a/detection-rules/vip_impersonation_attack_surface_reduction.yml
+++ b/detection-rules/vip_impersonation_attack_surface_reduction.yml
@@ -36,6 +36,9 @@ source: |
       and not profile.by_sender().any_false_positives
     )
   )
+
+  // handle cases where type.inbound is incorrectly set
+  and sender.domain.domain not in $org_domains
 tags:
   - "Attack surface reduction"
 attack_types:


### PR DESCRIPTION
Looks like there are cases where we call a message `type.inbound` even when the org domain matches. One case is google calendar.

Now that we went from FTS to a more broad definition of first/outlier/untrusted/unsolicited, we're more FP prone. While investigating the `type.inbound` check, this should help resolve those FPs. 