### PR TITLE
Updating rule: attachment_any_html_unsolicited.yml

### DIFF
--- a/detection-rules/attachment_any_html_unsolicited.yml
+++ b/detection-rules/attachment_any_html_unsolicited.yml
@@ -12,11 +12,11 @@ source: |
   type.inbound
   and any(attachments, .file_extension in~ ('htm', 'html') or .file_type == "html")
   and (
-    (
+    not profile.by_sender().any_false_positives
+    and (
       profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_false_positives
+      or not profile.by_sender().solicited
     )
-    and not profile.by_sender().solicited
   )
 tags:
   - "Attack surface reduction"

--- a/detection-rules/attachment_any_html_unsolicited.yml
+++ b/detection-rules/attachment_any_html_unsolicited.yml
@@ -13,10 +13,7 @@ source: |
   and any(attachments, .file_extension in~ ('htm', 'html') or .file_type == "html")
   and (
     not profile.by_sender().any_false_positives
-    and (
-      profile.by_sender().any_messages_malicious_or_spam
-      or not profile.by_sender().solicited
-    )
+    and not profile.by_sender().solicited
   )
 tags:
   - "Attack surface reduction"

--- a/detection-rules/attachment_any_html_unsolicited.yml
+++ b/detection-rules/attachment_any_html_unsolicited.yml
@@ -12,11 +12,11 @@ source: |
   type.inbound
   and any(attachments, .file_extension in~ ('htm', 'html') or .file_type == "html")
   and (
-    not profile.by_sender().solicited
-    or (
+    (
       profile.by_sender().any_messages_malicious_or_spam
       and not profile.by_sender().any_false_positives
     )
+    and not profile.by_sender().solicited
   )
 tags:
   - "Attack surface reduction"


### PR DESCRIPTION
Fixing FPs, rule will only flag if the sender isn't known to FP _and_ is unsolicited.