### PR TITLE
Update spam_attendee_list_solicitation.yml

### DIFF
--- a/detection-rules/spam_attendee_list_solicitation.yml
+++ b/detection-rules/spam_attendee_list_solicitation.yml
@@ -11,7 +11,10 @@ source: |
                     "(Attendee|Member|Participant|User|Visitor|Registrant|Buyer|Email)(s)?.{0,20}(list|database)"
     )
     or regex.icontains(body.current_thread.text,
-                       "((demand|lead) .{0,20} (manager|head|lead|supervisor|executive))"
+                    "(list|database).{0,20}(Attendee|Member|Participant|User|Visitor|Registrant|Buyer|Email)(s)?"
+    )
+    or regex.icontains(body.current_thread.text,
+                       "((demand|lead|marketing).{0,20}(manager|head|lead|supervisor|executive))"
     )
   )
   and regex.icontains(body.current_thread.text,


### PR DESCRIPTION
# Description

Adding another clause, the inverse of the first regex ("list of users" instead of "user list", etc.), and additional title (`marketing`)

# Associated samples

- https://platform.sublime.security/messages/e9e0152e566ab9343f0f2d615ec299e3ea2aacd85ec1f7ef917a9096595b4846?from_canonical_id=ebb590d2bec6f71e390a0e08ca8ba09805d73c355b53d09b9d5612944b880e8e

## Associated hunts
- https://platform.sublime.security/hunts/dbb192f1-7322-4703-b99e-0ef98dea441d
