### PR TITLE
Update impersonation_recipient_domain_display_name_subject.yml

### DIFF
--- a/detection-rules/impersonation_recipient_domain_display_name_subject.yml
+++ b/detection-rules/impersonation_recipient_domain_display_name_subject.yml
@@ -70,7 +70,7 @@ source: |
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
   and (
-    (not profile.by_sender().solicited)
+    not profile.by_sender().solicited
     or (
       profile.by_sender().any_messages_malicious_or_spam
       and not profile.by_sender().any_false_positives

--- a/detection-rules/impersonation_recipient_domain_display_name_subject.yml
+++ b/detection-rules/impersonation_recipient_domain_display_name_subject.yml
@@ -9,10 +9,13 @@ source: |
   and (
     // recipient SLD is being impersonated in the subject + display name
     (
-       // these are usually targeted with just 1 recipient,
+      // these are usually targeted with just 1 recipient,
       // but sometimes they CC themselves or have a blank CC
-      length(recipients.to) + length(recipients.cc) + length(recipients.bcc) <= 2
+      length(recipients.to) + length(recipients.cc)
+   + length(recipients.bcc) <= 2
       and any(recipients.to,
+              length(.email.domain.sld) >= 4
+              and 
               // ensure that we're checking the org SLD
               .email.domain.sld in $org_slds
               and strings.icontains(subject.subject, .email.domain.sld)
@@ -22,37 +25,38 @@ source: |
     or (
       // accounts for BCC'd messages where the recipients are empty
       // if BCC, sometimes the recipient will be the attacker's email
-      length(recipients.to) + length(recipients.cc) + length(recipients.bcc) <= 2
+      length(recipients.to) + length(recipients.cc)
+   + length(recipients.bcc) <= 2
+      and length(mailbox.email.domain.sld) >= 4
       and strings.icontains(subject.subject, mailbox.email.domain.sld)
       and strings.icontains(sender.display_name, mailbox.email.domain.sld)
     )
   )
-
   and (
-      // at least 1 link or non-image attachment
-      (
-        length(body.links) > 0
-        // these attacks all use compromosed senders, so we look for a domain
-        // that doesn't match the sender's domain to weed out legit messages
-        and any(body.links, .href_url.domain.root_domain != sender.email.domain.root_domain)
+    // at least 1 link or non-image attachment
+    (
+      length(body.links) > 0
+      // these attacks all use compromosed senders, so we look for a domain
+      // that doesn't match the sender's domain to weed out legit messages
+      and any(body.links,
+              .href_url.domain.root_domain != sender.email.domain.root_domain
       )
-      or length(filter(attachments, .file_type not in $file_types_images)) > 0
+    )
+    or length(filter(attachments, .file_type not in $file_types_images)) > 0
   )
-
   and not (
     strings.contains(sender.display_name, "on behalf of")
     and sender.email.domain.root_domain == "microsoftonline.com"
   )
-
   and all(recipients.to, .email.email != sender.email.email)
-
+  
   // negate org domain senders, which can often be misconfigured and fail
   // authentication, causing them to be type.inbound instead of type.internal.
   // this is fine because we should catch spoofs in other ways.
   // also, we use root_domain here to account for subdomains used by internal tools that aren't connected to the tenant.
   // this should also be safe because domains like onmicrosoft[.]com are tracked as FQDNs in $org_domains, so they won't match
   and sender.email.domain.root_domain not in $org_domains
-
+  
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (
@@ -66,15 +70,14 @@ source: |
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
   and (
-    (
-      not profile.by_sender().solicited
-    )
+    (not profile.by_sender().solicited)
     or (
       profile.by_sender().any_messages_malicious_or_spam
       and not profile.by_sender().any_false_positives
     )
   )
   and not profile.by_sender().any_false_positives
+
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/impersonation_recipient_domain_display_name_subject.yml
+++ b/detection-rules/impersonation_recipient_domain_display_name_subject.yml
@@ -16,9 +16,8 @@ source: |
       )
       and any(recipients.to,
               length(.email.domain.sld) >= 4
-              and 
               // ensure that we're checking the org SLD
-              .email.domain.sld in $org_slds
+              and .email.domain.sld in $org_slds
               and strings.icontains(subject.subject, .email.domain.sld)
               and strings.icontains(sender.display_name, .email.domain.sld)
       )

--- a/detection-rules/impersonation_recipient_domain_display_name_subject.yml
+++ b/detection-rules/impersonation_recipient_domain_display_name_subject.yml
@@ -11,8 +11,9 @@ source: |
     (
       // these are usually targeted with just 1 recipient,
       // but sometimes they CC themselves or have a blank CC
-      length(recipients.to) + length(recipients.cc)
-   + length(recipients.bcc) <= 2
+      (
+        length(recipients.to) + length(recipients.cc) + length(recipients.bcc) <= 2
+      )
       and any(recipients.to,
               length(.email.domain.sld) >= 4
               and 
@@ -25,8 +26,9 @@ source: |
     or (
       // accounts for BCC'd messages where the recipients are empty
       // if BCC, sometimes the recipient will be the attacker's email
-      length(recipients.to) + length(recipients.cc)
-   + length(recipients.bcc) <= 2
+      (
+        length(recipients.to) + length(recipients.cc) + length(recipients.bcc) <= 2
+      )
       and length(mailbox.email.domain.sld) >= 4
       and strings.icontains(subject.subject, mailbox.email.domain.sld)
       and strings.icontains(sender.display_name, mailbox.email.domain.sld)


### PR DESCRIPTION
Adding min length requirements to recipient and mailbox slds to prevent short domains < 4 chars from firing