### PR TITLE
Update credential_phishing_docusign_embedded_image_lure.yml

### DIFF
--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -43,16 +43,14 @@ source: |
           )
           or any(body.links,
                  not strings.ilike(.href_url.domain.root_domain, "docusign.*")
-                 and (
-                   .display_text is null and .display_url.url is null
-                   or regex.contains(.display_text,
+                 and regex.contains(.display_text,
                                      '(\bDOCUMENT|View Docu|Access Document|((re)?view|access|sign|complete(d)?) documen(t)?(s)?)'
                    )
                  )
           )
         )
     )
-  )
+  
   // links with null display_text that do not go to docusign.* (indicative of hyperlinked image) or the display text contains DOCUMENT 
   and (
     not profile.by_sender().solicited
@@ -100,6 +98,7 @@ source: |
       )
     )
   )
+  
 
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -44,12 +44,12 @@ source: |
           or any(body.links,
                  not strings.ilike(.href_url.domain.root_domain, "docusign.*")
                  and regex.icontains(.display_text,
-                                     '(\bDOCUMENT|View (Docu|File)|Access Document|((re)?view|access|sign|complete(d)?) documen(t)?(s)?)'
-                   )
+                                     '(\bDOCUMENT|(View|get your) (Docu|File)|Access Document|((re)?view|access|sign|complete(d)?) documen(t)?(s)?)'
                  )
           )
         )
     )
+  )
   
   // links with null display_text that do not go to docusign.* (indicative of hyperlinked image) or the display text contains DOCUMENT 
   and (
@@ -98,6 +98,8 @@ source: |
       )
     )
   )
+
+
 
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -99,8 +99,6 @@ source: |
     )
   )
 
-
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -43,8 +43,8 @@ source: |
           )
           or any(body.links,
                  not strings.ilike(.href_url.domain.root_domain, "docusign.*")
-                 and regex.contains(.display_text,
-                                     '(\bDOCUMENT|View Docu|Access Document|((re)?view|access|sign|complete(d)?) documen(t)?(s)?)'
+                 and regex.icontains(.display_text,
+                                     '(\bDOCUMENT|View (Docu|File)|Access Document|((re)?view|access|sign|complete(d)?) documen(t)?(s)?)'
                    )
                  )
           )
@@ -98,7 +98,6 @@ source: |
       )
     )
   )
-  
 
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -44,7 +44,7 @@ source: |
           or any(body.links,
                  not strings.ilike(.href_url.domain.root_domain, "docusign.*")
                  and regex.icontains(.display_text,
-                                     '(\bDOCUMENT|(View|get your) (Docu|File)|Access Document|((re)?view|access|sign|complete(d)?) documen(t)?(s)?)'
+                                     '(\bdocument|(view|get your) (docu|file))'
                  )
           )
         )


### PR DESCRIPTION
Finishing tightening this thing up. This knocks out the remainder of the Fp's and a couple I've seen today. There's also a [static file update ](https://github.com/sublime-security/static-files/pull/166)that will take care of the rest from infotrack.co.uk aka SignIT which is an official docusign partner (https://www.docusign.com/en-gb/blog/interview-with-infotrack-and-the-partnership) 