### PR TITLE
Create link_adobe_share_suspicious.yml

### DIFF
--- a/detection-rules/link_adobe_share_suspicious.yml
+++ b/detection-rules/link_adobe_share_suspicious.yml
@@ -15,6 +15,8 @@ source: |
   and not any($org_domains,
               strings.icontains(sender.display_name,
                                 strings.concat("@", ., ' via Adobe')
+                                // sometimes the email is in parentheses
+                                or strings.concat("@", ., ') via Adobe')
               )
   )
   and (

--- a/detection-rules/link_adobe_share_suspicious.yml
+++ b/detection-rules/link_adobe_share_suspicious.yml
@@ -41,7 +41,7 @@ source: |
                        '<td style=\"color:#000000; font-family:adobe-clean, Helvetica Neue, Helvetica, Verdana, Arial, sans-serif; font-size:24px; line-height:26px; padding-top:65px;\">[\r\n]+<strong>[^\<]+<\/strong> invited you to review <strong>[^\<]*(Invoice|Payment|Agreement|Settlements|Overdue|Confidential|Transaction)[^\<]*<\/strong></td>[\r\n]+</tr>')
     // the NLU detected "sender" is included within the body wrapped with new lines indicating it's a "signature"
     or any(filter(ml.nlu_classifier(body.current_thread.text).entities,
-                  .name == "sender" and .text not in ('Customer Support')
+                  .name == "sender" and .text not in ('Customer Support', 'SHARED ON')
            ),
            strings.icontains(body.current_thread.text,
                              strings.concat("\n", .text, "\n")

--- a/detection-rules/link_adobe_share_suspicious.yml
+++ b/detection-rules/link_adobe_share_suspicious.yml
@@ -15,8 +15,10 @@ source: |
   and not any($org_domains,
               strings.icontains(sender.display_name,
                                 strings.concat("@", ., ' via Adobe')
-                                // sometimes the email is in parentheses
-                                or strings.concat("@", ., ') via Adobe')
+              )
+              // sometimes the email is in parentheses
+              or strings.icontains(sender.display_name,
+                                strings.concat("@", ., ') via Adobe')
               )
   )
   and (

--- a/detection-rules/link_adobe_share_suspicious.yml
+++ b/detection-rules/link_adobe_share_suspicious.yml
@@ -37,7 +37,7 @@ source: |
                        '<td style=\"color:#000000; font-family:adobe-clean, Helvetica Neue, Helvetica, Verdana, Arial, sans-serif; font-size:24px; line-height:26px; padding-top:65px;\">[\r\n]+<strong>[^\<]+<\/strong> invited you to review <strong>[^\<]*(Invoice|Payment|Agreement|Settlements|Overdue|Confidential|Transaction)[^\<]*<\/strong></td>[\r\n]+</tr>')
     // the NLU detected "sender" is included within the body wrapped with new lines indicating it's a "signature"
     or any(filter(ml.nlu_classifier(body.current_thread.text).entities,
-                  .name == "sender"
+                  .name == "sender" and .text not in ('Customer Support')
            ),
            strings.icontains(body.current_thread.text,
                              strings.concat("\n", .text, "\n")
@@ -49,7 +49,6 @@ source: |
       any(ml.logo_detect(ml.link_analysis(., mode="aggressive").screenshot).brands, .name in ("Microsoft") and .confidence == "high")
     )
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/link_adobe_share_suspicious.yml
+++ b/detection-rules/link_adobe_share_suspicious.yml
@@ -1,0 +1,63 @@
+name: "Link: Adobe Share with Suspicious Indicators"
+description: "The detection rule matches messages sent from Adobe and contain indicators of malicious use. The indicators include observed call to action phrases, suspicious filenames, all capital filenames, the sender's display name (as determined by NLU) included in the comment section, or Microsoft branding on the shared link."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  // from Adobe Actual
+  and strings.icontains(sender.display_name, 'via Adobe')
+  and sender.email.email == 'message@adobe.com'
+  and headers.auth_summary.dmarc.pass
+  // contains a link to open or review a share
+  and any(body.links, .display_text =~ "open" or .display_text =~ "review")
+  
+  // not sent from a Adobe User within the org's domains
+  and not any($org_domains,
+              strings.icontains(sender.display_name,
+                                strings.concat("@", ., ' via Adobe')
+              )
+  )
+  and (
+    // the comments observed wording, using the html to make sure it's in the actor controlled section of the message
+    regex.icontains(body.html.raw,
+                    '<tr>[\r\n]+<td style="color:#505050; font-family:adobe-clean, Helvetica Neue, Helvetica, Verdana, Arial, sans-serif; font-size:18px; line-height:26px; padding-top:20px;">[\r\n]+<xmp style="font-family:adobe-clean, Helvetica Neue, Helvetica, Verdana, Arial, sans-serif; font-size:18px; line-height:26px overflow-x:auto; white-space:pre-wrap; white-space:-moz-pre-wrap; white-space:-pre-wrap; white-space:-o-pre-wrap; word-wrap:break-word;">Please review the attached below for your reference,'
+    )
+    // the filename shared
+    or regex.icontains(body.html.raw,
+                       // , ends in some random numbers
+                       '<td style="color:#000000; font-family:adobe-clean, Helvetica Neue, Helvetica, Verdana, Arial, sans-serif; font-size:24px; line-height:26px; padding-top:65px;">[\r\n]+<strong>[^\<]+<\/strong> (invited you to review|has shared) <strong>[^\<]+([]|[[:punct:]\s](?:AP|AR)?\d+[a-z]?)<\/strong></td>[\r\n]+</tr>'
+    )
+    // contains all capital letters, allowing for numbers
+    or regex.contains(body.html.raw,
+                      '<td style="color:#000000; font-family:adobe-clean, Helvetica Neue, Helvetica, Verdana, Arial, sans-serif; font-size:24px; line-height:26px; padding-top:65px;">[\r\n]+<strong>[^\<]+<\/strong> (invited you to review|has shared) <strong>(?:[A-Z0-9_\-\s]+)<\/strong></td>[\r\n]+</tr>',
+    )
+    // contains commonly observed themes used by actors
+    or regex.icontains(body.html.raw,
+                       // , ends in some random numbers
+                       '<td style=\"color:#000000; font-family:adobe-clean, Helvetica Neue, Helvetica, Verdana, Arial, sans-serif; font-size:24px; line-height:26px; padding-top:65px;\">[\r\n]+<strong>[^\<]+<\/strong> invited you to review <strong>[^\<]*(Invoice|Payment|Agreement|Settlements|Overdue|Confidential|Transaction)[^\<]*<\/strong></td>[\r\n]+</tr>')
+    // the NLU detected "sender" is included within the body wrapped with new lines indicating it's a "signature"
+    or any(filter(ml.nlu_classifier(body.current_thread.text).entities,
+                  .name == "sender"
+           ),
+           strings.icontains(body.current_thread.text,
+                             strings.concat("\n", .text, "\n")
+           )
+    )
+    // finally we'll hit the actual page and see if we can get some enrichment functions to give up some gold
+    or any(filter(body.links, .display_text =~ "open" or .display_text =~ "review"),
+      // detected as Microsoft
+      any(ml.logo_detect(ml.link_analysis(., mode="aggressive").screenshot).brands, .name in ("Microsoft") and .confidence == "high")
+    )
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Free file host"
+detection_methods:
+  - "Content analysis"
+  - "URL screenshot"
+  - "Sender analysis"
+  - "Natural Language Understanding"
+  - "URL analysis"

--- a/detection-rules/link_adobe_share_suspicious.yml
+++ b/detection-rules/link_adobe_share_suspicious.yml
@@ -61,3 +61,4 @@ detection_methods:
   - "Sender analysis"
   - "Natural Language Understanding"
   - "URL analysis"
+id: "b33cae80-adbc-59b6-b732-21e739c3cb96"


### PR DESCRIPTION
# Description

Add additional coverage to malicious (with higher confidence) Adobe shares, regardless of sender relationship to the recipient domain

# Associated samples

Samples shared privately
