### PR TITLE
Improved Filtering for Changed Rules

### DIFF
--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -139,10 +139,9 @@ jobs:
         id: find_ids
         run: |
           for file in detection-rules/*.yml; do
-            echo "$file was changed"
             rule_id=$(yq '.id' $file)
           
-            if [ ${{ steps.get_base_ref.outputs.run_all != 'true' }} ]; then
+            if [ ${{ steps.get_base_ref.outputs.run_all }} = 'true']; then
               altered_rule_ids=$(echo "$rule_id"" ""$altered_rule_ids")
               continue
             fi
@@ -150,7 +149,6 @@ jobs:
             echo "$file has rule ID $rule_id"
             new_source=$(yq '.source' "$file")
             old_source=$(yq '.source' "sr-main/detection-rules/$rule_id.yml" || echo '')
-            echo $old_source
             
             # We only need to care when rule source is changed. This will handle renames, tag changes, etc.
             if [ "$new_source" != "$old_source" ]; then

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -11,7 +11,7 @@ concurrency:
   # For pull_request_target workflows we want to use head_ref -- the branch triggering the workflow. Otherwise,
   # use ref, which is the branch for a push event.
   group: ${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
 
 jobs:
   tests:
@@ -26,7 +26,7 @@ jobs:
         uses: mikefarah/yq@v4.27.3
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -42,52 +42,52 @@ jobs:
           pip install -r scripts/generate-rule-ids/requirements.txt
           python scripts/generate-rule-ids/main.py
 
-      - name: Validate Rules
-        run: |
-          for f in *-rules/*.yml
-          do
-            echo "Processing $f"
-            http_code=$(yq -o=json eval 'del(.type)' "$f" | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
-            echo '' >> response.txt
-            cat response.txt
-            if [[ "$http_code" != "200" ]]; then
-              echo "Unexpected response $http_code"
-              exit 1
-            fi
-          done
+#      - name: Validate Rules
+#        run: |
+#          for f in *-rules/*.yml
+#          do
+#            echo "Processing $f"
+#            http_code=$(yq -o=json eval 'del(.type)' "$f" | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
+#            echo '' >> response.txt
+#            cat response.txt
+#            if [[ "$http_code" != "200" ]]; then
+#              echo "Unexpected response $http_code"
+#              exit 1
+#            fi
+#          done
+#
+#      - name: Validate Insights and Signals
+#        run: |
+#          for f in {insights,signals}/**/*.yml
+#          do
+#            echo "Processing $f"
+#            http_code=$(yq eval 'del(.type) | .source = "length([\n\n" + .source + "\n]) >= 0"' "$f" -o=json | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
+#            echo '' >> response.txt
+#            cat response.txt
+#            if [[ "$http_code" != "200" ]]; then
+#              echo "Unexpected response $http_code"
+#              exit 1
+#            fi
+#          done
 
