### PR TITLE
Update link_credential_phishing_intent_and_other_indicators.yml

### DIFF
--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -232,7 +232,7 @@ source: |
                        "Information",
                        "Invoice",
                        '\bIT\b',
-                       "Legal",
+                       '\bLegal\b',
                        "Lottery",
                        "Management",
                        "Manager",


### PR DESCRIPTION
wrapping 'legal' in boundaries. Should probably consider doing this to all the single words in the list. 