### PR TITLE
New rule: Callback phishing via Intuit service abuse

### DIFF
--- a/detection-rules/callback_phishing_intuit.yml
+++ b/detection-rules/callback_phishing_intuit.yml
@@ -157,4 +157,3 @@ detection_methods:
   - "Content analysis"
   - "Header analysis"
   - "Optical Character Recognition"
-id: "f2fe1294-ca43-5290-84fd-02f8149c5de7"

--- a/detection-rules/callback_phishing_intuit.yml
+++ b/detection-rules/callback_phishing_intuit.yml
@@ -1,0 +1,135 @@
+name: "Callback phishing via Intuit service abuse"
+description: "Callback phishing campaigns have been observed abusing Intuit Quickbooks services to send fraudulent invoices with callback phishing contents."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  
+  // Legitimate Intuit sending infratructure
+  and (
+    sender.email.domain.root_domain in ('intuit.com', 'intuit.co.uk')
+    // check for SPF or DMARC passed
+    and (headers.auth_summary.spf.pass or headers.auth_summary.dmarc.pass)
+  )
+  
+  // Callback Phishing in body
+  and (
+    (
+      length(attachments) == 0
+      and regex.icontains(body.current_thread.text,
+                          (
+                            "mcafee|norton|geek.{0,5}squad|paypal|ebay|symantec|best buy|lifelock"
+                          )
+      )
+      and 3 of (
+        strings.ilike(body.current_thread.text, '*purchase*'),
+        strings.ilike(body.current_thread.text, '*payment*'),
+        strings.ilike(body.current_thread.text, '*transaction*'),
+        strings.ilike(body.current_thread.text, '*subscription*'),
+        strings.ilike(body.current_thread.text, '*antivirus*'),
+        strings.ilike(body.current_thread.text, '*order*'),
+        strings.ilike(body.current_thread.text, '*support*'),
+        strings.ilike(body.current_thread.text, '*help line*'),
+        strings.ilike(body.current_thread.text, '*receipt*'),
+        strings.ilike(body.current_thread.text, '*invoice*'),
+        strings.ilike(body.current_thread.text, '*call*'),
+        strings.ilike(body.current_thread.text, '*cancel*'),
+        strings.ilike(body.current_thread.text, '*renew*'),
+        strings.ilike(body.current_thread.text, '*refund*')
+      )
+      // phone number regex
+      and any([body.current_thread.text, subject.subject],
+              regex.icontains(., '\b\+?(\d{1}.)?\(?\d{3}?\)?.\d{3}.?\d{4}\b')
+      )
+    )
+    or 
+    // all attachments are PDFs with callback phishing indicators 
+    (
+      length(attachments) < 3
+      and all(attachments, .file_extension == "pdf")
+      // the attachment is a pdf with 1 page, and at least 60 ocr chars
+      and any(attachments,
+              (
+                .file_extension == "pdf"
+                and any(file.explode(.), .scan.exiftool.page_count < 3)
+                and any(file.explode(.), length(.scan.ocr.raw) > 60)
+              )
+  
+              // 4 of the following strings are found        
+              and (
+                any(file.explode(.),
+                    4 of (
+                      strings.icontains(.scan.ocr.raw, "purchase"),
+                      strings.icontains(.scan.ocr.raw, "payment"),
+                      strings.icontains(.scan.ocr.raw, "transaction"),
+                      strings.icontains(.scan.ocr.raw, "subscription"),
+                      strings.icontains(.scan.ocr.raw, "antivirus"),
+                      strings.icontains(.scan.ocr.raw, "order"),
+                      strings.icontains(.scan.ocr.raw, "support"),
+                      strings.icontains(.scan.ocr.raw, "help line"),
+                      strings.icontains(.scan.ocr.raw, "receipt"),
+                      strings.icontains(.scan.ocr.raw, "invoice"),
+                      strings.icontains(.scan.ocr.raw, "call"),
+                      strings.icontains(.scan.ocr.raw, "helpdesk"),
+                      strings.icontains(.scan.ocr.raw, "cancel"),
+                      strings.icontains(.scan.ocr.raw, "renew"),
+                      strings.icontains(.scan.ocr.raw, "refund"),
+                      strings.icontains(.scan.ocr.raw, "amount"),
+                      strings.icontains(.scan.ocr.raw, "crypto"),
+                      strings.icontains(.scan.ocr.raw, "wallet address"),
+                      regex.icontains(.scan.ocr.raw, '\$\d{3}\.\d{2}\b'),
+                      regex.icontains(.scan.ocr.raw,
+                                      '(\+\d|1.(\()?\d{3}(\))?\D\d{3}\D\d{4})'
+                      ),
+                      regex.icontains(.scan.ocr.raw,
+                                      '\+?(\d{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}\d{3}[\s\.\-⋅]{0,5}\d{4}'
+                      )
+                    )
+                )
+              )
+  
+              // 1 of the following strings is found, representing common Callback brands          
+              and (
+                any(file.explode(.),
+                    1 of (
+                      strings.icontains(.scan.ocr.raw, "geek squad"),
+                      strings.icontains(.scan.ocr.raw, "lifelock"),
+                      strings.icontains(.scan.ocr.raw, "best buy"),
+                      strings.icontains(.scan.ocr.raw, "mcafee"),
+                      strings.icontains(.scan.ocr.raw, "norton"),
+                      strings.icontains(.scan.ocr.raw, "ebay"),
+                      strings.icontains(.scan.ocr.raw, "paypal"),
+                    )
+                )
+                or any(ml.logo_detect(.).brands,
+                       .name in ("PayPal", "Norton", "GeekSquad", "Ebay")
+                )
+              )
+              // Negate bank statements
+              and not (
+                any(file.explode(.),
+                    2 of (
+                      strings.icontains(.scan.ocr.raw, "opening balance"),
+                      strings.icontains(.scan.ocr.raw, "closing balance"),
+                      strings.icontains(.scan.ocr.raw, "direct debit"),
+                      strings.icontains(.scan.ocr.raw, "interest"),
+                      strings.icontains(.scan.ocr.raw, "account balance"),
+                    )
+                )
+              )
+      )
+    )
+  )
+
+attack_types:
+  - "Callback Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Free email provider"
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Computer Vision"
+  - "Content analysis"
+  - "Header analysis"
+  - "Optical Character Recognition"

