### PR TITLE
Update attachment_docusign_image_suspicious_links.yml

### DIFF
--- a/detection-rules/attachment_docusign_image_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_image_suspicious_links.yml
@@ -27,7 +27,7 @@ source: |
                    any(ml.nlu_classifier(.scan.ocr.raw).intents,
                        .name == "cred_theft" and .confidence != "low"
                    )
-                   or regex.icontains(.scan.ocr.raw,
+                   or (regex.icontains(.scan.ocr.raw,
                                       "((re)?view|access|complete(d)?) document(s)?",
                                       "[^d][^o][^c][^u]sign",
                                       "important edocs",
@@ -35,7 +35,7 @@ source: |
                                       "Dokument (überprüfen|prüfen|unterschreiben|geschickt)",
                                       // German (important|urgent|immediate)
                                       "(wichtig|dringend|sofort)"
-                   )
+                   ) and not strings.count(.scan.ocr.raw, "\n\n\n\n\n\n\n\n\n\n") > 3 )
                  )
           )
         )


### PR DESCRIPTION
# Description

In order to avoid triggering on poorly rendered OCR Add negation for 4 or more sets of 10 new lines

## Associated hunts

Samples that will no longer match this rule
- [Hunt 1](https://platform.sublimesecurity.com/hunts/08b023f2-1d6e-4cac-bedd-f58c1c74e75c)
