### PR TITLE
Update attachment_docusign_image_lure_qr_code.yml

### DIFF
--- a/detection-rules/attachment_docusign_image_lure_qr_code.yml
+++ b/detection-rules/attachment_docusign_image_lure_qr_code.yml
@@ -16,8 +16,19 @@ source: |
           )
           and (
             any(file.explode(.),
-                .scan.qr.type is not null
-                and regex.contains(.scan.qr.data, '\.')
+                (
+                  (
+                    .scan.qr.type is not null
+                    and regex.contains(.scan.qr.data, '\.')
+                  )
+                  or 
+                  // QR code language
+                  ( 
+                    regex.icontains(.scan.ocr.raw, 'scan|camera')
+                    and regex.icontains(.scan.ocr.raw, '\bQR\b|Q\.R\.|barcode')
+                  )
+                )
+  
                 // exclude images taken with mobile cameras and screenshots from android
                 and not any(.scan.exiftool.fields,
                             .key == "Model"
@@ -51,7 +62,6 @@ source: |
       and not profile.by_sender().any_false_positives
     )
   )
-
 
 attack_types:
   - "Credential Phishing"


### PR DESCRIPTION
# Description

Reusing the QR code language as a failsafe if the QR code is not detected. This logic has been in the Google QR code rule without issues.


# Associated samples

https://platform.sublimesecurity.com/rules/editor?canonical_id=c194c0d6cf63b052913fec2aef1cef4397c5d97bbf21d5850a0ed24c3a1e4799