### PR TITLE
Create open_redirect_nested_doubleclick.yml

### DIFF
--- a/detection-rules/open_redirect_nested_doubleclick.yml
+++ b/detection-rules/open_redirect_nested_doubleclick.yml
@@ -29,3 +29,4 @@ tactics_and_techniques:
 detection_methods:
   - "Sender analysis"
   - "URL analysis"
+id: "bbed5cc6-4c39-5a53-9255-269cbd4e27cb"

--- a/detection-rules/open_redirect_nested_doubleclick.yml
+++ b/detection-rules/open_redirect_nested_doubleclick.yml
@@ -1,5 +1,5 @@
 name: "Open redirect: Nested Doubleclick.net"
-description: Doubleclick.net link leveraging a nested doubleclick.net open redirect from a new or outlier sender.
+description: "Doubleclick.net link leveraging a nested doubleclick.net open redirect from a new or outlier sender. The unusual behavior of nesting a doubleclick URL inside another doubleclick link warrants increasing the severity of this rule."
 type: "rule"
 severity: "high"
 source: |

--- a/detection-rules/open_redirect_nested_doubleclick.yml
+++ b/detection-rules/open_redirect_nested_doubleclick.yml
@@ -1,0 +1,31 @@
+name: "Open redirect: Nested Doubleclick.net"
+description: Doubleclick.net link leveraging a nested doubleclick.net open redirect from a new or outlier sender.
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and length(body.links) < 10
+  and any(body.links,
+          .href_url.domain.root_domain == "doubleclick.net"
+          and (
+            strings.icontains(.href_url.path, "/aclk")
+            or strings.icontains(.href_url.path, "/pcs/click")
+            or strings.icontains(.href_url.path, "/searchads/link/click")
+          )
+    and regex.icontains(.href_url.query_params, '&(?:adurl|ds_dest_url)=(?:https?(\:|%3a))?(?:\/|%2f)(?:\/|%2f)adclick.g.doubleclick.net')
+  )
+  and (
+    profile.by_sender().prevalence in ("new", "outlier")
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and not profile.by_sender().any_false_positives
+    )
+  )
+attack_types:
+  - "Credential Phishing"
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Open redirect"
+detection_methods:
+  - "Sender analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description

Add a high severity rule for an unusual behavior of nested doubleclick.net urls.  The update to https://github.com/sublime-security/sublime-rules/pull/1706/ should catch this as well, but I thought given the unique nature of this behavior it might warrant a high severity rule by itself. 

Thoughts/Feedback welcome.

# Associated samples

- [Sample 1](https://platform.sublimesecurity.com/messages/bdc1a4c176bcec52fcc949d0387725716dbc6e171b3165bcd33b8275e65261d0)
- [Sample 2](https://platform.sublimesecurity.com/messages/01f4b9b112bc145694b76437ac364d34ada600487a1d08e0ca4e4928cde4df40)

## Associated hunts

- [Hunt 1](https://platform.sublimesecurity.com/hunts/93f5717f-7a04-46a6-a76d-50790afc125c)
