### PR TITLE
Update link_microsoft_impersonation_using_hosted_png.yml

### DIFF
--- a/detection-rules/link_microsoft_impersonation_using_hosted_png.yml
+++ b/detection-rules/link_microsoft_impersonation_using_hosted_png.yml
@@ -14,7 +14,7 @@ source: |
   and sender.email.domain.root_domain not in~ ('microsoft.com', 'microsoftsupport.com', 'office.com')
 
   // logo hosted on microsoft.com
-  and any(body.links,
+  **and any(body.links,
           regex.icontains(.display_url.url, '.{0,50}microsoft\.com\/.{0,70}logo.{0,25}\.png')
   )
 


### PR DESCRIPTION
Hello Team,

First of all, I would like to thank you for this project, which I have admired.

In the part of the rule that I marked with an asterisk, is the goal to detect a logo image embedded in the HTML mail content with an img tag? If so, I guess the URL referenced in the src attribute of the img tag is not included in the 'link' array. The best solution at this point would be to pass the output of the function that takes a screenshot of the message to the ml.logo_detection function. I've noticed in some other rules that only attachment images are subject to some detection; I think it might be a good practice to include images embedded in the message with the img tag in the HTML content in the detection rule, by subjecting the message screenshot to the same procedure. Actually, more generally, it would be great to design a function that outputs the raw HTML value parse with beautifulsoup.