### PR TITLE
Update attachment_docusign_image_suspicious_links.yml

### DIFF
--- a/detection-rules/attachment_docusign_image_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_image_suspicious_links.yml
@@ -4,7 +4,8 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and length(filter(attachments, .file_type not in $file_types_images)) == 0
+  and length(attachments) > 0 
+  and all(attachments, .file_type not in $file_types_images)
   and any(body.links,
           not strings.ilike(.href_url.domain.root_domain, "docusign.*")
   )


### PR DESCRIPTION
Adding a minimum of 1 attachment, for the image attachment. This rule is FP'ing on digests from MS and pfpt