### PR TITLE
Update link_google_presentation_open_redirect.yml

### DIFF
--- a/detection-rules/link_google_presentation_open_redirect.yml
+++ b/detection-rules/link_google_presentation_open_redirect.yml
@@ -27,8 +27,11 @@ source: |
                 length(.display_text) * 1.20 >= length(body.current_thread.text)
                 // display text ends in some random chars that includes a number
                 // https://platform.sublime.security/messages/b94de99b5c7c49cad1b3374d3c2885fb042de4ed6006467ca41e5c4f74e79095
-                or regex.icontains(.display_text,
-                                   '[[:punct:]\s](?:[a-zA-Z0-9]{3}[0-9][a-zA-Z0-9]{0,6}$|[a-zA-Z0-9]{2}[0-9][a-zA-Z0-9]{1,6}$|[a-zA-Z0-9]{1}[0-9][a-zA-Z0-9]{2,6}$|[0-9][a-zA-Z0-9]{3,9}$)'
+                or (
+                  // the regex ends with a word that is 4-10 long
+                  regex.icontains(.display_text, '[[:punct:]\s][a-zA-Z0-9]{4,10}$')
+                  // that word has to include a letter AND a number
+                  and regex.icontains(.display_text, '[[:punct:]\s](?:[a-z0-9]*[a-z][a-z0-9]*[0-9][a-z0-9]*|[a-z0-9]*[0-9][a-z0-9]*[a-z][a-z0-9]*)$')
                 )
               )
             )


### PR DESCRIPTION
# Description

Fix FP where the display_text ended in a year, doesn't match the intended pattern because it doesn't contain _both_ a letter and a number. 


# Associated samples
FP Sample that will no longer match
- [Sample 1](https://platform.sublime.security/messages/f845c003a6938910ac419a3c738afb146aa0dc37a0524c3f0934a636704c0868)

TP Sample that still matches
- [Sample 1](https://platform.sublime.security/messages/b94de99b5c7c49cad1b3374d3c2885fb042de4ed6006467ca41e5c4f74e79095)

## Associated hunts

If you ran any hunts with your rule, please link them here.

hits with only the new logic
- [Hunt 1](https://platform.sublime.security/hunts/c9936675-1f9f-415e-87dd-990b4a76f806)

FPs that don't hit the new logic
- [Hunt 1](https://platform.sublime.security/hunts/d2790644-5350-4e40-9257-5a5efd581955)


