### PR TITLE
Update link_fake_storage_alert.yml

### DIFF
--- a/detection-rules/link_fake_storage_alert.yml
+++ b/detection-rules/link_fake_storage_alert.yml
@@ -14,15 +14,15 @@ source: |
     or (
       any(file.explode(beta.message_screenshot()),
           any(ml.nlu_classifier(.scan.ocr.raw).intents,
-              .name == "cred_theft" and .confidence == "high"
+               .name == "cred_theft" and .confidence == "high"
           )
-          and strings.ilike(.scan.ocr.raw,
-                            "*storage*full*",
-                            "*free*upgrade*",
-                            "*storage*details*",
-                            "*storage*quot",
-                            "*email*storage*",
-                            "*total*storage*"
+          and regex.icontains(.scan.ocr.raw,
+                            "storage.{0,50}full",
+                            "free.{0,50}upgrade",
+                            "storage.{0,50}details",
+                            "storage.{0,50}quot",
+                            "email.{0,50}storage",
+                            "total.{0,50}storage"
           )
           and not strings.ilike(.scan.ocr.raw, "*free plan*")
       )
@@ -41,14 +41,14 @@ source: |
                   .file_type in $file_types_images
                   and .size > 2000
                   and any(file.explode(.),
-                          strings.ilike(.scan.ocr.raw,
-                                        "*storage*full*",
-                                        "*free*upgrade*",
-                                        "*storage*details*",
-                                        "*storage*quot",
-                                        "*email*storage*",
-                                        "*total*storage*"
-                          )
+                          regex.icontains(.scan.ocr.raw,
+                            "storage.{0,50}full",
+                            "free.{0,50}upgrade",
+                            "storage.{0,50}details",
+                            "storage.{0,50}quot",
+                            "email.{0,50}storage",
+                            "total.{0,50}storage"
+          )
                   )
           )
       )
@@ -82,7 +82,18 @@ source: |
       )
     )
     or sender.email.email != "no-reply@sharepointonline.com"
+  
   )
+  // negate content likely to be related to storage rental facilities 
+  // and not (
+  //     3 of (
+  //         strings.icontains(body.current_thread.text, 'gate code'),
+  //         strings.icontains(body.current_thread.text, 'unlock code'),
+  //         strings.icontains(body.current_thread.text, 'location manager'),
+  //         strings.icontains(body.current_thread.text, 'drop box' ),
+  //         strings.icontains(body.current_thread.text, 'unlock with code'),
+  //     )
+  // )
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (
@@ -95,7 +106,6 @@ source: |
     not profile.by_sender().solicited
     or profile.by_sender().any_messages_malicious_or_spam
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
remove FPs on actual storage facilities emails

# Description

Explain your change and why. For example, "negating legitimate replies," or "adding additional credential theft keywords."

If it's a new rule or insight, explain what the rule is designed to catch/what the insight should fire on.

# Associated samples

Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.

- Sample 1
- Sample 2

## Associated hunts

If you ran any hunts with your rule, please link them here.

- Hunt 1

# Screenshot (insights)

**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
