### PR TITLE
Create credential_phishing_cross_site_scripting_in_sub.yml

### DIFF
--- a/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
+++ b/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
@@ -35,10 +35,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-  
-  
-  
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
+++ b/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
@@ -8,7 +8,8 @@ source: |
   and regex.icontains(subject.subject,
                       '\b(?:script|iframe|embed|object|onload|onerror|onfocus|onclick|onmouseover|onmouseout|onkeydown|onkeypress|onkeyup|onchange|oninput|onsubmit|eval|alert|document\.cookie|document\.write|window\.location|setTimeout|setInterval|atob|innerHTML|outerHTML|XMLHttpRequest|fetch|import|execCommand)\b'
   )
-  and regex.contains(subject.subject, '(&#?[a-zA-Z0-9]+;|%[0-9A-Fa-f]{2})')
+  // and contains html or url encoded strings, hex escaped strings, opening or closing html tags, or escaped non word characters
+  and regex.contains(subject.subject, '(?:&#?[a-zA-Z0-9]+;|%[0-9A-Fa-f]{2}|\\[xu][a-fA-F0-9]{2,4}|[\x22\x27](?:>|&gt;)|(?:<|&lt;)\/?(?:[a-z]+|[A-Z]+)|\\[^\\a-zA-Z0-9])'))
   
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (

--- a/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
+++ b/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
@@ -9,7 +9,7 @@ source: |
                       '\b(?:script|iframe|embed|onload|onerror|onfocus|onclick|onmouseover|onmouseout|onkeydown|onkeypress|onkeyup|onchange|oninput|onsubmit|eval|document\.cookie|document\.write|window\.location|setTimeout|setInterval|atob|innerHTML|outerHTML|XMLHttpRequest|fetch|execCommand)\b'
   )
   // and contains html or url encoded strings, hex escaped strings, opening or closing html tags, or escaped non word characters
-  and regex.contains(subject.subject, '(?:&#?[a-zA-Z0-9]+;|%[0-9A-Fa-f]{2}|\\[xu][a-fA-F0-9]{2,4}|[\x22\x27](?:>|&gt;)|(?:<|&lt;)\/?(?:[a-z]+|[A-Z]+)|\\[^\\a-zA-Z0-9])'))
+  and regex.contains(subject.subject, '(?:&#?[a-zA-Z0-9]+;|%[0-9A-Fa-f]{2}|\\[xu][a-fA-F0-9]{2,4}|[\x22\x27](?:>|&gt;)|(?:<|&lt;)\/?(?:[a-z]+|[A-Z]+)|\\[^\\a-zA-Z0-9])')
   
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (

--- a/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
+++ b/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
@@ -6,7 +6,7 @@ source: |
   type.inbound
   // subject contains suspected cross site scripting
   and regex.icontains(subject.subject,
-                      '\b(?:script|iframe|embed|object|onload|onerror|onfocus|onclick|onmouseover|onmouseout|onkeydown|onkeypress|onkeyup|onchange|oninput|onsubmit|eval|alert|document\.cookie|document\.write|window\.location|setTimeout|setInterval|atob|innerHTML|outerHTML|XMLHttpRequest|fetch|import|execCommand)\b'
+                      '\b(?:script|iframe|embed|onload|onerror|onfocus|onclick|onmouseover|onmouseout|onkeydown|onkeypress|onkeyup|onchange|oninput|onsubmit|eval|document\.cookie|document\.write|window\.location|setTimeout|setInterval|atob|innerHTML|outerHTML|XMLHttpRequest|fetch|execCommand)\b'
   )
   // and contains html or url encoded strings, hex escaped strings, opening or closing html tags, or escaped non word characters
   and regex.contains(subject.subject, '(?:&#?[a-zA-Z0-9]+;|%[0-9A-Fa-f]{2}|\\[xu][a-fA-F0-9]{2,4}|[\x22\x27](?:>|&gt;)|(?:<|&lt;)\/?(?:[a-z]+|[A-Z]+)|\\[^\\a-zA-Z0-9])'))

--- a/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
+++ b/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
@@ -47,3 +47,4 @@ tactics_and_techniques:
 detection_methods:
   - "Content analysis"
   - "Sender analysis"
+id: "8a946cfa-58ea-59c5-9726-94a1892b5556"

--- a/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
+++ b/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
@@ -1,0 +1,49 @@
+name: "Suspected Cross-Site Scripting (XSS) found in subject"
+description: "This rule detects Cross-Site Scripting (XSS) attempts within email subjects. It bypasses messages from highly trusted domains unless they fail authentication. However, the rule remains flexible, triggering even for trusted domains when emails are sent from Google Groups, ensuring thorough protection against potential threats while minimizing false positives."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // subject contains suspected cross site scripting
+  and regex.icontains(subject.subject,
+                      '\b(?:script|iframe|embed|object|onload|onerror|onfocus|onclick|onmouseover|onmouseout|onkeydown|onkeypress|onkeyup|onchange|oninput|onsubmit|eval|alert|document\.cookie|document\.write|window\.location|setTimeout|setInterval|atob|innerHTML|outerHTML|XMLHttpRequest|fetch|import|execCommand)\b'
+  )
+  and regex.contains(subject.subject, '(&#?[a-zA-Z0-9]+;|%[0-9A-Fa-f]{2})')
+  
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and (
+        any(distinct(headers.hops, .authentication_results.dmarc is not null),
+            strings.ilike(.authentication_results.dmarc, "*fail")
+        )
+        or (
+          strings.icontains(sender.display_name, "via")
+          and any(headers.hops,
+                  any(.fields,
+                      .name == "List-ID"
+                      and strings.ends_with(.value,
+                                            strings.concat(sender.email.domain.domain,
+                                                           ">"
+                                            )
+                      )
+                  )
+          )
+        )
+      )
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  
+  
+  
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Scripting"
+detection_methods:
+  - "Content analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

This rule detects Cross-Site Scripting (XSS) attempts within email subjects. It bypasses messages from highly trusted domains unless they fail authentication. However, the rule remains flexible, triggering even for trusted domains when emails are sent from Google Groups, ensuring thorough protection against potential threats while minimizing false positives.




## Associated hunts



- [Hunt 1](https://platform.sublime.security/hunts/8f1cd31b-346d-4449-9b65-b2c482ad097c)
