### PR TITLE
Two Follow Ups: Expand Permissions + Hopefully fix check logic

### DIFF
--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -2,7 +2,7 @@ name: Rules PR CI
 
 on:
   push:
-    branches: [ "main", "test-rules", "cd.test-comment" ]
+    branches: [ "main", "test-rules" ]
   pull_request_target:
     branches: [ "**" ]
   workflow_dispatch: {}

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-20.04
     permissions:
       contents: write
+      issues: read
+      pull-requests: read
       checks: write
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request && contains(github.event.comment.body, '/mql-mimic-exempt')
 

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -2,7 +2,7 @@ name: Rules PR CI
 
 on:
   push:
-    branches: [ "main", "test-rules" ]
+    branches: [ "main", "test-rules", "cd.test-comment" ]
   pull_request_target:
     branches: [ "**" ]
   workflow_dispatch: {}
@@ -125,7 +125,7 @@ jobs:
       # the latest commit, and we can depend on that as a required check.
       - name: "Create a check run"
         uses: actions/github-script@v6
-        if: github.event_name == 'pull_request_target' && ${{ always() }}
+        if: github.event_name == 'pull_request_target' && always()
         env:
           parameter_url: '${{ github.event.pull_request.html_url }}'
           conclusion: "${{ steps.final_basic_validation.outcome == 'success' && 'success' || 'failure' }}"

--- a/detection-rules/attachment_adobe_image_lure_qr_code.yml
+++ b/detection-rules/attachment_adobe_image_lure_qr_code.yml
@@ -16,6 +16,7 @@ source: |
             )
           )
   )
+  
   and any(attachments,
           (
             .file_type in $file_types_images

--- a/detection-rules/attachment_adobe_image_lure_qr_code.yml
+++ b/detection-rules/attachment_adobe_image_lure_qr_code.yml
@@ -16,7 +16,6 @@ source: |
             )
           )
   )
-  
   and any(attachments,
           (
             .file_type in $file_types_images


### PR DESCRIPTION
Two follow ups from https://github.com/sublime-security/sublime-rules/pull/1195

1. Expand workflow permissions (needed to read comments)
2. CI failed on `main` because we tried to post the "Rule Tests and ID Updated" check (we shouldn't)