### PR TITLE
Create credential_phishing_docusign_dummy_pdf_attachment.yml

### DIFF
--- a/detection-rules/credential_phishing_docusign_dummy_pdf_attachment.yml
+++ b/detection-rules/credential_phishing_docusign_dummy_pdf_attachment.yml
@@ -114,3 +114,4 @@ detection_methods:
   - "File analysis"
   - "Optical Character Recognition"
   - "Sender analysis"
+id: "b162ceca-eddf-5d46-bd32-bfd04f5c133c"

--- a/detection-rules/credential_phishing_docusign_dummy_pdf_attachment.yml
+++ b/detection-rules/credential_phishing_docusign_dummy_pdf_attachment.yml
@@ -1,5 +1,5 @@
 name: "Credential Phishing: Docusign dummy PDF attachment(s)"
-description: "This rule detects DocuSign impersonations with empty, or dummy pdf file attachments attempting to add validity. The message contains a link with Suspicious display_text but does not link to a docusign domain. "
+description: "This rule detects DocuSign impersonations with empty, or dummy pdf file attachments attempting to add validity. The message contains a link with suspicious display_text but does not link to a DocuSign domain."
 type: "rule"
 severity: "high"
 source: |

--- a/detection-rules/credential_phishing_docusign_dummy_pdf_attachment.yml
+++ b/detection-rules/credential_phishing_docusign_dummy_pdf_attachment.yml
@@ -1,0 +1,116 @@
+name: "Credential Phishing: Docusign dummy PDF attachment(s)"
+description: "This rule detects DocuSign impersonations with empty, or dummy pdf file attachments attempting to add validity. The message contains a link with Suspicious display_text but does not link to a docusign domain. "
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  
+  // link boundary
+  and length(filter(body.links, .href_url.domain.valid)) < 25
+  and length(attachments) > 0
+  
+  // the pdf files are distractions, no links nor readable text is observed
+  and all(attachments,
+          .file_type == "pdf"
+          and any(file.explode(.),
+                  (
+                    length(.scan.url.urls) > 0
+                    or length(.scan.pdf.urls) > 0
+                    or length(body.links) > 0
+                  )
+                  and .scan.ocr.raw is null
+          )
+  )
+  
+  // Screenshot indicates a docusign logo or docusign name with cta to documents
+  and (
+    any(file.explode(beta.message_screenshot()),
+        (
+          strings.ilike(.scan.ocr.raw, "*DocuSign*")
+          or any(ml.logo_detect(beta.message_screenshot()).brands,
+                 .name == "DocuSign"
+          )
+        )
+        and (
+          (
+            regex.icontains(.scan.ocr.raw,
+                            "((re)?view|access|sign|complete(d)?) documen(t)?(s)?",
+                            "Your document has been completed",
+                            "New Document Shared with you",
+                            "Kindly click the link",
+                            "important edocs",
+                            // German (Document (check|check|sign|sent))
+                            "Dokument (überprüfen|prüfen|unterschreiben|geschickt)",
+                            // German (important|urgent|immediate)
+                            "(wichtig|dringend|sofort)"
+            )
+            and any(body.links,
+                    not strings.ilike(.href_url.domain.root_domain, "docusign.*")
+                    and (.display_text is null and .display_url.url is null)
+            )
+          )
+          or any(body.links,
+                 not strings.ilike(.href_url.domain.root_domain, "docusign.*")
+                 and regex.icontains(.display_text,
+                                     '(\bdocument|(view|get your) (docu|file))'
+                 )
+          )
+        )
+    )
+  )
+  
+  // links with null display_text that do not go to docusign.* (indicative of hyperlinked image) or the display text contains DOCUMENT 
+  and (
+    not profile.by_sender().solicited
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and not profile.by_sender().any_false_positives
+    )
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  
+  // negate legit replies
+  and not (
+    length(headers.references) > 0
+    or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+  )
+  and not profile.by_sender().any_false_positives
+  
+  // negate docusign X-Return-Path
+  and not any(headers.hops,
+              .index == 0
+              and any(.fields,
+                      .name == "X-Return-Path"
+                      and strings.ends_with(.value, "docusign.net")
+              )
+  )
+  
+  // negate "via" senders via dmarc authentication
+  and (
+    not coalesce(headers.auth_summary.dmarc.pass
+                 and strings.contains(sender.display_name, "via")
+                 and sender.email.domain.domain in $org_domains,
+                 false
+    )
+  )
+  
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Impersonation: Brand"
+  - "PDF"
+  - "Social engineering"
+detection_methods:
+  - "Computer Vision"
+  - "Content analysis"
+  - "File analysis"
+  - "Optical Character Recognition"
+  - "Sender analysis"


### PR DESCRIPTION
Less specific way of handling 
https://github.com/sublime-security/sublime-rules/pull/1778

# Description

Detects Docusign impersonation linking to non docusign domains, using dummy pdf files. 

# Associated samples

https://platform.sublimesecurity.com/messages/19fdd5237c884cfdecbcc6c02c813b6cd191831458b23e060e36db8fd817125e

# Related hunt 
still running at time of PR creation
https://platform.sublimesecurity.com/hunts/3c6fdcc3-bbee-4181-856f-0394a24c25c0