### PR TITLE
Update impersonation_zoom_strict.yml

### DIFF
--- a/detection-rules/impersonation_zoom_strict.yml
+++ b/detection-rules/impersonation_zoom_strict.yml
@@ -13,21 +13,27 @@ source: |
     or sender.display_name =~ 'zoom video communications, inc.'
     or sender.display_name =~ 'zoom call'
   )
-  and sender.email.domain.root_domain not in ('zoom.us', 'zuora.com','zoomgov.com')
+  and sender.email.domain.root_domain not in (
+    'zoom.us',
+    'zuora.com',
+    'zoomgov.com',
+    'zoom.com'
+  )
   and (
     // if this comes from a free email provider,
     // flag if org has never sent an email to sender's email before
     (
       sender.email.domain.root_domain in $free_email_providers
-      and sender.email.email not in $recipient_emails
+      and not profile.by_sender().solicited
     )
     // if this comes from a custom domain,
     // flag if org has never sent an email to sender's domain before
     or (
       sender.email.domain.root_domain not in $free_email_providers
-      and sender.email.domain.domain not in $recipient_domains
+      and not profile.by_sender().solicited
     )
   )
+
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION


# Description

This rule is 3 years old. At the time of it's creation, zoom did not send communications from zoom.com, but rather zoom.us. 

This rule overall could probably use an overhaul, but to prevent FP's, I'm adding zoom.com and I've updated the recipient lists to use profile.by_sender().solicited.

# Associated samples

Link to samples that are affected by your change. 

- 4ab886fcb89f6a934ae00b8ef8f7a10ace6854658fb024e4d15c4789b2eb862d


