### PR TITLE
Update link_cyrillic_substitutions_unsolicited.yml

### DIFF
--- a/detection-rules/link_cyrillic_substitutions_unsolicited.yml
+++ b/detection-rules/link_cyrillic_substitutions_unsolicited.yml
@@ -22,6 +22,7 @@ source: |
   and not headers.return_path.domain.domain == 'identity-reachout.bounces.google.com'
   and not headers.return_path.domain.domain == 'bounce-sg.zoom.us'
   and not headers.return_path.domain.domain == 'bounce.dataminr.com'
+  and not headers.return_path.domain.domain == 'mail-us.atlassian.net'
   
   // the message is unsolicited and no false positives
   and (
@@ -33,15 +34,6 @@ source: |
   )
   and not profile.by_sender().any_false_positives
 
-  // high trust
-  and (
-    (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and not headers.auth_summary.dmarc.pass
-    )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
-  )
-  
 tags:
  - "Attack surface reduction"
 attack_types:

--- a/detection-rules/link_cyrillic_substitutions_unsolicited.yml
+++ b/detection-rules/link_cyrillic_substitutions_unsolicited.yml
@@ -32,6 +32,15 @@ source: |
     )
   )
   and not profile.by_sender().any_false_positives
+
+  // high trust
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
   
 tags:
  - "Attack surface reduction"


### PR DESCRIPTION
# Description
Negating atlassian emails from eastern european senders

The sender.email is dynamically generated which is problematic when trying to use it to make exemptions to this rule
![image](https://github.com/sublime-security/sublime-rules/assets/6809735/c60849fe-6d30-4525-8cf8-f2ab9af97a6b)
