### PR TITLE
Create spam_image_hidden_element.yml

### DIFF
--- a/detection-rules/spam_image_hidden_element.yml
+++ b/detection-rules/spam_image_hidden_element.yml
@@ -13,9 +13,13 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-  // find the template for the html body
-  and regex.icontains(body.html.raw,
-                      '<a href="https?:\/\/[^\x22]+\x22><img\s*src=\x22https:\/\/[^\x22]+\x22\><\/a>(?:<\/?[^>]*>){0,3}<(?:span|div)\s*style=\x22\s*display\s*\x3a\s*none\x3b[^\x22]*\x22>(?:_|&nbsp\x3b\x200c?){3,}'
+  // find the template - a link that is an image with an optional few html tags after it
+  and regex.contains(body.html.raw,
+                      '(?:<a href=\"https?:\/\/[^\x22]+\x22(?:\s[a-z]+=\x22[^\x22]+\x22)*>\s*(?:<img\s*src=\x22(?:https?:)?\/\/[^\x22]+\x22\>\s*){1,}(?:<\/?[^>]*>|\s){0,3}<\/a>)+'
+  )
+  // and where there is a span/div that is hidden
+  and regex.contains(body.html.raw,
+                      '<(?:span|div)\s*style=\x22\s*display\s*\x3a\s*none\x3b[^\x22]*\x22>'
   )
 
 attack_types:

--- a/detection-rules/spam_image_hidden_element.yml
+++ b/detection-rules/spam_image_hidden_element.yml
@@ -13,13 +13,15 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-  // find the template - a link that is an image with an optional few html tags after it
-  and regex.contains(body.html.raw,
-                      '(?:<a href=\"https?:\/\/[^\x22]+\x22(?:\s[a-z]+=\x22[^\x22]+\x22)*>\s*(?:<img\s*src=\x22(?:https?:)?\/\/[^\x22]+\x22\>\s*){1,}(?:<\/?[^>]*>|\s){0,3}<\/a>)+'
-  )
-  // and where there is a span/div that is hidden
-  and regex.contains(body.html.raw,
-                      '<(?:span|div)\s*style=\x22\s*display\s*\x3a\s*none\x3b[^\x22]*\x22>'
+  and (
+    // find the template - a link that is a centered image
+    regex.contains(body.html.raw,
+                   'center(?:\x22[^\>]+)?\>\s*<a href=\"https?:\/\/[^\x22]+\x22(?:\s[a-z]+=\x22[^\x22]+\x22)*>\s*[^\n]+\<img src=\x22[^\x22]+\x22><\/a>\s*<\/'
+    )
+    // and where there is a span/div that is hidden with either &nbsp\x3b\x200c? or underscores repeating multiple times OR followed by a new metatag
+    and regex.contains(body.html.raw,
+                       '<(?:span|div)\s*style=\x22\s*display\s*\x3a\s*none\x3b[^\x22]*\x22>(?:(?:_|&nbsp\x3b\x200c?){3,}\s+\<|\s+\<meta )'
+    )
   )
 
 attack_types:

--- a/detection-rules/spam_image_hidden_element.yml
+++ b/detection-rules/spam_image_hidden_element.yml
@@ -1,0 +1,29 @@
+name: "Spam: Image as content with Hidden HTML Element"
+description: "This has been observed in the delivery of emails containing account/membership expiration lure themes of popular online services or delivery notifications."
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and not profile.by_sender().solicited
+  // not high trust sender domains
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  // find the template for the html body
+  and regex.icontains(body.html.raw,
+                      '<a href="https?:\/\/[^\x22]+\x22><img\s*src=\x22https:\/\/[^\x22]+\x22\><\/a>(?:<\/?[^>]*>){0,3}<(?:span|div)\s*style=\x22\s*display\s*\x3a\s*none\x3b[^\x22]*\x22>(?:_|&nbsp\x3b\x200c?){3,}'
+  )
+  // any logo detection
+
+
+attack_types:
+  - "Spam"
+tactics_and_techniques:
+  - "Evasion"
+  - "Image as content"
+detection_methods:
+  - "Content analysis"

--- a/detection-rules/spam_image_hidden_element.yml
+++ b/detection-rules/spam_image_hidden_element.yml
@@ -25,4 +25,6 @@ tactics_and_techniques:
   - "Image as content"
 detection_methods:
   - "Content analysis"
+  - "HTML analysis"
+  - "Sender analysis"
 id: "5de8861f-a343-521f-ac8c-b4b91e389a6e"

--- a/detection-rules/spam_image_hidden_element.yml
+++ b/detection-rules/spam_image_hidden_element.yml
@@ -20,7 +20,7 @@ source: |
     )
     // and where there is a span/div that is hidden with either &nbsp\x3b\x200c? or underscores repeating multiple times OR followed by a new metatag
     and regex.contains(body.html.raw,
-                       '<(?:span|div)\s*style=\x22\s*display\s*\x3a\s*none\x3b[^\x22]*\x22>(?:(?:_|&nbsp\x3b\x200c?){3,}\s+\<|\s+\<meta )'
+                       '<(?:span|div)\s*style=\x22\s*display\s*\x3a\s*none\x3b[^\x22]*\x22>(?:(?:_|&nbsp\x3b\x200c?){3,}\s+\<|\s+\<meta |\s+\<center )'
     )
   )
 

--- a/detection-rules/spam_image_hidden_element.yml
+++ b/detection-rules/spam_image_hidden_element.yml
@@ -27,3 +27,4 @@ tactics_and_techniques:
   - "Image as content"
 detection_methods:
   - "Content analysis"
+id: "5de8861f-a343-521f-ac8c-b4b91e389a6e"

--- a/detection-rules/spam_image_hidden_element.yml
+++ b/detection-rules/spam_image_hidden_element.yml
@@ -17,8 +17,6 @@ source: |
   and regex.icontains(body.html.raw,
                       '<a href="https?:\/\/[^\x22]+\x22><img\s*src=\x22https:\/\/[^\x22]+\x22\><\/a>(?:<\/?[^>]*>){0,3}<(?:span|div)\s*style=\x22\s*display\s*\x3a\s*none\x3b[^\x22]*\x22>(?:_|&nbsp\x3b\x200c?){3,}'
   )
-  // any logo detection
-
 
 attack_types:
   - "Spam"


### PR DESCRIPTION
# Description
Adding detection for emails with observed body html template that uses a single image as body content and hides the rest of the html.

# Associated samples
- [Sample 1](https://platform.sublimesecurity.com/messages/c4f3fe0398d704f0d88db9988ca5d85cc2452ae74581b2c3492a2b9bb72da121)
- [Sample 2](https://platform.sublimesecurity.com/messages/e9feb03520daad74e2fe1dcda262cbb0b54c68ab012a41dd1cc6edf27e1a28b3)
- [Sample 3](https://platform.sublimesecurity.com/messages/00d31f1821cd55ea499d35b7df6c0f89f3b64acb9909b1ffe4dea02fe43f49c2)

## Associated hunts
- [Hunt 1](https://platform.sublimesecurity.com/hunts/a34d973e-74f6-443f-9dae-ed983063cd99)


