### PR TITLE
Update impersonation_linkedin.yml

### DIFF
--- a/detection-rules/impersonation_linkedin.yml
+++ b/detection-rules/impersonation_linkedin.yml
@@ -35,7 +35,8 @@ source: |
   )
   and sender.email.domain.root_domain not in (
     'linkedin.com',
-    'smartrecruiters.com'
+    'smartrecruiters.com',
+    'teams-events.com'
   )
   and sender.email.domain.domain not in (
     'linkedin.coupahost.com'


### PR DESCRIPTION
# Description

Negating teams-events.com root domain, as it is now used by Microsoft to send out legitimate LinkedIn event invites.

# Associated samples

- https://platform.sublimesecurity.com/messages/b36dc995908364689911fe20e411a427553a63d1eb125716f58cbad800d21d41
- https://platform.sublimesecurity.com/messages/ae9096cc119c4af9a672e0c6238783487fe77d1bd998400d04d5b6fd3aa9476e
- https://platform.sublimesecurity.com/messages/3f6a85f205bf4bb8e1c1ed9588a43032daa221bcd451582bd7f000fc3efabb6c
- https://platform.sublimesecurity.com/messages/303e3dce9ccb3466aa64b34f281ea6004d5cbab9b2a2c2f19665a156b7e76caa
