### PR TITLE
Changes to Docusign rule to reduce false positives.

### DIFF
--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -34,10 +34,6 @@ source: |
       and not profile.by_sender().any_false_positives
     )
   )
-
-  //negate sender from Docusign
-  and not strings.like(sender.email.domain.root_domain, "docusign.com")
-
   // negate highly trusted sender domains unless they fail DMARC authentication
   and
   (

--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -34,6 +34,10 @@ source: |
       and not profile.by_sender().any_false_positives
     )
   )
+
+  //negate sender from Docusign
+  and not strings.like(sender.email.domain.root_domain, "docusign.com")
+
   // negate highly trusted sender domains unless they fail DMARC authentication
   and
   (

--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -5,7 +5,7 @@ severity: "high"
 source: |
   type.inbound
   and length(attachments) <= 1
-  and any(body.links,
+  and all(body.links,
           not strings.ilike(.href_url.domain.root_domain, "docusign.*")
   )
   and (

--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -5,6 +5,7 @@ severity: "high"
 source: |
   type.inbound
   and length(attachments) <= 1
+  and length(body.links) > 0
   and all(body.links,
           not strings.ilike(.href_url.domain.root_domain, "docusign.*")
   )


### PR DESCRIPTION
Hi,

This rule was causing false positives with docusign marketing emails. I suggest two changes. 

Check all the links for docusign domain instead of any:
```
and all(body.links,
          not strings.ilike(.href_url.domain.root_domain, "docusign.*")
  )
``` 

Check the sender is not Docusign itself:
```
and not strings.like(sender.email.domain.root_domain, "docusign.com")
```

Many thanks! 