### PR TITLE
Update impersonation_facebook.yml

### DIFF
--- a/detection-rules/impersonation_facebook.yml
+++ b/detection-rules/impersonation_facebook.yml
@@ -36,6 +36,18 @@ source: |
         )
       )
     )
+    or 
+    // or the body contains a facebook/meta footer with the address citing "community support" 
+    (
+      strings.icontains(body.current_thread.text,
+                        "Meta Platforms, Inc., Attention: Community Support, 1 Facebook Way, Menlo Park, CA 94025"
+      )
+      // and it contains a link to spawn a chat with facebook - this is not the way support operates
+      and any(body.links,
+              strings.ends_with(.href_url.domain.domain, 'facebook.com')
+              and strings.starts_with(.href_url.path, '/msg/')
+      )
+    )
   )
   and sender.email.domain.root_domain not in~ (
     'facebook.com',


### PR DESCRIPTION
# Description

Adding indicators of a different meta impersonation campaign that doesn't always include indicators in the display_name/sender domain. It looks for a footer mentioning Community Support and a link to spawn a facebook chat. 

# Associated samples
https://platform.sublimesecurity.com/rules/editor?canonical_id=fa983fecac19faecafbd61a4c32eca355574171727121d9628d04c1b68571a4f