### PR TITLE
Update impersonation_amex.yml

### DIFF
--- a/detection-rules/impersonation_amex.yml
+++ b/detection-rules/impersonation_amex.yml
@@ -27,7 +27,8 @@ source: |
     'amexgbt.com',
     'herrickstravelamex.com',
     'citi.com',
-    'secure.com'
+    'secure.com',
+    'nectar.com'
   )
   and sender.email.domain.domain not in ('accountprotection.microsoft.com', 'amex.membershipmail.net')
 


### PR DESCRIPTION
# Description

Negating Nectar.com (issuer of co-branded American Express cards)

# Associated samples

Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.

- https://platform.sublime.security/messages/52f89f472587dab2503e5389ab01515cd86ace03c09a31d5292f7770104c6107
- https://platform.sublime.security/messages/fa4fe99c591515e32957d811ee4017452ae1c06198d29ce2ffa26225d8055137
- https://platform.sublime.security/messages/0814412dd77dd684326cdecccab0465b9c363f660e3bb56142d8c0577b1bb194
