### PR TITLE
Update impersonation_sharepoint_fake_file_share.yml

### DIFF
--- a/detection-rules/impersonation_sharepoint_fake_file_share.yml
+++ b/detection-rules/impersonation_sharepoint_fake_file_share.yml
@@ -19,7 +19,6 @@ source: |
       and strings.ilike(subject.subject, "*shared*", "*updated*")
     )
     or any([
-             // "with you" in mutliple languages
              "Contigo", // Spanish
              "Avec vous", // French
              "Mit Ihnen", // German
@@ -35,7 +34,7 @@ source: |
              "آپ کے ساتھ", // Urdu
              "আপনার সাথে", // Bengali
              "आपके साथ", // Hindi
-             "Sizinle", // Turkish
+             "Sizinle", // Turkish // Azerbaijani
              "Med dig", // Swedish
              "Z tobą", // Polish
              "З вами", // Ukrainian
@@ -44,8 +43,7 @@ source: |
              "איתך", // Hebrew
              "กับคุณ", // Thai
              "Với bạn", // Vietnamese
-             "Dengan Anda", // Indonesian
-             "Dengan anda", // Malay
+             "Dengan Anda", // Indonesian // Malay
              "Nawe", // Swahili
              "Cu dumneavoastră", // Romanian
              "S vámi", // Czech
@@ -53,10 +51,8 @@ source: |
              "S vami", // Slovak
              "Med dig", // Danish
              "Amb vostè", // Catalan
-             "Sizinle", // Azerbaijani
              "Teiega", // Estonian
              "S vama", // Serbian
-             "Sizinle", // Azerbaijani (Latin scrip
            ],
            strings.icontains(subject.subject, .)
     )

--- a/detection-rules/impersonation_sharepoint_fake_file_share.yml
+++ b/detection-rules/impersonation_sharepoint_fake_file_share.yml
@@ -7,16 +7,28 @@ source: |
   type.inbound
 
   // Sharepoint body content looks like this
