### PR TITLE
Update impersonation_microsoft_credential_theft.yml

### DIFF
--- a/detection-rules/impersonation_microsoft_credential_theft.yml
+++ b/detection-rules/impersonation_microsoft_credential_theft.yml
@@ -5,28 +5,26 @@ severity: "high"
 source: |
   type.inbound
   and length(attachments) == 0
-  and any(ml.logo_detect(beta.message_screenshot()).brands, 
-      strings.starts_with(.name, "Microsoft")
+  and any(ml.logo_detect(beta.message_screenshot()).brands,
+          strings.starts_with(.name, "Microsoft")
   )
-  and any(ml.nlu_classifier(body.current_thread.text).intents, 
-      .name == "cred_theft" and .confidence in ("medium", "high")
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "cred_theft" and .confidence in ("medium", "high")
   )
   and (
-    not any(headers.hops,
-            .authentication_results.compauth.verdict is not null
-            and .authentication_results.compauth.verdict == "pass"
-            and sender.email.domain.root_domain in (
-              "microsoft.com",
-              "sharepointonline.com",
-              "cloudappsecurity.com",
-              "microsoftsupport.com"
-            )
+    not (
+      headers.auth_summary.dmarc.pass
+      and headers.auth_summary.dmarc.details.from.domain in (
+        "microsoft.com",
+        "sharepointonline.com",
+        "cloudappsecurity.com",
+        "microsoftsupport.com",
+        "microsoft.onmicrosoft.com"
+      )
     )
   )
   and (
-    (
-      not profile.by_sender().solicited
-    )
+    not profile.by_sender().solicited
     or (
       profile.by_sender().any_messages_malicious_or_spam
       and not profile.by_sender().any_false_positives
@@ -41,8 +39,8 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-  
   and not profile.by_sender().any_false_positives
+
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/impersonation_microsoft_credential_theft.yml
+++ b/detection-rules/impersonation_microsoft_credential_theft.yml
@@ -23,6 +23,7 @@ source: |
       )
     )
     or headers.auth_summary.dmarc.pass is null
+    or headers.auth_summary.dmarc.details.from.domain is null
   )
   and (
     not profile.by_sender().solicited

--- a/detection-rules/impersonation_microsoft_credential_theft.yml
+++ b/detection-rules/impersonation_microsoft_credential_theft.yml
@@ -22,6 +22,7 @@ source: |
         "microsoft.onmicrosoft.com"
       )
     )
+    or headers.auth_summary.dmarc.pass is null
   )
   and (
     not profile.by_sender().solicited


### PR DESCRIPTION
# Description

Compauth checks performing late in the hop chain are not sufficient enough to negate FP's
Moving to a dmarc check with known microsoft domain.domains

# Associated samples

Link to samples that are affected by your change. 

https://platform.sublimesecurity.com/rules/editor?canonical_id=350bb2f27438ea802d19d40b6e097cc983ad261205907305c5ea9f952b95255c