### PR TITLE
Update impersonation_sharepoint_fake_file_share.yml

### DIFF
--- a/detection-rules/impersonation_sharepoint_fake_file_share.yml
+++ b/detection-rules/impersonation_sharepoint_fake_file_share.yml
@@ -11,7 +11,7 @@ source: |
   and strings.icontains(subject.subject, "shared")
   and any(ml.logo_detect(beta.message_screenshot()).brands, .name == "Microsoft")
 
-  // Negate matches the message id observed from MS actual. DKIM/SPF domains can be custom and therefore are unpredictable.
+  // Negate messages when the message-id indciates the message is from MS actual. DKIM/SPF domains can be custom and therefore are unpredictable.
   and not (
       strings.starts_with(headers.message_id, '<Share-')
       and strings.ends_with(headers.message_id, '@odspnotify>')

--- a/detection-rules/impersonation_sharepoint_fake_file_share.yml
+++ b/detection-rules/impersonation_sharepoint_fake_file_share.yml
@@ -10,7 +10,13 @@ source: |
   and strings.like(body.current_thread.text, "*shared a file with you*", "*shared with you*", "*invited you to access a file*")
   and strings.icontains(subject.subject, "shared")
   and any(ml.logo_detect(beta.message_screenshot()).brands, .name == "Microsoft")
-  
+
+  // Negate matches the message id observed from MS actual. DKIM/SPF domains can be custom and therefore are unpredictable.
+  and not (
+      strings.starts_with(headers.message_id, '<Share-')
+      and strings.ends_with(headers.message_id, '@odspnotify>')
+  )
+
   // fake Sharepoint shares are easy to identify if there are any links
   // that don't point to microsoft[.]com or *.sharepoint[.]com
   and not all(body.links,


### PR DESCRIPTION
# Description
Negate message groups which are from SharePoint actual based on the defined message-id. 

The "Fake" file share was triggering on a subset of message group that were not fake. 

## Associated hunts

Message Groups that will no longer fire this rule
-[ Hunt 1](https://platform.sublimesecurity.com/hunts/df0b65fd-ce5e-4088-8ea3-cce32eb3fc9c)
