### PR TITLE
Update link_fake_password_expiration.yml

### DIFF
--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -85,15 +85,15 @@ source: |
   
     // excessive whitespace
     or (
-      regex.icontains(body.html.raw, '((<br\s*/?>\s*){20,}|\n{20,})')
-      or regex.icontains(body.html.raw, '(<p[^>]*>\s*<br\s*/?>\s*</p>\s*){30,}')
+      regex.icontains(body.html.raw, '(?:(?:<br\s*/?>\s*){20,}|\n{20,})')
+      or regex.icontains(body.html.raw, '(?:<p[^>]*>\s*<br\s*/?>\s*</p>\s*){30,}')
       or regex.icontains(body.html.raw,
-                         '(<p class=".*?"><span style=".*?"><o:p>&nbsp;</o:p></span></p>\s*){30,}'
+                         '(?:<p class=".*?"><span style=".*?"><o:p>&nbsp;</o:p></span></p>\s*){30,}'
       )
-      or regex.icontains(body.html.raw, '(<p>&nbsp;</p>\s*){7,}')
-      or regex.icontains(body.html.raw, '(<p>&nbsp;</p><br>\s*){7,}')
-      or regex.icontains(body.html.raw, '(<p[^>]*>\s*&nbsp;<br>\s*</p>\s*){5,}')
-      or regex.icontains(body.html.raw, '(<p[^>]*>&nbsp;</p>\s*){7,}')
+      or regex.icontains(body.html.raw, '(?:<p>\s*&nbsp;\s*</p>\s*){7,}')
+      or regex.icontains(body.html.raw, '(?:<p>\s*&nbsp;\s*</p>\s*<br>\s*){7,}')
+      or regex.icontains(body.html.raw, '(?:<p[^>]*>\s*&nbsp;\s*<br>\s*</p>\s*){5,}')
+      or regex.icontains(body.html.raw, '(?:<p[^>]*>&nbsp;</p>\s*){7,}')
     )
   )
 

--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -26,20 +26,18 @@ source: |
     )
     and not strings.icontains(body.current_thread.text, 'link expires in ')
   )
-  
   and (
     // subject or body contains account or access
     any([subject.subject, body.current_thread.text],
-        regex.icontains(body.current_thread.text, "account|access|your email")
+        regex.icontains(., "account|access|your email")
     )
     // suspicious use of recipients email address
     or any(recipients.to,
-           strings.icontains(strings.replace_confusables(subject.subject),
-                             .email.local_part
-           )
-           or strings.icontains(strings.replace_confusables(body.current_thread.text
-                                ),
-                                .email.email
+           any([subject.subject, body.current_thread.text],
+               strings.icontains(strings.replace_confusables(.),
+                                 ..email.local_part
+               )
+               or strings.icontains(strings.replace_confusables(.), ..email.email)
            )
     )
   )
@@ -49,7 +47,7 @@ source: |
             strings.replace_confusables(subject.subject),
             strings.replace_confusables(body.current_thread.text)
           ],
-          regex.icontains(body.current_thread.text, '\bpassword\b')
+          regex.icontains(., '\bpassword\b')
   )
   and (
     any(ml.nlu_classifier(strings.replace_confusables(body.current_thread.text)).intents,
@@ -84,7 +82,7 @@ source: |
   // body length between 200 and 2000
   and (
     200 < length(body.current_thread.text) < 2000
-    
+  
     // excessive whitespace
     or (
       regex.icontains(body.html.raw, '((<br\s*/?>\s*){20,}|\n{20,})')


### PR DESCRIPTION
# Description

Fix this rule's logic to actually use the values within an outer `any` 

# Associated samples
## Associated hunts

If you ran any hunts with your rule, please link them here.

L14 days new samples covered by this change
- [Hunt 1](https://platform.sublime.security/hunts/1b3b763b-a954-46f5-970c-c42d42d94f9c)
