### PR TITLE
Update link_credential_phishing_voicemail_language.yml

### DIFF
--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -6,7 +6,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(body.links) <= 5
+  and length(body.links) <= 20
   // voicemail related
   and (
     any([subject.subject, sender.display_name, body.current_thread.text],

--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -11,7 +11,7 @@ source: |
   and (
     any([subject.subject, sender.display_name, body.current_thread.text],
         regex.icontains(.,
-                        '(v[nm]|voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|playback|\([0-9]{3}\).(\*\*\*|[0-9]{3}).\*\*\*'
+                        '(v[nm]|voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|audio note|listen|playback|\([0-9]{3}\).(\*\*\*|[0-9]{3}).\*\*\*'
         )
     )
   )
@@ -58,7 +58,7 @@ source: |
       any(body.links,
           regex.contains(.display_text, '[^a-z]*[A-Z][^a-z]*')
           and regex.icontains(.display_text,
-                              '(v[nm]|voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|playback|\([0-9]{3}\).(\*\*\*|[0-9]{3}).\*\*\*'
+                              '(v[nm]|voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|audio note|listen|playback|\([0-9]{3}\).(\*\*\*|[0-9]{3}).\*\*\*'
           )
       )
     ),
@@ -66,7 +66,7 @@ source: |
       any(body.links,
           .href_url.path == "/ctt"
           and regex.icontains(.display_text,
-                              '(v[nm]|voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|playback|\([0-9]{3}\).(\*\*\*|[0-9]{3}).\*\*\*'
+                              '(v[nm]|voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|audio note|listen|playback|\([0-9]{3}\).(\*\*\*|[0-9]{3}).\*\*\*'
           )
       )
     ),

--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -42,7 +42,8 @@ source: |
     ),
     (
       // sender domain matches no body domains
-      all(body.links,
+      // filter out "links" that are missing a display_text to remove "plain text" email address from being caught
+      all(filter(body.links, .display_text is not null),
           .href_url.domain.root_domain != sender.email.domain.root_domain
           and .href_url.domain.root_domain not in $org_domains
           and .href_url.domain.root_domain not in (

--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -6,15 +6,12 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(body.links) < 5
+  and length(body.links) <= 5
   // voicemail related
   and (
-    any([subject.subject, sender.display_name, ],
+    any([subject.subject, sender.display_name, body.current_thread.text],
         regex.icontains(.,
                         '(voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|playback|\([0-9]{3}\).(\*\*\*|[0-9]{3}).\*\*\*'
-        )
-        or regex.icontains(body.current_thread.text,
-                           '(voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|\([0-9]{3}\).(\*\*\*|[0-9]{3}).\*\*\*'
         )
     )
   )
@@ -30,11 +27,6 @@ source: |
           and any(ml.logo_detect(file.html_screenshot(.)).brands,
                   .name in ("Microsoft") and .confidence in ("medium", "high")
           )
-      )
-    ),
-    (
-      regex.icontains(sender.display_name,
-                      '(voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription'
       )
     ),
     (
@@ -60,7 +52,7 @@ source: |
       any(body.links,
           regex.contains(.display_text, '[^a-z]*[A-Z][^a-z]*')
           and regex.icontains(.display_text,
-                              '(voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|audio note'
+                              '(voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|audio note|listen'
           )
       )
     ),
@@ -68,7 +60,7 @@ source: |
       any(body.links,
           .href_url.path == "/ctt"
           and regex.icontains(.display_text,
-                              '(voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|audio note'
+                              '(voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|audio note|listen'
           )
       )
     ),
@@ -92,7 +84,7 @@ source: |
       )
     ),
   )
-  
+
   // negating legit replies and legitimate audio file attachments and known voicemail senders
   and sender.email.domain.root_domain not in (
     "magicjack.com",
@@ -123,7 +115,6 @@ source: |
       and not profile.by_sender().any_false_positives
     )
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -83,6 +83,13 @@ source: |
           )
       )
     ),
+    (
+      length(attachments) == 1
+      and any(attachments,
+              (.file_type in $file_types_images or .file_type == "pdf")
+              and any(file.explode(.), .scan.qr.type == "url")
+      )
+    )
   )
 
   // negating legit replies and legitimate audio file attachments and known voicemail senders

--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -42,8 +42,8 @@ source: |
     ),
     (
       // sender domain matches no body domains
-      // filter out "links" that are missing a display_text to remove "plain text" email address from being caught
-      all(filter(body.links, .display_text is not null),
+      // filter out "links" that are missing a display_text and display_url to remove "plain text" email address from being caught
+      all(filter(body.links, .display_text is not null and .display_url.url is not null),
           .href_url.domain.root_domain != sender.email.domain.root_domain
           and .href_url.domain.root_domain not in $org_domains
           and .href_url.domain.root_domain not in (

--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -11,7 +11,7 @@ source: |
   and (
     any([subject.subject, sender.display_name, body.current_thread.text],
         regex.icontains(.,
-                        '(voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|playback|\([0-9]{3}\).(\*\*\*|[0-9]{3}).\*\*\*'
+                        '(v[nm]|voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|playback|\([0-9]{3}\).(\*\*\*|[0-9]{3}).\*\*\*'
         )
     )
   )
@@ -27,6 +27,11 @@ source: |
           and any(ml.logo_detect(file.html_screenshot(.)).brands,
                   .name in ("Microsoft") and .confidence in ("medium", "high")
           )
+      )
+    ),
+    (
+      regex.icontains(sender.display_name,
+                      '(voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription'
       )
     ),
     (
@@ -52,7 +57,7 @@ source: |
       any(body.links,
           regex.contains(.display_text, '[^a-z]*[A-Z][^a-z]*')
           and regex.icontains(.display_text,
-                              '(voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|audio note|listen'
+                              '(v[nm]|voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|playback|\([0-9]{3}\).(\*\*\*|[0-9]{3}).\*\*\*'
           )
       )
     ),
@@ -60,7 +65,7 @@ source: |
       any(body.links,
           .href_url.path == "/ctt"
           and regex.icontains(.display_text,
-                              '(voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|audio note|listen'
+                              '(v[nm]|voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|playback|\([0-9]{3}\).(\*\*\*|[0-9]{3}).\*\*\*'
           )
       )
     ),
@@ -91,7 +96,7 @@ source: |
       )
     )
   )
-
+  
   // negating legit replies and legitimate audio file attachments and known voicemail senders
   and sender.email.domain.root_domain not in (
     "magicjack.com",


### PR DESCRIPTION
# Description

1) Adjust initial regex check to remove "or" and instead inspect all 3 fields within the any
2) Adjust max link limit 
3) remove check for display_name from "2 of" conditions, which was already checked once as part of the initial regex
4) add "listen" to keywords

# Associated samples

FN that now matches
- [Sample 1](https://platform.sublime.security/messages/21a5b2b1aadabcbbdbdc7b0049787c940677edff66347b4ba57b025a6e17108a)
