### PR TITLE
Update link_google_notification_untrusted_sender.yml

### DIFF
--- a/detection-rules/link_google_notification_untrusted_sender.yml
+++ b/detection-rules/link_google_notification_untrusted_sender.yml
@@ -9,10 +9,10 @@ source: |
   // ignore messages from google[.]com unlesss they fail DMARC authentication
   and (
     (
-      sender.email.domain.root_domain in ("google.com", "youtube.com")
+      sender.email.domain.root_domain in ("google.com", "youtube.com", "nest.com")
       and not headers.auth_summary.dmarc.pass
     )
-    or sender.email.domain.root_domain not in ("google.com", "youtube.com")
+    or sender.email.domain.root_domain not in ("google.com", "youtube.com", "nest.com")
   )
   and any(body.links,
           .href_url.domain.domain == "notifications.google.com"


### PR DESCRIPTION
# Description
Negate nest.com which is owned by google and sends notifications

# Associated samples

Nest Notification that will no longer match
- [Sample 1](https://platform.sublime.security/messages/b892465767183f0537292c72a312e1ce4d68c0a06605d6c536ce80926f9d9bc2)