### PR TITLE
Create open_redirect_cartoonnetwork.yml

### DIFF
--- a/detection-rules/open_redirect_cartoonnetwork.yml
+++ b/detection-rules/open_redirect_cartoonnetwork.yml
@@ -1,0 +1,24 @@
+name: "Open Redirect: Cartoon Network"
+description: "This rule detects the use of Cartoon Network's Denmark domain as an open redirect."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // it has to be www. - note hitting the www doesn't work
+  and any(body.links,
+          .href_url.domain.domain == 'www.cartoonnetwork.dk'
+          // the path startswith a double //
+          and strings.starts_with(.href_url.path, '//')
+          // the path has to end in a trailing /
+          and strings.ends_with(.href_url.path, '/')
+   )
+
+attack_types:
+  - "Credential Phishing"
+  - "Spam"
+tactics_and_techniques:
+  - "Open redirect"
+  - "Evasion"
+detection_methods:
+  - "Content analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description

Detect the use of an open redirect via the Cartoon Network's Denmark domain.
# Associated samples

- [Sample 1](https://platform.sublimesecurity.com/messages/39192bf7285d1f3638ac1e39ca72f2ae8fec42ae635bfcd4c6203693258bf0f1)
- [Sample 2
](https://platform.sublimesecurity.com/messages/789fb78c11222b95b975425ea77cc6be96168375da20557aa3251c07d76fac21)
## Associated hunts

- [Hunt 1](https://platform.sublimesecurity.com/hunts/26a506a3-718e-4bd3-9b7f-a9d82dfea340)
