### PR TITLE
Update impersonation_linkedin.yml

### DIFF
--- a/detection-rules/impersonation_linkedin.yml
+++ b/detection-rules/impersonation_linkedin.yml
@@ -37,6 +37,9 @@ source: |
     'linkedin.com',
     'smartrecruiters.com'
   )
+  and sender.email.domain.domain not in (
+    'linkedin.coupahost.com'
+  )
   and sender.email.email not in $recipient_emails
   and not strings.iends_with(headers.message_id, "linkedin.com>")
 


### PR DESCRIPTION
Negating linkedin.coupahost.com domain (used to send POs on behalf of LinkedIn corp)