-  and any([body.current_thread.text, body.plain.raw],
-          strings.ilike(.,
-                        "*shared a file with you*",
-                        "*shared with you*",
-                        "*invited you to access a file*"
-          )
-          // or the current thread is empty but has an image (image as content)
-          or . == "" and any(attachments, .file_type in $file_types_images)
+  and (
+    any([body.current_thread.text, body.plain.raw],
+        strings.ilike(.,
+                      "*shared a file with you*",
+                      "*shared with you*",
+                      "*invited you to access a file*"
+        )
+    )
+    // or the current thread is empty but has an image (image as content) with logo_detect of MS
+    or (
+      body.current_thread.text == ""
+      and any(attachments,
+              .file_type in $file_types_images
+              and any(ml.logo_detect(.).brands,
+                      strings.starts_with(.name, "Microsoft")
+              )
+      )
+    )
+    // the subject contains indicators of sharepoint shares
+    or strings.ilike(subject.subject, "*shared*", "*updated*")
   )
-  and strings.ilike(subject.subject, "*share*", "*updated*")
+  // contains logic that impersonates Microsoft
   and (
     any(ml.logo_detect(beta.message_screenshot()).brands,
         strings.starts_with(.name, "Microsoft")
@@ -191,6 +203,7 @@ source: |
     )
   )
   and not profile.by_sender().any_false_positives
+
 
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/impersonation_sharepoint_fake_file_share.yml
+++ b/detection-rules/impersonation_sharepoint_fake_file_share.yml
@@ -5,29 +5,62 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-
+  
   // Sharepoint body content looks like this
   and (
-    any([body.current_thread.text, body.plain.raw],
-        strings.ilike(.,
-                      "*shared a file with you*",
-                      "*shared with you*",
-                      "*invited you to access a file*"
-        )
-    )
-    // or the current thread is empty but has an image (image as content) with logo_detect of MS
-    or (
-      body.current_thread.text == ""
-      and any(attachments,
-              .file_type in $file_types_images
-              and any(ml.logo_detect(.).brands,
-                      strings.starts_with(.name, "Microsoft")
-              )
+    (
+      any([body.current_thread.text, body.plain.raw],
+          strings.ilike(.,
+                        "*shared a file with you*",
+                        "*shared with you*",
+                        "*invited you to access a file*"
+          )
       )
+      and strings.ilike(subject.subject, "*shared*", "*updated*")
     )
-    // the subject contains indicators of sharepoint shares
-    or strings.ilike(subject.subject, "*shared*", "*updated*")
+    or any([
+             "Contigo", // Spanish
+             "Avec vous", // French
+             "Mit Ihnen", // German
+             "Con te", // Italian
+             "Com você", // Portuguese
+             "Met u", // Dutch
+             "С вами", // Russian
+             "与你", // Chinese (Simplified)
+             "與您", // Chinese (Traditional)
+             "あなたと", // Japanese
+             "당신과", // Korean
+             "معك", // Arabic
+             "آپ کے ساتھ", // Urdu
+             "আপনার সাথে", // Bengali
+             "आपके साथ", // Hindi
+             "Sizinle", // Turkish
+             "Med dig", // Swedish
+             "Z tobą", // Polish
+             "З вами", // Ukrainian
+             "Önnel", // Hungarian
+             "Μαζί σας", // Greek
+             "איתך", // Hebrew
+             "กับคุณ", // Thai
+             "Với bạn", // Vietnamese
+             "Dengan Anda", // Indonesian
+             "Dengan anda", // Malay
+             "Nawe", // Swahili
+             "Cu dumneavoastră", // Romanian
+             "S vámi", // Czech
+             "Med deg", // Norwegian
+             "S vami", // Slovak
+             "Med dig", // Danish
+             "Amb vostè", // Catalan
+             "Sizinle", // Azerbaijani
+             "Teiega", // Estonian
+             "S vama", // Serbian
+             "Sizinle", // Azerbaijani (Latin scrip
+           ],
+           strings.icontains(subject.subject, .)
+    )
   )
+  
   // contains logic that impersonates Microsoft
   and (
     any(ml.logo_detect(beta.message_screenshot()).brands,
@@ -155,13 +188,13 @@ source: |
       )
     )
   )
-
+  
   // Negate messages when the message-id indciates the message is from MS actual. DKIM/SPF domains can be custom and therefore are unpredictable.
   and not (
     strings.starts_with(headers.message_id, '<Share-')
     and strings.ends_with(headers.message_id, '@odspnotify>')
   )
-
+  
   // fake Sharepoint shares are easy to identify if there are any links
   // that don't point to microsoft[.]com or *.sharepoint[.]com
   and not all(body.links,
@@ -186,7 +219,7 @@ source: |
     // ignore microsoft privacy statement links
     "aka.ms"
   )
-
+  
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (
@@ -203,8 +236,6 @@ source: |
     )
   )
   and not profile.by_sender().any_false_positives
-
-
 attack_types:
   - "Credential Phishing"
   - "Malware/Ransomware"

--- a/detection-rules/impersonation_sharepoint_fake_file_share.yml
+++ b/detection-rules/impersonation_sharepoint_fake_file_share.yml
@@ -13,8 +13,10 @@ source: |
                         "*shared with you*",
                         "*invited you to access a file*"
           )
+          // or the current thread is empty but has an image (image as content)
+          or . == "" and any(attachments, .file_type in $file_types_images)
   )
-  and strings.ilike(subject.subject, "*shared*", "*updated*")
+  and strings.ilike(subject.subject, "*share*", "*updated*")
   and (
     any(ml.logo_detect(beta.message_screenshot()).brands,
         strings.starts_with(.name, "Microsoft")

--- a/detection-rules/impersonation_sharepoint_fake_file_share.yml
+++ b/detection-rules/impersonation_sharepoint_fake_file_share.yml
@@ -19,6 +19,7 @@ source: |
       and strings.ilike(subject.subject, "*shared*", "*updated*")
     )
     or any([
+             // "with you" in mutliple languages
              "Contigo", // Spanish
              "Avec vous", // French
              "Mit Ihnen", // German


### PR DESCRIPTION
# Description

Add coverage for samples of non-english variants 

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/bb0830645ed5b8b6d279a90c0b24484f1bcf88a59831202d416ecdd6052e7cc9)

## Associated hunts

L14D New Samples covered after this change. 
- [Hunt 1](https://platform.sublime.security/hunts/1d7be695-d2cd-4172-8d06-97682349d74c)
