### PR TITLE
Update Fake Threads logic 

### DIFF
--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -30,11 +30,15 @@ source: |
           or strings.istarts_with(subject.subject, "FWD:")
         )
       )
-      and 3 of (
-        strings.icontains(body.html.display_text, "from:"),
-        strings.icontains(body.html.display_text, "to:"),
-        strings.icontains(body.html.display_text, "sent:"),
-        strings.icontains(body.html.display_text, "subject:")
+      and any([body.current_thread.text, body.html.display_text, body.plain.raw],
+              3 of (
+                strings.icontains(., "from:"),
+                strings.icontains(., "to:"),
+                strings.icontains(., "sent:"),
+                strings.icontains(., "date:"),
+                strings.icontains(., "cc:"),
+                strings.icontains(., "subject:")
+              )
       )
       and (
         length(body.current_thread.text) + 100 < length(body.html.display_text)

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -51,8 +51,8 @@ source: |
   )
   
   and (
-    (length(headers.references) == 0 and headers.in_reply_to is null)
-    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    length(headers.references) == 0 
+    or headers.in_reply_to is null
   )
   
   // and not solicited

--- a/detection-rules/impersonation_fake_msg_thread_mismatched_from_freemail_replyto.yml
+++ b/detection-rules/impersonation_fake_msg_thread_mismatched_from_freemail_replyto.yml
@@ -45,7 +45,7 @@ source: |
 
   // Check for the Presence of References or In-Reply-To properties
   and (
-    length(headers.references) == 0 
+    length(headers.references) == 0
     or headers.in_reply_to is null
   )
 attack_types:

--- a/detection-rules/impersonation_fake_msg_thread_mismatched_from_freemail_replyto.yml
+++ b/detection-rules/impersonation_fake_msg_thread_mismatched_from_freemail_replyto.yml
@@ -30,15 +30,22 @@ source: |
 
   // Check for Message Thread Indicators
   and (
-    strings.istarts_with(subject.subject, "RE:")
-    or regex.icontains(body.current_thread.text,
-                       "From:[ a-z0-9<>_@\\.]{0,80}Sent:[ a-z0-9<>_@\\.:]{0,40}To:[ a-z0-9<>_@\\.;]{0,300}(Cc:)?.{0,300}Subject:"
+    regex.icontains(subject.subject, '\b(?:RE|FWD?)\s*:')
+    or any([body.current_thread.text, body.html.display_text, body.plain.raw],
+           3 of (
+             strings.icontains(., "from:"),
+             strings.icontains(., "to:"),
+             strings.icontains(., "sent:"),
+             strings.icontains(., "date:"),
+             strings.icontains(., "cc:"),
+             strings.icontains(., "subject:")
+           )
     )
   )
 
   // Check for the Presence of References or In-Reply-To properties
   and (
-    length(headers.references) == 0
+    (length(headers.references) == 0 and headers.in_reply_to is null)
     or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
   )
 attack_types:

--- a/detection-rules/impersonation_fake_msg_thread_mismatched_from_freemail_replyto.yml
+++ b/detection-rules/impersonation_fake_msg_thread_mismatched_from_freemail_replyto.yml
@@ -45,8 +45,8 @@ source: |
 
   // Check for the Presence of References or In-Reply-To properties
   and (
-    (length(headers.references) == 0 and headers.in_reply_to is null)
-    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    length(headers.references) == 0 
+    or headers.in_reply_to is null
   )
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/vip_impersonation_fake_thread.yml
+++ b/detection-rules/vip_impersonation_fake_thread.yml
@@ -26,7 +26,7 @@ source: |
           )
   )
   and (
-    length(headers.references) == 0 
+    length(headers.references) == 0
     or headers.in_reply_to is null
   )
   and (

--- a/detection-rules/vip_impersonation_fake_thread.yml
+++ b/detection-rules/vip_impersonation_fake_thread.yml
@@ -26,8 +26,8 @@ source: |
           )
   )
   and (
-    (length(headers.references) == 0 and headers.in_reply_to is null)
-    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    length(headers.references) == 0 
+    or headers.in_reply_to is null
   )
   and (
     network.whois(sender.email.domain).days_old < 90

--- a/detection-rules/vip_impersonation_fake_thread.yml
+++ b/detection-rules/vip_impersonation_fake_thread.yml
@@ -26,8 +26,8 @@ source: |
           )
   )
   and (
-    length(headers.references) == 0
-    and not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    (length(headers.references) == 0 and headers.in_reply_to is null)
+    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
   )
   and (
     network.whois(sender.email.domain).days_old < 90

--- a/detection-rules/vip_impersonation_fake_thread.yml
+++ b/detection-rules/vip_impersonation_fake_thread.yml
@@ -15,11 +15,15 @@ source: |
                                 )
           )
   )
