### PR TITLE
Collect mql-mimic-exempt Comments & Sent to MQL Mimic

### DIFF
--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -61,33 +61,33 @@ jobs:
           pip install -r scripts/generate-rule-ids/requirements.txt
           python scripts/generate-rule-ids/main.py
 
-#      - name: Validate Rules
-#        run: |
-#          for f in *-rules/*.yml
-#          do
-#            echo "Processing $f"
-#            http_code=$(yq -o=json eval 'del(.type)' "$f" | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
-#            echo '' >> response.txt
-#            cat response.txt
-#            if [[ "$http_code" != "200" ]]; then
-#              echo "Unexpected response $http_code"
-#              exit 1
-#            fi
-#          done
-#
-#      - name: Validate Insights and Signals
-#        run: |
-#          for f in {insights,signals}/**/*.yml
-#          do
-#            echo "Processing $f"
-#            http_code=$(yq eval 'del(.type) | .source = "length([\n\n" + .source + "\n]) >= 0"' "$f" -o=json | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
-#            echo '' >> response.txt
-#            cat response.txt
-#            if [[ "$http_code" != "200" ]]; then
-#              echo "Unexpected response $http_code"
-#              exit 1
-#            fi
-#          done
+      - name: Validate Rules
+        run: |
+          for f in *-rules/*.yml
+          do
+            echo "Processing $f"
+            http_code=$(yq -o=json eval 'del(.type)' "$f" | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
+            echo '' >> response.txt
+            cat response.txt
+            if [[ "$http_code" != "200" ]]; then
+              echo "Unexpected response $http_code"
+              exit 1
+            fi
+          done
+
+      - name: Validate Insights and Signals
+        run: |
+          for f in {insights,signals}/**/*.yml
+          do
+            echo "Processing $f"
+            http_code=$(yq eval 'del(.type) | .source = "length([\n\n" + .source + "\n]) >= 0"' "$f" -o=json | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
+            echo '' >> response.txt
+            cat response.txt
+            if [[ "$http_code" != "200" ]]; then
+              echo "Unexpected response $http_code"
+              exit 1
+            fi
+          done
 
       - name: Verify no .yaml files exist
         run: |
@@ -101,7 +101,7 @@ jobs:
       - name: Commit & Push Results, if needed
         id: final_basic_validation
         run: |
-          #rm response.txt
+          rm response.txt
 
           if [ -z "$(git status --porcelain)" ]; then
             echo "No files changed, nothing to do"

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -292,6 +292,7 @@ jobs:
             }
             
             console.log("All EMLs: " + JSON.stringify(allEMLsToSkip))
+            # MQL Mimic will handle duplicates gracefully, no need to handle here.
             return allEMLsToSkip.join(" ")
 
 
@@ -305,7 +306,6 @@ jobs:
           only_rule_ids: '${{ steps.find_ids.outputs.rule_ids }}'
           skip_eml_ids: '${{ steps.find_emls_to_skip.outputs.result }}'
         run: |
-          echo "[$skip_eml_ids]"
           body='{"branch":"'$branch'","repo":"'$repo'","token":"'$token'","sha":"'$sha'","only_rule_ids":"'$only_rule_ids'","skip_eml_ids":"'$skip_eml_ids'"}'
           echo $body
           

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -265,7 +265,7 @@ jobs:
                 console.log("Ignoring comment from non-member" + comment.user.login)
               }
 
