### PR TITLE
Update recon_recipients_bccd_undisclosed.yml

### DIFF
--- a/detection-rules/recon_recipients_bccd_undisclosed.yml
+++ b/detection-rules/recon_recipients_bccd_undisclosed.yml
@@ -9,16 +9,35 @@ source: |
   type.inbound
   and (
     length(recipients.bcc) > 0
-    or any(recipients.to, .display_name == "undisclosed-recipients")
+    or any(recipients.to, strings.ilike(.display_name, "undisclosed?recipients"))
   )
   and length(subject.subject) <= 10
-  and length(body.links) == 0
   and length(attachments) == 0
-  and (body.current_thread.text is null or length(body.current_thread.text) < 50)
+  // and there are no links. Or all the links are to aka.ms or an extraction from a warning banner that match the senders domain
+  and (
+    length(body.links) == 0
+    or length(filter(body.links,
+                     (
+                       .display_text is null
+                       and .display_url.url == sender.email.domain.root_domain
+                     )
+                     or .href_url.domain.domain == "aka.ms"
+              )
+    ) == length(body.links)
+  )
+  and (
+    body.current_thread.text is null
+    or length(body.current_thread.text) < 50
+    or (
+      length(body.current_thread.text) < 900
+      // or body is most likely all warning banner ending with a generic greeting
+      and regex.imatch(body.current_thread.text, '.*(hi|hello)')
+    )
+  )
   and profile.by_sender().prevalence != "common"
   and not profile.by_sender().solicited
   and not profile.by_sender().any_false_positives
-
+  
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (


### PR DESCRIPTION
Accounting for further variations of "undisclosed-recipients" eg "Undisclosed Recipients" was observed in unflagged but similar style emails.

Also broadening the tolerance of the body, when orgs append disclaimers, the attackers text is appended to the end bumping it beyond the 50 threshold previously specified. 

Also adjusted tolerances on body links. Now if all links have no display_text and the display_url.url matches the senders domain it's likely spawned from an extraction from  a warning banner text.  eg "You don't normally get mail from X@x.com". The MDM extracts the domain from that. 

or all links are to aka.ms or a combination of the above with aka.ms, also commonly observed in appended warning banners.