### PR TITLE
Update attachment_callback_phish_with_pdf.yml

### DIFF
--- a/detection-rules/attachment_callback_phish_with_pdf.yml
+++ b/detection-rules/attachment_callback_phish_with_pdf.yml
@@ -14,22 +14,25 @@ source: |
       and not profile.by_sender().any_false_positives
     )
   )
-
+  
   // single attachment
   and length(attachments) == 1
-
+  
   // sender is freemail
   and sender.email.domain.root_domain in $free_email_providers
-
+  
   // the attachment is a pdf with less than 3 pages, and at least 60 ocr chars
   and any(attachments,
           (
             .file_extension == "pdf"
             and (
+              // get the length of the attached pdf
               any(file.explode(.),
-                  .scan.exiftool.page_count < 3
-                  and .depth <= 1
-                  and length(.scan.ocr.raw) > 60
+                  .depth == 0 and .scan.exiftool.page_count < 3
+              )
+              // check that any _single_ result in the file.explode matches these conditions
+              and any(file.explode(.),
+                  length(.scan.ocr.raw) > 60
                   // 4 of the following strings are found        
                   and (
                     4 of (
@@ -60,7 +63,7 @@ source: |
                       )
                     )
                   )
-
+  
                   // 1 of the following strings is found, representing common Callback brands          
                   and 1 of (
                     strings.icontains(.scan.ocr.raw, "geek squad"),
@@ -82,7 +85,7 @@ source: |
                     )
                   )
               )
-
+            
             or any(ml.logo_detect(.).brands,
                    .name in ("PayPal", "Norton", "GeekSquad", "Ebay")
             )

--- a/detection-rules/attachment_callback_phish_with_pdf.yml
+++ b/detection-rules/attachment_callback_phish_with_pdf.yml
@@ -70,6 +70,7 @@ source: |
                     strings.icontains(.scan.ocr.raw, "lifelock"),
                     strings.icontains(.scan.ocr.raw, "best buy"),
                     strings.icontains(.scan.ocr.raw, "mcafee"),
+                    regex.icontains(.scan.ocr.raw, "ma?c.?fee"),
                     strings.icontains(.scan.ocr.raw, "norton"),
                     strings.icontains(.scan.ocr.raw, "ebay"),
                     strings.icontains(.scan.ocr.raw, "paypal"),

--- a/detection-rules/attachment_callback_phish_with_pdf.yml
+++ b/detection-rules/attachment_callback_phish_with_pdf.yml
@@ -14,85 +14,81 @@ source: |
       and not profile.by_sender().any_false_positives
     )
   )
-  
+
   // single attachment
   and length(attachments) == 1
-  
+
   // sender is freemail
   and sender.email.domain.root_domain in $free_email_providers
