### PR TITLE
Update cc_infra_abuse.yml

### DIFF
--- a/detection-rules/cc_infra_abuse.yml
+++ b/detection-rules/cc_infra_abuse.yml
@@ -73,6 +73,7 @@ source: |
       or strings.istarts_with(subject.subject, "FW:")
       or strings.istarts_with(subject.subject, "FWD:")
       or strings.istarts_with(subject.subject, "Automatic reply:")
+      or regex.imatch(subject.subject, '(\[[^\]]+\]\s?){0,3}(re|fwd?|automat.*)\s?:.*')
     )
     and (
       length(headers.references) > 0


### PR DESCRIPTION
# Description

Negate messages which "miss" the negation due to email tags

# Associated samples

- [Sample 1](https://platform.sublimesecurity.com/rules/editor?canonical_id=48bd63e51f06bbc3208c12fe51e81a2f88981c596db6efc58519185d48cfb4e1)
