### PR TITLE
Update link_credential_phishing_intent_and_other_indicators.yml

### DIFF
--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -329,7 +329,7 @@ source: |
       length(filter(ml.nlu_classifier(body.current_thread.text).entities,
                     .name == "urgency"
              )
-      ) >= 3
+      ) >= 2
       // and any body links
       and any(body.links,
               // display text contains a request

--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -203,7 +203,8 @@ source: |
                     "your order with amazon",
                     "your password has been compromised",
     )
-    or regex.icontains(sender.display_name,
+    or (
+      regex.icontains(sender.display_name,
                        "Admin",
                        "Administrator",
                        "Alert",
@@ -278,6 +279,9 @@ source: |
                        "VIP",
                        "Webmaster",
                        "Winner",
+      ) 
+      // add negation for common FPs in the sender display_name
+      and not strings.icontains(sender.display_name, "service bulletin")
     )
   )
   and (
@@ -353,7 +357,7 @@ source: |
       and any(body.links,
               (
                 ml.link_analysis(., mode="aggressive").effective_url.domain.tld in $suspicious_tlds
-                or length(ml.link_analysis(., mode="aggressive").redirect_history) >= 4
+                or length(distinct(map(ml.link_analysis(., mode="aggressive").redirect_history, .domain.root_domain))) >= 4
                 or (
                   any(body.ips,
                       any(body.links, strings.icontains(.href_url.url, ..ip))

--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -282,6 +282,8 @@ source: |
       ) 
       // add negation for common FPs in the sender display_name
       and not strings.icontains(sender.display_name, "service bulletin")
+      and not strings.icontains(sender.display_name, "automotive service")
+
     )
   )
   and (

--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -208,6 +208,7 @@ source: |
                        "Administrator",
                        "Alert",
                        "Assistant",
+                       "Authenticat(or|ion)",
                        "Billing",
                        "Benefits",
                        "Bonus",
@@ -348,10 +349,11 @@ source: |
           and all(body.links, strings.ilike(.display_text, "*click here*", "*password*"))
         )
       )
-      // link leads to a suspicious TLD or contains an IP address
+      // link leads to a suspicious TLD or contains an IP address or contains multiple redirects
       and any(body.links,
               (
                 ml.link_analysis(., mode="aggressive").effective_url.domain.tld in $suspicious_tlds
+                or length(ml.link_analysis(., mode="aggressive").redirect_history) >= 4
                 or (
                   any(body.ips,
                       any(body.links, strings.icontains(.href_url.url, ..ip))


### PR DESCRIPTION
# Description

Adjust parameter to catch a FN
 
# Associated samples
Samples that will match after this change.  
- [Sample 1](https://platform.sublime.security/messages/3ef5615a12054541a356b3a1cf9acf4c0584993f76d38289e05f742b8fca07e0) - length of "urgency" w/ request display text
- [Sample 2](https://platform.sublime.security/messages/b211bc2144925c33057b55979dd0937905167d35ed75de1630b2e536e8f1d9a6)  - redirect length and sender display name

