### PR TITLE
Update link_content_credential_phishing.yml

### DIFF
--- a/detection-rules/link_content_credential_phishing.yml
+++ b/detection-rules/link_content_credential_phishing.yml
@@ -23,7 +23,8 @@ source: |
     )
   )
   and any(body.links,
-          ml.link_analysis(., mode="aggressive").credphish.disposition == "phishing"
+          .href_url.domain.domain != "play.google.com"
+          and ml.link_analysis(., mode="aggressive").credphish.disposition == "phishing"
           and ml.link_analysis(., mode="aggressive").credphish.confidence in (
             "medium",
             "high"


### PR DESCRIPTION
# Description

This rule is causing false positives for links to play.google.com. I previously added a negation to link analysis to prevent clicks on Play Store links. However, this rule invokes link analysis in aggressive mode, which is still triggering a click

To prevent this, I'm adding an explicit negation before the link analysis call to exclude play.google.com.


