### PR TITLE
Update spam_fake_photo_share.yml

### DIFF
--- a/detection-rules/spam_fake_photo_share.yml
+++ b/detection-rules/spam_fake_photo_share.yml
@@ -17,20 +17,18 @@ source: |
       strings.ilike(subject.subject, "*picture*", "*photo*", "*image*")
       or strings.icontains(subject.subject, sender.display_name)
       or (
-        (
-          length(body.html.display_text) < 500
-          and strings.ilike(body.html.display_text,
-                            "*picture*",
-                            "*photo*",
-                            "*image*"
-          )
+        length(body.html.display_text) < 500
+        and strings.ilike(body.html.display_text,
+                          "*picture*",
+                          "*photo*",
+                          "*image*"
         )
-        or strings.ilike(body.plain.raw, "*picture*", "*photo*", "*image*")
-        or strings.ilike(body.current_thread.text,
-                         "*picture*",
-                         "*photo*",
-                         "*image*"
-        )
+      )
+      or strings.ilike(body.plain.raw, "*picture*", "*photo*", "*image*")
+      or strings.ilike(body.current_thread.text,
+                       "*picture*",
+                       "*photo*",
+                       "*image*"
       )
     )
   )

--- a/detection-rules/spam_fake_photo_share.yml
+++ b/detection-rules/spam_fake_photo_share.yml
@@ -17,7 +17,14 @@ source: |
       strings.ilike(subject.subject, "*picture*", "*photo*", "*image*")
       or strings.icontains(subject.subject, sender.display_name)
       or (
-        strings.ilike(body.html.display_text, "*picture*", "*photo*", "*image*")
+        (
+          length(body.html.display_text) < 500
+          and strings.ilike(body.html.display_text,
+                            "*picture*",
+                            "*photo*",
+                            "*image*"
+          )
+        )
         or strings.ilike(body.plain.raw, "*picture*", "*photo*", "*image*")
         or strings.ilike(body.current_thread.text,
                          "*picture*",
@@ -31,6 +38,7 @@ source: |
   and any(body.links,
           (
             network.whois(.href_url.domain).days_old < 30
+            and .display_text is not null
             and .href_url.domain.root_domain != sender.email.domain.root_domain
           )
           or (


### PR DESCRIPTION
# Description

Seeing abnormal amounts of FP's on this. 
Setting size limitation on HTML display text to bring in line with the other body inspections

Also ensuring the display text of the < 30d old linked domain is not null. (This has been firing on emails in a thread)

# Associated samples
https://platform.sublimesecurity.com/messages/3ba4142a4ca7f29db7247b83adeb1bd2dbe35af2b0a4c46de920919ed16f3ffb
