### PR TITLE
Create attachment_html_hidden_body.yml

### DIFF
--- a/detection-rules/attachment_html_hidden_body.yml
+++ b/detection-rules/attachment_html_hidden_body.yml
@@ -16,8 +16,8 @@ source: |
   and any(attachments,
           .file_extension == "html"
           // starts with the hidden body element
-          and strings.starts_with(file.parse_html(.).raw,
-                                  '<body style="display:none;">'
+          and regex.icontains(file.parse_html(.).raw,
+                                  '^<body style\s*=\s*"\s*display\s*:\s*none\s*;\s*">'
           )
   )
 

--- a/detection-rules/attachment_html_hidden_body.yml
+++ b/detection-rules/attachment_html_hidden_body.yml
@@ -1,0 +1,32 @@
+name: "Attachment: HTML with Hidden Body"
+description: "This rule identifies HTML attachments which begin directly with a hidden body element.  This has been observed in phishing campaigns to hide the content of an otherwise benign HTML attachment that then has remote content injected into the body."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and not profile.by_sender().solicited
+  // not high trust sender domains
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  and any(attachments,
+          .file_extension == "html"
+          // starts with the hidden body element
+          and strings.starts_with(file.parse_html(.).raw,
+                                  '<body style="display:none;">'
+          )
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Scripting"
+detection_methods:
+  - "Content analysis"
+  - "HTML analysis"
+  - "File analysis"

--- a/detection-rules/attachment_html_hidden_body.yml
+++ b/detection-rules/attachment_html_hidden_body.yml
@@ -30,3 +30,4 @@ detection_methods:
   - "Content analysis"
   - "HTML analysis"
   - "File analysis"
+id: "b059a781-b681-5c84-98ba-416deb165555"


### PR DESCRIPTION
# Description

Detect emails that start with a hidden body tag in an HTML attachment

# Associated samples

- [Sample 1](https://platform.sublimesecurity.com/messages/5327229f8c716a40457c7a136439dd9a6d50f72446547d155e4aea79493f97cb)
- [Sample 2](https://platform.sublimesecurity.com/messages/fe1fe38aef6dd926393e3670b237ad92b0a396b146155b185d25672140af7373)
- [Sample 3](https://platform.sublimesecurity.com/messages/bdb8c5b07b1bb0b9a3765fb045229939acdb498965a98f22a255502643a5e862)

## Associated hunts

If you ran any hunts with your rule, please link them here.

- [Hunt 1](https://platform.sublimesecurity.com/hunts/15e54b56-90eb-41ca-b481-a2568eddd532)


