### PR TITLE
Update link_google_presentation_open_redirect.yml

### DIFF
--- a/detection-rules/link_google_presentation_open_redirect.yml
+++ b/detection-rules/link_google_presentation_open_redirect.yml
@@ -4,35 +4,25 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
+  and not strings.icontains(body.current_thread.text, 'invited you to edit')
   and any(body.links,
           // body link is to a google doc presentation
           .href_url.domain.domain == "docs.google.com"
           and strings.istarts_with(.href_url.path, '/presentation/')
   
           // prefilter some to avoid clicking on _every_ google presentation link
-          // the link appears as plain text in the and makes up the majority of the the current thread
-          and (
-            ( // determine if the plain text url link is in the current thread and not a previous one.
-              strings.icontains(body.current_thread.text, .href_url.url)
-              // the length of the url + 20% is greater than the length of the body (which includes the url)
-              and length(.href_url.url) * 1.20 >= length(body.current_thread.text)
-            )
-            or ( // the display text appears in the current thread and makes up the majority of the the current thread
+          and ( 
+            ( 
+              // https://platform.sublime.security/messages/b94de99b5c7c49cad1b3374d3c2885fb042de4ed6006467ca41e5c4f74e79095
               // make sure the display text is in the current thread and not a previous one.
               strings.icontains(body.current_thread.text, .display_text)
-              // the display text length of the link + 20% is greater than the length of the body (which includes the display text)
-              and (
-                length(.display_text) * 1.20 >= length(body.current_thread.text)
-                // display text ends in some random chars that includes a number
-                // https://platform.sublime.security/messages/b94de99b5c7c49cad1b3374d3c2885fb042de4ed6006467ca41e5c4f74e79095
-                or (
-                  // the regex ends with a word that is 4-10 long
-                  regex.icontains(.display_text, '[[:punct:]\s][a-zA-Z0-9]{5,9}$')
-                  // that word has to include a letter AND a number
-                  and regex.icontains(.display_text, '[[:punct:]\s](?:[a-z0-9]*[a-z][0-9][a-z0-9]*|[a-z0-9]*[0-9][a-z][a-z0-9]*)$')
-                  and strings.iends_with(.href_url.path, '/pub')
-                )
+              // the display_text ends with a word that is 4-10 long
+              and regex.icontains(.display_text, '[[:punct:]\s][a-z0-9]{5,9}$')
+              // that word has to include a letter AND a number
+              and regex.icontains(.display_text,
+                                  '[[:punct:]\s](?:[a-z0-9]*[a-z][0-9][a-z0-9]*|[a-z0-9]*[0-9][a-z][a-z0-9]*)$'
               )
+              and strings.iends_with(.href_url.path, '/pub')
             )
             or 
             // finally send the link to link analysis that presentation...
@@ -79,7 +69,6 @@ source: |
             )
           )
   )
-  
   // when the sender is not google, the sender should not be a common prevalence
   and (
     ( // the message is not from google actual


### PR DESCRIPTION
# Description

Avoid FPs based on the length of the display_text or href_url.url compared to the current_thread length.  Too many people copy/paste just a link and send it to others. 

# Associated samples

FPs that will no longer match
- [Sample 1](https://platform.sublime.security/messages/1d8d4be38335fb8c16eeb0cebb3add48c5364d05d62e048ebcdae8e642fda718)
- [Sample 2](https://platform.sublime.security/messages/d2335b813cf245dcec6d18e63a555d9638cf64c6c0b0a0dac10e3b3ecd54e191)
- [Sample 3](https://platform.sublime.security/messages/187c0a8b340346e4314aa44e19c53b199c96e41833fb6604eb249c736939f611)

## Associated hunts

Updated logic showing fewer FPs
- [Hunt 1](https://platform.sublime.security/hunts/d7f651f5-9866-4996-9c28-21b1efb18914)

