### PR TITLE
Update impersonation_twitter.yml

### DIFF
--- a/detection-rules/impersonation_twitter.yml
+++ b/detection-rules/impersonation_twitter.yml
@@ -13,6 +13,11 @@ source: |
     or strings.ilike(sender.email.domain.domain, '*twitter*')
   )
   and sender.email.domain.domain not in~ ('twitter.com', 'privaterelay.appleid.com', 'stripe.com', 'x.com', 'twitter.discoursemail.com')
+  // negate Hearsay Systems which sends notificaitons from sender domain ending in twitter.com
+  and not (
+    strings.ends_with(sender.email.domain.domain, '.hearsay.twitter.com')
+    and strings.ends_with(headers.message_id, '@hearsaysystems.com>')
+  )
   and sender.email.email not in $recipient_emails
 attack_types:
   - "Credential Phishing"


### PR DESCRIPTION
# Description

Negate matches from Hearsay Systems which sends email notifications from a dynamic sender localpart, and the domain ending in 'twitter.com'. 

# Associated samples

- [Sample 1](https://platform.sublimesecurity.com/messages/ccde143a4b319a93afc101a01af33ea1db2292a4001be20cacb64cd5562a9bcc)
- [Sample 2](https://platform.sublimesecurity.com/messages/ddb1abd408939dad472a3ca88054a07201d3a5d94afc4dbd6ea16af60d65d70e)
