### PR TITLE
Update link_sharepoint_netorgft.yml

### DIFF
--- a/detection-rules/link_sharepoint_netorgft.yml
+++ b/detection-rules/link_sharepoint_netorgft.yml
@@ -14,7 +14,7 @@ source: |
   // any of the links are the default netorgft name from GoDaddy
   and any(body.links,
           // Default GoDaddy tenant names
-          strings.starts_with(.href_url.domain.subdomain, 'netorgft')
+          strings.starts_with(.href_url.domain.subdomain, 'netorg')
           and .href_url.domain.root_domain == "sharepoint.com"
   )
   


### PR DESCRIPTION
# Description
Found multiple misses due to the missing `ft` within the netorg tenant name

# Associated samples

New samples which will match based on this PR:
- [Sample 1](https://platform.sublimesecurity.com/messages/1b4f7c6c363ef4fbb48d145fc75cc29807f8eeba72031f796a121a539ba95f9f)
- [Sample 2](https://platform.sublimesecurity.com/messages/a925d734a65206169495dde6c744a6f7beee1c61f2f10b2fa466b68b627dfeff)

## Associated hunts

- [Hunt 1](https://platform.sublimesecurity.com/hunts/7e07d119-653f-4f1b-87d0-1a6ecf95014d)
