### PR TITLE
Update paypal_invoice_abuse.yml

### DIFF
--- a/detection-rules/paypal_invoice_abuse.yml
+++ b/detection-rules/paypal_invoice_abuse.yml
@@ -56,6 +56,9 @@ source: |
         (
           4 of (
             strings.ilike(body.html.inner_text, '*you did not*'),
+            strings.ilike(body.html.inner_text, '*is not for*'),
+            regex.icontains(body.html.inner_text, "didn\'t ma[kd]e this"),
+            strings.ilike(body.html.inner_text, "*Fruad Alert*"),
             strings.ilike(body.html.inner_text, '*using your PayPal*'),
             strings.ilike(body.html.inner_text, '*subscription*'),
             strings.ilike(body.html.inner_text, '*antivirus*'),
@@ -67,6 +70,9 @@ source: |
             strings.ilike(body.html.inner_text, '*Market*Value*'),
             strings.ilike(body.html.inner_text, '*BTC*'),
             strings.ilike(body.html.inner_text, '*call*'),
+            strings.ilike(body.html.inner_text, '*get in touch with our*'),
+            strings.ilike(body.html.inner_text, '*quickly inform*'),
+            strings.ilike(body.html.inner_text, '*detected unusual transactions*'),
             strings.ilike(body.html.inner_text, '*cancel*'),
             strings.ilike(body.html.inner_text, '*renew*'),
             strings.ilike(body.html.inner_text, '*refund*'),

--- a/detection-rules/paypal_invoice_abuse.yml
+++ b/detection-rules/paypal_invoice_abuse.yml
@@ -10,7 +10,7 @@ severity: "medium"
 source: |
   type.inbound
   and length(attachments) == 0
-  and sender.email.domain.root_domain in ("paypal.com", "paypal.com.mx")
+  and sender.email.domain.root_domain in ("paypal.com", "paypal.com.mx", "paypal.com.br", "paypal.com.ar")
   and not any(headers.hops, .authentication_results.dmarc == "fail")
   and (
     strings.ilike(body.html.display_text, "*seller note*")

--- a/detection-rules/paypal_invoice_abuse.yml
+++ b/detection-rules/paypal_invoice_abuse.yml
@@ -10,7 +10,7 @@ severity: "medium"
 source: |
   type.inbound
   and length(attachments) == 0
-  and sender.email.domain.root_domain == "paypal.com"
+  and sender.email.domain.root_domain in ("paypal.com", "paypal.com.mx")
   and not any(headers.hops, .authentication_results.dmarc == "fail")
   and (
     strings.ilike(body.html.display_text, "*seller note*")
@@ -21,34 +21,34 @@ source: |
       // icontains a phone number
       (
         regex.icontains(strings.replace_confusables(body.current_thread.text),
-                        '.*\+?(\d{1}.)?\(?\d{3}?\)?.\d{3}.?\d{4}.*\n'
+                        '.*\+?([lo0-9]{1}.)?\(?[lo0-9]{3}?\)?.[lo0-9]{3}.?[lo0-9]{4}.*\n'
         )
         or regex.icontains(strings.replace_confusables(body.current_thread.text),
-                           '.*\+\d{1,3}[0-9]{10}.*\n'
+                           '.*\+[lo0-9]{1,3}[lo0-9]{10}.*\n'
         )
         or // +12028001238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[0-9]{3}\.[0-9]{3}\.[0-9]{4}.*\n'
+       regex.icontains(strings.replace_confusables(body.current_thread.text),
+                   '.*[lo0-9]{3}\.[lo0-9]{3}\.[lo0-9]{4}.*\n'
         )
         or // 202-800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[0-9]{3}-[0-9]{3}-[0-9]{4}.*\n'
+       regex.icontains(strings.replace_confusables(body.current_thread.text),
+                   '.*[lo0-9]{3}-[lo0-9]{3}-[lo0-9]{4}.*\n'
         )
         or // (202) 800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([0-9]{3}\)\s[0-9]{3}-[0-9]{4}.*\n'
+       regex.icontains(strings.replace_confusables(body.current_thread.text),
+                   '.*\([lo0-9]{3}\)\s[lo0-9]{3}-[lo0-9]{4}.*\n'
         )
         or // (202)-800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([0-9]{3}\)-[0-9]{3}-[0-9]{4}.*\n'
-        ) // 8123456789
-        or (
+       regex.icontains(strings.replace_confusables(body.current_thread.text),
+                   '.*\([lo0-9]{3}\)-[lo0-9]{3}-[lo0-9]{4}.*\n'
+        )
+        or ( // 8123456789
           regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          '.*8\d{9}.*\n'
+                          '.*8[lo0-9]{9}.*\n'
           )
           and regex.icontains(strings.replace_confusables(body.current_thread.text
                               ),
-                              '\+1'
+                              '\+[1l]'
           )
         )
       )
@@ -56,12 +56,16 @@ source: |
         (
           4 of (
             strings.ilike(body.html.inner_text, '*you did not*'),
+            strings.ilike(body.html.inner_text, '*using your PayPal*'),
             strings.ilike(body.html.inner_text, '*subscription*'),
             strings.ilike(body.html.inner_text, '*antivirus*'),
             strings.ilike(body.html.inner_text, '*order*'),
             strings.ilike(body.html.inner_text, '*support*'),
             strings.ilike(body.html.inner_text, '*receipt*'),
             strings.ilike(body.html.inner_text, '*invoice*'),
+            strings.ilike(body.html.inner_text, '*Purchase*'),
+            strings.ilike(body.html.inner_text, '*Market*Value*'),
+            strings.ilike(body.html.inner_text, '*BTC*'),
             strings.ilike(body.html.inner_text, '*call*'),
             strings.ilike(body.html.inner_text, '*cancel*'),
             strings.ilike(body.html.inner_text, '*renew*'),


### PR DESCRIPTION
# Description

- Cover cases where replace_confusables replaces with a `l` (lowercase letter L) or `O` (Capital Letter O) intead of `1` (digit one) or `0` (digit zero)
- Cover additional PayPal domains
- Add additional keywords/phases from the actor
- Cover additional types of emails (estimates and invoices) which do not include "notes" 

# Associated samples


- [Sample 1](https://platform.sublime.security/messages/28b191979d7b649327450c1d2f45893534c4df8099586efa7780f8f124be4450)
- [Sample 2](https://platform.sublime.security/messages/ce23d359e73a85652f58254167aff410f134359368f69dad7d1ac34e6ea59c9f)
- [Sample 3](https://platform.sublime.security/rules/editor?canonical_id=21e6994ee07842d692b74210b466f38f743ebe0ef62d77706f33a47ad07534bc&message_id=0191c3f8-43cc-7dc9-a72f-2369137c29d7)
- [Sample 4](https://platform.sublime.security/messages/9e853eaaaeba3ced75b70d5c47f48ba4b20a545f571b142af5de675b25c53fd8)

## Associated hunts


New Samples previously not covered
- [Hunt 1](https://platform.sublime.security/hunts/7546aef1-852a-4309-b5d4-2ea857b5383f)
