### PR TITLE
Update attachment_microsoft_image_lure_qr_code.yml

### DIFF
--- a/detection-rules/attachment_microsoft_image_lure_qr_code.yml
+++ b/detection-rules/attachment_microsoft_image_lure_qr_code.yml
@@ -12,7 +12,18 @@ source: |
           or .file_type == "pdf"
           or .file_type in~ $file_extensions_macros
         )
-        and any(ml.logo_detect(.).brands, strings.starts_with(.name, "Microsoft"))
+        and (
+          any(ml.logo_detect(.).brands, strings.starts_with(.name, "Microsoft"))
+          or any(file.explode(.),
+                  // for Office documents
+                 .flavors.mime == "text/xml"
+                 and any(.scan.strings.strings,
+                         regex.icontains(.,
+                                         'Microsoft (Authenticat(e|or|ion)|2fa|Multi.Factor|(qr|bar).code|action.require|alert|Att(n|ention):)'
+                         )
+                 )
+          )
+        )
     )
     or any(ml.logo_detect(beta.message_screenshot()).brands,
            strings.starts_with(.name, "Microsoft")


### PR DESCRIPTION
# Description

Added logic to cover additional Office documents, as we do not (and should not) recursively run LogoDetect.

# Associated samples

- https://platform.sublime.security/messages/60e183c1637c6633c72448ee4ca4df4054dc936aa2180997e4d8454230ee3e3b
