### PR TITLE
Update credential_phishing_esign_document_notification.yml

### DIFF
--- a/detection-rules/credential_phishing_esign_document_notification.yml
+++ b/detection-rules/credential_phishing_esign_document_notification.yml
@@ -18,6 +18,7 @@ source: |
                           "DocuCenter",
                           "DocCenter",
                           "DocsOnline",
+                          "DocSend",
                           "\\beSign",
                           "e\\.sign",
                           "e-doc",
@@ -47,6 +48,7 @@ source: |
           )
   )
   and (
+    // unusal repeated patterns in HTML 
     regex.icontains(body.html.raw, '((<br\s*/?>\s*){20,}|\n{20,})')
     or regex.icontains(body.html.raw, '(<p[^>]*>\s*<br\s*/?>\s*</p>\s*){30,}')
     or regex.icontains(body.html.raw,
@@ -55,8 +57,13 @@ source: |
     or regex.icontains(body.html.raw, '(<p>&nbsp;</p>\s*){7,}')
     or regex.icontains(body.html.raw, '(<p[^>]*>\s*&nbsp;<br>\s*</p>\s*){5,}')
     or regex.icontains(body.html.raw, '(<p[^>]*>&nbsp;</p>\s*){7,}')
-    or regex.icontains(body.html.raw, '>Docus[1l]gn<')
     or strings.count(body.html.raw, '&nbsp;‌&nbsp;‌&nbsp') > 50
+    or regex.count(body.html.raw,
+                  '<span\s*class\s*=\s*"[^\"]+"\s*>\s*[a-z]\s*<\/span><span\s*class\s*=\s*"[^\"]+"\s*>\s*[a-z]+\s*<\/span>'
+      ) > 50
+    // lookalike docusign
+    or regex.icontains(body.html.raw, '>Docus[1l]gn<')
+    // common greetings via email.local_part
     or any(recipients.to, strings.icontains(body.current_thread.text, .email.local_part))
   )
   and (
@@ -67,7 +74,7 @@ source: |
                         "verify",
                         "acknowledg",
                         "(keep|change).{0,20}(active|password|access)",
-                        '((verify|view|click|download|goto|keep|Vιew|release).{0,10}(attachment|current|download|fax|file|document|message|same)s?)',
+                        '((verify|view|click|download|goto|keep|Vιew|release).{0,15}(attachment|current|download|fax|file|document|message|same)s?)',
                         'use.same.pass',
                         'validate.{0,15}account',
                         'recover.{0,15}messages',


### PR DESCRIPTION
# Description

Update to catch observed message

# Associated samples

Sample that would match once body.links.display_text is updated to account for non-displayable chars.  
- [Sample 1](https://platform.sublime.security/messages/7ffdef1829950e3279aa3462ec582c6c9487b0dbf3dae4ab842ba6d89144151e)

