### PR TITLE
Update impersonation_employee_urgent_request.yml

### DIFF
--- a/detection-rules/impersonation_employee_urgent_request.yml
+++ b/detection-rules/impersonation_employee_urgent_request.yml
@@ -35,7 +35,7 @@ source: |
           or (
             length(body.current_thread.text) > 200
             and any(ml.nlu_classifier(body.current_thread.text).entities,
-                    .name == "sender" and .text in $org_display_names
+                    .name == "sender" and .text in~ $org_display_names
             )
           )
         )


### PR DESCRIPTION
# Description

Add case insensitive check on inner $org_display_names check to match the first check.  Just noticed it while looking at an FN on this rule for another reason. 
