### PR TITLE
Update link_google_presentation_open_redirect.yml

### DIFF
--- a/detection-rules/link_google_presentation_open_redirect.yml
+++ b/detection-rules/link_google_presentation_open_redirect.yml
@@ -8,8 +8,6 @@ source: |
           // body link is to a google doc presentation
           .href_url.domain.domain == "docs.google.com"
           and strings.istarts_with(.href_url.path, '/presentation/')
-          // skip where the URL contains a direct link to a specific slide
-          and not strings.icontains(.href_url.url, 'slide=id.')
   
           // prefilter some to avoid clicking on _every_ google presentation link
           // the link appears as plain text in the and makes up the majority of the the current thread
@@ -29,9 +27,10 @@ source: |
                 // https://platform.sublime.security/messages/b94de99b5c7c49cad1b3374d3c2885fb042de4ed6006467ca41e5c4f74e79095
                 or (
                   // the regex ends with a word that is 4-10 long
-                  regex.icontains(.display_text, '[[:punct:]\s][a-zA-Z0-9]{4,10}$')
+                  regex.icontains(.display_text, '[[:punct:]\s][a-zA-Z0-9]{5,9}$')
                   // that word has to include a letter AND a number
-                  and regex.icontains(.display_text, '[[:punct:]\s](?:[a-z0-9]*[a-z][a-z0-9]*[0-9][a-z0-9]*|[a-z0-9]*[0-9][a-z0-9]*[a-z][a-z0-9]*)$')
+                  and regex.icontains(.display_text, '[[:punct:]\s](?:[a-z0-9]*[a-z][0-9][a-z0-9]*|[a-z0-9]*[0-9][a-z][a-z0-9]*)$')
+                  and strings.iends_with(.href_url.path, '/pub')
                 )
               )
             )

--- a/detection-rules/link_google_presentation_open_redirect.yml
+++ b/detection-rules/link_google_presentation_open_redirect.yml
@@ -9,7 +9,7 @@ source: |
           .href_url.domain.domain == "docs.google.com"
           and strings.istarts_with(.href_url.path, '/presentation/')
           // skip where the URL contains a direct link to a specific slide
-          and not strings.icontains(.href_url.url, 'slide=id.p')
+          and not strings.icontains(.href_url.url, 'slide=id.')
   
           // prefilter some to avoid clicking on _every_ google presentation link
           // the link appears as plain text in the and makes up the majority of the the current thread


### PR DESCRIPTION
# Description

Tighten regex patterns to avoid FPs while removing the `slide=` in the url param (was observed in malicious use

# Associated samples

For example, samples you are negating, samples you are including, or samples your new insight should fire on.

- [Sample 1](https://platform.sublime.security/messages/b12691df2acf7285b31edcf10b6cf40f16db47af55039f131c1cbc3ffa63fa6b)
- [Sample 2](https://platform.sublime.security/messages/267171f7c78faef36d33f345080f75cc002f80224d81a50b2b4ae8208a710ac3)

## Associated hunts

Can observe a mix of message here that hit on the current version and are picked up. 
- [Hunt 1](https://platform.sublime.security/hunts/a6bccd2f-461b-42d6-bc1f-9ea4d9a28e1d)

