### PR TITLE
Update impersonation_fake_msg_thread_mismatched_from_freemail_replyto.yml

### DIFF
--- a/detection-rules/impersonation_fake_msg_thread_mismatched_from_freemail_replyto.yml
+++ b/detection-rules/impersonation_fake_msg_thread_mismatched_from_freemail_replyto.yml
@@ -10,7 +10,7 @@ source: |
   type.inbound
   and (
     (
-      profile.by_sender().prevalence in ("new", "outlier")
+      profile.by_sender_email().prevalence in ("new", "outlier")
       and not profile.by_sender().solicited
     )
     or (


### PR DESCRIPTION
# Description

Adjusting prevalence check to use email instead of domain. Hunts show that this catches more TPs.

## Associated hunts

- https://platform.sublime.security/hunts/d33d4224-4ea1-41d6-a813-45381e12577d
