### PR TITLE
Update attachment_fake_attachment_image.yml

### DIFF
--- a/detection-rules/attachment_fake_attachment_image.yml
+++ b/detection-rules/attachment_fake_attachment_image.yml
@@ -10,18 +10,18 @@ source: |
     any(attachments,
         .file_type in $file_types_images
         and (
-        any(ml.logo_detect(.).brands, .name == "FakeAttachment")
-        or (
-          .size < 30000
-          and any(file.explode(.),
-                  strings.icontains(.scan.ocr.raw, 'sent you')
-                  // the attached image includes a filesize string
-                  and regex.icontains(.scan.ocr.raw,
-                                      '\b\d+.\d{1,2}\s?(k|m)b(\s|$)'
-                  )
+          any(ml.logo_detect(.).brands, .name == "FakeAttachment")
+          or (
+            .size < 30000
+            and any(file.explode(.),
+                    strings.icontains(.scan.ocr.raw, 'sent you')
+                    // the attached image includes a filesize string
+                    and regex.icontains(.scan.ocr.raw,
+                                        '\b\d+.\d{1,2}\s?(k|m)b(\s|$)'
+                    )
+            )
           )
         )
-      )
     )
     // fake file attachment preview in attached EML
     or any(attachments,
@@ -29,18 +29,18 @@ source: |
            and any(file.parse_eml(.).attachments,
                    .file_type in $file_types_images
                    and (
-                    any(ml.logo_detect(.).brands, .name == "FakeAttachment")
-                    or (
-                      .size < 30000
-                      and any(file.explode(.),
-                              strings.icontains(.scan.ocr.raw, 'sent you')
-                              // the attached image includes a filesize string
-                              and regex.icontains(.scan.ocr.raw,
-                                                  '\b\d+.\d{1,2}\s?(k|m)b(\s|$)'
-                              )
-                      )
-                    )
-                  )
+                     any(ml.logo_detect(.).brands, .name == "FakeAttachment")
+                     or (
+                       .size < 30000
+                       and any(file.explode(.),
+                               strings.icontains(.scan.ocr.raw, 'sent you')
+                               // the attached image includes a filesize string
+                               and regex.icontains(.scan.ocr.raw,
+                                                   '\b\d+.\d{1,2}\s?(k|m)b(\s|$)'
+                               )
+                       )
+                     )
+                   )
            )
     )
   )
@@ -53,7 +53,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-  
   and (
     not profile.by_sender().solicited
     or profile.by_sender().any_messages_malicious_or_spam

--- a/detection-rules/attachment_fake_attachment_image.yml
+++ b/detection-rules/attachment_fake_attachment_image.yml
@@ -9,14 +9,38 @@ source: |
     // fake file attachment preview in original email
     any(attachments,
         .file_type in $file_types_images
-        and any(ml.logo_detect(.).brands, .name == "FakeAttachment")
+        and (
+        any(ml.logo_detect(.).brands, .name == "FakeAttachment")
+        or (
+          .size < 30000
+          and any(file.explode(.),
+                  strings.icontains(.scan.ocr.raw, 'sent you')
+                  // the attached image includes a filesize string
+                  and regex.icontains(.scan.ocr.raw,
+                                      '\b\d+.\d{1,2}\s?(k|m)b(\s|$)'
+                  )
+          )
+        )
+      )
     )
     // fake file attachment preview in attached EML
     or any(attachments,
            (.content_type == "message/rfc822" or .file_extension == "eml")
            and any(file.parse_eml(.).attachments,
                    .file_type in $file_types_images
-                   and any(ml.logo_detect(.).brands, .name == "FakeAttachment")
+                   and (
+                    any(ml.logo_detect(.).brands, .name == "FakeAttachment")
+                    or (
+                      .size < 30000
+                      and any(file.explode(.),
+                              strings.icontains(.scan.ocr.raw, 'sent you')
+                              // the attached image includes a filesize string
+                              and regex.icontains(.scan.ocr.raw,
+                                                  '\b\d+.\d{1,2}\s?(k|m)b(\s|$)'
+                              )
+                      )
+                    )
+                  )
            )
     )
   )


### PR DESCRIPTION
# Description

Add additional logic for when the FakeAttachment logo detect doesn't match

## Associated hunts

If you ran any hunts with your rule, please link them here.

-[ Hunt 1](https://platform.sublimesecurity.com/hunts/9c95e8b3-c45e-430f-8024-7a2590b09f73)
