### PR TITLE
Ross.html screenshot fixes

### DIFF
--- a/detection-rules/attachment_fake_slack_installer.yml
+++ b/detection-rules/attachment_fake_slack_installer.yml
@@ -12,36 +12,17 @@ source: |
           or .file_type == "html"
           or .content_type == "text/html"
         )
+        any(ml.logo_detect(file.html_screenshot(..)).brands,
+            .name == "Slack" and .confidence in ("medium", "high")
+        )
+        and any(ml.nlu_classifier(file.parse_html(..).display_text).entities,
+                .name == "request" and .text =~ "download"
+        )
         and any(file.explode(.),
-                any(ml.logo_detect(file.html_screenshot(..)).brands,
-                    .name == "Slack" and .confidence in ("medium", "high")
-                )
-                and any(ml.nlu_classifier(file.parse_html(..).display_text).entities,
-                        .name == "request" and .text =~ "download"
-                )
-                and any(.scan.url.urls,
-                        strings.iends_with(.path, ".exe") and .domain.root_domain not in $org_domains
+                any(.scan.url.urls,
+                    strings.iends_with(.path, ".exe") and .domain.root_domain not in $org_domains
                 )
         )
-    )
-    or any(attachments,
-           (.file_extension in~ $file_extensions_common_archives)
-           and any(file.explode(.),
-                   (
-                     .file_extension in~ ("html", "htm", "shtml", "dhtml")
-                     or ..file_type == "html"
-                     or ..content_type == "text/html"
-                   )
-                   and any(ml.logo_detect(file.html_screenshot(..)).brands,
-                           .name == "Slack" and .confidence in ("medium", "high")
-                   )
-                   and any(ml.nlu_classifier(file.parse_html(..).display_text).entities,
-                           .name == "request" and .text =~ "download"
-                   )
-                   and any(.scan.url.urls,
-                           strings.iends_with(.path, ".exe") and .domain.root_domain not in $org_domains
-                   )
-           )
     )
   )
 attack_types:

--- a/detection-rules/attachment_fake_zoom_installer.yml
+++ b/detection-rules/attachment_fake_zoom_installer.yml
@@ -12,37 +12,17 @@ source: |
           or .file_type == "html"
           or .content_type == "text/html"
         )
+        any(ml.logo_detect(file.html_screenshot(.)).brands,
+            .name == "Zoom" and .confidence in ("medium", "high")
+        )
+        and any(ml.nlu_classifier(file.parse_html(.).display_text).entities,
+                .name == "request" and .text =~ "download"
+        )
         and any(file.explode(.),
-                any(ml.logo_detect(file.html_screenshot(..)).brands,
-                    .name == "Zoom" and .confidence in ("medium", "high")
-                )
-                and any(ml.nlu_classifier(file.parse_html(..).display_text).entities,
-                        .name == "request" and .text =~ "download"
-                )
                 and any(.scan.url.urls,
                         strings.iends_with(.path, ".exe") and .domain.root_domain not in $org_domains
                 )
         )
-    )
-    or any(attachments,
-           (.file_extension in~ $file_extensions_common_archives)
-           and any(file.explode(.),
-                   (
-                     .file_extension in~ ("html", "htm", "shtml", "dhtml")
-                     or ..file_type == "html"
-                     or ..content_type == "text/html"
-                   )
-                   and any(ml.logo_detect(file.html_screenshot(..)).brands,
-                           .name == "Zoom" and .confidence in ("medium", "high")
-                   )
-                   and any(ml.nlu_classifier(file.parse_html(..).display_text).entities,
-                           .name == "request" and .text =~ "download"
-                   )
-                   and any(.scan.url.urls,
-                           strings.iends_with(.path, ".exe") and .domain.root_domain not in $org_domains
-                   )
-           )
-    )
   )
 attack_types:
   - "Malware/Ransomware"

--- a/detection-rules/attachment_fake_zoom_installer.yml
+++ b/detection-rules/attachment_fake_zoom_installer.yml
@@ -19,7 +19,7 @@ source: |
                 .name == "request" and .text =~ "download"
         )
         and any(file.explode(.),
-                and any(.scan.url.urls,
+                any(.scan.url.urls,
                         strings.iends_with(.path, ".exe") and .domain.root_domain not in $org_domains
                 )
         )


### PR DESCRIPTION
FYI @aidenmitchell.

I didn't look at any other rules to check for invalid usage of `..` inside `file.explode(.)`.
 Remember that `..` inside a `file.explode` is referring to the _attachment_, not the exploded file. In the archive case, the attachment is the archive file.