### PR TITLE
Update impersonation_ups.yml

### DIFF
--- a/detection-rules/impersonation_ups.yml
+++ b/detection-rules/impersonation_ups.yml
@@ -15,8 +15,16 @@ source: |
     or strings.ilike(sender.email.local_part, "*united*parcel*service*")
     or strings.ilike(sender.email.domain.domain, '*united*parcel*service*')
     or sender.email.local_part =~ "ups"
+    or regex.icontains(sender.display_name,
+                       "U[^a-zA-Z]P[^a-zA-Z]S(?:[^a-zA-Z]|$)"
+    )
   )
-  and any(ml.logo_detect(beta.message_screenshot()).brands, .name is not null)
+  and (
+    // Observed in the "footer" of impersation messages
+    // added this due to the UPS image not loading on some emails
+    strings.icontains(body.current_thread.text, "United Parcel Service of")
+    or any(ml.logo_detect(beta.message_screenshot()).brands, .name is not null)
+  )
   and sender.email.email not in $recipient_emails
 
   // negate highly trusted sender domains unless they fail DMARC authentication
@@ -27,7 +35,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description

Add logic to catch display_name with variation of UPS and where the "footer" contains UPS wording

# Associated samples


- [Sample 1](https://platform.sublimesecurity.com/messages/65543da416512c3d81a55a03ae7f23a3953b96ca1eb4e786cec03a6e76e8ea82)
- [Sample 2](https://platform.sublimesecurity.com/messages/1440c043cfb471665c9c366f4ca9d72816ef90a1e9d320c8027dee3f219745e5)

## Associated hunts

If you ran any hunts with your rule, please link them here.

- [Hunt 1](https://platform.sublimesecurity.com/hunts/89810e90-f169-4706-ba11-12f9f4281e9b) - had to disable the message_screenshot/nlu for the hunt

