### PR TITLE
Update impersonation_barracuda.yml

### DIFF
--- a/detection-rules/impersonation_barracuda.yml
+++ b/detection-rules/impersonation_barracuda.yml
@@ -21,7 +21,10 @@ source: |
     'sjbarracuda.com',
   
     // Barracuda Barcatering
-    'barracuda-barcatering.de'
+    'barracuda-barcatering.de',
+    
+   // Barracuda Events Team
+    'worldspan.co.uk'
   )
   and (
     profile.by_sender().prevalence in ("new", "outlier")


### PR DESCRIPTION
# Description

Negating worldspan.co.uk root domain (Barracuda Events Team)

# Associated samples

- https://platform.sublimesecurity.com/messages/3fdf90ee44605267cce0eeacfefbfc20d134f2ebfc1e26ed7b1e38e85b9c3b6d