### PR TITLE
Update link_google_presentation_open_redirect.yml

### DIFF
--- a/detection-rules/link_google_presentation_open_redirect.yml
+++ b/detection-rules/link_google_presentation_open_redirect.yml
@@ -8,22 +8,46 @@ source: |
           // body link is to a google doc presentation
           .href_url.domain.domain == "docs.google.com"
           and strings.istarts_with(.href_url.path, '/presentation/')
+          // skip where the URL contains a direct link to a specific slide
+          and not strings.icontains(.href_url.url, 'slide=id.p')
+  
+          // prefilter some to avoid clicking on _every_ google presentation link
+          // the link appears as plain text in the and makes up the majority of the the current thread
           and (
-            // and that presentation...
+            ( // determine if the plain text url link is in the current thread and not a previous one.
+              strings.icontains(body.current_thread.text, .href_url.url)
+              // the length of the url + 20% is greater than the length of the body (which includes the url)
+              and length(.href_url.url) * 1.20 >= length(body.current_thread.text)
+            )
+            or ( // the display text appears in the current thread and makes up the majority of the the current thread
+              // make sure the display text is in the current thread and not a previous one.
+              strings.icontains(body.current_thread.text, .display_text)
+              // the display text length of the link + 20% is greater than the length of the body (which includes the display text)
+              and (
+                length(.display_text) * 1.20 >= length(body.current_thread.text)
+                // display text ends in some random chars that includes a number
+                // https://platform.sublime.security/messages/b94de99b5c7c49cad1b3374d3c2885fb042de4ed6006467ca41e5c4f74e79095
+                or regex.icontains(.display_text,
+                                   '[[:punct:]\s](?:[a-zA-Z0-9]{3}[0-9][a-zA-Z0-9]{0,6}$|[a-zA-Z0-9]{2}[0-9][a-zA-Z0-9]{1,6}$|[a-zA-Z0-9]{1}[0-9][a-zA-Z0-9]{2,6}$|[0-9][a-zA-Z0-9]{3,9}$)'
+                )
+              )
+            )
+            or 
+            // finally send the link to link analysis that presentation...
             (
               // contains a slingle link
               length(ml.link_analysis(., mode="aggressive").final_dom.links) == 1
-              
+  
               // cannot be edited via link provided
               and strings.contains(ml.link_analysis(., mode="aggressive").final_dom.raw,
                                    'canEdit:  false'
               )
-              
+  
               // and a single page
               and strings.contains(ml.link_analysis(., mode="aggressive").final_dom.raw,
                                    'slidePageCount:  1.0'
               )
-              
+  
               // where we have links which have been written via a google open redirect
               and any(ml.link_analysis(., mode="aggressive").final_dom.links,
                       // links are not in thhe org_domains
@@ -53,7 +77,47 @@ source: |
             )
           )
   )
-
+  
+  // not where the sender display name of the message is within org_display_names
+  and not (
+    // the message is from google actual
+    sender.email.email in (
+      'comments-noreply@docs.google.com',
+      'drive-shares-dm-noreply@google.com',
+      'drive-shares-noreply@google.com',
+      'calendar-notification@google.com'
+    )
+    and headers.auth_summary.dmarc.pass
+    // but the sender display name is within org_display_names
+    and any($org_display_names,
+            strings.istarts_with(sender.display_name,
+                                 strings.concat(., " (via Google ")
+            )
+            or strings.istarts_with(sender.display_name,
+                                    strings.concat(., " (Google ")
+            )
+    )
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  // but ignore high_trust if the sender is one of the google actual senders
+  and (
+    (
+      (
+        sender.email.domain.root_domain in $high_trust_sender_root_domains
+        and not headers.auth_summary.dmarc.pass
+      )
+      or (
+        sender.email.domain.root_domain in $high_trust_sender_root_domains
+        and sender.email.email in (
+          'comments-noreply@docs.google.com',
+          'drive-shares-dm-noreply@google.com',
+          'drive-shares-noreply@google.com',
+          'calendar-notification@google.com'
+        )
+      )
+      or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+    )
+  )
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description
Attempt to reduce the amount of submissions to Link Analysis by ensuring the message is: 
1) Not from a high trust sender domain (with consideration to google being in high trust)
2) The sender display name does not match an org display name
3) Add patterns of observed malicious messages to "short-circuit" LA 