-              while ((m = regex.exec(str)) !== null) {
+              while ((m = regex.exec(comment)) !== null) {
                 // This is necessary to avoid infinite loops with zero-width matches
                 if (m.index === regex.lastIndex) {
                   regex.lastIndex++;

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -269,9 +269,8 @@ jobs:
               }
 
               while ((m = exemptRegex.exec(comment.body)) !== null) {
-                // This is necessary to avoid infinite loops with zero-width matches
-                if (m.index === regex.lastIndex) {
-                  regex.lastIndex++;
+                if (m.index === exemptRegex.lastIndex) {
+                  break
                 }
                   
                 // The result can be accessed through the `m`-variable.

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -257,14 +257,25 @@ jobs:
               issue_number: "${{ steps.find_pr_number.outputs.result }}",
             })
             const comments = await github.paginate(opts)
-                    
-            console.log(JSON.stringify(comments))
+            
+            const regex = /\/mql-mimic-exempt(?:[\s:,;\/]+\d+)+/gis
+
             for (const comment of comments) {
               if (comment.author_association !== "MEMBER") {
-                console.log("Ignoring comment from " + comment.user.login)
+                console.log("Ignoring comment from non-member" + comment.user.login)
               }
 
-              console.log("Body: " + comment.body)
+              while ((m = regex.exec(str)) !== null) {
+                // This is necessary to avoid infinite loops with zero-width matches
+                if (m.index === regex.lastIndex) {
+                  regex.lastIndex++;
+                }
+                  
+                // The result can be accessed through the `m`-variable.
+                m.forEach((match, groupIndex) => {
+                  console.log(`Found match, group ${groupIndex}: ${match}`);
+                });
+              }
             }
             
             

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -236,9 +236,9 @@ jobs:
         id: find_pr_number
         run:
           if [[ "${{ github.event_name }}" == 'pull_request_target' ]]; then
-            result=${{ github.event.number }}
+            result="${{ github.event.number }}"
           elif [[ "${{ github.event_name }}" == 'issue_comment' ]]; then
-            result=${{ github.event.issue.number }}
+            result="${{ github.event.issue.number }}"
           fi
 
           echo "PR $result"

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -258,7 +258,7 @@ jobs:
             })
             const comments = await github.paginate(opts)
             
