### PR TITLE
Update attachment_credential_phishing_secure_message.yml

### DIFF
--- a/detection-rules/attachment_credential_phishing_secure_message.yml
+++ b/detection-rules/attachment_credential_phishing_secure_message.yml
@@ -49,6 +49,9 @@ source: |
               .root_domain in ("zixport.com", "zixcorp.com", "zixmail.net")
       )
     )
+    and not all(body.links,
+              .href_url.domain.root_domain in ("mimecast.com", "cisco.com")
+    )
   )
   and (
     (


### PR DESCRIPTION
# Description

Negating Cisco and Mimecast.

# Associated samples

- https://platform.sublime.security/messages/ecb9c85215f37dfc3713984cc2ea9f7ce73a271a0055428084681e55e417bd63
