### PR TITLE
Exempting "paddle.com" from callback phishing

### DIFF
--- a/detection-rules/body_callback_phishing_no_attachment.yml
+++ b/detection-rules/body_callback_phishing_no_attachment.yml
@@ -107,7 +107,8 @@ source: |
   )
   and sender.email.domain.root_domain not in (
     // paypal domain
-    "xoom.com"
+    "xoom.com",
+    "paddle.com"
   )
   and not strings.ends_with(headers.message_id, "@shopify.com>")
 


### PR DESCRIPTION
# Description
Exempting paddle.com

# Associated samples

https://platform.sublimesecurity.com/messages/f3596a7fbbea94ca717c6a1bcb21784e350f41cebc31e7be76e0396562daef4d