### PR TITLE
Update impersonation_recipient_domain_display_name.yml

### DIFF
--- a/detection-rules/impersonation_recipient_domain_display_name.yml
+++ b/detection-rules/impersonation_recipient_domain_display_name.yml
@@ -46,6 +46,10 @@ source: |
     strings.contains(sender.display_name, "on behalf of")
     and sender.email.domain.root_domain == "microsoftonline.com"
   )
+  // negate pageproof updates
+  and not (
+      sender.email.email == 'team@pageproof.com'
+  )
   and all(recipients.to,
           .email.email != sender.email.email
           and (


### PR DESCRIPTION
# Description

Negating updates and notifications sent through Pageproof

# Associated samples

- https://platform.sublime.security/messages/8df987663a1837c42bfd8f83e4e9f017d572eaf12aebd3606b8a40d9815d1300
- https://platform.sublime.security/messages/6c6a041b145a78b81ae15364d2eff9da687b7b05130e01fe4cee37240750b40d
- https://platform.sublime.security/messages/cd5ce0e1d4b1edfed056518bd457e60bac4758b27dff43cfd4487a33ab8c03fd