### PR TITLE
Update link_fake_password_expiration.yml

### DIFF
--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -20,8 +20,11 @@ source: |
   )
   
   // body contains expire, expiration, loose, lose 
-  and regex.icontains(body.current_thread.text,
-                      '(expir(e)?(ation|s)|\blo(o)?se\b|office 365|re.{0,3}confirm)'
+  and (
+    regex.icontains(body.current_thread.text,
+                    '(expir(e)?(ation|s)|\blo(o)?se\b|office 365|re.{0,3}confirm)'
+    )
+    and not strings.icontains(body.current_thread.text, 'link expires in ')
   )
   
   // subject or body contains account or access


### PR DESCRIPTION
# Description

Add negation for "link expires in"  when evaluating expire(s).  No option for lookbehind with RE2.

# Associated samples

- [Sample 1](https://platform.sublimesecurity.com/messages/e020f30a78ac6c120741fc5effbc0ca08a4340a3d53f519d46bde592fd7252cd)
- [Sample 2](https://platform.sublimesecurity.com/messages/7dadeae1ba63d2a3d0b12bf5bc6d577c65a55924414d0756328627af69466a19)

## Associated hunts

- [Hunt 1](https://platform.sublimesecurity.com/hunts/5ce79525-542f-453b-9c71-c47d304c07d0) - L180D showing messages that will no longer match
