### PR TITLE
New Insights: Malformed QR code link extractions from body && attachment

### DIFF
--- a/insights/content/attachment_qr_code_malformed_link.yml
+++ b/insights/content/attachment_qr_code_malformed_link.yml
@@ -1,0 +1,12 @@
+name: "Malformed QR code link in attachment"
+type: "query"
+source: |
+  map(filter(attachments, .file_type in $file_types_images or .file_type == "pdf"),
+    map(filter(file.explode(.),
+               .scan.qr.type == "undefined"
+               and strings.contains(.scan.qr.data, ".")
+        ),
+        .scan.qr.data
+    )
+  )
+severity: "medium"

--- a/insights/content/body_qr_code_malformed_link.yml
+++ b/insights/content/body_qr_code_malformed_link.yml
@@ -1,0 +1,8 @@
+name: "Malformed QR code link in body"
+type: "query"
+source: |
+  map(filter(file.explode(beta.message_screenshot()),
+           .scan.qr.type == "undefined" and strings.contains(.scan.qr.data, ".")
+    ),
+    .scan.qr.data)
+severity: "medium"


### PR DESCRIPTION
2 new insights to capture malformed(non URL compliant) links from QR codes. 

![image](https://github.com/sublime-security/sublime-rules/assets/6809735/c2e5188f-3b66-4dbf-b027-92b6964da9d4)
Same for body.