### PR TITLE
Fixing "Encrypted attachments" to include zip

### DIFF
--- a/insights/attachments/encrypted.yml
+++ b/insights/attachments/encrypted.yml
@@ -1,7 +1,7 @@
 name: "Encrypted attachments"
 type: "query"
 source: |
-  map(filter(attachments, .file_extension in~ ("doc", "dot", "docm", "dotm", "docx", "xlm", "xls", "xlsb", "xlsm", "pptm", "ppsm")
+  map(filter(attachments, .file_extension in~ ("doc", "dot", "docm", "dotm", "docx", "xlm", "xls", "xlsb", "xlsm", "pptm", "ppsm", "zip")
     and (file.oletools(.).indicators.encryption.exists
          or any(file.explode(.), 
               any(.flavors.yara, . == 'encrypted_zip'))

--- a/insights/attachments/encrypted_zip_inside.yml
+++ b/insights/attachments/encrypted_zip_inside.yml
@@ -1,0 +1,9 @@
+name: "Files inside encrypted zip"
+type: "query"
+source: |
+  map(filter(attachments, .file_extension == "zip"),
+      map(file.explode(.), .scan.zip.all_paths)
+  )
+severity: "low"
+tags:
+  - "Suspicious attachments"

--- a/insights/attachments/encrypted_zip_inside.yml
+++ b/insights/attachments/encrypted_zip_inside.yml
@@ -2,7 +2,7 @@ name: "Files inside encrypted zip"
 type: "query"
 source: |
   map(filter(attachments, .file_extension == "zip"),
-      map(file.explode(.), .scan.zip.all_paths)
+      map(file.explode(.), .scan.zip.attempted_files)
   )
 severity: "low"
 tags:


### PR DESCRIPTION
# Description
- Fixed `Encrypted attachments` insight to fire on encrypted zips
- New insight `Files inside encrypted zip`

![image](https://github.com/user-attachments/assets/099c95be-f17e-4d3b-9021-ad0bd0c0a7ad)


