### PR TITLE
FP fix: qr_code_suspicious_indicators.yml

### DIFF
--- a/detection-rules/qr_code_suspicious_indicators.yml
+++ b/detection-rules/qr_code_suspicious_indicators.yml
@@ -57,7 +57,12 @@ source: |
       or regex.contains(subject.subject,
                         "(Authenticat(e|or|ion)|2fa|Multi.Factor|(qr|bar).code|action.require|alert|Att(n|ention):)"
       )
-      or (any(recipients.to, strings.icontains(subject.subject, .display_name)))
+      or (
+        any(recipients.to,
+            strings.icontains(subject.subject, .display_name)
+            and .email.domain.root_domain != sender.email.domain.root_domain
+        )
+      )
       or (
         regex.icontains(subject.subject,
                         "termination.*notice",

--- a/detection-rules/qr_code_suspicious_indicators.yml
+++ b/detection-rules/qr_code_suspicious_indicators.yml
@@ -271,7 +271,6 @@ source: |
         )
         and length(recipients.cc) == 0
         and length(recipients.bcc) == 0
-        and length(body.links) < 10
       )
       or any(file.explode(beta.message_screenshot()),
              (

--- a/detection-rules/qr_code_suspicious_indicators.yml
+++ b/detection-rules/qr_code_suspicious_indicators.yml
@@ -271,6 +271,7 @@ source: |
         )
         and length(recipients.cc) == 0
         and length(recipients.bcc) == 0
+        and length(body.links) < 10
       )
       or any(file.explode(beta.message_screenshot()),
              (


### PR DESCRIPTION
# Description

Adding additional logic in the "recipient's display name in subject" to negate situations when the sender's and recipients root domain are the same., and link count checks.

# Associated samples

https://platform.sublimesecurity.com/messages/b6eed995323bf6f0f260c8bfc57375ba3876b024189d00a4259d9ceac5339901
https://platform.sublimesecurity.com/messages/142c699e7d4ffbe9dd7373d3a7c026cf2eaa226c0592f85fcb53fd8184137b74