### PR TITLE
Fix - free_file_hosts - Update Free File sharing links insight to user domain.domain or .domain.root_domain

### DIFF
--- a/insights/links/free_file_host.yml
+++ b/insights/links/free_file_host.yml
@@ -1,8 +1,8 @@
 name: "Free file sharing links"
 type: "query"
 source: |
-  distinct(map(filter(body.links, 
-               .href_url.domain.domain in $free_file_hosts), 
+  distinct(map(filter(body.links,
+               any(.href_url.domain.domain, .href_url.domain.root_domain], . in $free_file_hosts),
   .href_url.url), .)
 severity: "low"
 tags:

--- a/insights/links/free_file_host.yml
+++ b/insights/links/free_file_host.yml
@@ -1,9 +1,9 @@
 name: "Free file sharing links"
 type: "query"
 source: |
-  distinct(map(filter(body.links,
-               any([.href_url.domain.domain, .href_url.domain.root_domain], . in $free_file_hosts),
-  .href_url.url), .)
+  distinct(map(filter(body.links, 
+   .href_url.domain.root_domain in $free_file_hosts or .href_url.domain.domain in $free_file_hosts) .href_url.url)
+   )
 severity: "low"
 tags:
   - "Links"

--- a/insights/links/free_file_host.yml
+++ b/insights/links/free_file_host.yml
@@ -2,8 +2,7 @@ name: "Free file sharing links"
 type: "query"
 source: |
     distinct(map(filter(body.links, 
- .href_url.domain.root_domain in $free_file_hosts or .href_url.domain.domain in $free_file_hosts)
-    .href_url.url)
+        .href_url.domain.root_domain in $free_file_hosts or .href_url.domain.domain in $free_file_hosts), .href_url.url)
     )
 severity: "low"
 tags:

--- a/insights/links/free_file_host.yml
+++ b/insights/links/free_file_host.yml
@@ -1,9 +1,10 @@
 name: "Free file sharing links"
 type: "query"
 source: |
-  distinct(map(filter(body.links, 
-   .href_url.domain.root_domain in $free_file_hosts or .href_url.domain.domain in $free_file_hosts) .href_url.url)
-   )
+    distinct(map(filter(body.links, 
+ .href_url.domain.root_domain in $free_file_hosts or .href_url.domain.domain in $free_file_hosts)
+    .href_url.url)
+    )
 severity: "low"
 tags:
   - "Links"

--- a/insights/links/free_file_host.yml
+++ b/insights/links/free_file_host.yml
@@ -2,7 +2,7 @@ name: "Free file sharing links"
 type: "query"
 source: |
   distinct(map(filter(body.links,
-               any(.href_url.domain.domain, .href_url.domain.root_domain], . in $free_file_hosts),
+               any([.href_url.domain.domain, .href_url.domain.root_domain], . in $free_file_hosts),
   .href_url.url), .)
 severity: "low"
 tags:


### PR DESCRIPTION
![image](https://github.com/sublime-security/sublime-rules/assets/6809735/02d7a71b-f894-45a6-9724-6652fe1ffdc9)
Verified locally