### PR TITLE
Update impersonation_sharepoint_fake_file_share.yml

### DIFF
--- a/detection-rules/impersonation_sharepoint_fake_file_share.yml
+++ b/detection-rules/impersonation_sharepoint_fake_file_share.yml
@@ -7,9 +7,25 @@ source: |
   type.inbound
   
   // Sharepoint body content looks like this
-  and strings.like(body.current_thread.text, "*shared a file with you*", "*shared with you*", "*invited you to access a file*")
-  and strings.icontains(subject.subject, "shared")
-  and any(ml.logo_detect(beta.message_screenshot()).brands, .name == "Microsoft")
+  and any([body.current_thread.text, body.plain.raw],
+          strings.ilike(.,
+                        "*shared a file with you*",
+                        "*shared with you*",
+                        "*invited you to access a file*"
+          )
+  )
+  and strings.ilike(subject.subject, "*shared*", "*updated*")
+  and (
+    any(ml.logo_detect(beta.message_screenshot()).brands,
+        strings.starts_with(.name, "Microsoft")
+    )
+    or any(attachments,
+           .file_type in $file_types_images
+           and any(ml.logo_detect(.).brands,
+                   strings.starts_with(.name, "Microsoft")
+           )
+    )
+  )
 
   // Negate messages when the message-id indciates the message is from MS actual. DKIM/SPF domains can be custom and therefore are unpredictable.
   and not (


### PR DESCRIPTION
# Description
Added additional coverage for keyword detection, and included image attachments in the `logo_detect` block.

# Associated samples

- https://platform.sublime.security/messages/5118c66c2967c57e180161146c4e87d1e1cbe4478571ff8ab6feb00476890079?ph-e6489411-a22d-4959-9ecc-30170413281d=018df67c-8ba7-7da6-9dae-e3b03c7cd881
