### PR TITLE
New insight: Salesforce HTML attachment

### DIFF
--- a/insights/attachments/salesforce_html.yml
+++ b/insights/attachments/salesforce_html.yml
@@ -1,0 +1,25 @@
+name: "Salesforce HTML attachment"
+type: "query"
+source: |
+  type.inbound
+  and length(attachments) == 1
+  and any(attachments,
+          (
+            .file_extension in~ ("html", "htm", "shtml", "dhtml")
+            or .file_extension in~ $file_extensions_common_archives
+            or .file_type == "html"
+          )
+          and any(file.explode(.),
+                  length(.scan.url.urls) == 1
+                  and all(.scan.url.urls,
+                          // looking for mydomain.my.salesforce.com
+                          .domain.root_domain == "salesforce.com"
+                          and strings.ends_with(.domain.subdomain, "my")
+                          and strings.starts_with(.path, "/sfc")
+                  )
+          )
+          and strings.starts_with(file.parse_html(.).display_text,
+                                  "Attachment not opening? Click this link"
+          )
+  )
+severity: "informational"


### PR DESCRIPTION
To call out attachments sent from Salesforce (example):
```
<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><meta http-equiv="Refresh" content="0; URL=https://sublime.my.salesforce.com/sfc/p/2b111156a/a/Vo0000002a/dskalfjiwaejfiwofjdklsanvdasjfl"></head><body><div>Attachment not opening? Click this link: <a href="https://sublime.my.salesforce.com/sfc/p/2b111156a/a/Vo0000002a/dskalfjiwaejfiwofjdklsanvdasjfl">testdocument.pdf</a></div></html>
```