### PR TITLE
Update impersonation_norton_lifelock.yml

### DIFF
--- a/detection-rules/impersonation_norton_lifelock.yml
+++ b/detection-rules/impersonation_norton_lifelock.yml
@@ -14,7 +14,12 @@ source: |
   and any(attachments,
           (.file_type in $file_types_images or .file_type == "pdf")
           and (
+          (
             strings.ilike(.file_name, "*norton*")
+            and not (
+              any(recipients.to, strings.iends_with(.display_name, "Norton"))
+            )
+          )
             or any(file.explode(.),
                    regex.icontains(.scan.ocr.raw,
                                    ".*norton.?60.*",


### PR DESCRIPTION
# Description

Negating the last name "Norton".

# Associated samples

- https://platform.sublime.security/messages/6cb7cc5311241564a355001a72fc8ed36702ba4efa88eee186a3f9eea785545e