-  and 3 of (
-    strings.icontains(body.html.display_text, "from:"),
-    strings.icontains(body.html.display_text, "to:"),
-    strings.icontains(body.html.display_text, "sent:"),
-    strings.icontains(body.html.display_text, "subject:")
+  and any([body.current_thread.text, body.html.display_text, body.plain.raw],
+          3 of (
+            strings.icontains(., "from:"),
+            strings.icontains(., "to:"),
+            strings.icontains(., "sent:"),
+            strings.icontains(., "date:"),
+            strings.icontains(., "cc:"),
+            strings.icontains(., "subject:")
+          )
   )
   and (
     length(headers.references) == 0
@@ -30,7 +34,6 @@ source: |
     or profile.by_sender().days_known == 0
   )
   and not profile.by_sender().solicited
-
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:

--- a/insights/headers/fake_thread.yml
+++ b/insights/headers/fake_thread.yml
@@ -4,7 +4,7 @@ source: |
   type.inbound
   and regex.icontains(subject.subject, '\b(?:RE|FWD?)\s*:')
   and (
-    (length(headers.references) == 0 and headers.in_reply_to is null)
-    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    length(headers.references) == 0 
+    or headers.in_reply_to is null
   )
 severity: "medium"

--- a/insights/headers/fake_thread.yml
+++ b/insights/headers/fake_thread.yml
@@ -4,7 +4,7 @@ source: |
   type.inbound
   and regex.icontains(subject.subject, '\b(?:RE|FWD?)\s*:')
   and (
-    length(headers.references) == 0 
+    length(headers.references) == 0
     or headers.in_reply_to is null
   )
 severity: "medium"

--- a/insights/headers/fake_thread.yml
+++ b/insights/headers/fake_thread.yml
@@ -1,10 +1,10 @@
 name: "Fake message thread"
 type: "query"
 source: | 
-  type.inbound 
-  and strings.istarts_with(subject.subject, "RE:")
+  type.inbound
+  and regex.icontains(subject.subject, '\b(?:RE|FWD?)\s*:')
   and (
-      length(headers.references) == 0
-      or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
-    )
+    (length(headers.references) == 0 and headers.in_reply_to is null)
+    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+  )
 severity: "medium"


### PR DESCRIPTION
# Description

Update Fake Thread rules with the objectives of:

- Better account for forwards and emails with tags in subjects
- Use consistent logic
- Add additional conditions to find the forward/reply "headers" in emails

## Associated hunts

- [Insight - New Matches](https://platform.sublimesecurity.com/hunts/fcc589bc-d9fb-4c4a-b917-890b1ce8c396)
- [impersonation_fake_msg_thread_mismatched_from_freemail_replyto.yml - New Matches](https://platform.sublimesecurity.com/hunts/1f7ac530-2a2e-442c-a42d-8f1b54a7e1c2)
	I had to exclude a the `any(header.hops, any(.fields, ...` logic to get the hunt to complete
- vip_impersonation_fake_thread.yml
	No delta in Shared EMLs, even without the $org_vip domains