-            const regex = /\/mql-mimic-exempt((?:[\s:,;\/]+\d+)+)/gis
+            const regex = /\/mql-mimic-exempt((?:[\s:,;\/]+#*\d+)+)/gis
 
             for (const comment of comments) {
               if (comment.author_association !== "MEMBER") {

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -247,6 +247,7 @@ jobs:
 
       - name: "Find mql-mimic-exempt Comments"
         uses: actions/github-script@v6
+        id: find_emls_to_skip
         if: steps.find_pr_number.outputs.result != ''
         with:
           debug: ${{ secrets.ACTIONS_STEP_DEBUG || false }}
@@ -258,14 +259,16 @@ jobs:
             })
             const comments = await github.paginate(opts)
             
-            const regex = /\/mql-mimic-exempt((?:[\s:,;\/]+#*\d+)+)/gis
+            const seperatorRegex = /[\s:,;\/]*/
+            const exemptRegex = /\/mql-mimic-exempt((?:[\s:,;\/]+#*\d+)+)/gis
 
+            let allEMLsToSkip = []
             for (const comment of comments) {
               if (comment.author_association !== "MEMBER") {
                 console.log("Ignoring comment from non-member" + comment.user.login)
               }
 
-              while ((m = regex.exec(comment.body)) !== null) {
+              while ((m = exemptRegex.exec(comment.body)) !== null) {
                 // This is necessary to avoid infinite loops with zero-width matches
                 if (m.index === regex.lastIndex) {
                   regex.lastIndex++;
@@ -273,12 +276,24 @@ jobs:
                   
                 // The result can be accessed through the `m`-variable.
                 m.forEach((match, groupIndex) => {
-                  console.log(`Found match, group ${groupIndex}: ${match}`);
+                  if (groupIndex != 1) {
+                    return
+                  }
+            
+                  console.log("Found MQL Mimic Exemption EMLs: " + match)
+                  
+                  // First cut out all (optional) #
+                  match = match.replaceAll("#", "")
+                  let emls = match.split(seperatorRegex)
+                  console.log("Split EMLs: " + JSON.stringify(match))
+                  allEMLsToSkip = allEMLsToSkip.concat(emls)
                 });
               }
             }
             
-            
+            console.log("All EMLs: " + JSON.stringify(allEMLsToSkip))
+            return allEMLsToSkip.join(" ")
+
 
       - name: "Trigger MQL Mimic Tests"
         env:
@@ -288,8 +303,9 @@ jobs:
           token: '${{ secrets.GITHUB_TOKEN }}'
           sha: '${{ steps.get_head.outputs.HEAD }}'
           only_rule_ids: '${{ steps.find_ids.outputs.rule_ids }}'
+          skip_eml_ids: '${{ steps.find_emls_to_skip.outputs.result }}'
         run: |
-          body='{"branch":"'$branch'","repo":"'$repo'","token":"'$token'","sha":"'$sha'","only_rule_ids":"'$only_rule_ids'"}'
+          body='{"branch":"'$branch'","repo":"'$repo'","token":"'$token'","sha":"'$sha'","only_rule_ids":"'$only_rule_ids'","skip_eml_ids":"'$skip_eml_ids'"}'
           echo $body
           
           curl -X POST $trigger_url  \

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -252,13 +252,13 @@ jobs:
           debug: ${{ secrets.ACTIONS_STEP_DEBUG || false }}
           script: |
             // https://octokit.github.io/rest.js/v18#checks-create
-            let comments = await github.rest.issues.listComments({
+            let response = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: "${{ steps.find_pr_number.outputs.result }}",
             });
             
-            for (let c in comments) {
+            for (let c in response["data"]) {
               console.log(c)
             }
             

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -251,14 +251,31 @@ jobs:
         with:
           debug: ${{ secrets.ACTIONS_STEP_DEBUG || false }}
           script: |
-            // https://octokit.github.io/rest.js/v18#checks-create
-            let response = await github.rest.issues.listComments({
+#            // https://octokit.github.io/rest.js/v18#checks-create
+#            let response = await github.rest.issues.listComments({
+#              owner: context.repo.owner,
+#              repo: context.repo.repo,
+#              issue_number: "${{ steps.find_pr_number.outputs.result }}",
+#            });
+#
+#            console.log(JSON.stringify(response))
+
+            const opts = github.rest.issues.listComments.endpoint.merge({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: "${{ steps.find_pr_number.outputs.result }}",
-            });
+            })
+            const comments = await github.paginate(opts)
+                    
+            console.log(JSON.stringify(comments))
+            for (const comment of comments) {
+              if (comment.author_association !== "MEMBER") {
+                console.log("Ignoring comment from " + comment.user.login)
+              }
+
+              console.log("Body: " + comment.body)
+            }
             
-            console.log(JSON.stringify(response))
             
 
       - name: "Trigger MQL Mimic Tests"

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -285,7 +285,7 @@ jobs:
                   match = match.replaceAll("#", "")
                   let emls = match.split(seperatorRegex)
                   console.log("Split EMLs: " + JSON.stringify(emls))
-                  allEMLsToSkip = allEMLsToSkip.concat(emls)
+                  allEMLsToSkip = allEMLsToSkip.concat(emls.filter((s) => s !== ""))
                 });
               }
             }

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -251,15 +251,6 @@ jobs:
         with:
           debug: ${{ secrets.ACTIONS_STEP_DEBUG || false }}
           script: |
-#            // https://octokit.github.io/rest.js/v18#checks-create
-#            let response = await github.rest.issues.listComments({
-#              owner: context.repo.owner,
-#              repo: context.repo.repo,
-#              issue_number: "${{ steps.find_pr_number.outputs.result }}",
-#            });
-#
-#            console.log(JSON.stringify(response))
-
             const opts = github.rest.issues.listComments.endpoint.merge({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -236,9 +236,9 @@ jobs:
         id: find_pr_number
         run:
           if [[ "${{ github.event_name }}" == 'pull_request_target' ]]; then
-            result=${{ github.event.number }}"
+            result=${{ github.event.number }}
           elif [[ "${{ github.event_name }}" == 'issue_comment' ]]; then
-            result=${{ github.event.issue.number }}"
+            result=${{ github.event.issue.number }}
           fi
 
           echo "PR $result"

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -265,7 +265,7 @@ jobs:
                 console.log("Ignoring comment from non-member" + comment.user.login)
               }
 
-              while ((m = regex.exec(comment)) !== null) {
+              while ((m = regex.exec(comment.body)) !== null) {
                 // This is necessary to avoid infinite loops with zero-width matches
                 if (m.index === regex.lastIndex) {
                   regex.lastIndex++;

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -292,7 +292,7 @@ jobs:
             }
             
             console.log("All EMLs: " + JSON.stringify(allEMLsToSkip))
-            # MQL Mimic will handle duplicates gracefully, no need to handle here.
+            // MQL Mimic will handle duplicates gracefully, no need to handle here.
             return allEMLsToSkip.join(" ")
 
 

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -39,8 +39,8 @@ jobs:
         uses: actions/checkout@v3
         if: github.event_name == 'issue_comment'
         with:
-          repository: ${{ steps.comment-branch.outputs.head_owner }}/${{ steps.comment-branch.outputs.head_repo }}
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          repository: ${{ steps.comment_branch.outputs.head_owner }}/${{ steps.comment_branch.outputs.head_repo }}
+          ref: ${{ steps.comment_branch.outputs.head_ref }}
           fetch-depth: 0
 
       - name: Checkout
@@ -175,7 +175,7 @@ jobs:
             # Run on a target, so run for all rules.
             echo "##[set-output name=run_all;]true"
           elif [[ "${{ github.event_name }}" == 'issue_comment' ]]; then
-            echo "##[set-output name=ref;]${{ steps.comment-branch.outputs.base_ref }}"
+            echo "##[set-output name=ref;]${{ steps.comment_branch.outputs.base_ref }}"
           fi
 
       - name: Checkout base

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -251,6 +251,7 @@ jobs:
         if: steps.find_pr_number.outputs.result != ''
         with:
           debug: ${{ secrets.ACTIONS_STEP_DEBUG || false }}
+          result-encoding: string
           script: |
             const opts = github.rest.issues.listComments.endpoint.merge({
               owner: context.repo.owner,
@@ -304,6 +305,7 @@ jobs:
           only_rule_ids: '${{ steps.find_ids.outputs.rule_ids }}'
           skip_eml_ids: '${{ steps.find_emls_to_skip.outputs.result }}'
         run: |
+          echo "[$skip_eml_ids]"
           body='{"branch":"'$branch'","repo":"'$repo'","token":"'$token'","sha":"'$sha'","only_rule_ids":"'$only_rule_ids'","skip_eml_ids":"'$skip_eml_ids'"}'
           echo $body
           

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -234,7 +234,7 @@ jobs:
       - name: Get PR Number
         if: github.event_name == 'pull_request_target' || github.event_name == 'issue_comment'
         id: find_pr_number
-        run:
+        run: |
           if [[ "${{ github.event_name }}" == 'pull_request_target' ]]; then
             result="${{ github.event.number }}"
           elif [[ "${{ github.event_name }}" == 'issue_comment' ]]; then

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Commit & Push Results, if needed
         id: final_basic_validation
         run: |
-          rm response.txt
+          #rm response.txt
 
           if [ -z "$(git status --porcelain)" ]; then
             echo "No files changed, nothing to do"

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -258,9 +258,7 @@ jobs:
               issue_number: "${{ steps.find_pr_number.outputs.result }}",
             });
             
-            for (let c in response["data"]) {
-              console.log(c)
-            }
+            console.log(JSON.stringify(response))
             
 
       - name: "Trigger MQL Mimic Tests"

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -259,7 +259,7 @@ jobs:
             })
             const comments = await github.paginate(opts)
             
-            const seperatorRegex = /[\s:,;\/]*/
+            const seperatorRegex = /[\s:,;\/]+/
             const exemptRegex = /\/mql-mimic-exempt((?:[\s:,;\/]+#*\d+)+)/gis
 
             let allEMLsToSkip = []
@@ -284,7 +284,7 @@ jobs:
                   // First cut out all (optional) #
                   match = match.replaceAll("#", "")
                   let emls = match.split(seperatorRegex)
-                  console.log("Split EMLs: " + JSON.stringify(match))
+                  console.log("Split EMLs: " + JSON.stringify(emls))
                   allEMLsToSkip = allEMLsToSkip.concat(emls)
                 });
               }

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -258,7 +258,7 @@ jobs:
             })
             const comments = await github.paginate(opts)
             
-            const regex = /\/mql-mimic-exempt(?:[\s:,;\/]+\d+)+/gis
+            const regex = /\/mql-mimic-exempt((?:[\s:,;\/]+\d+)+)/gis
 
             for (const comment of comments) {
               if (comment.author_association !== "MEMBER") {

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -61,33 +61,33 @@ jobs:
           pip install -r scripts/generate-rule-ids/requirements.txt
           python scripts/generate-rule-ids/main.py
 
-      - name: Validate Rules
-        run: |
-          for f in *-rules/*.yml
-          do
-            echo "Processing $f"
-            http_code=$(yq -o=json eval 'del(.type)' "$f" | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
-            echo '' >> response.txt
-            cat response.txt
-            if [[ "$http_code" != "200" ]]; then
-              echo "Unexpected response $http_code"
-              exit 1
-            fi
-          done
-
-      - name: Validate Insights and Signals
-        run: |
-          for f in {insights,signals}/**/*.yml
-          do
-            echo "Processing $f"
-            http_code=$(yq eval 'del(.type) | .source = "length([\n\n" + .source + "\n]) >= 0"' "$f" -o=json | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
-            echo '' >> response.txt
-            cat response.txt
-            if [[ "$http_code" != "200" ]]; then
-              echo "Unexpected response $http_code"
-              exit 1
-            fi
-          done
+#      - name: Validate Rules
+#        run: |
+#          for f in *-rules/*.yml
+#          do
+#            echo "Processing $f"
+#            http_code=$(yq -o=json eval 'del(.type)' "$f" | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
+#            echo '' >> response.txt
+#            cat response.txt
+#            if [[ "$http_code" != "200" ]]; then
+#              echo "Unexpected response $http_code"
+#              exit 1
+#            fi
+#          done
+#
+#      - name: Validate Insights and Signals
+#        run: |
+#          for f in {insights,signals}/**/*.yml
+#          do
+#            echo "Processing $f"
+#            http_code=$(yq eval 'del(.type) | .source = "length([\n\n" + .source + "\n]) >= 0"' "$f" -o=json | curl -H "Content-Type: application/json" -X POST --data-binary @- -o response.txt -w "%{http_code}" --silent https://playground.sublimesecurity.com/v1/rules/validate)
+#            echo '' >> response.txt
+#            cat response.txt
+#            if [[ "$http_code" != "200" ]]; then
+#              echo "Unexpected response $http_code"
+#              exit 1
+#            fi
+#          done
 
       - name: Verify no .yaml files exist
         run: |
@@ -230,6 +230,38 @@ jobs:
           echo "##[set-output name=rule_ids;]$(echo $altered_rule_ids)"
           # TODO: This doesn't solve for a modified rule_id. We could merge with any files known on 'main', but changing
           # a rule ID is a separate problem.
+
+      - name: Get PR Number
+        if: github.event_name == 'pull_request_target' || github.event_name == 'issue_comment'
+        id: find_pr_number
+        run:
+          if [[ "${{ github.event_name }}" == 'pull_request_target' ]]; then
+            result=${{ github.event.number }}"
+          elif [[ "${{ github.event_name }}" == 'issue_comment' ]]; then
+            result=${{ github.event.issue.number }}"
+          fi
+
+          echo "PR $result"
+          echo "##[set-output name=result;]$result"
+
+
+      - name: "Find mql-mimic-exempt Comments"
+        uses: actions/github-script@v6
+        if: steps.find_pr_number.outputs.result != ''
+        with:
+          debug: ${{ secrets.ACTIONS_STEP_DEBUG || false }}
+          script: |
+            // https://octokit.github.io/rest.js/v18#checks-create
+            let comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: "${{ steps.find_pr_number.outputs.result }}",
+            });
+            
+            for (let c in comments) {
+              console.log(c)
+            }
+            
 
       - name: "Trigger MQL Mimic Tests"
         env:

--- a/.github/workflows/update-test-rules.yml
+++ b/.github/workflows/update-test-rules.yml
@@ -45,12 +45,12 @@ jobs:
 
       - name: Get PR branch
         uses: alessbell/pull-request-comment-branch@v1.1 # Fork of xt0rted/pull-request-comment-branch, see https://github.com/xt0rted/pull-request-comment-branch/issues/322
-        id: comment-branch
+        id: comment_branch
 
       - name: Wait for Rule Validation Succeed
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
-          ref: ${{ steps.comment-branch.outputs.head_sha }}
+          ref: ${{ steps.comment_branch.outputs.head_sha }}
           check-name: 'Rule Tests and ID Updated'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10
@@ -70,13 +70,13 @@ jobs:
     steps:
       - name: Get PR branch
         uses: alessbell/pull-request-comment-branch@v1.1 # Fork of xt0rted/pull-request-comment-branch, see https://github.com/xt0rted/pull-request-comment-branch/issues/322
-        id: comment-branch
+        id: comment_branch
 
       - name: Checkout PR branch
         uses: actions/checkout@v3
         with:
           repository: ${{ steps.comment-branch.outputs.head_owner }}/${{ steps.comment-branch.outputs.head_repo }}
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          ref: ${{ steps.comment_branch.outputs.head_ref }}
           fetch-depth: 0
           path: source
 
@@ -117,7 +117,7 @@ jobs:
           
           # Used to testing_sha key in the rule. If the PR is updated multiple times without changing all files, we'll
           # always use the latest sha.
-          export sha=${{ steps.comment-branch.outputs.head_sha }}
+          export sha=${{ steps.comment_branch.outputs.head_sha }}
           
           # Copy any file that was added/changed/modified to the destination git folder (we could do this with git checkout
           # but it doesn't seem any simpler). And then add testing metadata.

--- a/detection-rules/attachment_adobe_image_lure_qr_code.yml
+++ b/detection-rules/attachment_adobe_image_lure_qr_code.yml
@@ -22,6 +22,7 @@ source: |
             or .file_type == "pdf"
             or .file_type in $file_extensions_macros
           )
+  
           and (
             any(file.explode(.),
                 regex.icontains(.scan.ocr.raw, 'scan|camera')

--- a/detection-rules/attachment_adobe_image_lure_qr_code.yml
+++ b/detection-rules/attachment_adobe_image_lure_qr_code.yml
@@ -22,7 +22,6 @@ source: |
             or .file_type == "pdf"
             or .file_type in $file_extensions_macros
           )
-  
           and (
             any(file.explode(.),
                 regex.icontains(.scan.ocr.raw, 'scan|camera')


### PR DESCRIPTION
With some luck, this will be the last change on the `sublime-rules` side to support a system where we can make exceptions to MQL Mimic by commenting:

```
/mql-mimic-exempt: 12234, 556
```

That would cause 12234 & 556 to be skipped in the test suite. This will allow bypassing when the team decides that a apparent regression is actually a good thing, e.g. the EML shouldn't have matched the rule in the first place.

The behavior is that:
1. Whenever a commit is pushed to a PR, or a comment with `/mql-mimic-exempt` is added by an org member, the test suite will be re-triggered and should update the existing checks.
    * Updating of the existing checks isn't tested yet, but I think it will work (I can't test till earlier issues are resolved on `main`)
2. All comments on the PR are inspected for `/mql-mimic-exempt`, and any numbers that appear on the same line are considered.
    * To be clear, this means that the comments accumulate rather than overwrite.
    * The syntax is pretty flexible, e.g. all of these are allowed:
        * `/mql-mimic-exempt     :123;456`
        * `/mql-mimic-exempt: 123 456`
        * `/mql-mimic-exempt: 123,#456`
        * `/mql-mimic-exempt 123/456`
        * etc.. `#` is ignored, `,`, `;`, `:`, `/` and any whitespace are allowed as separators

**Downstream support in MQL Mimic has not been added yet!** It's mostly done, but not merged.

Tested via https://github.com/sublime-security/sublime-rules/pull/1202, resulting trigger request body is `{"branch":"cd.test-2","repo":"sublime-security/sublime-rules","token":"***","sha":"de8c38262ed8cda7c55a087c9d0e802f7d462458","only_rule_ids":"2fc36c6d-86a2-5b12-b5a4-5d8744858381","skip_eml_ids":"123 456 789 123 456 789 444"}` which is correct for the comments I've put on that PR.