### PR TITLE
Update link_credential_phishing_voicemail_language.yml

### DIFF
--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -103,7 +103,8 @@ source: |
     "magicjack.com",
     "unitelvoice.com",
     "voipinterface.net",
-    "ringcentral.biz"
+    "ringcentral.biz",
+    "verizonwireless.com"
   )
   and not any(attachments, strings.starts_with(.content_type, "audio"))
   // filter out topics that mention audio and listening, but are not voicemails

--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -106,6 +106,12 @@ source: |
     "ringcentral.biz"
   )
   and not any(attachments, strings.starts_with(.content_type, "audio"))
+  // filter out topics that mention audio and listening, but are not voicemails
+  and not any(["podcast", "tune", "album", "episode", "study", "series", "coach"],
+              any([subject.subject, sender.display_name, body.current_thread.text],
+                  strings.icontains(., ..)
+              )
+  )
   and not (
     (
       strings.istarts_with(subject.subject, "RE:")
@@ -128,6 +134,7 @@ source: |
       and not profile.by_sender().any_false_positives
     )
   )
+
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -13,6 +13,18 @@ source: |
         regex.icontains(.,
                         '(v[nm]|voice|audio|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|audio note|listen|playback|\([0-9]{3}\).(\*\*\*|[0-9]{3}).\*\*\*'
         )
+        // filter out topics that mention audio and listening, but are not voicemails
+        and not any([
+                      "podcast",
+                      "tune",
+                      "album",
+                      "episode",
+                      "study",
+                      "series",
+                      "coach"
+                    ],
+                    strings.icontains(.., .)
+        )
     )
   )
   and 2 of (
@@ -43,7 +55,9 @@ source: |
     (
       // sender domain matches no body domains
       // filter out "links" that are missing a display_text and display_url to remove "plain text" email address from being caught
-      all(filter(body.links, .display_text is not null and .display_url.url is not null),
+      all(filter(body.links,
+                 .display_text is not null and .display_url.url is not null
+          ),
           .href_url.domain.root_domain != sender.email.domain.root_domain
           and .href_url.domain.root_domain not in $org_domains
           and .href_url.domain.root_domain not in (
@@ -108,12 +122,6 @@ source: |
     "t-mobile.com"
   )
   and not any(attachments, strings.starts_with(.content_type, "audio"))
-  // filter out topics that mention audio and listening, but are not voicemails
-  and not any(["podcast", "tune", "album", "episode", "study", "series", "coach"],
-              any([subject.subject, sender.display_name, body.current_thread.text],
-                  strings.icontains(., ..)
-              )
-  )
   and not (
     (
       strings.istarts_with(subject.subject, "RE:")
@@ -136,6 +144,7 @@ source: |
       and not profile.by_sender().any_false_positives
     )
   )
+
 
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -104,7 +104,8 @@ source: |
     "unitelvoice.com",
     "voipinterface.net",
     "ringcentral.biz",
-    "verizonwireless.com"
+    "verizonwireless.com",
+    "t-mobile.com"
   )
   and not any(attachments, strings.starts_with(.content_type, "audio"))
   // filter out topics that mention audio and listening, but are not voicemails


### PR DESCRIPTION
# Description

Removed false positives related to audio related emails, such as podcasts, that were being caught by this rule. Also added verizonwireless.com as an exclusion because they send wav files, but the content-type is PDF for some reason, so they were also flagged at times.
