### PR TITLE
Update brand_impersonation_ms_planner.yml

### DIFF
--- a/detection-rules/brand_impersonation_ms_planner.yml
+++ b/detection-rules/brand_impersonation_ms_planner.yml
@@ -82,22 +82,27 @@ source: |
     )
     
     // suspicious content
-    
     and (
-      1 of (
+      2 of (
         strings.ilike(body.current_thread.text, "*assigned*new team*"),
         strings.ilike(body.current_thread.text, "*Microsoft Office 365*"),
         strings.ilike(body.current_thread.text, "*internal planner*"),
-        strings.ilike(body.current_thread.text, "*internal task*")
+        strings.ilike(body.current_thread.text, "*internal task*"),
+        any(recipients.to,
+            strings.icontains(body.current_thread.text, .email.domain.sld)
+        )
       )
       or (
         any(ml.nlu_classifier(body.current_thread.text).intents,
             .name == "cred_theft" and .confidence in~ ("medium", "high")
         )
       )
+      // multiple links, but all the same root domain
+      or (
+        length(distinct(body.links, .href_url.domain.root_domain)) == 1
+        and length(body.links) > 2
+      )
     )
-    
-    
     and sender.email.domain.root_domain not in (
       "bing.com",
       "microsoft.com",

--- a/detection-rules/brand_impersonation_ms_planner.yml
+++ b/detection-rules/brand_impersonation_ms_planner.yml
@@ -3,133 +3,137 @@ description: "Impersonation of Microsoft Planner, a component of the Microsoft 3
 type: "rule"
 severity: "medium"
 source: |
-  type.inbound
-  // suspicious link 
-  and any(body.links,
-          (
-            .href_url.domain.root_domain not in $tranco_1m
-            or .href_url.domain.domain in $free_file_hosts
-            or .href_url.domain.root_domain in $free_file_hosts
-            or .href_url.domain.root_domain in $free_subdomain_hosts
-            or .href_url.domain.domain in $url_shorteners
-            or 
-  
-            // mass mailer link, masks the actual URL
-            .href_url.domain.root_domain in (
-              "hubspotlinks.com",
-              "mandrillapp.com",
-              "sendgrid.net",
-              "rs6.net"
+    type.inbound
+    // suspicious link 
+    and any(body.links,
+            (
+              .href_url.domain.root_domain not in $tranco_1m
+              or .href_url.domain.domain in $free_file_hosts
+              or .href_url.domain.root_domain in $free_file_hosts
+              or .href_url.domain.root_domain in $free_subdomain_hosts
+              or .href_url.domain.domain in $url_shorteners
+              or 
+    
+              // mass mailer link, masks the actual URL
+              .href_url.domain.root_domain in (
+                "hubspotlinks.com",
+                "mandrillapp.com",
+                "sendgrid.net",
+                "rs6.net"
+              )
+    
+              // Google AMP redirect
+              or (
+                .href_url.domain.sld == "google"
+                and strings.starts_with(.href_url.path, "/amp/")
+              )
+    
+              // Recipient email address in link
+              or any(body.links,
+                     any(recipients.to,
+                         strings.icontains(..href_url.url, .email.email)
+                         and any(recipients.to, .email.domain.valid)
+                     )
+              )
+              or .href_url.domain.root_domain == "beehiiv.com"
             )
-  
-            // Google AMP redirect
-            or (
-              .href_url.domain.sld == "google"
-              and strings.starts_with(.href_url.path, "/amp/")
+    
+            // exclude sources of potential FPs
+            and (
+              .href_url.domain.root_domain not in (
+                "svc.ms",
+                "sharepoint.com",
+                "1drv.ms",
+                "microsoft.com",
+                "aka.ms",
+                "msftauthimages.net",
+                "mimecastprotect.com",
+                "office.com",
+                "microsoftproject.com"
+              )
+              or any(body.links, .href_url.domain.domain in $free_file_hosts)
             )
-  
-            // Recipient email address in link
-            or any(body.links,
-                   any(recipients.to,
-                       strings.icontains(..href_url.url, .email.email)
-                       and any(recipients.to, .email.domain.valid)
-                   )
+            and .href_url.domain.root_domain not in $org_domains
+            and .href_url.domain.valid
+            and regex.icontains(.display_text,
+                                "(go.?to|view|show|display|access|open.?in) (team|planner|group|task|browser)"
             )
-            or .href_url.domain.root_domain == "beehiiv.com"
-          )
-  
-          // exclude sources of potential FPs
-          and (
-            .href_url.domain.root_domain not in (
-              "svc.ms",
-              "sharepoint.com",
-              "1drv.ms",
-              "microsoft.com",
-              "aka.ms",
-              "msftauthimages.net",
-              "mimecastprotect.com",
-              "office.com",
-              "microsoftproject.com"
-            )
-            or any(body.links, .href_url.domain.domain in $free_file_hosts)
-          )
-          and .href_url.domain.root_domain not in $org_domains
-          and .href_url.domain.valid
-          and regex.icontains(.display_text,
-                              "(go.?to|view|show|display|access) (team|planner|group|task)"
-          )
-  )
-  
-  // not a reply
-  and (
-    length(headers.references) == 0
-    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
-  )
-  
-  // Planner logo
-  // LogoDetect coming soon
-  and (
-    all(attachments,
-        .file_type in $file_types_images
-        and any(file.explode(.),
-                // small, relatively square image
-                (
-                  .scan.exiftool.image_height / .scan.exiftool.image_width
-                ) > 0.9
-                and (.scan.exiftool.image_height + .scan.exiftool.image_width) < 500
-        )
     )
-  )
-  
-  // suspicious content
-  and (
-    2 of (
-      strings.ilike(body.current_thread.text, "*assigned*new team*"),
-      strings.ilike(body.current_thread.text, "*Microsoft Office 365*"),
-      strings.ilike(body.current_thread.text, "*internal planner*")
+    
+    // not a reply
+    and (
+      length(headers.references) == 0
+      or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
     )
-    or (
-      any(ml.nlu_classifier(body.current_thread.text).intents,
-          .name == "cred_theft" and .confidence in~ ("medium", "high")
+    
+    // Planner logo
+    // LogoDetect coming soon
+    and (
+      all(attachments,
+          .file_type in $file_types_images
+          and any(file.explode(.),
+                  // small, relatively square image
+                  (
+                    .scan.exiftool.image_height / .scan.exiftool.image_width
+                  ) > 0.9
+                  and (.scan.exiftool.image_height + .scan.exiftool.image_width) < 500
+          )
       )
     )
-  )
-  and sender.email.domain.root_domain not in (
-    "bing.com",
-    "microsoft.com",
-    "microsoftonline.com",
-    "microsoftproject.com",
-    "microsoftstoreemail.com",
-    "microsoftsupport.com",
-    "microsoft365.com",
-    "office.com",
-    "office365.com",
-    "onedrive.com",
-    "sharepointonline.com",
-    "yammer.com",
-  )
-  
-  // negate highly trusted sender domains unless they fail DMARC authentication
-  and (
-    (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and not headers.auth_summary.dmarc.pass
+    
+    // suspicious content
+    
+    and (
+      1 of (
+        strings.ilike(body.current_thread.text, "*assigned*new team*"),
+        strings.ilike(body.current_thread.text, "*Microsoft Office 365*"),
+        strings.ilike(body.current_thread.text, "*internal planner*"),
+        strings.ilike(body.current_thread.text, "*internal task*")
+      )
+      or (
+        any(ml.nlu_classifier(body.current_thread.text).intents,
+            .name == "cred_theft" and .confidence in~ ("medium", "high")
+        )
+      )
     )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
-  )
-  and (
-    not profile.by_sender().solicited
-    or (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_false_positives
+    
+    
+    and sender.email.domain.root_domain not in (
+      "bing.com",
+      "microsoft.com",
+      "microsoftonline.com",
+      "microsoftproject.com",
+      "microsoftstoreemail.com",
+      "microsoftsupport.com",
+      "microsoft365.com",
+      "office.com",
+      "office365.com",
+      "onedrive.com",
+      "sharepointonline.com",
+      "yammer.com",
     )
-  )
-  and not profile.by_sender().any_false_positives
-  
-  // exclude marketing jargon from ms partners
-  and not regex.icontains(body.current_thread.text,
-                          '(schedul(e|ing)|set up).{0,20}(call|meeting|demo|zoom|conversation|time|tool|discussion)|book.{0,10}(meeting|demo|call|slot|time)|connect.{0,12}(with me|phone|email)|my.{0,10}(calendar|cal)|reserve.{0,10}s[pl]ot|break the ice|want to know more?|miss your chance|if you no longer wish|if you no longer want|if you wish to opt out|low-code (development|approach|solution|journey|platform)|invite.{0,30}(webinar|presentation)'
-  )
+    
+    // negate highly trusted sender domains unless they fail DMARC authentication
+    and (
+      (
+        sender.email.domain.root_domain in $high_trust_sender_root_domains
+        and not headers.auth_summary.dmarc.pass
+      )
+      or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+    )
+    and (
+      not profile.by_sender().solicited
+      or (
+        profile.by_sender().any_messages_malicious_or_spam
+        and not profile.by_sender().any_false_positives
+      )
+    )
+    and not profile.by_sender().any_false_positives
+    
+    // exclude marketing jargon from ms partners
+    and not regex.icontains(body.current_thread.text,
+                            '(schedul(e|ing)|set up).{0,20}(call|meeting|demo|zoom|conversation|time|tool|discussion)|book.{0,10}(meeting|demo|call|slot|time)|connect.{0,12}(with me|phone|email)|my.{0,10}(calendar|cal)|reserve.{0,10}s[pl]ot|break the ice|want to know more?|miss your chance|if you no longer wish|if you no longer want|if you wish to opt out|low-code (development|approach|solution|journey|platform)|invite.{0,30}(webinar|presentation)'
+    )
 
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/brand_impersonation_ms_planner.yml
+++ b/detection-rules/brand_impersonation_ms_planner.yml
@@ -100,7 +100,8 @@ source: |
       // multiple links, but all the same root domain
       or (
         length(distinct(body.links, .href_url.domain.root_domain)) == 1
-        and length(body.links) > 2
+        and 2 < length(body.links) < 10
+        and all(body.links, .href_url.domain.root_domain != sender.email.domain.root_domain)
       )
     )
     and sender.email.domain.root_domain not in (


### PR DESCRIPTION
Added  the latest attack pattern.

Changed:

```
and regex.icontains(.display_text,
                            **"(go.?to|view|show|display|access|open.?in) (team|planner|group|task|browser)"**

// and this one

 and (
  **1** of (
    strings.ilike(body.current_thread.text, "*assigned*new team*"),
    strings.ilike(body.current_thread.text, "*Microsoft Office 365*"),
    strings.ilike(body.current_thread.text, "*internal planner*"),
    **strings.ilike(body.current_thread.text, "*internal task*")**
  )
```


# Description
Missed the latest spear phishings.