-  
+
   // the attachment is a pdf with less than 3 pages, and at least 60 ocr chars
   and any(attachments,
           (
             .file_extension == "pdf"
-            and any(file.explode(.), .scan.exiftool.page_count < 3)
-            and any(file.explode(.), length(.scan.ocr.raw) > 60)
-          )
-  
-          // 4 of the following strings are found        
-          and (
-            any(file.explode(.),
-                4 of (
-                  strings.icontains(.scan.ocr.raw, "purchase"),
-                  strings.icontains(.scan.ocr.raw, "payment"),
-                  strings.icontains(.scan.ocr.raw, "transaction"),
-                  strings.icontains(.scan.ocr.raw, "subscription"),
-                  strings.icontains(.scan.ocr.raw, "antivirus"),
-                  strings.icontains(.scan.ocr.raw, "order"),
-                  strings.icontains(.scan.ocr.raw, "support"),
-                  strings.icontains(.scan.ocr.raw, "help line"),
-                  strings.icontains(.scan.ocr.raw, "receipt"),
-                  strings.icontains(.scan.ocr.raw, "invoice"),
-                  strings.icontains(.scan.ocr.raw, "call"),
-                  strings.icontains(.scan.ocr.raw, "helpdesk"),
-                  strings.icontains(.scan.ocr.raw, "cancel"),
-                  strings.icontains(.scan.ocr.raw, "renew"),
-                  strings.icontains(.scan.ocr.raw, "refund"),
-                  strings.icontains(.scan.ocr.raw, "amount"),
-                  strings.icontains(.scan.ocr.raw, "crypto"),
-                  strings.icontains(.scan.ocr.raw, "wallet address"),
-                  regex.icontains(.scan.ocr.raw, '\$\d{3}\.\d{2}\b'),
-                  regex.icontains(.scan.ocr.raw,
-                                  '(\+\d|1.(\()?\d{3}(\))?\D\d{3}\D\d{4})'
-                  ),
-                  regex.icontains(.scan.ocr.raw,
-                                  '\+?(\d{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}\d{3}[\s\.\-⋅]{0,5}\d{4}'
+            and (
+              any(file.explode(.),
+                  .scan.exiftool.page_count < 3
+                  and .depth <= 1
+                  and length(.scan.ocr.raw) > 60
+                  // 4 of the following strings are found        
+                  and (
+                    4 of (
+                      strings.icontains(.scan.ocr.raw, "purchase"),
+                      strings.icontains(.scan.ocr.raw, "payment"),
+                      strings.icontains(.scan.ocr.raw, "transaction"),
+                      strings.icontains(.scan.ocr.raw, "subscription"),
+                      strings.icontains(.scan.ocr.raw, "antivirus"),
+                      strings.icontains(.scan.ocr.raw, "order"),
+                      strings.icontains(.scan.ocr.raw, "support"),
+                      strings.icontains(.scan.ocr.raw, "help line"),
+                      strings.icontains(.scan.ocr.raw, "receipt"),
+                      strings.icontains(.scan.ocr.raw, "invoice"),
+                      strings.icontains(.scan.ocr.raw, "call"),
+                      strings.icontains(.scan.ocr.raw, "helpdesk"),
+                      strings.icontains(.scan.ocr.raw, "cancel"),
+                      strings.icontains(.scan.ocr.raw, "renew"),
+                      strings.icontains(.scan.ocr.raw, "refund"),
+                      strings.icontains(.scan.ocr.raw, "amount"),
+                      strings.icontains(.scan.ocr.raw, "crypto"),
+                      strings.icontains(.scan.ocr.raw, "wallet address"),
+                      regex.icontains(.scan.ocr.raw, '\$\d{3}\.\d{2}\b'),
+                      regex.icontains(.scan.ocr.raw,
+                                      '(\+\d|1.(\()?\d{3}(\))?\D\d{3}\D\d{4})'
+                      ),
+                      regex.icontains(.scan.ocr.raw,
+                                      '\+?(\d{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}\d{3}[\s\.\-⋅]{0,5}\d{4}'
+                      )
+                    )
                   )
-                )
-            )
-          )
-  
-          // 1 of the following strings is found, representing common Callback brands          
-          and (
-            any(file.explode(.),
-                1 of (
-                  strings.icontains(.scan.ocr.raw, "geek squad"),
-                  strings.icontains(.scan.ocr.raw, "lifelock"),
-                  strings.icontains(.scan.ocr.raw, "best buy"),
-                  strings.icontains(.scan.ocr.raw, "mcafee"),
-                  strings.icontains(.scan.ocr.raw, "norton"),
-                  strings.icontains(.scan.ocr.raw, "ebay"),
-                  strings.icontains(.scan.ocr.raw, "paypal"),
-                )
-            )
+
+                  // 1 of the following strings is found, representing common Callback brands          
+                  and 1 of (
+                    strings.icontains(.scan.ocr.raw, "geek squad"),
+                    strings.icontains(.scan.ocr.raw, "lifelock"),
+                    strings.icontains(.scan.ocr.raw, "best buy"),
+                    strings.icontains(.scan.ocr.raw, "mcafee"),
+                    strings.icontains(.scan.ocr.raw, "norton"),
+                    strings.icontains(.scan.ocr.raw, "ebay"),
+                    strings.icontains(.scan.ocr.raw, "paypal"),
+                  )
+                  // Negate bank statements
+                  and not (
+                    2 of (
+                      strings.icontains(.scan.ocr.raw, "opening balance"),
+                      strings.icontains(.scan.ocr.raw, "closing balance"),
+                      strings.icontains(.scan.ocr.raw, "direct debit"),
+                      strings.icontains(.scan.ocr.raw, "interest"),
+                      strings.icontains(.scan.ocr.raw, "account balance"),
+                    )
+                  )
+              )
+
             or any(ml.logo_detect(.).brands,
                    .name in ("PayPal", "Norton", "GeekSquad", "Ebay")
             )
           )
-          // Negate bank statements
-          and not (
-            any(file.explode(.),
-                2 of (
-                  strings.icontains(.scan.ocr.raw, "opening balance"),
-                  strings.icontains(.scan.ocr.raw, "closing balance"),
-                  strings.icontains(.scan.ocr.raw, "direct debit"),
-                  strings.icontains(.scan.ocr.raw, "interest"),
-                  strings.icontains(.scan.ocr.raw, "account balance"),
-                )
-            )
-        )
   )
-  
+  )
   and (
     (
       (
@@ -112,8 +108,8 @@ source: |
           or strings.istarts_with(subject.subject, "TR:")
           or strings.istarts_with(subject.subject, "FWD:")
           or regex.imatch(subject.subject,
-                        '(\[[^\]]+\]\s?){0,3}(re|fwd?|automat.*)\s?:.*'
-        )
+                          '(\[[^\]]+\]\s?){0,3}(re|fwd?|automat.*)\s?:.*'
+          )
         )
       )
     )


### PR DESCRIPTION
# Description

- Reduce FPs by enforcing that the conditions for matching within the pdf all occur with in the same file.explode() object.
- Increase TP matches (and thus satisfying mimic failures) by adding variations of mcafee with the logic.

# Associated samples

FP Sample that no longer matches
- [Sample 1](https://platform.sublimesecurity.com/messages/a6ce79edef70dd0120320585528af4154e91382c84892b6d961a085c40cdf067)
