### PR TITLE
Update attachment_html_smuggling_embedded_b64_pe.yml

### DIFF
--- a/detection-rules/attachment_html_smuggling_embedded_b64_pe.yml
+++ b/detection-rules/attachment_html_smuggling_embedded_b64_pe.yml
@@ -18,7 +18,7 @@ source: |
           and any(file.explode(.),
                   (
                     .file_extension in~ ("html", "htm", "shtml", "dhtml")
-                    or ..file_type == "html"
+                    or .flavors.mime == "text/plain"
                   )
                   and any(.flavors.yara, . == 'base64_pe')
           )

--- a/detection-rules/attachment_html_smuggling_embedded_b64_pe.yml
+++ b/detection-rules/attachment_html_smuggling_embedded_b64_pe.yml
@@ -15,7 +15,13 @@ source: |
             or .file_extension in~ $file_extensions_common_archives
             or .file_type == "html"
           )
-          and any(file.explode(.), any(.flavors.yara, . == 'base64_pe'))
+          and any(file.explode(.),
+                  (
+                    .file_extension in~ ("html", "htm", "shtml", "dhtml")
+                    or ..file_type == "html"
+                  )
+                  and any(.flavors.yara, . == 'base64_pe')
+          )
   )
 attack_types:
   - "Malware/Ransomware"


### PR DESCRIPTION
Ensuring the explosion match is on an HTML file otherwise the rule title makes no sense.