### PR TITLE
Update impersonation_employee_payroll_fraud.yml

### DIFF
--- a/detection-rules/impersonation_employee_payroll_fraud.yml
+++ b/detection-rules/impersonation_employee_payroll_fraud.yml
@@ -12,7 +12,7 @@ source: |
   and sender.display_name in~ $org_display_names
   and length(attachments) == 0
   and length(body.links) < 10
-  and length(body.current_thread.text) < 400
+  and length(body.current_thread.text) < 800
   and (
     sender.email.domain.root_domain not in $org_domains
     or sender.email.domain.root_domain in $free_email_providers


### PR DESCRIPTION
# Description

Increasing `current_thread` length count to 800 characters, from 600.

# Associated samples

- https://platform.sublime.security/messages/be716ec383afdeb313cfff81ef12de1b0f7be36f16432725d495ed4c456547b8?ph-e6489411-a22d-4959-9ecc-30170413281d=018df67c-8ba7-7da6-9dae-e3b03c7cd881
