### PR TITLE
Update names.yml

### DIFF
--- a/insights/attachments/names.yml
+++ b/insights/attachments/names.yml
@@ -1,6 +1,6 @@
 name: "Attachment names"
 type: "query"
-source: map(attachments, .file_name)
+source: map(attachments, coalesce(.file_name, "Unnamed Attachment"))
 severity: "informational"
 tags:
   - "Attachments"


### PR DESCRIPTION
# Description

Updating the insight to produce "unnamed attachment" when a file name is null. This keeps the array count in line with the message details. 

