### PR TITLE
Trigger via Comment + Always Post "Rule Tests and ID Updated" Check

### DIFF
--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -6,6 +6,8 @@ on:
   pull_request_target:
     branches: [ "**" ]
   workflow_dispatch: {}
+  issue_comment:
+    types: [ created ]
 
 concurrency:
   # For pull_request_target workflows we want to use head_ref -- the branch triggering the workflow. Otherwise,
@@ -20,13 +22,28 @@ jobs:
     permissions:
       contents: write
       checks: write
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request && contains(github.event.comment.body, '/mql-mimic-exempt')
 
     steps:
       - name: Set up yq
         uses: mikefarah/yq@v4.27.3
 
+      - name: Get PR branch
+        if: github.event_name == 'issue_comment'
+        uses: alessbell/pull-request-comment-branch@v1.1 # Fork of xt0rted/pull-request-comment-branch, see https://github.com/xt0rted/pull-request-comment-branch/issues/322
+        id: comment_branch
+
+      - name: Checkout (from comment)
+        uses: actions/checkout@v3
+        if: github.event_name == 'issue_comment'
+        with:
+          repository: ${{ steps.comment-branch.outputs.head_owner }}/${{ steps.comment-branch.outputs.head_repo }}
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          fetch-depth: 0
+
       - name: Checkout
         uses: actions/checkout@v4
+        if: github.event_name != 'issue_comment'
         with:
           ref: ${{ github.head_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -80,6 +97,7 @@ jobs:
           ! /bin/sh -c 'ls *.yml'
 
       - name: Commit & Push Results, if needed
+        id: final_basic_validation
         run: |
           rm response.txt
 
@@ -96,7 +114,44 @@ jobs:
 
       - name: Get the head SHA
         id: get_head
+        if: ${{ always() }}
         run: echo "##[set-output name=HEAD;]$(git rev-parse HEAD)"
+
+      # When we add a commit, GitHub won't trigger actions on the auto commit, so we're missing a required check on the
+      # HEAD commit.
+      # Various alternatives were explored, but all run into issues when dealing with forks. This sets a "Check" for
+      # the latest commit, and we can depend on that as a required check.
+      - name: "Create a check run"
+        uses: actions/github-script@v6
+        if: github.event_name == 'pull_request_target' && ${{ always() }}
+        env:
+          parameter_url: '${{ github.event.pull_request.html_url }}'
+          conclusion: "${{ steps.final_basic_validation.outcome == 'success' && 'success' || 'failure' }}"
+        with:
+          debug: ${{ secrets.ACTIONS_STEP_DEBUG || false }}
+          retries: 3
+          # Default includes 422 which GitHub returns when it doesn't know about the head_sha we set the status for.
+          # This occurs when the previous push succeeds, but the checks/pull request component of GitHub isn't yet aware
+          # of the new commit. This isn't the common case, but it comes up enough to be annoying.
+          retry-exempt-status-codes: 400, 401, 403, 404
+          script: |
+            // any JavaScript code can go here, you can use Node JS APIs too.
+            // Docs: https://docs.github.com/en/rest/checks/runs#create-a-check-run
+            // Rest: https://octokit.github.io/rest.js/v18#checks-create
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: "${{ steps.get_head.outputs.HEAD }}",
+              name: "Rule Tests and ID Updated",
+              status: "completed",
+              conclusion: process.env.conclusion,
+              details_url: process.env.parameter_url,
+              output: {
+                title: "Rule Tests and ID Updated",
+                summary: "Rule Tests and ID Updated",
+                text: "Rule Tests and ID Updated",
+              },
+            });
 
       - name: Get changed detection-rules
         id: changed-files
@@ -117,6 +172,8 @@ jobs:
           elif [[ "${{ github.event_name }}" == 'workflow_dispatch' ]]; then
             # Run on a target, so run for all rules.
             echo "##[set-output name=run_all;]true"
+          elif [[ "${{ github.event_name }}" == 'issue_comment' ]]; then
+            echo "##[set-output name=ref;]${{ steps.comment-branch.outputs.base_ref }}"
           fi
 
       - name: Checkout base
@@ -187,41 +244,6 @@ jobs:
           curl -X POST $trigger_url  \
             -H 'Content-Type: application/json' \
             -d "$body"
-
-      # When we add a commit, GitHub won't trigger actions on the auto commit, so we're missing a required check on the
-      # HEAD commit.
-      # Various alternatives were explored, but all run into issues when dealing with forks. This sets a "Check" for
-      # the latest commit, and we can depend on that as a required check.
-      - name: "Create a check run"
-        uses: actions/github-script@v6
-        if: github.event_name == 'pull_request_target'
-        env:
-          parameter_url: '${{ github.event.pull_request.html_url }}'
-        with:
-          debug: ${{ secrets.ACTIONS_STEP_DEBUG || false }}
-          retries: 3
-          # Default includes 422 which GitHub returns when it doesn't know about the head_sha we set the status for.
-          # This occurs when the previous push succeeds, but the checks/pull request component of GitHub isn't yet aware
-          # of the new commit. This isn't the common case, but it comes up enough to be annoying.
-          retry-exempt-status-codes: 400, 401, 403, 404
-          script: |
-            // any JavaScript code can go here, you can use Node JS APIs too.
-            // Docs: https://docs.github.com/en/rest/checks/runs#create-a-check-run
-            // Rest: https://octokit.github.io/rest.js/v18#checks-create
-            await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              head_sha: "${{ steps.get_head.outputs.HEAD }}",
-              name: "Rule Tests and ID Updated",
-              status: "completed",
-              conclusion: "success",
-              details_url: process.env.parameter_url,
-              output: {
-                title: "Rule Tests and ID Updated",
-                summary: "Rule Tests and ID Updated",
-                text: "Rule Tests and ID Updated",
-              },
-            });
 
       - name: Wait for MQL Mimic check to be completed
         uses: fountainhead/action-wait-for-check@v1.1.0


### PR DESCRIPTION
First step for adding the ability to comment to accept certain MQL Mimic failures. I have to basically develop on `main` because workflows triggered by comments only run for actions defined on `main`. If this gets too painful I can test on a scratch repo though.

Also this change moves the `Rule Tests and ID Updated` check up to earlier & it'll always post a status. This just means that PRs that fail early non-mimic validations will show this check with a red X instead of being pending.