### PR TITLE
Update open_redirect_clubos.yml

### DIFF
--- a/detection-rules/open_redirect_clubos.yml
+++ b/detection-rules/open_redirect_clubos.yml
@@ -14,6 +14,8 @@ source: |
         regex.icontains(.href_url.query_params, 'target=[a-f0-9]{40}(?:$|&)')
         and strings.icontains(.href_url.query_params, '&hashLookup=true')
       )
+      // negate urls that go back to club-os
+      and not regex.icontains(.href_url.query_params, 'target=[^\&]*club-os.com/')   
   )
   and (
     not profile.by_sender().solicited
@@ -22,7 +24,7 @@ source: |
       and not profile.by_sender().any_false_positives
     )
   )
-
+  
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (


### PR DESCRIPTION
# Description

Address FPs of non-malicious use of the target= param

# Associated samples

FP which no longer matches
- [Sample 1](https://platform.sublime.security/messages/48cae0a81d2101b4921bf6d6b5f1477c68ab38f2def460c1ae9c296db4ffd5e8)
- Sample 2

## Associated hunts

Hunt of remaining TP samples
- [Hunt 1](https://platform.sublime.security/hunts/d651034f-2ed6-4c4c-b9fe-2a4739204f40)
