### PR TITLE
Update qr_code_suspicious_indicators.yml

### DIFF
--- a/detection-rules/qr_code_suspicious_indicators.yml
+++ b/detection-rules/qr_code_suspicious_indicators.yml
@@ -13,46 +13,49 @@ source: |
           and any(file.explode(.),
                   .scan.qr.type is not null
                   // exclude images taken with mobile cameras and screenshots from android
-                  and not any(.scan.exiftool.fields,
-                              .key == "Model" or .key == "Megapixels"
-                              or .key == "Software" and strings.starts_with(.value, "Android")
-                  )
+                  and length(filter(.scan.exiftool.fields,
+                                        .key == "Model"
+                                        or .key == "Megapixels"
+                                        or (
+                                          .key == "Software"
+                                          and strings.starts_with(.value, "Android")
+                                        )
+                                 )
+                  ) != length(attachments)
           )
       )
       or (
         length(attachments) == 0
-        and any(file.explode(beta.message_screenshot()), .scan.qr.type is not null)
+        and any(file.explode(beta.message_screenshot()),
+                .scan.qr.type is not null
+        )
       )
-    )
-    and (
-      any(recipients.to, strings.icontains(sender.display_name, .email.domain.sld))
-      or length(body.current_thread.text) is null
-      or body.current_thread.text == ""
-      or regex.contains(subject.subject,
-                        "(Authenticat(e|or|ion)|2fa|Multi.Factor|(qr|bar).code|action.require|alert|Att(n|ention):)"
-      )
-      or (any(recipients.to, strings.icontains(subject.subject, .display_name)))
-      or (
-        (length(recipients.to) == 0 or all(recipients.to, .display_name == "Undisclosed recipients"))
-        and length(recipients.cc) == 0
-        and length(recipients.bcc) == 0
-      )
-      or any(file.explode(beta.message_screenshot()), (.scan.qr.url.domain.tld in $suspicious_tlds))
-      or any(attachments,
-             .file_type in $file_types_images
-             and any(file.explode(.), .scan.qr.url.domain.tld in $suspicious_tlds)
-      )
-      or sender.email.domain.tld in $suspicious_tlds
     )
   )
-  
-  // sender profile is new or outlier
   and (
-    profile.by_sender().prevalence in ("new", "outlier")
-    or (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_false_positives
+    any(recipients.to, strings.icontains(sender.display_name, .email.domain.sld))
+    or length(body.current_thread.text) is null
+    or body.current_thread.text == ""
+    or regex.contains(subject.subject,
+                      "(Authenticat(e|or|ion)|2fa|Multi.Factor|(qr|bar).code|action.require|alert|Att(n|ention):)"
     )
+    or (any(recipients.to, strings.icontains(subject.subject, .display_name)))
+    or (
+      (
+        length(recipients.to) == 0
+        or all(recipients.to, .display_name == "Undisclosed recipients")
+      )
+      and length(recipients.cc) == 0
+      and length(recipients.bcc) == 0
+    )
+    or any(file.explode(beta.message_screenshot()),
+           (.scan.qr.url.domain.tld in $suspicious_tlds)
+    )
+    or any(attachments,
+           .file_type in $file_types_images
+           and any(file.explode(.), .scan.qr.url.domain.tld in $suspicious_tlds)
+    )
+    or sender.email.domain.tld in $suspicious_tlds
   )
   
   // negate highly trusted sender domains unless they fail DMARC authentication


### PR DESCRIPTION
The negations being made for mobile phones right now means that if a single image contains these keys, then to ignore the other images. 

This new update ensures that the negations need to be present in all images to be negated.