### PR TITLE
Create link_sharepoint_sus_name.yml

### DIFF
--- a/link_sharepoint_sus_name.yml
+++ b/link_sharepoint_sus_name.yml
@@ -1,0 +1,71 @@
+name: "Link: Suspicious SharePoint Document Name"
+description: "The detection rule is intended to match on emails sent from SharePoint indicating a shared file to the recipient that contain suspicious content within the document name.  The Link display text is leveraged to identify the name of the shared file."
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and strings.icontains(subject.subject, "shared")
+  and strings.ilike(body.current_thread.text,
+                    "*shared a file with you*",
+                    "*shared with you*",
+                    "*invited you to access a file*"
+  )
+  and any(body.links,
+          (
+  
+            // file sharing service references
+            strings.icontains(.display_text, 'dropbox')
+            or strings.icontains(.display_text, 'docusign')
+  
+            // file name lures
+            or regex.icontains(.display_text, 'secure.(?:file|document)')
+            or regex.icontains(.display_text, 'important.(?:file|document)')
+            or regex.icontains(.display_text, 'shared.(?:file|document)')
+            or regex.icontains(.display_text, 'document\s?\d+$')
+            or regex.icontains(.display_text, '^\d+$')
+            or strings.icontains(.display_text, 'one_docx')
+            or regex.icontains(.display_text, 'A document.*One.?Drive')
+  
+            // action in file name
+            or strings.icontains(.display_text, 'click here')
+            or strings.icontains(.display_text, 'Download PDF')
+  
+            // limited file name to "confidential"
+            or .display_text =~ 'Confidentiality'
+            or .display_text =~ 'Confidential'
+  
+            // invoice themes
+            or strings.icontains(.display_text, 'payment')
+            or strings.icontains(.display_text, 'invoice')
+            or regex.icontains(.display_text, 'INV(?:_|\s)?\d+$')
+            // starts with INV_ or INV\x20
+            or regex.icontains(.display_text, '^INV(?:_|\s)')
+            or regex.icontains(.display_text, 'PO(?:_|\s)?\d+$')
+            or strings.icontains(.display_text, 'receipt')
+            or strings.icontains(.display_text, 'billing')
+            or strings.icontains(.display_text, 'statement')
+            or strings.icontains(.display_text, 'Past Due')
+            or regex.icontains(.display_text, 'Remit(tance)?')
+            or strings.icontains(.display_text, 'Purchase Order')
+  
+            // contract language
+            or strings.icontains(.display_text, 'settlement')
+            or strings.icontains(.display_text, 'contract agreement')
+            or strings.icontains(.display_text, 'Proposal')
+            or strings.icontains(.display_text, 'contract doc')
+          )
+          and .href_url.domain.root_domain == "sharepoint.com"
+  )
+  // and sender has never had email sent to them
+  and not profile.by_sender().solicited
+    
+  // and there haven't been any FPs reported for the sender
+  and not profile.by_sender().any_false_positives
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Free file host"
+  - "Evasion"
+detection_methods:
+  - "Content analysis"


### PR DESCRIPTION
# Description
New rule to detect file shares via SharePoint that contains suspicious document names. 

# Associated samples

- [Sample 1](https://platform.sublimesecurity.com/messages/3f8f43108b1d72b46aee20d92ba385b3bb204d22f2c977374e7c016de881a293)
- [Sample 2](https://platform.sublimesecurity.com/messages/030a88b95102665c5e276f5bb16e70c2837d3133a5fa7f98d284da363ad2123d)
- [Sample 3](https://platform.sublimesecurity.com/messages/fee0f93375c9dbb89fc42fd32e629df567fae9921110ed1deabac09729639e0e)

## Associated hunts

- [Hunt 1](https://platform.sublimesecurity.com/hunts/0cc7fcb1-6d87-4bc8-ac1b-c85a6912bd79)
