### PR TITLE
Update attachment_encrypted_pdf_cred_theft.yml

### DIFF
--- a/detection-rules/attachment_encrypted_pdf_cred_theft.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft.yml
@@ -8,6 +8,12 @@ source: |
           .file_type == "pdf"
           and any(file.explode(.),
                   any(.scan.exiftool.fields, .key == "Encryption")
+                  or (
+                    .scan.entropy.entropy > 7
+                    and any(.scan.strings.strings,
+                            strings.icontains(., "/Encrypt")
+                    )
+                  )
           )
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents,


### PR DESCRIPTION
# Description
Adding additional logic to catch encrypted PDFs that do not contain the exif key.

# Associated samples

- https://platform.sublime.security/messages/85795604bfadc67e3fe101ac5ed09d491345e1739f3d57b858e9c9d5d7fd3fb6?ph-e6489411-a22d-4959-9ecc-30170413281d=018df67c-8ba7-7da6-9dae-e3b03c7cd881
