### PR TITLE
Add PDF to QR code attachment detection

### DIFF
--- a/detection-rules/attachment_qr_code_suspicious_components.yml
+++ b/detection-rules/attachment_qr_code_suspicious_components.yml
@@ -9,7 +9,7 @@ source: |
   
   // Inspects image attachments for QR codes
   and any(attachments,
-          .file_type in $file_types_images
+          (.file_type in $file_types_images or .file_type == "pdf")
           and (
             any(file.explode(.),
                 .scan.qr.type == "url"


### PR DESCRIPTION
Some misses otherwise! We still need to get the QR code parsing to work without a protocol for some of the misses, that's a separate thing that doesn't need to happen here