### PR TITLE
Update link_credential_phishing_intent_and_other_indicators.yml

### DIFF
--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -281,7 +281,10 @@ source: |
     4 of (
       any(recipients.to,
           .email.domain.valid
-          and strings.icontains(body.current_thread.text, .email.email)
+          and (
+            strings.icontains(body.current_thread.text, .email.email)
+            or strings.icontains(body.current_thread.text, .email.local_part)
+          )
       ),
       any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == "cred_theft" and .confidence in ("medium", "high")
@@ -340,7 +343,7 @@ source: |
         // suspicious display text
         or (
           length(body.links) == 1
-          and all(body.links, strings.ilike(.display_text, "*click here*"))
+          and all(body.links, strings.ilike(.display_text, "*click here*", "*password*"))
         )
       )
       // link leads to a suspicious TLD or contains an IP address

--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -39,6 +39,7 @@ source: |
                     "app[li]e.[il]d",
                     "authenticate.*account",
                     "been.*suspend",
+                    "crediential.*notif",
                     "clos.*of.*account.*processed",
                     "confirm.your.account",
                     "courier.*able",


### PR DESCRIPTION
# Description

Add additional coverage for missed password reset phish

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/31e34f2461bae43be307c952e8a529e312ce4415aff6ab3b87cc16185159f537)
## Associated hunts

L14D of messages that will now match this rule
- Hunt 1

# Screenshot (insights)

**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
