### PR TITLE
Update attachment_qr_code_suspicious_components.yml

### DIFF
--- a/detection-rules/attachment_qr_code_suspicious_components.yml
+++ b/detection-rules/attachment_qr_code_suspicious_components.yml
@@ -13,6 +13,7 @@ source: |
           and (
             any(file.explode(.),
                 .scan.qr.type == "url"
+                and not .scan.qr.url.domain.domain == "geico.app.link"
                 and (
                   // pass the QR URL to LinkAnalysis
                   any([ml.link_analysis(.scan.qr.url)],


### PR DESCRIPTION
Excluding links to Geico via QR code.

# Description

Excluding QR code links to Geico, for future exceptions we should turn this into a list in ("geico.com", "example.com")

# Associated samples

https://platform.sublimesecurity.com/rules/editor?canonical_id=c83ddc90a0f57fc212f1bb8962e7bdffc2237e1345d719afd362a912d7d187ae
