### PR TITLE
Update link_google_presentation_open_redirect.yml

### DIFF
--- a/detection-rules/link_google_presentation_open_redirect.yml
+++ b/detection-rules/link_google_presentation_open_redirect.yml
@@ -90,7 +90,7 @@ source: |
         'calendar-notification@google.com'
       )
       // ensure the sender prevalence is not common
-      and profile.by_sender().prevalence == "common"
+      and profile.by_sender().prevalence != "common"
     )
     // or the message is from google actual
     or (

--- a/detection-rules/link_google_presentation_open_redirect.yml
+++ b/detection-rules/link_google_presentation_open_redirect.yml
@@ -80,6 +80,29 @@ source: |
           )
   )
   
+  // when the sender is not google, the sender should not be a common prevalence
+  and (
+    ( // the message is not from google actual
+      sender.email.email not in (
+        'comments-noreply@docs.google.com',
+        'drive-shares-dm-noreply@google.com',
+        'drive-shares-noreply@google.com',
+        'calendar-notification@google.com'
+      )
+      // ensure the sender prevalence is not common
+      and profile.by_sender().prevalence == "common"
+    )
+    // or the message is from google actual
+    or (
+      sender.email.email in (
+        'comments-noreply@docs.google.com',
+        'drive-shares-dm-noreaply@google.com',
+        'drive-shares-noreply@google.com',
+        'calendar-notification@google.com'
+      )
+    )
+  )
+  
   // not where the sender display name of the message is within org_display_names
   and not (
     // the message is from google actual
@@ -90,6 +113,7 @@ source: |
       'calendar-notification@google.com'
     )
     and headers.auth_summary.dmarc.pass
+  
     // but the sender display name is within org_display_names
     and any($org_display_names,
             strings.istarts_with(sender.display_name,


### PR DESCRIPTION
# Description

Avoid FPs on common senders when the sender is not google. 

# Associated samples

FP that will no longer match (note, sender prevalence was "common" in the observed environment)
- [Sample 1](https://platform.sublime.security/messages/cf3260111579f812fb865a4a282f948700bee11d265794be870cb6c6f87c40ae)
