### PR TITLE
Update impersonation_docusign.yml

### DIFF
--- a/detection-rules/impersonation_docusign.yml
+++ b/detection-rules/impersonation_docusign.yml
@@ -10,17 +10,20 @@ source: |
   and (
     // orgs can have docusign.company.com
     strings.ilike(sender.email.email, '*docusign.net*', '*docusign.com*')
-
+  
     // if the above is true, you'll see a "via Docusign"
     or strings.ilike(sender.display_name, '*docusign*')
-
+  
     // detects 1 character variations,
     // such as DocuSlgn (with an "L" instead of an "I")
     or strings.ilevenshtein(sender.display_name, "docusign") == 1
-
     or strings.ilike(sender.display_name, "*docuonline*", "*via *signature*")
+    or (
+      strings.istarts_with(body.html.inner_text, "docusign")
+      and not strings.istarts_with(body.current_thread.text, "docusign")
+    )
   )
-
+  
   // identifies the main CTA in the email, eg "Review now" or "Review document"
   // this should always be a known docusign domain,
   // even with branded docusign subdomains
@@ -38,7 +41,7 @@ source: |
           )
           and .href_url.domain.root_domain not in ("docusign.com", "docusign.net")
   )
-
+  
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     coalesce(sender.email.domain.root_domain in $high_trust_sender_root_domains
@@ -47,12 +50,14 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
+  
   // adding negation for messages originating from docusigns api
   // and the sender.display.name contains "via"
   and not (
     any(headers.hops,
-        any(.fields, .name == "X-Api-Host" and strings.ends_with(.value, "docusign.net"))
+        any(.fields,
+            .name == "X-Api-Host" and strings.ends_with(.value, "docusign.net")
+        )
     )
     and strings.contains(sender.display_name, "via")
   )


### PR DESCRIPTION


# Description

Adding html_inner text starts with docusign but the current thread does not. 

# Associated samples

https://platform.sublimesecurity.com/rules/editor?canonical_id=f30a6b3c28364d55ad562bebd19c51a548c552defb6c19f0d3a78172de73b4e7
