### PR TITLE
New Rule: Suspicious Attachment: Duplicate decoy PDF files

### DIFF
--- a/detection-rules/suspicious_attachment_duplicate_decoy_pdf_attachments.yml
+++ b/detection-rules/suspicious_attachment_duplicate_decoy_pdf_attachments.yml
@@ -1,0 +1,31 @@
+name: "Suspicious Attachment: Duplicate decoy PDF files"
+description: "This rule identifies messages that contain duplicate PDF attachments, defined as either having identical filenames or matching MD5 hash values. Furthermore, the PDF files in question must lack any readable text and must not include hyperlinks."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and length(attachments) > 1
+  and all(attachments, .file_type == "pdf")
+  and (
+    length(distinct(attachments, .file_name)) == 1
+    or length(distinct(attachments, .md5)) == 1
+  )
+  and all(attachments,
+          .file_type == "pdf"
+          and any(file.explode(.),
+                  (
+                    length(.scan.url.urls) > 0
+                    or length(.scan.pdf.urls) > 0
+                    or length(body.links) > 0
+                  )
+                  and .scan.ocr.raw is null
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "PDF"
+detection_methods:
+  - "File analysis"
+  - "Optical Character Recognition"

--- a/detection-rules/suspicious_attachment_duplicate_decoy_pdf_attachments.yml
+++ b/detection-rules/suspicious_attachment_duplicate_decoy_pdf_attachments.yml
@@ -29,3 +29,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "Optical Character Recognition"
+id: "79b9b2e7-295f-59d2-97fb-4f5fe13bc869"


### PR DESCRIPTION
# Description

This rule identifies messages that contain duplicate PDF attachments, defined as either having identical filenames or matching MD5 hash values. Furthermore, the PDF files in question must lack any readable text and must not include hyperlinks.

# Associated samples

- [Sample 1](https://platform.sublimesecurity.com/rules/editor?canonical_id=1e45a5c2c5294fbbfd19bf14ee5c782867c2058f8dc1fabb7dabf0b5f2a1d314)


## Associated hunts

If you ran any hunts with your rule, please link them here.

- [Hunt 1](https://platform.sublimesecurity.com/hunts/1468225f-e751-4373-ad52-615a7c526761)

