### PR TITLE
New Rule: Detect PDF attachments with links created with Python

### DIFF
--- a/detection-rules/attachment_python_pdf_link.yml
+++ b/detection-rules/attachment_python_pdf_link.yml
@@ -28,3 +28,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   
+id: "2fec884d-71f4-58ae-82ce-e3ca5bf65109"

--- a/detection-rules/attachment_python_pdf_link.yml
+++ b/detection-rules/attachment_python_pdf_link.yml
@@ -1,0 +1,32 @@
+name: "Attachment: Python generated PDF with link"
+description: |
+  The PDF attachment was created with a Python-based script. The PDF attachment also contains one or more links. These techniques were used by PikaBot, among others.
+references:
+  - "Internal Research"
+type: "rule"
+severity: "medium"
+source: |
+  // The goal of this detection rule is to ensure that PDF files generated with Python with one or more links in the PDF are detected. These techniques were used by PikaBot (they used ReportLab), among others.
+  
+  type.inbound
+     // and profile.by_sender().prevalence in ("new", "outlier")
+  and any(attachments,.file_extension == "pdf" and
+     any(file.explode(.),
+     any(.scan.strings.strings, 
+          // create the raw PDF from code with this tools
+          strings.ilike(., "*ReportLab*", "*pypdf*", "*pypdf2", "*pikepdf*", "*PyMuPDF*", "*IronPDF*")
+          // create an intermediate format and convert it to PDF
+          or strings.ilike(., "*pdfkit*", "*xhtml2pdf*", "*pdflatex*")
+          // image to pdf
+          or strings.ilike(., "*img2pdf*", "*sphinxcontrib-svg2pdfconverter*")
+      )
+  ) and any(file.explode(.),
+      length(.scan.url.urls) < 0
+      )      
+  ) 
+tactics_and_techniques:
+  - "Evasion"
+  - "PDF"
+detection_methods:
+  - "File analysis"
+  

--- a/detection-rules/attachment_python_pdf_link.yml
+++ b/detection-rules/attachment_python_pdf_link.yml
@@ -6,8 +6,6 @@ references:
 type: "rule"
 severity: "medium"
 source: |
-  // The goal of this detection rule is to ensure that PDF files generated with Python with one or more links in the PDF are detected. These techniques were used by PikaBot (they used ReportLab), among others.
-  
   type.inbound
      // and profile.by_sender().prevalence in ("new", "outlier")
   and any(attachments,.file_extension == "pdf" and


### PR DESCRIPTION
The goal of this detection rule is to ensure that PDF files generated with a Python and with one or more links in the PDF are detected. These techniques were used by PikaBot (they used ReportLab), among others.