### PR TITLE
Update link_fake_password_expiration.yml

### DIFF
--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -98,6 +98,11 @@ source: |
       or regex.icontains(body.html.raw, '(<p[^>]*>&nbsp;</p>\s*){7,}')
     )
   )
+
+  // a body link does not match the sender domain
+  and any(body.links,
+          .href_url.domain.root_domain != sender.email.domain.root_domain
+  )
   
   // and no false positives and not solicited
   and (


### PR DESCRIPTION
# Description

Negating when all body links match the sender domain

# Associated samples

- https://platform.sublime.security/messages/80f9b63091767041867ea574a5e6f99e9aa741c55676eba8a66183b4ad0ec735
