### PR TITLE
Revert "Changes to Docusign rule to reduce false positives."

### DIFF
--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -5,8 +5,7 @@ severity: "high"
 source: |
   type.inbound
   and length(attachments) <= 1
-  and length(body.links) > 0
-  and all(body.links,
+  and any(body.links,
           not strings.ilike(.href_url.domain.root_domain, "docusign.*")
   )
   and (


### PR DESCRIPTION
Reverts sublime-security/sublime-rules#1083

Reverting the change, the inclusion of docusign.com to high trust senders mitigates the original issue. The "all" check on the docusign links is causing FN's when the docusign logo is being embedded from a docusign domain. 