### PR TITLE
Use body.current_thread.text more consistently

### DIFF
--- a/detection-rules/attachment_eml_cred_theft.yml
+++ b/detection-rules/attachment_eml_cred_theft.yml
@@ -52,12 +52,12 @@ source: |
           // identifies other suspicious indicators
           and (
             // engaging language in the original body
-            any(ml.nlu_classifier(body.html.display_text).entities,
+            any(ml.nlu_classifier(body.current_thread.text).entities,
                 .name == "request"
             )
 
             // // engaging language in the attached EML
-            or any(ml.nlu_classifier(file.parse_eml(.).body.html.display_text).entities,
+            or any(ml.nlu_classifier(file.parse_eml(.).body.current_thread.text).entities,
                    .name == "request"
             )
             // recipient SLD impersonated in the subject or display name

--- a/detection-rules/attachment_eml_cred_theft_language.yml
+++ b/detection-rules/attachment_eml_cred_theft_language.yml
@@ -8,7 +8,7 @@ source: |
   and any(attachments,
           (.content_type == "message/rfc822" or .file_extension =~ "eml")
           // credential theft language in the attached EML
-          and any(ml.nlu_classifier(file.parse_eml(.).body.html.display_text).intents,
+          and any(ml.nlu_classifier(file.parse_eml(.).body.current_thread.text).intents,
                   .name == "cred_theft" and .confidence == "high"
           )
   )

--- a/detection-rules/attachment_pdf_with_low_reputation_link_to_suspicious_files.yml
+++ b/detection-rules/attachment_pdf_with_low_reputation_link_to_suspicious_files.yml
@@ -5,9 +5,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and any([body.plain.raw, body.html.inner_text],
-          any(ml.nlu_classifier(.).entities, .name == "request")
-  )
+  and any(ml.nlu_classifier(body.current_thread.text).entities, .name == "request")
   and any(attachments,
           .file_extension == "pdf"
           and any(file.explode(.),

--- a/detection-rules/attachment_pdf_with_low_reputation_link_to_zip_file.yml
+++ b/detection-rules/attachment_pdf_with_low_reputation_link_to_zip_file.yml
@@ -7,9 +7,7 @@ authors:
   - name: "Michael Tingle"
 source: |
   type.inbound
-  and any([body.plain.raw, body.html.inner_text],
-          any(ml.nlu_classifier(.).entities, .name == "request")
-  )
+  and any(ml.nlu_classifier(body.current_thread.text).entities, .name == "request")
   and any(attachments,
           .file_extension == "pdf"
           and any(file.explode(.),

--- a/detection-rules/body_bec_covid_international_org_scam.yml
+++ b/detection-rules/body_bec_covid_international_org_scam.yml
@@ -33,15 +33,13 @@ source: |
   )
   
   // and mention of covid in subject or body
-  and any([body.current_thread.text, subject.subject],
-          regex.icontains(., 'covid(.0,5}19)?\b')
-  )
+  and regex.icontains(body.current_thread.text, 'covid(.0,5}19)?\b')
   
   // urgent financial requests
   and 2 of (
-    any(ml.nlu_classifier(body.html.display_text).entities, .name == "urgency"),
-    any(ml.nlu_classifier(body.html.display_text).entities, .name == "request"),
-    any(ml.nlu_classifier(body.html.display_text).entities, .name == "financial")
+    any(ml.nlu_classifier(body.current_thread.text).entities, .name == "urgency"),
+    any(ml.nlu_classifier(body.current_thread.text).entities, .name == "request"),
+    any(ml.nlu_classifier(body.current_thread.text).entities, .name == "financial")
   )
   
    // negate highly trusted sender domains unless they fail DMARC authentication

--- a/detection-rules/impersonation_amazon_suspicious_text.yml
+++ b/detection-rules/impersonation_amazon_suspicious_text.yml
@@ -28,7 +28,7 @@ source: |
                     .name != "benign" and .confidence == "high"
                 )
             )
-            or any(ml.nlu_classifier(coalesce(body.html.display_text, body.plain.raw)).intents,
+            or any(ml.nlu_classifier(body.current_thread.text).intents,
                    .name != "benign" and .confidence == "high"
             )
           )

--- a/detection-rules/impersonation_aramco.yml
+++ b/detection-rules/impersonation_aramco.yml
@@ -15,11 +15,11 @@ source: |
   and sender.email.domain.root_domain not in~ (
     'aramco.com', 'aramcoamericas.com', 'aramcoventures.com'
   )
-  and any(ml.nlu_classifier(body.html.display_text).entities, strings.ilike(.text, "*aramco*"))
-  and any(ml.nlu_classifier(body.html.display_text).entities,
+  and any(ml.nlu_classifier(body.current_thread.text).entities, strings.ilike(.text, "*aramco*"))
+  and any(ml.nlu_classifier(body.current_thread.text).entities,
           .name == "financial" or .name == "request"
   )
-  and any(ml.nlu_classifier(body.html.display_text).entities, .name == "urgency")
+  and any(ml.nlu_classifier(body.current_thread.text).entities, .name == "urgency")
   
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (

--- a/detection-rules/impersonation_binance.yml
+++ b/detection-rules/impersonation_binance.yml
@@ -12,12 +12,12 @@ source: |
     or strings.ilike(subject.subject, '*binance*')
   )
   and sender.email.domain.root_domain not in~ ('binance.com', 'trustwallet.com', 'binance.charity')
-  and any(ml.nlu_classifier(body.html.display_text).entities, .text == "Binance")
-  and any(ml.nlu_classifier(body.html.display_text).entities, .name == "financial")
-  and any(ml.nlu_classifier(body.html.display_text).entities, .name == "urgency")
+  and any(ml.nlu_classifier(body.current_thread.text).entities, .text == "Binance")
+  and any(ml.nlu_classifier(body.current_thread.text).entities, .name == "financial")
+  and any(ml.nlu_classifier(body.current_thread.text).entities, .name == "urgency")
   and (
-    any(ml.nlu_classifier(body.html.display_text).entities, .text in~ ("withdrawal", "deposit"))
-    or any(ml.nlu_classifier(body.html.display_text).intents, .name != "benign")
+    any(ml.nlu_classifier(body.current_thread.text).entities, .text in~ ("withdrawal", "deposit"))
+    or any(ml.nlu_classifier(body.current_thread.text).intents, .name != "benign")
   )
   and (
     // if this comes from a free email provider,

--- a/detection-rules/impersonation_domain_replyto_freemail_lookalike_financial_request.yml
+++ b/detection-rules/impersonation_domain_replyto_freemail_lookalike_financial_request.yml
@@ -13,15 +13,15 @@ source: |
           and .email.email not in $sender_emails
           and strings.contains(.email.local_part, sender.email.domain.sld)
   )
-  and any([body.plain.raw, body.html.inner_text],
-          any(ml.nlu_classifier(.).intents, .name == "bec" and .confidence in ("medium", "high"))
-          or (
-            any(ml.nlu_classifier(.).entities, .name == "financial")
-            and any(ml.nlu_classifier(.).entities, .name == "request")
-            and any(ml.nlu_classifier(.).entities, .name == "urgency")
-            and any(ml.nlu_classifier(.).entities, .name == "sender")
-            and any(ml.nlu_classifier(.).intents, .name != "benign")
-          )
+  and (
+    any(ml.nlu_classifier(body.current_thread.text).intents, .name == "bec" and .confidence in ("medium", "high"))
+        or (
+          any(ml.nlu_classifier(body.current_thread.text).entities, .name == "financial")
+          and any(ml.nlu_classifier(body.current_thread.text).entities, .name == "request")
+          and any(ml.nlu_classifier(body.current_thread.text).entities, .name == "urgency")
+          and any(ml.nlu_classifier(body.current_thread.text).entities, .name == "sender")
+          and any(ml.nlu_classifier(body.current_thread.text).intents, .name != "benign")
+        )
   )
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/impersonation_fake_msg_thread_mismatched_from_freemail_replyto.yml
+++ b/detection-rules/impersonation_fake_msg_thread_mismatched_from_freemail_replyto.yml
@@ -31,10 +31,8 @@ source: |
   // Check for Message Thread Indicators
   and (
     strings.istarts_with(subject.subject, "RE:")
-    or any([body.plain.raw, body.html.display_text],
-           regex.icontains(.,
-                           "From:[ a-z0-9<>_@\\.]{0,80}Sent:[ a-z0-9<>_@\\.:]{0,40}To:[ a-z0-9<>_@\\.;]{0,300}(Cc:)?.{0,300}Subject:"
-           )
+    or regex.icontains(body.current_thread.text,
+                       "From:[ a-z0-9<>_@\\.]{0,80}Sent:[ a-z0-9<>_@\\.:]{0,40}To:[ a-z0-9<>_@\\.;]{0,300}(Cc:)?.{0,300}Subject:"
     )
   )
 

--- a/detection-rules/impersonation_google_groups_suspicious.yml
+++ b/detection-rules/impersonation_google_groups_suspicious.yml
@@ -40,7 +40,7 @@ source: |
     ),
   
     // invoice entity in display_text
-    any(ml.nlu_classifier(body.html.display_text).tags, .name == "invoice"),
+    any(ml.nlu_classifier(body.current_thread.text).tags, .name == "invoice"),
   
     // fake thread
     (

--- a/detection-rules/link_credential_phishing_language_ipfs.yml
+++ b/detection-rules/link_credential_phishing_language_ipfs.yml
@@ -7,7 +7,7 @@ source: |
   type.inbound
   and strings.ilike(body.html.display_text, "*expir*")
   and strings.ilike(body.html.display_text, "*password*")
-  and any(ml.nlu_classifier(body.html.display_text).intents,
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == "cred_theft"
   )
   and any(body.links,

--- a/detection-rules/link_credential_phishing_suspicious_sender_tld_and_signals.yml
+++ b/detection-rules/link_credential_phishing_suspicious_sender_tld_and_signals.yml
@@ -17,13 +17,13 @@ source: |
   and strings.ilike(sender.email.domain.tld, "*.jp")
   and 3 of (
     // language attempting to engage
-    any(ml.nlu_classifier(body.html.display_text).entities, .name == "request"),
+    any(ml.nlu_classifier(body.current_thread.text).entities, .name == "request"),
 
     // financial request
-    any(ml.nlu_classifier(body.html.display_text).entities, .name == "financial"),
+    any(ml.nlu_classifier(body.current_thread.text).entities, .name == "financial"),
 
     // urgency request
-    any(ml.nlu_classifier(body.html.display_text).entities, .name == "urgency"),
+    any(ml.nlu_classifier(body.current_thread.text).entities, .name == "urgency"),
 
     // known suspicious pattern in the URL path
     any(body.links, regex.match(.href_url.path, '\/[a-z]{3}\d[a-z]')),

--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -31,9 +31,7 @@ source: |
     ),
     (
       length(body.current_thread.text) < 700
-      and any([body.current_thread.text],
-              regex.icontains(., 'Méssãge|Méssage|Recéived|Addréss')
-      )
+      and regex.icontains(body.current_thread.text, 'Méssãge|Méssage|Recéived|Addréss')
     ),
     (
       // sender domain matches no body domains

--- a/detection-rules/link_dynamics_form.yml
+++ b/detection-rules/link_dynamics_form.yml
@@ -17,26 +17,14 @@ source: |
           )
 
           // analyze for credential phishing signals
-          and 1 of (
-            (
-              // analyze the link
-              any(file.explode(ml.link_analysis(.).screenshot),
-                  any(ml.nlu_classifier(.scan.ocr.raw).intents,
-                      .name == "cred_theft" and .confidence != "low"
-                  )
-              )
-            ),
-            (
-              // analyze the HTML body
-              any(ml.nlu_classifier(body.html.display_text).intents,
-                  .name == "cred_theft" and .confidence != "low"
-              )
-            ),
-            (
-              // analyze the plain body
-              any(ml.nlu_classifier(body.plain.raw).intents,
-                  .name == "cred_theft" and .confidence != "low"
-              )
+          and (
+            any(file.explode(ml.link_analysis(.).screenshot),
+                any(ml.nlu_classifier(.scan.ocr.raw).intents,
+                   .name == "cred_theft" and .confidence != "low"
+                )
+            )
+            or any(ml.nlu_classifier(body.current_thread.text).intents,
+                   .name == "cred_theft" and .confidence != "low"
             )
           )
   )

--- a/detection-rules/mass_campaign_recipient_address_new_sender.yml
+++ b/detection-rules/mass_campaign_recipient_address_new_sender.yml
@@ -31,11 +31,9 @@ source: |
         and (.email.domain.valid or strings.icontains(.display_name, "undisclosed"))
     )
   )
-  and any([body.html.inner_text, body.plain.raw],
-          any(recipients.to, strings.icontains(.., .email.email))
-  )
+  and any(recipients.to, strings.icontains(body.current_thread.text, .email.email))
   and any(body.links, any(recipients.to, strings.icontains(..href_url.query_params, .email.email)))
-  and any(ml.nlu_classifier(coalesce(body.html.display_text, body.plain.raw)).intents,
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name in ("cred_theft") and .confidence == "high"
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents,

--- a/detection-rules/spam_attendee_list_solicitation.yml
+++ b/detection-rules/spam_attendee_list_solicitation.yml
@@ -6,13 +6,11 @@ source: |
   type.inbound
   and length(body.current_thread.text) < 2000
   and length(body.links) < 5
-  and any([body.html.display_text, body.current_thread.text],
-          regex.icontains(.,
-                          "(Attendee|Member|Participants) (list|database)"
-          )
+  and regex.icontains(body.current_thread.text,
+                      "(Attendee|Member|Participants) (list|database)"
   )
-  and any([body.html.display_text, body.current_thread.text],
-          regex.icontains(., "(interested|accessing|purchas|obtain|acuir|sample)")
+  and regex.icontains(body.current_thread.text,
+                      "(interested|accessing|purchas|obtain|acuir|sample)"
   )
   
   and not profile.by_sender().solicited

--- a/detection-rules/spoofable_internal_domain_suspicious_signals.yml
+++ b/detection-rules/spoofable_internal_domain_suspicious_signals.yml
@@ -68,7 +68,7 @@ source: |
     ),
     (
       // suspicious language
-      any(ml.nlu_classifier(coalesce(body.html.display_text, body.plain.raw)).intents,
+      any(ml.nlu_classifier(body.current_thread.text).intents,
           .name != "benign" and .confidence == "high"
       )
     ),

--- a/detection-rules/suspicious_request_for_quote_or_purchase.yml
+++ b/detection-rules/suspicious_request_for_quote_or_purchase.yml
@@ -20,28 +20,28 @@ source: |
   )
   and 2 of (
     (
-      regex.icontains(coalesce(body.html.display_text, body.plain.raw),
+      regex.icontains(body.current_thread.text,
                       '(discuss.{0,15}purchas(e|ing))'
       )
     ),
     (
-      regex.icontains(coalesce(body.html.display_text, body.plain.raw),
+      regex.icontains(body.current_thread.text,
                       '(sign(ed?)|view).{0,10}(purchase order)|Request for a Quot(e|ation)'
       )
     ),
-    (regex.icontains(coalesce(body.html.display_text, body.plain.raw), '(please|kindly).{0,30}quote')),
+    (regex.icontains(body.current_thread.text, '(please|kindly).{0,30}quote')),
     (regex.icontains(subject.subject, '(request for (purchase|quot(e|ation))|\bRFQ\b|\bRFP\b)')),
     (any(attachments, regex.icontains(.file_name, "(purchase.?order|Quot(e|ation))"))),
     (
-      any(ml.nlu_classifier(coalesce(body.html.display_text, body.plain.raw)).entities,
+      any(ml.nlu_classifier(body.current_thread.text).entities,
           .name == "request"
       )
-      and any(ml.nlu_classifier(coalesce(body.html.display_text, body.plain.raw)).entities,
+      and any(ml.nlu_classifier(body.current_thread.text).entities,
               .name == "urgency"
       )
     ),
     (
-      any(ml.nlu_classifier(coalesce(body.html.display_text, body.plain.raw)).tags,
+      any(ml.nlu_classifier(body.current_thread.text).tags,
           .name == "purchase_order" and .confidence == "high"
       )
     )

--- a/detection-rules/suspicious_shipping_notification.yml
+++ b/detection-rules/suspicious_shipping_notification.yml
@@ -8,20 +8,20 @@ source: |
   // contains at least 1 link
   and length(body.links) > 0
   and 3 of (
-    strings.ilike(coalesce(body.html.display_text, body.plain.raw), "*(1)*"),
-    strings.ilike(coalesce(body.html.display_text, body.plain.raw), "*waiting for delivery*"),
-    strings.ilike(coalesce(body.html.display_text, body.plain.raw), "*delivery missed*"),
-    strings.ilike(coalesce(body.html.display_text, body.plain.raw), "*tracking number*")
+    strings.ilike(body.current_thread.text, "*(1)*"),
+    strings.ilike(body.current_thread.text, "*waiting for delivery*"),
+    strings.ilike(body.current_thread.text, "*delivery missed*"),
+    strings.ilike(body.current_thread.text, "*tracking number*")
   )
 
   // urgent/time-sensitive language
-  and any(ml.nlu_classifier(coalesce(body.html.display_text, body.plain.raw)).entities,
+  and any(ml.nlu_classifier(body.current_thread.text).entities,
           .name == "urgency"
   )
 
   // email is not personalized with recipients name
   and any(recipients.to,
-          any(ml.nlu_classifier(coalesce(body.html.display_text, body.plain.raw)).entities,
+          any(ml.nlu_classifier(body.current_thread.text).entities,
               .text == ..email.local_part
           )
   )

--- a/discovery-rules/impersonation_dmarc_failure_high_cred_phish_conclusion.yml
+++ b/discovery-rules/impersonation_dmarc_failure_high_cred_phish_conclusion.yml
@@ -7,7 +7,7 @@ source: |
   and any(distinct(headers.hops, .authentication_results.dmarc is not null),
           strings.ilike(.authentication_results.dmarc, "*fail")
   )
-  and any(ml.nlu_classifier(coalesce(body.html.display_text, body.plain.raw)).intents,
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name in ("cred_theft") and .confidence == "high"
   )
 tags:

--- a/discovery-rules/link_freefile_freemail_nlu.yml
+++ b/discovery-rules/link_freefile_freemail_nlu.yml
@@ -6,12 +6,12 @@ source: |
   type.inbound
   
   // short body
-  and length(body.plain.raw) < 500
+  and length(body.current_thread.text) < 500
   
   // NLU intent
   and (
-    any(ml.nlu_classifier(body.plain.raw).intents, .name != "benign")
-    and length(ml.nlu_classifier(body.plain.raw).intents) > 0
+    any(ml.nlu_classifier(body.current_thread.text).intents, .name != "benign")
+    and length(ml.nlu_classifier(body.current_thread.text).intents) > 0
   )
   
   // free file host link


### PR DESCRIPTION
Because this simplified logic in a few places, I also made some other updates like formatting. I tried to stay focused and only look for usage of `body.plain.raw`, `body.html.display_text`, `body.html.inner_text` that look like they are intended to use `body.current_thread.text`.

There are a few cases where we checked both and now only check one, and I think that's actually okay, since `current_thread` already handles that. Also, `current_thread` strips out banners which can make NLU results more accurate.