### PR TITLE
Stop using levenshtein distance on body fields

### DIFF
--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -35,7 +35,7 @@ source: |
         strings.icontains(body.html.display_text, "subject:")
       )
       and (
-        strings.ilevenshtein(body.current_thread.text, body.html.display_text) > 100
+        length(body.current_thread.text)+100 < length(body.html.display_text)
       )
       //negating bouncebacks
       and not any(attachments,


### PR DESCRIPTION
Levenshtein distance is expensive for large strings and is soon disabled for strings above a certain length.
There's one rule that does levenshtein distance on body text compared to the current thread. This can be quite expensive and is actually not totally necessary, because we know that `body.current_thread.text` is actually a subset of `body.html.display_text`. We can simply do a length check and get the same result!

<!-- https://www.notion.so/668a6392ff324c5d919dc1a513756fa3 -->