### PR TITLE
Update attachment_small_html_recipient_address.yml

### DIFF
--- a/detection-rules/attachment_small_html_recipient_address.yml
+++ b/detection-rules/attachment_small_html_recipient_address.yml
@@ -4,6 +4,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
+  and type.inbound
   and (
     any(attachments,
         (
@@ -16,7 +17,10 @@ source: |
                 .size < 10000
                 and length(.scan.strings.strings) < 20
                 and any(recipients.to,
-                        any(..scan.strings.strings, strings.icontains(., ..email.email)) and .email.domain.valid
+                        any(..scan.strings.strings,
+                            strings.icontains(., ..email.email)
+                        )
+                        and .email.domain.valid
                 )
         )
     )
@@ -31,9 +35,27 @@ source: |
                    and .size < 10000
                    and length(.scan.strings.strings) < 20
                    and any(recipients.to,
-                           any(..scan.strings.strings, strings.icontains(., ..email.email)) and .email.domain.valid
+                           any(..scan.strings.strings,
+                               strings.icontains(., ..email.email)
+                           )
+                           and .email.domain.valid
                    )
            )
+    )
+  )
+  // bounce-back negations
+  and (
+    not strings.like(sender.email.local_part,
+                     "*postmaster*",
+                     "*mailer-daemon*",
+                     "*administrator*"
+    )
+    and not any(attachments,
+                .content_type in (
+                  "message/rfc822",
+                  "message/delivery-status",
+                  "text/calendar"
+                )
     )
   )
   and (


### PR DESCRIPTION
Seeing this fire on bouncebacks and other returned mail, because of the content_type inclusion of message/rfc822, and no check within the file explode to ensure the recipient match is in an HTML file.

Adding negation for bouncebacks to mitigate