### PR TITLE
New Rules: Attachment and Link PikaBot Februar 2024

### DIFF
--- a/detection-rules/attachment_pikabot_malicious_office_doc.yml
+++ b/detection-rules/attachment_pikabot_malicious_office_doc.yml
@@ -15,6 +15,9 @@ source: |
         and any(file.explode(.), 
           any(.scan.strings.strings, strings.icontains(., "file:///\\"))
           and any(.scan.strings.strings, strings.icontains(., ".js"))
+          and any(.scan.strings.strings, strings.icontains(., ".vbs"))
+          or and any(.scan.strings.strings, strings.icontains(., ".exe"))
+          or and any(.scan.strings.strings, strings.icontains(., ".bat"))
         ))
 tags:
 - 'Malfam: PikaBot'

--- a/detection-rules/attachment_pikabot_malicious_office_doc.yml
+++ b/detection-rules/attachment_pikabot_malicious_office_doc.yml
@@ -20,3 +20,4 @@ tags:
 - 'Malfam: PikaBot'
 - Attachments
 - Malware
+id: "97ddf52c-38d1-5d1d-8ba6-514a3b5ffbd6"

--- a/detection-rules/attachment_pikabot_malicious_office_doc.yml
+++ b/detection-rules/attachment_pikabot_malicious_office_doc.yml
@@ -15,7 +15,7 @@ source: |
         and any(file.explode(.), 
           any(.scan.strings.strings, strings.icontains(., "file:///\\"))
           and any(.scan.strings.strings, strings.icontains(., ".js"))
-          and any(.scan.strings.strings, strings.icontains(., ".vbs"))
+          or any(.scan.strings.strings, strings.icontains(., ".vbs"))
           or any(.scan.strings.strings, strings.icontains(., ".exe"))
           or any(.scan.strings.strings, strings.icontains(., ".bat"))
         ))

--- a/detection-rules/attachment_pikabot_malicious_office_doc.yml
+++ b/detection-rules/attachment_pikabot_malicious_office_doc.yml
@@ -16,8 +16,8 @@ source: |
           any(.scan.strings.strings, strings.icontains(., "file:///\\"))
           and any(.scan.strings.strings, strings.icontains(., ".js"))
           and any(.scan.strings.strings, strings.icontains(., ".vbs"))
-          or and any(.scan.strings.strings, strings.icontains(., ".exe"))
-          or and any(.scan.strings.strings, strings.icontains(., ".bat"))
+          or any(.scan.strings.strings, strings.icontains(., ".exe"))
+          or any(.scan.strings.strings, strings.icontains(., ".bat"))
         ))
 tags:
 - 'Malfam: PikaBot'

--- a/detection-rules/attachment_pikabot_malicious_office_doc.yml
+++ b/detection-rules/attachment_pikabot_malicious_office_doc.yml
@@ -1,0 +1,22 @@
+name: 'Attachment: PikaBot Malicious Office Document'
+authors:
+  - twitter: "affje0x65"
+description: |
+ Malicious Office docs with embedded SMB/file link to trick the user into downloading a JS file. This JS file contains the payload. TA577 aka PikaBot uses this technique right now. 
+references:
+- https://twitter.com/DTCERT/status/1758436565825487102
+- https://twitter.com/Max_Mal_/status/1758076107943718947
+severity: "critical"
+type: "rule"
+source: |
+    type.inbound
+    and any(attachments,
+      .file_extension in~ ("doc", "docm", "docx", "dot", "dotm", "pptm", "ppsm", "xlm", "xls", "xlsx", "xlsb", "xlsm", "xlt", "xltm")
+        and any(file.explode(.), 
+          any(.scan.strings.strings, strings.icontains(., "file:///\\"))
+          and any(.scan.strings.strings, strings.icontains(., ".js"))
+        ))
+tags:
+- 'Malfam: PikaBot'
+- Attachments
+- Malware

