### PR TITLE
Update link_google_share_notificaiton_sus_comments.yml

### DIFF
--- a/detection-rules/link_google_share_notificaiton_sus_comments.yml
+++ b/detection-rules/link_google_share_notificaiton_sus_comments.yml
@@ -30,6 +30,26 @@ source: |
                        '</div>\s*<div style="margin-top:24px; color:#5F6368">[^<]*(?:<[^\/][^<]*)*(?:file (?:access (?:request|invite)|sent to you)|(?:s(?:ent you|hared) a|open shared) file|d(?:rive file request|ocument shared)|(?:invited|request|click) to view|view (?:shared document|a file)|pending file request)[^<]*(?:<[^\/][^<]*)*</div>\s*</td>'
     )
   )
+  // not where the sender display name of the message is within org_display_names
+  and not (
+    // the message is from google actual
+    sender.email.email in (
+      'comments-noreply@docs.google.com',
+      'drive-shares-dm-noreply@google.com',
+      'drive-shares-noreply@google.com',
+      'calendar-notification@google.com'
+    )
+    and headers.auth_summary.dmarc.pass
+    // but the sender display name is within org_display_names
+    and any($org_display_names,
+            strings.istarts_with(sender.display_name,
+                                 strings.concat(., " (via Google ")
+            )
+            or strings.istarts_with(sender.display_name,
+                                    strings.concat(., " (Google ")
+            )
+    )
+  )
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description
Negate shares from org_display_names, reuse logic from `Google Presentation Open Redirect Phishing`

# Associated samples

FP that will no longer match
- [Sample 1](https://platform.sublime.security/messages/a4ec9d8a2152b2eb381e29bef0cef1d43547d31bb19a98224fb1b370c40fd87c)
