### PR TITLE
Create brand_impersonation_docusign_pdf_with_suspicious_links.yml

### DIFF
--- a/detection-rules/brand_impersonation_docusign_pdf_with_suspicious_links.yml
+++ b/detection-rules/brand_impersonation_docusign_pdf_with_suspicious_links.yml
@@ -35,3 +35,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Optical Character Recognition"
   - "URL analysis"
+id: "2601cbb7-0a07-5289-a32f-68c0db3c3170"

--- a/detection-rules/brand_impersonation_docusign_pdf_with_suspicious_links.yml
+++ b/detection-rules/brand_impersonation_docusign_pdf_with_suspicious_links.yml
@@ -1,0 +1,37 @@
+name: "Brand Impersonation: DocuSign pdf attachment with suspicious link"
+description: "This rule detects DocuSign logos within PDF's that do not link to reputable domains, nor docusign themselves. This is typically indicative of Credential Phishing."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(attachments,
+          .file_type == "pdf"
+          and any(ml.logo_detect(.).brands, .name == "DocuSign")
+          and any(file.explode(.),
+                  length(.scan.url.urls) <=9
+                  and any(.scan.url.urls,
+                          .domain.root_domain not in $tranco_1m
+                          and .domain.root_domain not in $org_domains
+                          and .domain.root_domain != "sublimesecurity.com"
+                          and not strings.ilike(.domain.root_domain, "docusign.*")
+                  )
+                  and any(ml.nlu_classifier(.scan.ocr.raw).entities,
+                          .name == "org" and .text == "DocuSign"
+                  )
+                  and any(ml.nlu_classifier(.scan.ocr.raw).entities,
+                          .name == "request"
+                  )
+          )
+  )
+  
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "PDF"
+  - "Social engineering"
+detection_methods:
+  - "File analysis"
+  - "Natural Language Understanding"
+  - "Optical Character Recognition"
+  - "URL analysis"


### PR DESCRIPTION
# Description

New rule to detect PDF's with DocuSign logos, a CTA and no links to docusign.

