### PR TITLE
Add first automation to core feed

### DIFF
--- a/automations/remediate_malicious_messages.yml
+++ b/automations/remediate_malicious_messages.yml
@@ -1,0 +1,11 @@
+name: "Remediate malicious messages"
+description: "Remediate messages Sublime thinks are malicious."
+type: "triage_rule"
+severity: "high"
+triage_abuse_reports: true
+triage_flagged_messages: true
+default_actions: ["delete_message"]
+source: |
+  type.inbound
+  and beta.attack_score().verdict == "malicious"
+  and not all(triage.flagged_rules, strings.starts_with(.name, "Spam"))

--- a/automations/remediate_malicious_messages.yml
+++ b/automations/remediate_malicious_messages.yml
@@ -6,4 +6,4 @@ triage_flagged_messages: true
 default_actions: ["delete_message"]
 source: |
   type.inbound
-  and beta.attack_score().verdict == "malicious"
+  and ml.attack_score().verdict == "malicious"

--- a/automations/remediate_malicious_messages.yml
+++ b/automations/remediate_malicious_messages.yml
@@ -1,7 +1,6 @@
 name: "Remediate malicious messages"
 description: "Remediate messages Sublime thinks are malicious."
 type: "triage_rule"
-severity: "high"
 triage_abuse_reports: true
 triage_flagged_messages: true
 default_actions: ["delete_message"]

--- a/automations/remediate_malicious_messages.yml
+++ b/automations/remediate_malicious_messages.yml
@@ -1,5 +1,5 @@
 name: "Remediate malicious messages"
-description: "Remediate messages Sublime thinks are malicious."
+description: "Remediate messages where the Attack Score is Malicious."
 type: "triage_rule"
 triage_abuse_reports: true
 triage_flagged_messages: true

--- a/automations/remediate_malicious_messages.yml
+++ b/automations/remediate_malicious_messages.yml
@@ -8,4 +8,3 @@ default_actions: ["delete_message"]
 source: |
   type.inbound
   and beta.attack_score().verdict == "malicious"
-  and not all(triage.flagged_rules, strings.starts_with(.name, "Spam"))


### PR DESCRIPTION
# Description

Adds the first automation to the feed. After integrating, we'll add the rest.

# Associated samples

n/a

## Associated hunts

n/a

# Screenshot (insights)

n/a
