### PR TITLE
Create cred_theft_suspicious_invoice_w_missing_or_image_only_attachme…

### DIFF
--- a/detection-rules/cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml
+++ b/detection-rules/cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml
@@ -72,3 +72,4 @@ detection_methods:
   - "File analysis"
   - "Natural Language Understanding"
   - "Sender analysis"
+id: "466c1680-b9ff-5bd0-baf8-e65cca99d18b"

--- a/detection-rules/cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml
+++ b/detection-rules/cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml
@@ -14,7 +14,7 @@ source: |
     or length(attachments) == 0
   )
   
-  // a logo/brand is detected or the subject contains payment/invoice language
+  // subject contains payment/invoice language
   and (
     any(ml.nlu_classifier(subject.subject).tags, .name in ("payment", "invoice"))
     or regex.contains(subject.subject,

--- a/detection-rules/cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml
+++ b/detection-rules/cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml
@@ -31,7 +31,7 @@ source: |
     )
     or any(body.links,
            regex.icontains(.display_text,
-                           '(?:\binv(?:oice|o)\b|in_v|in-voice|pay(?:ment|mnt)|pymt|\brec(?:eipt|pt|iept)\b|rcpt|req(?:uest)|rqst|rq|\bpo\b|p\.o\.|purch(?:ase)?-?order|\bord(?:er)?\b|bill(?:ing)|billing-info|transact(?:ion)|txn|trx|\bstmt\b|\bstmnt\b|remit(?:tance)|rmt|remndr|remind|\bdue(?:-date)\b|ovrdue|overdue|\bbal(?:ance)\b|\bpaid(?:-invoice)\b)'
+                           '(?:\binv(?:oice|o)\b|in_v|in-voice|pay(?:ment|mnt)|pymt|\brec(?:eipt|pt|iept)\b|rcpt|req(?:uest)|rqst|\brq\b|\bpo\b|p\.o\.|purch(?:ase)?-?order|\bord(?:er)?\b|bill(?:ing)|billing-info|transact(?:ion)|txn|trx|\bstmt\b|\bstmnt\b|remit(?:tance)|rmt|remndr|remind|\bdue(?:-date)\b|ovrdue|overdue|\bbal(?:ance)\b|\bpaid(?:-invoice)\b)'
            )
     )
   )

--- a/detection-rules/cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml
+++ b/detection-rules/cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml
@@ -16,23 +16,22 @@ source: |
   
   // a logo/brand is detected or the subject contains payment/invoice language
   and (
-    any(ml.logo_detect(beta.message_screenshot()).brands, .name is not null)
-    or any(ml.nlu_classifier(subject.subject).tags,
-           .name in ("payment", "invoice")
-    )
+    any(ml.nlu_classifier(subject.subject).tags, .name in ("payment", "invoice"))
     or regex.contains(subject.subject,
-                      '(?:\binv(?:oice|o|)\b|in_v|in-voice|pay(?:ment|mnt|)|pymt|\brec(?:eipt|pt|iept)\b|rcpt|confirm(?:ation|)|cnfrm|cnf|req(?:uest|)|rqst|rq|\bpo\b|p\.o\.|purch(?:ase)?-?order|\bord(?:er)?\b|bill(?:ing|)|billing-info|transact(?:ion|)|txn|trx|\bstmt\b|\bstmnt\b|remit(?:tance|)|rmt|remndr|remind|\bdue(?:-date|)\b|ovrdue|overdue|\bbal(?:ance|)\b|\bpaid(?:-invoice|)\b)'
+                      '(?:\binv(?:oice|o)\b|in_v|in-voice|pay(?:ment|mnt)|pymt|\brec(?:eipt|pt|iept)\b|rcpt|confirm(?:ation)|cnfrm|cnf|po\b|p\.o\.|purch(?:ase)?-?order|\bord(?:er)?\b|bill(?:ing)|billing-info|transact(?:ion)|txn|trx|\bstmt\b|\bstmnt\b|remit(?:tance)|rmt|remndr|remind|\bdue(?:-date)\b|ovrdue|overdue|\bbal(?:ance)\b|\bpaid(?:-invoice)\b)'
     )
   )
   
   // link display text ends in a file extension or contain common payment terms
   and (
-    any(body.links, regex.imatch(.display_text, '.*\.(?:doc|docm|docx|dot|dotm|pdf|ppa|ppam|ppsm|ppt|pptm|pptx|wbk|xla|xlam|xlm|xls|xlsb|xlsm|xlsx|xlt|xltm)$')
-   )
-    //any(body.links, regex.match(.display_text, '.*\.[a-z]{3,4}$'))
+    any(body.links,
+        regex.imatch(.display_text,
+                     '.*\.(?:doc|docm|docx|dot|dotm|pdf|ppa|ppam|ppsm|ppt|pptm|pptx|wbk|xla|xlam|xlm|xls|xlsb|xlsm|xlsx|xlt|xltm)$'
+        )
+    )
     or any(body.links,
            regex.icontains(.display_text,
-                           '(?:\binv(?:oice|o|)\b|in_v|in-voice|pay(?:ment|mnt|)|pymt|\brec(?:eipt|pt|iept)\b|rcpt|confirm(?:ation|)|cnfrm|cnf|req(?:uest|)|rqst|rq|\bpo\b|p\.o\.|purch(?:ase)?-?order|\bord(?:er)?\b|bill(?:ing|)|billing-info|transact(?:ion|)|txn|trx|\bstmt\b|\bstmnt\b|remit(?:tance|)|rmt|remndr|remind|\bdue(?:-date|)\b|ovrdue|overdue|\bbal(?:ance|)\b|\bpaid(?:-invoice|)\b)'
+                           '(?:\binv(?:oice|o)\b|in_v|in-voice|pay(?:ment|mnt)|pymt|\brec(?:eipt|pt|iept)\b|rcpt|req(?:uest)|rqst|rq|\bpo\b|p\.o\.|purch(?:ase)?-?order|\bord(?:er)?\b|bill(?:ing)|billing-info|transact(?:ion)|txn|trx|\bstmt\b|\bstmnt\b|remit(?:tance)|rmt|remndr|remind|\bdue(?:-date)\b|ovrdue|overdue|\bbal(?:ance)\b|\bpaid(?:-invoice)\b)'
            )
     )
   )
