### PR TITLE
Add extra length check to rule

### DIFF
--- a/detection-rules/attachment_pdf_credtheft_link_suspicious_file.yml
+++ b/detection-rules/attachment_pdf_credtheft_link_suspicious_file.yml
@@ -10,7 +10,8 @@ source: |
   and any(attachments,
           .file_type == "pdf"
           and any(file.explode(.),
-                  any(ml.nlu_classifier(.scan.ocr.raw).intents,
+                  length(.scan.url.urls) > 0
+                  and any(ml.nlu_classifier(.scan.ocr.raw).intents,
                       .name == "cred_theft" and .confidence in~ ("medium", "high")
                   )
                   and any(.scan.url.urls,


### PR DESCRIPTION
It's redundant, but this can help with some short-circuiting until I improve an MQL optimization to do this automatically. It's redundant because of the `any(.scan.url.urls)` check later