### PR TITLE
Update impersonation_github.yml

### DIFF
--- a/detection-rules/impersonation_github.yml
+++ b/detection-rules/impersonation_github.yml
@@ -33,7 +33,8 @@ source: |
     'githubnext.com',
     'lithub.com',
     'icims.com',
-    'bithub.email'
+    'bithub.email',
+    'goldcast.io'
   )
 
   // negate highly trusted sender domains unless they fail DMARC authentication


### PR DESCRIPTION
# Description

Negating goldcast.io root domain (Used by GitHub to send GitHub-branded event invites and newsletters)

# Associated samples

Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.

- https://platform.sublimesecurity.com/messages/795951b632fa0115679287c2980e16efa3af9097f0507f82efdbbc66b83d6397
- https://platform.sublimesecurity.com/messages/09b8701591841aa3e567519ef86d179bd9bb0f4934da2faccdc8107d5c6ff044
- https://platform.sublimesecurity.com/messages/8afe0598e01e4028ca8d79d182bafda8a81ab6e0827d1298002f8ab316e88616