### PR TITLE
Update fake_thread_suspicious_indicators.yml

### DIFF
--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -111,10 +111,13 @@ source: |
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
   and not profile.by_sender().any_false_positives
-
+  
+tags:
+  - "Attack surface reduction"
 attack_types:
   - "BEC/Fraud"
   - "Credential Phishing"
+  - "Spam"
 tactics_and_techniques:
   - "Evasion"
   - "Social engineering"

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -37,12 +37,15 @@ source: |
       and (
         strings.ilevenshtein(body.current_thread.text, body.html.display_text) > 100
       )
+      //negating bouncebacks
+      and not any(attachments,
+                  .content_type in ("message/delivery-status", "message/rfc822")
+      )
     )
   )
   
   // unusual sender (email address rarely sends to your organization)
   and profile.by_sender().prevalence in ("new", "outlier", "rare")
-  
   and 4 of (
     // language attempting to engage
     (
@@ -111,7 +114,7 @@ source: |
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
   and not profile.by_sender().any_false_positives
-  
+
 tags:
   - "Attack surface reduction"
 attack_types:


### PR DESCRIPTION
This rule is great, but seem to flag Spam more often than not. Moving to ASR and adding spam tag. ||

Also adding some gating around the new fake thread logic. Counting the from, to, sent, subject strings is resulting in FP's on bounce-backs. Added bounce-back negation
