### PR TITLE
Add DHL Netherlands Domain

### DIFF
--- a/detection-rules/impersonation_dhl.yml
+++ b/detection-rules/impersonation_dhl.yml
@@ -24,7 +24,8 @@ source: |
     'dhl.de',
     'dhl.fr',
     'dhlending.com',
-    'inmotion.dhl'
+    'inmotion.dhl',
+    'dhlparcel.nl'
   )
   and (
     profile.by_sender().prevalence in ("new", "outlier")


### PR DESCRIPTION
The domain dhlparcel.nl is a legitimate DHL domain