### PR TITLE
Delete remediate_malicious_messages.yml

### DIFF
--- a/automations/remediate_malicious_messages.yml
+++ b/automations/remediate_malicious_messages.yml
@@ -1,8 +1,0 @@
-name: "Remediate malicious messages"
-description: "Remediate messages where the Attack Score is Malicious."
-type: "triage_rule"
-triage_abuse_reports: true
-triage_flagged_messages: true
-default_actions: ["delete_message"]
-source: |
-  false


### PR DESCRIPTION
# Description

Deletes `remediate_malicious_messages.yml`. We will add this back in the near future, but we want to force the feed syncs to delete this rule.
