### PR TITLE
Update credential_phishing_docusign_embedded_image_lure.yml

### DIFF
--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -6,7 +6,7 @@ source: |
   type.inbound
   and length(attachments) == 0
   and any(body.links,
-          not strings.ilike(.href_url.domain.root_domain, "docusign.*")
+          not strings.ilike(.href_url.domain.root_domain, "docusign.*") and .display_text is null 
   )
   and (
     any(ml.logo_detect(beta.message_screenshot()).brands,

--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -4,33 +4,41 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and length(attachments) == 0
-  and any(body.links,
-          not strings.ilike(.href_url.domain.root_domain, "docusign.*") and .display_text is null 
-  )
+  
+  // there are no attachments, or only small, likely signature images
   and (
-    any(ml.logo_detect(beta.message_screenshot()).brands,
-        .name == "DocuSign"
-        or any(file.explode(beta.message_screenshot()),
-               strings.ilike(.scan.ocr.raw, "*DocuSign*")
-               and any(ml.nlu_classifier(.scan.ocr.raw).intents,
-                       .name == "cred_theft" and .confidence != "low"
-               )
-        )
+    length(attachments) == 0
+    or (
+      length(attachments) > 0
+      and all(attachments, .size < 8000 and .file_type in $file_types_images)
     )
   )
+  
+  // Screenshot indicates a docusign logo or docusign name with cta to documents
   and any(file.explode(beta.message_screenshot()),
-          regex.icontains(.scan.ocr.raw,
-                          "review document",
-                          "[^d][^o][^c][^u]sign",
-                          "important edocs",
-                          "completed document",
-                          // German (Document (check|check|sign|sent))
-                          "Dokument (überprüfen|prüfen|unterschreiben|geschickt)",
-                          // German (important|urgent|immediate)
-                          "(wichtig|dringend|sofort)"
+          (
+            strings.ilike(.scan.ocr.raw, "*DocuSign*")
+            or any(ml.logo_detect(beta.message_screenshot()).brands,
+                   .name == "DocuSign"
+            )
+          )
+          and regex.icontains(.scan.ocr.raw,
+                              "((re)?view|access|complete(d)?) document(s)?",
+                              "[^d][^o][^c][^u]sign",
+                              "important edocs",
+                              // German (Document (check|check|sign|sent))
+                              "Dokument (überprüfen|prüfen|unterschreiben|geschickt)",
+                              // German (important|urgent|immediate)
+                              "(wichtig|dringend|sofort)"
           )
   )
+  
+  // links with null display_text that do not go to docusign.* (indicative of hyperlinked image)
+  and any(body.links,
+          not strings.ilike(.href_url.domain.root_domain, "docusign.*")
+          and .display_text is null
+  )
+  
   and (
     not profile.by_sender().solicited
     or (
@@ -39,8 +47,7 @@ source: |
     )
   )
   // negate highly trusted sender domains unless they fail DMARC authentication
-  and
-  (
+  and (
     (
       sender.email.domain.root_domain in $high_trust_sender_root_domains
       and (
@@ -58,7 +65,7 @@ source: |
     or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
   )
   and not profile.by_sender().any_false_positives
-
+  
   // negate docusign X-Return-Path
   and not any(headers.hops,
               .index == 0
@@ -67,7 +74,7 @@ source: |
                       and strings.ends_with(.value, "docusign.net")
               )
   )
-
+  
   // negate "via" senders via dmarc authentication
   and (
     not (

--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -4,6 +4,7 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
+  and length(attachments) == 0
   and any(body.links,
           not strings.ilike(.href_url.domain.root_domain, "docusign.*")
   )

--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -36,7 +36,7 @@ source: |
   // links with null display_text that do not go to docusign.* (indicative of hyperlinked image) or the display text contains DOCUMENT 
   and any(body.links,
           not strings.ilike(.href_url.domain.root_domain, "docusign.*")
-          and .display_text is null or regex.contains(.display_text, "DOCUMENT")
+          and .display_text is null or regex.contains(.display_text, '\bDOCUMENT')
   )
   
   and (
@@ -85,6 +85,7 @@ source: |
       )
     )
   )
+
 
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -4,7 +4,6 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and length(attachments) <= 1
   and any(body.links,
           not strings.ilike(.href_url.domain.root_domain, "docusign.*")
   )

--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -33,10 +33,10 @@ source: |
           )
   )
   
-  // links with null display_text that do not go to docusign.* (indicative of hyperlinked image)
+  // links with null display_text that do not go to docusign.* (indicative of hyperlinked image) or the display text contains DOCUMENT 
   and any(body.links,
           not strings.ilike(.href_url.domain.root_domain, "docusign.*")
-          and .display_text is null
+          and .display_text is null or regex.contains(.display_text, "DOCUMENT")
   )
   
   and (


### PR DESCRIPTION
Removing the attachment length requirement since this is supposed to be an embedded image rule.