--- a/detection-rules/link_pikabot_smb_feb24.yml
+++ b/detection-rules/link_pikabot_smb_feb24.yml
@@ -1,0 +1,38 @@
+name: "LinkAnalysis: PikaBot SMB link in message body (Feb 24)"
+description: |
+  Attackers are using a link to SMB share in emails to bypass the warning message about running a potentially malicious file. Downloads a zip file containing a exe file. 
+type: "rule"
+severity: "high"
+authors:
+  - twitter: "affje0x65"
+references:
+  - Internal Research
+  - https://twitter.com/anyrun_app/status/1760284876832473377
+  - https://twitter.com/1ZRR4H/status/1759609478222127515
+source: |
+    type.inbound
+        and any(body.links, strings.starts_with(.href_url.url, 'file://'))
+        and (
+        any(body.links,
+            .href_url.domain.domain in $abuse_ch_urlhaus_domains_trusted_reporters
+        )
+        or any(body.links,
+                any(beta.linkanalysis(., mode="aggressive").files_downloaded,
+                    .file_extension in~ $file_extensions_common_archives
+                    and (
+                    any(file.explode(.),
+                        .file_extension =~ "exe"
+                        or .scan.hash.sha256 in $abuse_ch_malwarebazaar_sha256_trusted_reporters
+                    )
+                    )
+                )
+        )
+        )     
+tags:
+  - "Malfam: PikaBot"
+attack_types:
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Evasion"
+detection_methods:
+  - "URL analysis"

--- a/detection-rules/link_pikabot_smb_feb24.yml
+++ b/detection-rules/link_pikabot_smb_feb24.yml
@@ -16,18 +16,10 @@ source: |
           and (
             .href_url.domain.domain in $abuse_ch_urlhaus_domains_trusted_reporters
             or any(body.links,
-                   any(beta.linkanalysis(., mode="aggressive").files_downloaded,
-                       .file_extension in~ $file_extensions_common_archives
-                       and (
-                         any(file.explode(.),
-                             .file_extension =~ "exe"
-                             or .scan.hash.sha256 in $abuse_ch_malwarebazaar_sha256_trusted_reporters
-                         )
-                       )
-                   )
+                   strings.ends_with(.href_url.url, '.zip')
             )
           )
-  )   
+  )  
 tags:
   - "Malfam: PikaBot"
 attack_types:

--- a/detection-rules/link_pikabot_smb_feb24.yml
+++ b/detection-rules/link_pikabot_smb_feb24.yml
@@ -36,3 +36,4 @@ tactics_and_techniques:
   - "Evasion"
 detection_methods:
   - "URL analysis"
+id: "df0c8512-e5f5-5379-acfe-d3b95764f92e"

--- a/detection-rules/link_pikabot_smb_feb24.yml
+++ b/detection-rules/link_pikabot_smb_feb24.yml
@@ -13,13 +13,10 @@ source: |
   type.inbound
   and any(body.links,
           .href_url.scheme == "file"
-          and (
-            .href_url.domain.domain in $abuse_ch_urlhaus_domains_trusted_reporters
-            or any(body.links,
+          and any(body.links,
                    strings.ends_with(.href_url.url, '.zip')
             )
-          )
-  )  
+  )
 tags:
   - "Malfam: PikaBot"
 attack_types:

--- a/detection-rules/link_pikabot_smb_feb24.yml
+++ b/detection-rules/link_pikabot_smb_feb24.yml
@@ -10,24 +10,24 @@ references:
   - https://twitter.com/anyrun_app/status/1760284876832473377
   - https://twitter.com/1ZRR4H/status/1759609478222127515
 source: |
-    type.inbound
-        and any(body.links, strings.starts_with(.href_url.url, 'file://'))
-        and (
-        any(body.links,
+  type.inbound
+  and any(body.links,
+          .href_url.scheme == "file"
+          and (
             .href_url.domain.domain in $abuse_ch_urlhaus_domains_trusted_reporters
-        )
-        or any(body.links,
-                any(beta.linkanalysis(., mode="aggressive").files_downloaded,
-                    .file_extension in~ $file_extensions_common_archives
-                    and (
-                    any(file.explode(.),
-                        .file_extension =~ "exe"
-                        or .scan.hash.sha256 in $abuse_ch_malwarebazaar_sha256_trusted_reporters
-                    )
-                    )
-                )
-        )
-        )     
+            or any(body.links,
+                   any(beta.linkanalysis(., mode="aggressive").files_downloaded,
+                       .file_extension in~ $file_extensions_common_archives
+                       and (
+                         any(file.explode(.),
+                             .file_extension =~ "exe"
+                             or .scan.hash.sha256 in $abuse_ch_malwarebazaar_sha256_trusted_reporters
+                         )
+                       )
+                   )
+            )
+          )
+  )   
 tags:
   - "Malfam: PikaBot"
 attack_types:


### PR DESCRIPTION
@morriscode - wanted to create a second PR for another rule, deleted my commits and closed the latest PR, sorry :D that was not my plan.

The link rule covers the smb link as a link in the body which bypasses some protections from windows/office. Opens the zip directly, exe is inside. This is my first rule which uses linkanalysis, not sure if everything is correct...

The attachment rule covers the office docs with smb links to a javascript file.