### PR TITLE
Create link_adobe_share_unsoliticed_sender.yml

### DIFF
--- a/detection-rules/link_adobe_share_unsoliticed_sender.yml
+++ b/detection-rules/link_adobe_share_unsoliticed_sender.yml
@@ -1,5 +1,5 @@
 name: "Link: Adobe Share from Unsolicited Sender"
-description: "This attack surface reduction rule matches on message from Adobe which was sent by an email address (as determined by the sender display name) which doesn't appear to have a relationship with the recipient organization."
+description: "This attack surface reduction rule matches on messages from Adobe which were sent by an email address (as determined by the sender display name) which doesn't appear to have a relationship with the recipient organization."
 type: "rule"
 severity: "medium"
 source: |

--- a/detection-rules/link_adobe_share_unsoliticed_sender.yml
+++ b/detection-rules/link_adobe_share_unsoliticed_sender.yml
@@ -28,3 +28,4 @@ tactics_and_techniques:
 detection_methods:
   - "Content analysis"
   - "Sender analysis"
+id: "8e29ab33-a52a-5a48-9e2b-f178ded7d7bb"

--- a/detection-rules/link_adobe_share_unsoliticed_sender.yml
+++ b/detection-rules/link_adobe_share_unsoliticed_sender.yml
@@ -1,0 +1,30 @@
+name: "Link: Adobe Share from Unsolicited Sender"
+description: "This attack surface reduction rule matches on message from Adobe which was sent by an email address (as determined by the sender display name) which doesn't appear to have a relationship with the recipient organization."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // from Adobe Actual
+  and strings.icontains(sender.display_name, 'via Adobe')
+  and sender.email.email == 'message@adobe.com'
+  and headers.auth_summary.dmarc.pass
+  // contains a link to open or review a share
+  and any(body.links, .display_text =~ "open" or .display_text =~ "review")
+  // attempt to ensure the sender (from the sender.display_name) does NOT have a relationship with to recipient org
+  
+  // not sent from a Adobe User within the org's domains
+  and not any($org_domains,
+              strings.icontains(sender.display_name, strings.concat("@", ., ' via Adobe'))
+  )
+  // the org has never sent a message to the address within the sender.display_name
+  and not any($recipient_emails, strings.istarts_with(sender.display_name, .))
+tags:
+ - "Attack surface reduction"
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Free file host"
+  - "Evasion"
+detection_methods:
+  - "Content analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

Add new coverage from observed abused Adobe message which link to an Adobe hosted file which links to cred phishing. 

# Associated samples

Sample was provided privately 
