### PR TITLE
Update regex in rules to remove line-based matches

### DIFF
--- a/detection-rules/attachment_eml_html_attachment_portal.yml
+++ b/detection-rules/attachment_eml_html_attachment_portal.yml
@@ -8,7 +8,7 @@ source: |
 
   // exclude bounce backs & read receipts
   and not strings.like(sender.email.local_part, "*postmaster*", "*mailer-daemon*", "*administrator*")
-  and not regex.icontains(subject.subject, "^(undeliverable|read:)")
+  and not regex.imatch(subject.subject, "(undeliverable|read:).*")
   and not any(attachments, .content_type == "message/delivery-status")
 
   // if the "References" is in the body of the message, it's probably a bounce

--- a/detection-rules/recipients_undisclosed_nlu_cred_theft_low_rep_links.yml
+++ b/detection-rules/recipients_undisclosed_nlu_cred_theft_low_rep_links.yml
@@ -13,7 +13,7 @@ source: |
         regex.icontains(.display_text,
                         '(view|click|download|goto)?(attachment|download|file|online|document)s?'
         )
-        or all(body.links, regex.contains(.display_text, "^[A-Z ]+$"))
+        or all(body.links, regex.match(.display_text, "[A-Z ]+"))
     )
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents,

--- a/signals/sender/sender_display_is_upper.yml
+++ b/signals/sender/sender_display_is_upper.yml
@@ -1,4 +1,4 @@
 name: "Sender: Display Name Contains All Capital Letters"
 type: "query"
 source: |
-  regex.match(sender.display_name, "^[^a-z]*[A-Z][^a-z]*$")
+  regex.match(sender.display_name, "[^a-z]*[A-Z][^a-z]*")


### PR DESCRIPTION
Line-based tokens `^` and `$` don't work for backtesting. We should be using `regex.match` in these cases anyway.