### PR TITLE
Update attachment_html_smuggling_atob.yml

### DIFF
--- a/detection-rules/attachment_html_smuggling_atob.yml
+++ b/detection-rules/attachment_html_smuggling_atob.yml
@@ -27,6 +27,8 @@ source: |
                     or any(.scan.strings.strings, regex.icontains(., "=.?atob.*;"))
                     // usage: atob(atob
                     or any(.scan.strings.strings, strings.ilike(., "*atob?atob*"))
+                    // usage: {src: atob
+                    or any(.scan.strings.strings, strings.ilike(., "*{src: atob*"))
                     // usage: eval(atob)
                     or any(.scan.strings.strings, strings.ilike(., "*eval?atob*"))
                       // usage: atob(_0x)


### PR DESCRIPTION
# Description
Adding coverage for atob in script bracket. 


// usage: {src: atob

# Associated samples

https://platform.sublimesecurity.com/rules/editor?canonical_id=f4a2b4d0446fc4c63e212eacb9bacd820f7ee9f9c69b25b1dd669b6e2c5bac8a