@@ -59,7 +58,6 @@ source: |
            .name == "request" and strings.icontains(.text, "kindly")
     )
   )
-  
   and not profile.by_sender().solicited
 
 attack_types:

--- a/detection-rules/cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml
+++ b/detection-rules/cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml
@@ -1,0 +1,74 @@
+name: "Suspicious invoice reference with missing or image-only attachments"
+description: "This rule flags emails that reference invoices or payments but have suspicious characteristics: attachments are either missing or only images. It also checks for misleading links disguised as attachments and the presence of invoice-related keywords. The rule looks for potential credential theft or unusual requests, making it a strong indicator of phishing attempts."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  
+  // more than 0 but less than 20 links
+  and 0 < length(body.links) < 20
+  
+  // all attachments are images or there are 0 attachments
+  and (
+    length(attachments) > 0 and all(attachments, .file_type in $file_types_images)
+    or length(attachments) == 0
+  )
+  
+  // a logo/brand is detected or the subject contains payment/invoice language
+  and (
+    any(ml.logo_detect(beta.message_screenshot()).brands, .name is not null)
+    or any(ml.nlu_classifier(subject.subject).tags,
+           .name in ("payment", "invoice")
+    )
+    or regex.contains(subject.subject,
+                      '(?:\binv(?:oice|o|)\b|in_v|in-voice|pay(?:ment|mnt|)|pymt|\brec(?:eipt|pt|iept)\b|rcpt|confirm(?:ation|)|cnfrm|cnf|req(?:uest|)|rqst|rq|\bpo\b|p\.o\.|purch(?:ase)?-?order|\bord(?:er)?\b|bill(?:ing|)|billing-info|transact(?:ion|)|txn|trx|\bstmt\b|\bstmnt\b|remit(?:tance|)|rmt|remndr|remind|\bdue(?:-date|)\b|ovrdue|overdue|\bbal(?:ance|)\b|\bpaid(?:-invoice|)\b)'
+    )
+  )
+  
+  // link display text ends in a file extension or contain common payment terms
+  and (
+    any(body.links, regex.imatch(.display_text, '.*\.(?:doc|docm|docx|dot|dotm|pdf|ppa|ppam|ppsm|ppt|pptm|pptx|wbk|xla|xlam|xlm|xls|xlsb|xlsm|xlsx|xlt|xltm)$')
+   )
+    //any(body.links, regex.match(.display_text, '.*\.[a-z]{3,4}$'))
+    or any(body.links,
+           regex.icontains(.display_text,
+                           '(?:\binv(?:oice|o|)\b|in_v|in-voice|pay(?:ment|mnt|)|pymt|\brec(?:eipt|pt|iept)\b|rcpt|confirm(?:ation|)|cnfrm|cnf|req(?:uest|)|rqst|rq|\bpo\b|p\.o\.|purch(?:ase)?-?order|\bord(?:er)?\b|bill(?:ing|)|billing-info|transact(?:ion|)|txn|trx|\bstmt\b|\bstmnt\b|remit(?:tance|)|rmt|remndr|remind|\bdue(?:-date|)\b|ovrdue|overdue|\bbal(?:ance|)\b|\bpaid(?:-invoice|)\b)'
+           )
+    )
+  )
+  // the body references an attachment 
+  and (
+    strings.contains(body.current_thread.text, "attach")
+    // negate warning banners warning about the attachment(s)
+    and (
+      not (
+        regex.count(body.current_thread.text, "attach") == 1
+        and regex.icontains(body.current_thread.text,
+                            "(caution|warning).{0,30}attach"
+        )
+      )
+    )
+  )
+  
+  // body text is determined to contain cred_theft language by nlu or contains a request with the word kindly
+  and (
+    any(ml.nlu_classifier(body.current_thread.text).intents,
+        .name == "cred_theft"
+    )
+    or any(ml.nlu_classifier(body.current_thread.text).entities,
+           .name == "request" and strings.icontains(.text, "kindly")
+    )
+  )
+  
+  and not profile.by_sender().solicited
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Computer Vision"
+  - "File analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"


### PR DESCRIPTION


# Description

new rule to detect messages using invoicing/payment language, mentioning an attachment and only image or no attachments found. also inspects the links for display text mimicking common invoice extensions and several NLU invocations.

# Associated samples

Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.

- [Sample 1](https://platform.sublime.security/rules/editor?canonical_id=9926fd419bf29143c243b178f7976566e68acaa662ed1c9aea8f9c513f7b763f&message_id=01926e29-5ae3-731e-b6aa-d5efbf44a61f)
- Sample 2

## Associated hunts

If you ran any hunts with your rule, please link them here.

- Hunt 1

# Screenshot (insights)

**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
