### PR TITLE
Update attachment_docusign_image_suspicious_links.yml

### DIFF
--- a/detection-rules/attachment_docusign_image_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_image_suspicious_links.yml
@@ -19,8 +19,8 @@ source: |
   )
   and (
     any(attachments,
-    .file_type in $file_types_images
-        (
+        .file_type in $file_types_images
+        and (
           any(ml.logo_detect(.).brands, .name == "DocuSign")
           or any(file.explode(.),
                  strings.ilike(.scan.ocr.raw, "*DocuSign*")
@@ -49,7 +49,7 @@ source: |
                     )
         )
     )
-  
+
     // accomidate truncated pngs and GIF files which can cause logodetect/OCR failures
     or any(attachments,
            (
@@ -106,7 +106,7 @@ source: |
     )
   )
   and not profile.by_sender().any_false_positives
-  
+
   // negate docusign 'via' messages
   and not (
     any(headers.hops,

--- a/detection-rules/attachment_docusign_image_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_image_suspicious_links.yml
@@ -19,8 +19,7 @@ source: |
   )
   and (
     any(attachments,
-        .file_type in $file_types_images
-        and (
+        (
           any(ml.logo_detect(.).brands, .name == "DocuSign")
           or any(file.explode(.),
                  strings.ilike(.scan.ocr.raw, "*DocuSign*")

--- a/detection-rules/attachment_docusign_image_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_image_suspicious_links.yml
@@ -19,6 +19,7 @@ source: |
   )
   and (
     any(attachments,
+    .file_type in $file_types_images
         (
           any(ml.logo_detect(.).brands, .name == "DocuSign")
           or any(file.explode(.),
@@ -29,7 +30,7 @@ source: |
                    )
                    or (regex.icontains(.scan.ocr.raw,
                                       "((re)?view|access|complete(d)?) document(s)?",
-                                      "[^d][^o][^c][^u]sign",
+                                      "[^d][^o][^cd][^ue]sign",
                                       "important edocs",
                                       // German (Document (check|check|sign|sent))
                                       "Dokument (überprüfen|prüfen|unterschreiben|geschickt)",


### PR DESCRIPTION
# Description

Adjust regex to not match on image OCRs which include "DocuSign" and "Graphics Design"

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/33f6d1f4a27e30de3dd3917ac52aebc7e08826eaa4b895bb3eb6eda90e4e1fdf)

