### PR TITLE
Update sender_ad_distinguished_name.yml

### DIFF
--- a/detection-rules/sender_ad_distinguished_name.yml
+++ b/detection-rules/sender_ad_distinguished_name.yml
@@ -6,6 +6,7 @@ severity: "medium"
 source: |
   type.inbound
   and regex.icontains(sender.display_name, '\b(EX|LABS|OU|CN|EXCHANGE)(=|/)')
+  and sender.email.domain.root_domain not in $org_domains
 tags:
   - "Suspicious sender"
 attack_types:


### PR DESCRIPTION
# Description

Ingest or mail issues were causing DNs to appear for org domains, exempting.
