### PR TITLE
Update attachment_eml_cred_theft_language.yml

### DIFF
--- a/detection-rules/attachment_eml_cred_theft_language.yml
+++ b/detection-rules/attachment_eml_cred_theft_language.yml
@@ -15,7 +15,7 @@ source: |
           // negate Mimecast Attachment Protection
           and not (
               any(attachments, .file_name == 'We sent you safe versions of your files')
-              and strings.icontains(body.current_thread.text, 'Mimecast Attachment Protection has deemed this file to be safe, but always exercise caution when opening files.')
+              and strings.contains(body.current_thread.text, 'Mimecast Attachment Protection has deemed this file to be safe, but always exercise caution when opening files.')
           )
   )
   // exclude bounce backs & read receipts

--- a/detection-rules/attachment_eml_cred_theft_language.yml
+++ b/detection-rules/attachment_eml_cred_theft_language.yml
@@ -12,6 +12,11 @@ source: |
                   .name == "cred_theft" and .confidence == "high"
           )
           and not strings.like(file.parse_eml(.).sender.email.local_part, "*postmaster*", "*mailer-daemon*", "*administrator*")
+          // negate Mimecast Attachment Protection
+          and not (
+              any(attachments, .file_name == 'We sent you safe versions of your files')
+              and strings.icontains(body.current_thread.text, 'Mimecast Attachment Protection has deemed this file to be safe, but always exercise caution when opening files.')
+          )
   )
   // exclude bounce backs & read receipts
   and not strings.like(sender.email.local_part,


### PR DESCRIPTION
# Description

Negating .eml attachments created by Mimecast Attachment Protection

# Associated samples

Link to samples that are affected by your change. 

- https://platform.sublimesecurity.com/messages/945c874da5c470b0a46c1f88424847afbc462b8c3b2e85069f05808831dddf45
- https://platform.sublimesecurity.com/messages/b807cc96d984a39be87800001f58a10a618aa4ee4aa5c11e393024ec2107f25f
- https://platform.sublimesecurity.com/messages/72a8dbe18751bfd6e53a8730afdf1af0dbd41e072d15c1fa90b76e4b3dd388e4
- https://platform.sublimesecurity.com/messages/ef44e7fd5efe7b1ce1072f81973f032f0448df287dddeec196c5e6618181dd2f
- https://platform.sublimesecurity.com/messages/c45e63dce5768fc617057b3e5c924cb7d742d4bbde7e20311420c4ca64a4a26d