### PR TITLE
Update body_microsoft_logo_open_redirect.yml

### DIFF
--- a/detection-rules/body_microsoft_logo_open_redirect.yml
+++ b/detection-rules/body_microsoft_logo_open_redirect.yml
@@ -1,6 +1,6 @@
 name: "Body: Microsoft logo or Suspicious Language and an open redirect"
 description: |
-  Email contains a Microsoft logo or suspicious terms and use of the Bing open redirect. This has been exploited in the wild to impersonate Microsoft.
+  Email contains a Microsoft logo or suspicious terms and use of an open redirect. This has been exploited in the wild to impersonate Microsoft.
 type: "rule"
 severity: "high"
 source: |
@@ -46,6 +46,7 @@ source: |
   // open redirect
   and any(body.links,
           any(.href_url.rewrite.encoders, strings.icontains(., "open_redirect"))
+          and not .href_url.domain.root_domain in $org_domains
   )
   and sender.email.domain.root_domain not in $org_domains
   and sender.email.domain.root_domain not in (


### PR DESCRIPTION
FP mitigation. Adding exclusion that the open_redirect is not routing to an $org_domain. This has been observed in some organizations to be used during the recruiting/hiring process.