-      - name: Validate Insights and Signals
-        run: |
-          for f in {insights,signals}/**/*.yml
-          do
-            echo "Processing $f"
-            http_code=$(yq eval 'del(.type) | .source = "length([\n\n" + .source + "\n]) >= 0"' "$f" -o=json | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
-            echo '' >> response.txt
-            cat response.txt
-            if [[ "$http_code" != "200" ]]; then
-              echo "Unexpected response $http_code"
-              exit 1
-            fi
-          done
-
-      - name: Verify no .yaml files exist
-        run: |
-          ! /bin/sh -c 'ls **/*.yaml'
-
-      - name: Commit & Push Results, if needed
-        run: |
-          rm response.txt
-          
-          if [ -z "$(git status --porcelain)" ]; then 
-            echo "No files changed, nothing to do"
-            exit 0
-          fi
-          
-          git config user.name 'ID Generator'
-          git config user.email 'hello@sublimesecurity.com'
-          git add **/*.yml
-          git commit -m "Auto add rule ID"
-          git push origin ${{ github.head_ref }}
+#      - name: Verify no .yaml files exist
+#        run: |
+#          ! /bin/sh -c 'ls **/*.yaml'
+#
+#      - name: Commit & Push Results, if needed
+#        run: |
+#          rm response.txt
+#
+#          if [ -z "$(git status --porcelain)" ]; then
+#            echo "No files changed, nothing to do"
+#            exit 0
+#          fi
+#
+#          git config user.name 'ID Generator'
+#          git config user.email 'hello@sublimesecurity.com'
+#          git add **/*.yml
+#          git commit -m "Auto add rule ID"
+#          git push origin ${{ github.head_ref }}
 
       - name: Get the head SHA
         id: get_head
@@ -100,14 +100,68 @@ jobs:
           files: "detection-rules/**"
           recover_deleted_files: true
 
+      - name: Get base ref
+        id: get_base_ref
+        run: |
+          if [ ${{ github.event_name }} == 'pull_request_target' ]; then
+            # Detect changes based on whatever we're merging into.
+            echo "##[set-output name=ref;]${{ github.base_ref }}"
+          elif [ ${{ github.event_name }} == 'push' ]; then
+            # Detect changes based on the previous commit
+            echo "##[set-output name=ref;]$(git rev-parse HEAD^)"
+          elif [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
+            # Run on a target, so run for all rules.
+            echo "##[set-output name=run_all;]true"
+          fi
+
+      - name: Checkout base
+        uses: actions/checkout@v4
+        if: ${{ steps.get_base_ref.outputs.run_all != 'true' }}
+        with:
+          ref: ${{ steps.get_base_ref.outputs.ref }}
+          repository: sublime-security/sublime-rules
+          depth: 0
+          path: sr-main
+
+      - name: Rename files in sr-main based on rule id
+        if: ${{ steps.get_base_ref.outputs.run_all != 'true' }}
+        run: |
+          cd sr-main/detection-rules
+
+          for file in *.yml
+          do
+            id=$(yq '.id' "$file")
+            mv "$file" "${id}.yml"
+          done
+
+
       - name: "Find updated rule IDs"
         id: find_ids
         run: |
-          for file in ${{ steps.changed-files.outputs.all_changed_and_modified_files }}; do
+          for file in detection-rules/*.yml; do
             echo "$file was changed"
             rule_id=$(yq '.id' $file)
           
+            if [ ${{ steps.get_base_ref.outputs.run_all != 'true' }} ]; then
+              altered_rule_ids=$(echo "$rule_id"" ""$altered_rule_ids")
+              continue
+            fi
+          
             echo "$file has rule ID $rule_id"
+            new_source=$(yq '.source' "$file")
+            old_source=$(yq '.source' "sr-main/detection-rules/$rule_id.yml" || echo '')
+            echo $old_source
+            
+            # We only need to care when rule source is changed. This will handle renames, tag changes, etc.
+            if [ "$new_source" != "$old_source" ]; then
+              echo "$file has altered source"
+              altered_rule_ids=$(echo "$rule_id"" ""$altered_rule_ids")
+            fi
+          done
+          
+          for file in ${{ steps.changed-files.outputs.deleted_files }}; do
+            rule_id=$(yq '.id' $file)
+            echo "$file has rule ID $rule_id and was deleted"
             altered_rule_ids=$(echo "$rule_id"" ""$altered_rule_ids")
           done
           

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -42,52 +42,52 @@ jobs:
           pip install -r scripts/generate-rule-ids/requirements.txt
           python scripts/generate-rule-ids/main.py
 
-#      - name: Validate Rules
-#        run: |
-#          for f in *-rules/*.yml
-#          do
-#            echo "Processing $f"
-#            http_code=$(yq -o=json eval 'del(.type)' "$f" | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
-#            echo '' >> response.txt
-#            cat response.txt
-#            if [[ "$http_code" != "200" ]]; then
-#              echo "Unexpected response $http_code"
-#              exit 1
-#            fi
-#          done
-#
-#      - name: Validate Insights and Signals
-#        run: |
-#          for f in {insights,signals}/**/*.yml
-#          do
-#            echo "Processing $f"
-#            http_code=$(yq eval 'del(.type) | .source = "length([\n\n" + .source + "\n]) >= 0"' "$f" -o=json | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
-#            echo '' >> response.txt
-#            cat response.txt
-#            if [[ "$http_code" != "200" ]]; then
-#              echo "Unexpected response $http_code"
-#              exit 1
-#            fi
-#          done
+      - name: Validate Rules
+        run: |
+          for f in *-rules/*.yml
+          do
+            echo "Processing $f"
+            http_code=$(yq -o=json eval 'del(.type)' "$f" | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
+            echo '' >> response.txt
+            cat response.txt
+            if [[ "$http_code" != "200" ]]; then
+              echo "Unexpected response $http_code"
+              exit 1
+            fi
+          done
 
-#      - name: Verify no .yaml files exist
-#        run: |
-#          ! /bin/sh -c 'ls **/*.yaml'
-#
-#      - name: Commit & Push Results, if needed
-#        run: |
-#          rm response.txt
-#
-#          if [ -z "$(git status --porcelain)" ]; then
-#            echo "No files changed, nothing to do"
-#            exit 0
-#          fi
-#
-#          git config user.name 'ID Generator'
-#          git config user.email 'hello@sublimesecurity.com'
-#          git add **/*.yml
-#          git commit -m "Auto add rule ID"
-#          git push origin ${{ github.head_ref }}
+      - name: Validate Insights and Signals
+        run: |
+          for f in {insights,signals}/**/*.yml
+          do
+            echo "Processing $f"
+            http_code=$(yq eval 'del(.type) | .source = "length([\n\n" + .source + "\n]) >= 0"' "$f" -o=json | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
+            echo '' >> response.txt
+            cat response.txt
+            if [[ "$http_code" != "200" ]]; then
+              echo "Unexpected response $http_code"
+              exit 1
+            fi
+          done
+
+      - name: Verify no .yaml files exist
+        run: |
+          ! /bin/sh -c 'ls **/*.yaml'
+
+      - name: Commit & Push Results, if needed
+        run: |
+          rm response.txt
+
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No files changed, nothing to do"
+            exit 0
+          fi
+
+          git config user.name 'ID Generator'
+          git config user.email 'hello@sublimesecurity.com'
+          git add **/*.yml
+          git commit -m "Auto add rule ID"
+          git push origin ${{ github.head_ref }}
 
       - name: Get the head SHA
         id: get_head

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -103,13 +103,13 @@ jobs:
       - name: Get base ref
         id: get_base_ref
         run: |
-          if [ ${{ github.event_name }} == 'pull_request_target' ]; then
+          if [[ "${{ github.event_name }}" == 'pull_request_target' ]]; then
             # Detect changes based on whatever we're merging into.
             echo "##[set-output name=ref;]${{ github.base_ref }}"
-          elif [ ${{ github.event_name }} == 'push' ]; then
+          elif [[ "${{ github.event_name }}" == 'push' ]]; then
             # Detect changes based on the previous commit
             echo "##[set-output name=ref;]$(git rev-parse HEAD^)"
-          elif [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
+          elif [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
             # Run on a target, so run for all rules.
             echo "##[set-output name=run_all;]true"
           fi
@@ -141,25 +141,24 @@ jobs:
           for file in detection-rules/*.yml; do
             rule_id=$(yq '.id' $file)
           
-            if [ ${{ steps.get_base_ref.outputs.run_all }} = 'true' ]; then
+            if [[ "${{ steps.get_base_ref.outputs.run_all }}" == "true" ]]; then
               altered_rule_ids=$(echo "$rule_id"" ""$altered_rule_ids")
               continue
             fi
           
-            echo "$file has rule ID $rule_id"
             new_source=$(yq '.source' "$file")
             old_source=$(yq '.source' "sr-main/detection-rules/$rule_id.yml" || echo '')
             
             # We only need to care when rule source is changed. This will handle renames, tag changes, etc.
-            if [ "$new_source" != "$old_source" ]; then
-              echo "$file has altered source"
+            if [[ "$new_source" != "$old_source" ]]; then
+              echo "$file ($rule_id) has altered source"
               altered_rule_ids=$(echo "$rule_id"" ""$altered_rule_ids")
             fi
           done
           
           for file in ${{ steps.changed-files.outputs.deleted_files }}; do
             rule_id=$(yq '.id' $file)
-            echo "$file has rule ID $rule_id and was deleted"
+            echo "$file ($rule_id) was deleted"
             altered_rule_ids=$(echo "$rule_id"" ""$altered_rule_ids")
           done
           

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -141,7 +141,7 @@ jobs:
           for file in detection-rules/*.yml; do
             rule_id=$(yq '.id' $file)
           
-            if [ ${{ steps.get_base_ref.outputs.run_all }} = 'true']; then
+            if [ ${{ steps.get_base_ref.outputs.run_all }} = 'true' ]; then
               altered_rule_ids=$(echo "$rule_id"" ""$altered_rule_ids")
               continue
             fi


### PR DESCRIPTION
Old logic didn't understand changes that weren't affecting rule logic, such as renames and tag changes. I moved further off of `tj-actions/changed-files` because I'm not sure how well it's handling `pull_request_target` events and it just generally is more obfuscated than what we're doing now -- mostly just comparing `source`. 