### PR TITLE
New Rule: Credential phishing: Suspicious link traversing Russian infrastructure

### DIFF
--- a/detection-rules/link_russian_traversed_credential_phishing.yml
+++ b/detection-rules/link_russian_traversed_credential_phishing.yml
@@ -50,3 +50,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "URL analysis"
 
+id: "a5203e3b-979f-5feb-bc6c-d62de08a2823"

--- a/detection-rules/link_russian_traversed_credential_phishing.yml
+++ b/detection-rules/link_russian_traversed_credential_phishing.yml
@@ -1,4 +1,4 @@
-name: "Link: Credential Phishing via messages with Russian TLD traversal"
+name: "Link: Credential Phishing traversing Russian infrastructure"
 description: "This rule detects credential phishing attempts in emails traversing Russian TLDs by aggressively analyzing links for signs of phishing, including suspicious keywords, login prompts, or links flagged for credential theft, excluding emails from trusted domains unless they fail DMARC verification."
 type: "rule"
 severity: "high"

--- a/detection-rules/link_russian_traversed_credential_phishing.yml
+++ b/detection-rules/link_russian_traversed_credential_phishing.yml
@@ -1,4 +1,4 @@
-name: "Credential phishing: Suspicious link from .ru/.su infrastructure"
+name: "Link: Credential Phishing via messages with Russian TLD traversal"
 description: "This rule detects credential phishing attempts in emails traversing Russian TLDs by aggressively analyzing links for signs of phishing, including suspicious keywords, login prompts, or links flagged for credential theft, excluding emails from trusted domains unless they fail DMARC verification."
 type: "rule"
 severity: "high"

--- a/detection-rules/link_russian_traversed_credential_phishing.yml
+++ b/detection-rules/link_russian_traversed_credential_phishing.yml
@@ -1,0 +1,52 @@
+name: "Credential phishing: Suspicious link from .ru/.su infrastructure"
+description: "This rule detects credential phishing attempts in emails traversing Russian TLDs by aggressively analyzing links for signs of phishing, including suspicious keywords, login prompts, or links flagged for credential theft, excluding emails from trusted domains unless they fail DMARC verification."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(headers.domains, .tld in ("ru", "su"))
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "cred_theft" and .confidence in ("medium", "high")
+  )
+  and 0 < length(body.links) < 5
+  and any(body.links,
+          beta.linkanalysis(., mode="aggressive").credphish.disposition == "phishing"
+          or (
+            strings.icontains(beta.linkanalysis(., mode="aggressive").final_dom.raw,
+                              "Pàsswórd"
+            )
+            and (
+              beta.linkanalysis(., mode="aggressive").credphish.contains_login
+              or beta.linkanalysis(.).credphish.contains_captcha
+            )
+          )
+          or beta.linkanalysis(., mode="aggressive").effective_url.domain.tld in $suspicious_tlds
+  )
+  and (
+    not profile.by_sender().solicited
+    or profile.by_sender().any_messages_malicious_or_spam
+  )
+  
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and (
+        any(distinct(headers.hops, .authentication_results.dmarc is not null),
+            strings.ilike(.authentication_results.dmarc, "*fail")
+        )
+      )
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Natural Language Understanding"
+  - "URL analysis"
+


### PR DESCRIPTION
Feel free to tweak the name, I was drawing a blank. 
We saw about 2000 of these earlier with the only rule firing being "Russia return-path TLD (untrusted sender)" thought they could use something of higher fidelity. 