### PR TITLE
Create link_google_presentation_open_redirect.yml

### DIFF
--- a/detection-rules/link_google_presentation_open_redirect.yml
+++ b/detection-rules/link_google_presentation_open_redirect.yml
@@ -1,0 +1,69 @@
+name: "Google Presentation Open Redirect Phishing"
+description: "Detects emails containing links to Google Document Presentations that either have a single page with a single external link, have been removed for Terms of Service violations, or have been deleted."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(body.links,
+          // body link is to a google doc presentation
+          .href_url.domain.domain == "docs.google.com"
+          and strings.istarts_with(.href_url.path, '/presentation/')
+          and (
+            // and that presentation...
+            (
+              // contains a slingle link
+              length(ml.link_analysis(., mode="aggressive").final_dom.links) == 1
+              
+              // cannot be edited via link provided
+              and strings.contains(ml.link_analysis(., mode="aggressive").final_dom.raw,
+                                   'canEdit:  false'
+              )
+              
+              // and a single page
+              and strings.contains(ml.link_analysis(., mode="aggressive").final_dom.raw,
+                                   'slidePageCount:  1.0'
+              )
+              
+              // where we have links which have been written via a google open redirect
+              and any(ml.link_analysis(., mode="aggressive").final_dom.links,
+                      // links are not in thhe org_domains
+                      .href_url.domain.domain not in $org_domains
+                      and (
+                        (
+                          // don't include high rep domains
+                          .href_url.domain.domain not in $tranco_1m
+                          and .href_url.domain.domain not in $umbrella_1m
+                        )
+                        // if it's in Tranco or Umbrella, still include it if it's one of these
+                        or .href_url.domain.domain in $free_file_hosts
+                        or .href_url.domain.root_domain in $free_file_hosts
+                        or .href_url.domain.root_domain in $free_subdomain_hosts
+                        // or it's a url shortner
+                        or .href_url.domain.root_domain in $url_shorteners
+                      )
+                      // which have been "unrolled" by the google_open_redirect rule
+                      and any(.href_url.rewrite.encoders,
+                              . == "google_open_redirect"
+                      )
+              )
+            )
+            // or the presentation has been removed for violation of terms of service
+            or strings.icontains(ml.link_analysis(., mode="aggressive").final_dom.display_text,
+                                 "We're sorry. You can't access this item because it is in violation of our Terms of Service."
+            )
+            // or the presentation has been deleted
+            or strings.icontains(ml.link_analysis(., mode="aggressive").final_dom.display_text,
+                                 "Sorry, the file you have requested has been deleted."
+            )
+          )
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Open redirect"
+  - "Social engineering"
+detection_methods:
+  - "URL analysis"
+  - "HTML analysis"

--- a/detection-rules/link_google_presentation_open_redirect.yml
+++ b/detection-rules/link_google_presentation_open_redirect.yml
@@ -67,3 +67,4 @@ tactics_and_techniques:
 detection_methods:
   - "URL analysis"
   - "HTML analysis"
+id: "5d01ee3a-9426-5a8b-bde3-328d6780af6f"


### PR DESCRIPTION
# Description

New coverage for links to google presentations which contain links to other pages, observed in cred phishing. 


# Associated samples

Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.

- [Sample 1](https://platform.sublimesecurity.com/messages/4bd5151babff75da6a386307605b6ca5d80641f0223de45b0baf12ac4b55b930)
- [Sample 2](https://platform.sublimesecurity.com/messages/d17ffe1f80a709366acc7aa458d69e9cf6573335722f0756b476706be74238c8)

## Associated hunts

- [Hunt 1](https://platform.sublimesecurity.com/hunts/a615b196-573d-4da0-bab5-715cf8707143)
