### PR TITLE
Exclude org_domains from spam_onmicrosoft.yml

### DIFF
--- a/detection-rules/spam_onmicrosoft.yml
+++ b/detection-rules/spam_onmicrosoft.yml
@@ -29,6 +29,7 @@ source: |
       and not profile.by_sender().any_false_positives
     )
   )
+  and not sender.email.domain.domain in $org_domains
 tags:
  - "Attack surface reduction"
 attack_types:


### PR DESCRIPTION
We have some instances where mailboxes for automation might send with our .onmicrosoft.com domain, adding this line excludes those messages from this rule.