### PR TITLE
Negating calendar invites from cred theft rule

### DIFF
--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -341,6 +341,11 @@ source: |
   // exclude Google shared calendar messages
   // Subject: "<sender name> has shared a calendar with you"
   and headers.return_path.domain.domain != "calendar-server.bounces.google.com"
+  // negate calendar invites
+  and not (
+    0 < length(attachments) < 3
+    and all(attachments, .content_type in ("text/calendar", "application/ics"))
+  )
   // bounce-back negations
   and not (
     strings.like(sender.email.local_part,


### PR DESCRIPTION
# Description
Negating calendar invites.

# Associated samples

https://platform.sublimesecurity.com/messages/eebc9ec48ef8dea6ab58255fa213a2cdc576c57b1ef1a3aefa8a35435a519e8c
