### PR TITLE
Update attachment_html_smuggling_atob.yml

### DIFF
--- a/detection-rules/attachment_html_smuggling_atob.yml
+++ b/detection-rules/attachment_html_smuggling_atob.yml
@@ -9,9 +9,10 @@ source: |
   type.inbound
   and any(attachments,
           (
-            .file_extension in~ ("html", "htm", "shtml", "dhtml")
+            .file_extension in~ ("html", "htm", "shtml", "dhtml", "eml")
             or .file_extension in~ $file_extensions_common_archives
             or .file_type == "html"
+            or .content_type == "message/rfc822"
           )
           and any(file.explode(.),
                   .scan.entropy.entropy >= 5


### PR DESCRIPTION
Adding EMLs to initial attachment logic to detect nested HTML attachments (attached EML with an HTML attachment).