### PR TITLE
Create brand_impersonation_stripe_notification.yml

### DIFF
--- a/detection-rules/brand_impersonation_stripe_notification.yml
+++ b/detection-rules/brand_impersonation_stripe_notification.yml
@@ -66,3 +66,4 @@ detection_methods:
   - "Header analysis"
   - "URL analysis"
   - "Whois"
+id: "3ffd2b03-ed17-575a-a9ef-ead2ee6fe660"

--- a/detection-rules/brand_impersonation_stripe_notification.yml
+++ b/detection-rules/brand_impersonation_stripe_notification.yml
@@ -1,0 +1,68 @@
+name: "Brand Impersonation: Stripe Notification"
+description: "Campaigns have been observed sending templated Stripe notification emails with the call-to-action button link replaced, clicking through to a malicious credential phishing page."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+    strings.ilike(sender.display_name, 'stripe*')
+    or strings.ilevenshtein(sender.display_name, 'stripe') <= 1
+    or strings.ilike(sender.email.domain.domain, '*stripe*')
+  )
+  and (
+    any(body.links,
+        (
+          .display_text in~ ("view in dashboard")
+          or (
+            network.whois(.href_url.domain).days_old < 30
+            and regex.icontains(.display_text, 'view|click|dashboard|portal')
+          )
+        )
+        and .href_url.domain.root_domain != "stripe.com"
+    )
+    // if it's a well done fake payment notification, the only 2 links that aren't from Stripe
+    // are the customer's email address and the CTA button (view in dashboard, click for more info, etc.)
+    or (
+      length(filter(body.links,
+                    .href_url.domain.root_domain != 'stripe.com'
+                    and .display_text is not null
+             )
+      ) == 2
+      and length(body.links) > 2
+    )
+  )
+  and not (
+    sender.email.domain.root_domain == "stripe.com"
+    and any(headers.hops, .authentication_results.dmarc == "pass")
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  and (
+    (
+      profile.by_sender().prevalence in ("new", "outlier")
+      and not profile.by_sender().solicited
+    )
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and not profile.by_sender().any_false_positives
+    )
+  )
+  and not profile.by_sender().any_false_positives
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "URL analysis"
+  - "Whois"


### PR DESCRIPTION
# Description

Campaigns have been observed sending templated Stripe notification emails with the call-to-action button link replaced, clicking through to a malicious credential phishing page.

# Associated samples

- https://platform.sublimesecurity.com/messages/efe0061f0fa1ae7bf6e7db7e3b1919d5b72a7fc9f82d8c068923763f53dec77c
- https://platform.sublimesecurity.com/messages/bedd0308cb99cab276f8cd7066331e9004a075ccbc8c7be071a6d64184431cf2

## Associated hunts

- https://platform.sublimesecurity.com/hunts/cde1c9aa-398d-4402-979e-a9f14b2a88a4
