### PR TITLE
Update impersonation_amex.yml

### DIFF
--- a/detection-rules/impersonation_amex.yml
+++ b/detection-rules/impersonation_amex.yml
@@ -28,7 +28,8 @@ source: |
     'herrickstravelamex.com',
     'citi.com',
     'secure.com',
-    'nectar.com'
+    'nectar.com',
+    'accentinfomedia.com'
   )
   and sender.email.domain.domain not in ('accountprotection.microsoft.com', 'amex.membershipmail.net')
 


### PR DESCRIPTION
# Description

Negating accentinfomedia.com root domain (marketing firm that sends out emails on behalf of American Express targeting Indian clients)

# Associated samples

- https://platform.sublime.security/messages/538bf1b324c6e0af5bfdf784404aeaca4b9ef1ab5f0e1d505832630eebb19c4b
