### PR TITLE
Update open_redirect_doubleclick.yml

### DIFF
--- a/detection-rules/open_redirect_doubleclick.yml
+++ b/detection-rules/open_redirect_doubleclick.yml
@@ -7,8 +7,8 @@ source: |
   and length(body.links) < 10
   and any(body.links,
           .href_url.domain.root_domain == "doubleclick.net"
-          and (.href_url.path == "/aclk" or .href_url.path == "/pcs/click")
-          and regex.icontains(.href_url.query_params, '&adurl=(?:[a-z]+(?:\:|%3a))?(?:%2f|/)(?:%2f|/)')
+          and (.href_url.path == "/aclk" or .href_url.path == "/pcs/click" or .href_url.path == "/searchads/link/click")
+          and regex.icontains(.href_url.query_params, '&(?:adurl|ds_dest_url)=(?:[a-z]+(?:\:|%3a))?(?:%2f|/)(?:%2f|/)')
   )
   and (
     profile.by_sender().prevalence in ("new", "outlier")

--- a/detection-rules/open_redirect_doubleclick.yml
+++ b/detection-rules/open_redirect_doubleclick.yml
@@ -7,8 +7,8 @@ source: |
   and length(body.links) < 10
   and any(body.links,
           .href_url.domain.root_domain == "doubleclick.net"
-          and .href_url.path == "/aclk"
-          and regex.icontains(.href_url.query_params, "&adurl=[a-zA-Z]{3,10}://.*$")
+          and (.href_url.path == "/aclk" or .href_url.path == "/pcs/click")
+          and regex.icontains(.href_url.query_params, '&adurl=(?:[a-z]+(?:\:|%3a))?(?:%2f|/)(?:%2f|/)')
   )
   and (
     profile.by_sender().prevalence in ("new", "outlier")

--- a/detection-rules/open_redirect_doubleclick.yml
+++ b/detection-rules/open_redirect_doubleclick.yml
@@ -7,8 +7,14 @@ source: |
   and length(body.links) < 10
   and any(body.links,
           .href_url.domain.root_domain == "doubleclick.net"
-          and (.href_url.path == "/aclk" or .href_url.path == "/pcs/click" or .href_url.path == "/searchads/link/click")
-          and regex.icontains(.href_url.query_params, '&(?:adurl|ds_dest_url)=(?:[a-z]+(?:\:|%3a))?(?:\/|%2f)(?:\/|%2f)')
+          and (
+            strings.icontains(.href_url.path, "/aclk")
+            or strings.icontains(.href_url.path, "/pcs/click")
+            or strings.icontains(.href_url.path, "/searchads/link/click")
+          )
+          and regex.icontains(.href_url.query_params,
+                              '&(?:adurl|ds_dest_url)=(?:[a-z]+(?:\:|%3a))?(?:\/|%2f)(?:\/|%2f)'
+          )
   )
   and (
     profile.by_sender().prevalence in ("new", "outlier")

--- a/detection-rules/open_redirect_doubleclick.yml
+++ b/detection-rules/open_redirect_doubleclick.yml
@@ -8,7 +8,7 @@ source: |
   and any(body.links,
           .href_url.domain.root_domain == "doubleclick.net"
           and (.href_url.path == "/aclk" or .href_url.path == "/pcs/click" or .href_url.path == "/searchads/link/click")
-          and regex.icontains(.href_url.query_params, '&(?:adurl|ds_dest_url)=(?:[a-z]+(?:\:|%3a))?(?:%2f|/)(?:%2f|/)')
+          and regex.icontains(.href_url.query_params, '&(?:adurl|ds_dest_url)=(?:[a-z]+(?:\:|%3a))?(?:\/|%2f)(?:\/|%2f)')
   )
   and (
     profile.by_sender().prevalence in ("new", "outlier")


### PR DESCRIPTION
# Description

Update to catch newly observed url strings and modify regex to further detect evasions. 


# Associated samples

- [Sample 1](https://platform.sublimesecurity.com/messages/0eff5d3abc84b8dfa26c7df7aec23e7691e0897c6662d17cc97fc5c20db2741c) - different url path
- [Sample 2](https://platform.sublimesecurity.com/messages/01f4b9b112bc145694b76437ac364d34ada600487a1d08e0ca4e4928cde4df40) - Missing the Scheme
- [Sample 3](https://platform.sublimesecurity.com/messages/5dc1693e42ce4aa8a8c68fc2c571b3f825cdf9fc0c8db72264664b57148d7775) - different url path with ds_dest_url instead of adurl

## Associated hunts

- [Hunt 1](https://platform.sublimesecurity.com/hunts/a880d760-123e-4b80-8a77-a2496c876ac8)

