### PR TITLE
Update credential_phishing_docusign_html_table_forgery.yml

### DIFF
--- a/detection-rules/credential_phishing_docusign_html_table_forgery.yml
+++ b/detection-rules/credential_phishing_docusign_html_table_forgery.yml
@@ -1,14 +1,34 @@
 name: "Brand Impersonation: Fake DocuSign HTML table not linking to DocuSign domains"
-description: "Detects HTML table elements that mimick DocuSign templates linking to non-DocuSign destinations. The rule negates high trusted sender domains and legitimate replies. 
-"
+description: "Detects HTML table elements that mimick DocuSign templates linking to non-DocuSign destinations. The rule negates high trusted sender domains and legitimate replies."
 type: "rule"
 severity: "medium"
 source: |
   type.inbound
   and length(attachments) == 0
   and 0 < length(body.links) < 10
-  and regex.icontains(body.html.raw,
-                      '<table[^>]*cellspacing="0"[^>]*cellpadding="0"[^>]*>\s*<tbody[^>]*>\s*<tr[^>]*>\s*<td[^>]*style="BACKGROUND:\s*rgb\(247,247,247\);\s*width:\s*[0-9]{2,3}px;\s*padding:20px;\s*margin:\s*[0-9]{2,3}px"[^>]*>.*<div[^>]*style="BACKGROUND:\s*rgb\(30,76,161\);\s*padding:[0-9]{2,3}px;\s*color:#EFEFEF"[^>]*align="center"[^>]*>.*DOCUMENT.*</a>'
+  and (
+    regex.icontains(body.html.raw, '<font size="[0-9]">DocuSign</font>')
+    or regex.icontains(body.html.raw, '<span[^>]*style="[^"]*">DocuSign<\/span>')
+    or regex.icontains(body.html.raw, '<strong>DocuSign</strong>')
+    or any(body.links, regex.icontains(.display_text, 'view.{0,3}doc'))
+    or any(body.links, regex.contains(.display_text, '\bDOCUMENT'))
+  )
+  and (
+    regex.icontains(body.html.raw, 'background:\s*rgb\(30,\s*76,\s*161\)')
+    or regex.icontains(body.html.raw,
+                       'background-color:\s*rgb\(30,\s*76,\s*161\)'
+    )
+    or regex.icontains(body.html.raw,
+                       'background-color:\s*rgb\(61,\s*170,\s*73\)'
+    )
+    or regex.icontains(body.html.raw,
+                       '<div[^>]*BACKGROUND-COLOR: #1e4ca1[^>]*>|<td[^>]*BACKGROUND-COLOR: #1e4ca1[^>]*>'
+    )
+    or regex.icontains(body.html.raw, 'background-color:#214e9f;')
+    or regex.icontains(body.html.raw, 'background-color:#3260a7')
+    or regex.icontains(body.html.raw,
+                       '<table[^>]*cellspacing="0"[^>]*cellpadding="0"[^>]*>\s*<tbody[^>]*>\s*<tr[^>]*>\s*<td[^>]*style="BACKGROUND:\s*rgb\(247,247,247\);\s*width:\s*[0-9]{2,3}px;\s*padding:20px;\s*margin:\s*[0-9]{2,3}px"[^>]*>.*<div[^>]*style="BACKGROUND:\s*rgb\(30,76,161\);\s*padding:[0-9]{2,3}px;\s*color:#EFEFEF"[^>]*align="center"[^>]*>.*DOCUMENT.*</a>'
+    )
   )
   and any(body.links,
           not strings.ilike(.href_url.domain.root_domain, "docusign.*")


### PR DESCRIPTION
Bringing parity from attack score. This rule also wasn't firing on recent samples, other less descriptive rules were catching it. This change now ensures coverage with specificity. 