### PR TITLE
Create link_sharepoint_netorgft.yml

### DIFF
--- a/detection-rules/link_sharepoint_netorgft.yml
+++ b/detection-rules/link_sharepoint_netorgft.yml
@@ -1,5 +1,5 @@
 name: "Link: SharePoint Files Shared from GoDaddy Federated Tenants"
-description: "This matches on inbound Shared File notiifcation emails from Microsoft, where any link to SharePoint contains a default GoDaddy Federated Tenant Name. These have been observed being frequenantly abused to send Credential Phishing."
+description: "This matches on inbound Shared File notiifcation emails from Microsoft, where any link to SharePoint contains a default GoDaddy Federated Tenant Name. These have been observed being frequently abused to send Credential Phishing."
 type: "rule"
 severity: "low"
 source: |

--- a/detection-rules/link_sharepoint_netorgft.yml
+++ b/detection-rules/link_sharepoint_netorgft.yml
@@ -32,3 +32,4 @@ tactics_and_techniques:
 detection_methods:
   - "Sender analysis"
   - "URL analysis"
+id: "0e26cdd2-cf19-53ed-8b30-b3e2e7ea912f"

--- a/detection-rules/link_sharepoint_netorgft.yml
+++ b/detection-rules/link_sharepoint_netorgft.yml
@@ -1,5 +1,5 @@
 name: "Link: SharePoint Files Shared from GoDaddy Federated Tenants"
-description: "This matches on inbound "Shared File" notiifcation emails from Microsoft, where any link to sharepoint contains a default GoDaddy Federated Tenant Name.  These have been observed being frequenantly abused to send Credential Phishing."
+description: "This matches on inbound Shared File notiifcation emails from Microsoft, where any link to sharepoint contains a default GoDaddy Federated Tenant Name. These have been observed being frequenantly abused to send Credential Phishing."
 type: "rule"
 severity: "low"
 source: |

--- a/detection-rules/link_sharepoint_netorgft.yml
+++ b/detection-rules/link_sharepoint_netorgft.yml
@@ -1,10 +1,10 @@
-name: "Link: SharePoint Files Shared from GoDaddy Federated Tenants"
-description: "This matches on inbound Shared File notiifcation emails from Microsoft, where any link to SharePoint contains a default GoDaddy Federated Tenant Name. These have been observed being frequently abused to send Credential Phishing."
+name: "Link: SharePoint files shared from GoDaddy federated tenants"
+description: "This matches on inbound Shared File notiifcation emails from Microsoft, where any link to SharePoint contains a default GoDaddy Federated Tenant Name. These have been observed being frequently abused to send credential phishing campaigns."
 type: "rule"
 severity: "low"
 source: |
   type.inbound
-  // Matches the message id observed. DKIM/SPF domains can be custom and therefor are unpredictable. 
+  // Matches the message id observed. DKIM/SPF domains can be custom and therefore are unpredictable.
   and strings.starts_with(headers.message_id, '<Share-')
   and strings.ends_with(headers.message_id, '@odspnotify>')
   

--- a/detection-rules/link_sharepoint_netorgft.yml
+++ b/detection-rules/link_sharepoint_netorgft.yml
@@ -1,0 +1,34 @@
+name: "Link: SharePoint Files Shared from GoDaddy Federated Tenants"
+description: "This matches on inbound "Shared File" notiifcation emails from Microsoft, where any link to sharepoint contains a default GoDaddy Federated Tenant Name.  These have been observed being frequenantly abused to send Credential Phishing."
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  // Matches the message id observed. DKIM/SPF domains can be custom and therefor are unpredictable. 
+  and strings.starts_with(headers.message_id, '<Share-')
+  and strings.ends_with(headers.message_id, '@odspnotify>')
+  
+  // subject matches the default "shared <filename> with you" format
+  and strings.ends_with(subject.subject, ' with you')
+  
+  // any of the links are the default netorgft name from GoDaddy
+  and any(body.links,
+          // Default GoDaddy tenant names
+          strings.starts_with(.href_url.domain.subdomain, 'netorgft')
+          and .href_url.domain.root_domain == "sharepoint.com"
+  )
+  
+  // and sender has never had email sent to them
+  and not profile.by_sender().solicited
+  
+  // and there haven't been any FPs reported for the sender
+  and not profile.by_sender().any_false_positives
+tags:
+ - "Attack surface reduction"
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+detection_methods:
+  - "Sender analysis"
+  - "URL analysis"

--- a/detection-rules/link_sharepoint_netorgft.yml
+++ b/detection-rules/link_sharepoint_netorgft.yml
@@ -1,5 +1,5 @@
 name: "Link: SharePoint Files Shared from GoDaddy Federated Tenants"
-description: "This matches on inbound Shared File notiifcation emails from Microsoft, where any link to sharepoint contains a default GoDaddy Federated Tenant Name. These have been observed being frequenantly abused to send Credential Phishing."
+description: "This matches on inbound Shared File notiifcation emails from Microsoft, where any link to SharePoint contains a default GoDaddy Federated Tenant Name. These have been observed being frequenantly abused to send Credential Phishing."
 type: "rule"
 severity: "low"
 source: |


### PR DESCRIPTION
# Description
ASR rule for links to sharepoint files which are owned by a GoDaddy federated tenant.  It's possible the rule will alert on non-malicious activity, hence being created as an ASR rule. 

# Associated samples

- [Sample 1](https://platform.sublimesecurity.com/messages/b008077ecca250a5b53835304a63f41e36de083369d5b3b575a800574447c5b3)
- [Sample 2](https://platform.sublimesecurity.com/messages/7a553f91a43c03d10b5286c05c4604a02399c100550157b0b582dc5b3d6c6ee3)
- [Sample 3](https://platform.sublimesecurity.com/messages/28a03f7f63d64334f76b4c4b08e25743e4990078287fc18ceee3571d2b2225c1)

## Associated hunts

- [Hunt 1](https://platform.sublimesecurity.com/hunts/38cc2fd1-8043-486a-9d03-074a427aee14)