--- a/detection-rules/callback_phishing_intuit.yml
+++ b/detection-rules/callback_phishing_intuit.yml
@@ -11,11 +11,12 @@ source: |
     // check for SPF or DMARC passed
     and (headers.auth_summary.spf.pass or headers.auth_summary.dmarc.pass)
   )
-  
-  // Callback Phishing in body
   and (
+    // Callback Phishing in body (brand names required)
     (
       length(attachments) == 0
+  
+      // brand names are required.
       and regex.icontains(body.current_thread.text,
                           (
                             "mcafee|norton|geek.{0,5}squad|paypal|ebay|symantec|best buy|lifelock"
@@ -42,9 +43,47 @@ source: |
               regex.icontains(., '\b\+?(\d{1}.)?\(?\d{3}?\)?.\d{3}.?\d{4}\b')
       )
     )
+    // Callback Phishing in the "billtoContent"
     or 
-    // all attachments are PDFs with callback phishing indicators 
+    // icontains a phone number
     (
+      regex.icontains(strings.replace_confusables(body.html.inner_text),
+                      'Bill to\n[^\n]+\+?(\d{1}.)?\(?\d{3}?\)?.\d{3}.?\d{4}.*\n'
+      )
+      or regex.icontains(strings.replace_confusables(body.html.inner_text),
+                         'Bill to\n[^\n]+\+\d{1,3}[0-9]{10}.*\n'
+      )
+      or // +12028001238
+   regex.icontains(strings.replace_confusables(body.html.inner_text),
+                   'Bill to\n[^\n]+[0-9]{3}\.[0-9]{3}\.[0-9]{4}.*\n'
+      )
+      or // 202-800-1238
+   regex.icontains(strings.replace_confusables(body.html.inner_text),
+                   'Bill to\n[^\n]+[0-9]{3}-[0-9]{3}-[0-9]{4}.*\n'
+      )
+      or // (202) 800-1238
+   regex.icontains(strings.replace_confusables(body.html.inner_text),
+                   'Bill to\n[^\n]+\([0-9]{3}\)\s[0-9]{3}-[0-9]{4}.*\n'
+      )
+      or // (202)-800-1238
+   regex.icontains(strings.replace_confusables(body.html.inner_text),
+                   'Bill to\n[^\n]+\([0-9]{3}\)-[0-9]{3}-[0-9]{4}.*\n'
+      )
+      or // 202 800 1238
+   regex.icontains(strings.replace_confusables(body.html.inner_text),
+                   'Bill to\n[^\n]+1\s?[0-9]{3} [0-9]{3} [0-9]{4}.*\n'
+      ) // 8123456789
+      or (
+        regex.icontains(strings.replace_confusables(body.html.inner_text),
+                        'Bill to\n[^\n]+8\d{9}.*\n'
+        )
+        and regex.icontains(strings.replace_confusables(body.html.inner_text),
+                            '\+1'
+        )
+      )
+    )
+    // all attachments are PDFs with callback phishing indicators Brands Required
+    or (
       length(attachments) < 3
       and all(attachments, .file_extension == "pdf")
       // the attachment is a pdf with 1 page, and at least 60 ocr chars
@@ -53,74 +92,59 @@ source: |
                 .file_extension == "pdf"
                 and any(file.explode(.), .scan.exiftool.page_count < 3)
                 and any(file.explode(.), length(.scan.ocr.raw) > 60)
-              )
   
-              // 4 of the following strings are found        
-              and (
-                any(file.explode(.),
-                    4 of (
-                      strings.icontains(.scan.ocr.raw, "purchase"),
-                      strings.icontains(.scan.ocr.raw, "payment"),
-                      strings.icontains(.scan.ocr.raw, "transaction"),
-                      strings.icontains(.scan.ocr.raw, "subscription"),
-                      strings.icontains(.scan.ocr.raw, "antivirus"),
-                      strings.icontains(.scan.ocr.raw, "order"),
-                      strings.icontains(.scan.ocr.raw, "support"),
-                      strings.icontains(.scan.ocr.raw, "help line"),
-                      strings.icontains(.scan.ocr.raw, "receipt"),
-                      strings.icontains(.scan.ocr.raw, "invoice"),
-                      strings.icontains(.scan.ocr.raw, "call"),
-                      strings.icontains(.scan.ocr.raw, "helpdesk"),
-                      strings.icontains(.scan.ocr.raw, "cancel"),
-                      strings.icontains(.scan.ocr.raw, "renew"),
-                      strings.icontains(.scan.ocr.raw, "refund"),
-                      strings.icontains(.scan.ocr.raw, "amount"),
-                      strings.icontains(.scan.ocr.raw, "crypto"),
-                      strings.icontains(.scan.ocr.raw, "wallet address"),
-                      regex.icontains(.scan.ocr.raw, '\$\d{3}\.\d{2}\b'),
-                      regex.icontains(.scan.ocr.raw,
-                                      '(\+\d|1.(\()?\d{3}(\))?\D\d{3}\D\d{4})'
-                      ),
-                      regex.icontains(.scan.ocr.raw,
-                                      '\+?(\d{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}\d{3}[\s\.\-⋅]{0,5}\d{4}'
+                // 4 of the following strings are found        
+                and (
+                  any(file.explode(.),
+                      4 of (
+                        strings.icontains(.scan.ocr.raw, "purchase"),
+                        strings.icontains(.scan.ocr.raw, "payment"),
+                        strings.icontains(.scan.ocr.raw, "transaction"),
+                        strings.icontains(.scan.ocr.raw, "subscription"),
+                        strings.icontains(.scan.ocr.raw, "antivirus"),
+                        strings.icontains(.scan.ocr.raw, "order"),
+                        strings.icontains(.scan.ocr.raw, "support"),
+                        strings.icontains(.scan.ocr.raw, "help line"),
+                        strings.icontains(.scan.ocr.raw, "receipt"),
+                        strings.icontains(.scan.ocr.raw, "invoice"),
+                        strings.icontains(.scan.ocr.raw, "call"),
+                        strings.icontains(.scan.ocr.raw, "helpdesk"),
+                        strings.icontains(.scan.ocr.raw, "cancel"),
+                        strings.icontains(.scan.ocr.raw, "renew"),
+                        strings.icontains(.scan.ocr.raw, "refund"),
+                        strings.icontains(.scan.ocr.raw, "amount"),
+                        strings.icontains(.scan.ocr.raw, "crypto"),
+                        strings.icontains(.scan.ocr.raw, "wallet address"),
+                        regex.icontains(.scan.ocr.raw, '\$\d{3}\.\d{2}\b'),
+                        regex.icontains(.scan.ocr.raw,
+                                        '(\+\d|1.(\()?\d{3}(\))?\D\d{3}\D\d{4})'
+                        ),
+                        regex.icontains(.scan.ocr.raw,
+                                        '\+?(\d{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}\d{3}[\s\.\-⋅]{0,5}\d{4}'
+                        )
                       )
-                    )
-                )
-              )
   
-              // 1 of the following strings is found, representing common Callback brands          
-              and (
-                any(file.explode(.),
-                    1 of (
-                      strings.icontains(.scan.ocr.raw, "geek squad"),
-                      strings.icontains(.scan.ocr.raw, "lifelock"),
-                      strings.icontains(.scan.ocr.raw, "best buy"),
-                      strings.icontains(.scan.ocr.raw, "mcafee"),
-                      strings.icontains(.scan.ocr.raw, "norton"),
-                      strings.icontains(.scan.ocr.raw, "ebay"),
-                      strings.icontains(.scan.ocr.raw, "paypal"),
-                    )
-                )
-                or any(ml.logo_detect(.).brands,
-                       .name in ("PayPal", "Norton", "GeekSquad", "Ebay")
-                )
-              )
-              // Negate bank statements
-              and not (
-                any(file.explode(.),
-                    2 of (
-                      strings.icontains(.scan.ocr.raw, "opening balance"),
-                      strings.icontains(.scan.ocr.raw, "closing balance"),
-                      strings.icontains(.scan.ocr.raw, "direct debit"),
-                      strings.icontains(.scan.ocr.raw, "interest"),
-                      strings.icontains(.scan.ocr.raw, "account balance"),
-                    )
+                      // 1 of the following strings is found, representing common Callback brands          
+                      and (
+                        1 of (
+                          strings.icontains(.scan.ocr.raw, "geek squad"),
+                          strings.icontains(.scan.ocr.raw, "lifelock"),
+                          strings.icontains(.scan.ocr.raw, "best buy"),
+                          strings.icontains(.scan.ocr.raw, "mcafee"),
+                          strings.icontains(.scan.ocr.raw, "norton"),
+                          strings.icontains(.scan.ocr.raw, "ebay"),
+                          strings.icontains(.scan.ocr.raw, "paypal"),
+                        )
+                      )
+                  )
+                  or any(ml.logo_detect(.).brands,
+                         .name in ("PayPal", "Norton", "GeekSquad", "Ebay")
+                  )
                 )
               )
       )
     )
   )
-
 attack_types:
   - "Callback Phishing"
 tactics_and_techniques:

--- a/detection-rules/callback_phishing_intuit.yml
+++ b/detection-rules/callback_phishing_intuit.yml
@@ -133,3 +133,4 @@ detection_methods:
   - "Content analysis"
   - "Header analysis"
   - "Optical Character Recognition"
+id: "f2fe1294-ca43-5290-84fd-02f8149c5de7"

--- a/detection-rules/callback_phishing_intuit.yml
+++ b/detection-rules/callback_phishing_intuit.yml
@@ -157,3 +157,4 @@ detection_methods:
   - "Content analysis"
   - "Header analysis"
   - "Optical Character Recognition"
+id: "f2fe1294-ca43-5290-84fd-02f8149c5de7"


### PR DESCRIPTION
Updated Version of #1699 

# Description

Make Attachment Logic all happen within the same file.explode().scan result
Add logic for callback detail in "bill to" section without any brands detected
Remove bank statement negations

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/2321786d197bb13fa23f73366d3070d20366d06cfaab8f8ab3d227a310e56dbf?ph-e6489411-a22d-4959-9ecc-30170413281d=019002b4-05ed-7bf5-8e38-692645fd5155)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/hunts/bd0168f2-55cc-48bd-b60f-c49f195d56b9)
