### PR TITLE
Update link_credential_phishing_voicemail_language.yml

### DIFF
--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -32,7 +32,7 @@ source: |
     or regex.icontains(
                        strings.replace_confusables(body.current_thread.text),
                        //body.current_thread.text,
-                       'you (?:have |received )*(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}\bvoice(?:mail|audio)? (?: message)?',
+                       'you (?:have |received )*(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}\bvoice\s?(?:mail|audio|message)',
                        'sent (?:from|by) (?:your )?voice (?:mail )?system',
                        'new (?:voice(?:mail)?|audio) (?:message|notification|record)',
                        'voicemail (is )?attached',

--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -13,10 +13,12 @@ source: |
     any([subject.subject, sender.display_name],
         regex.icontains(.,
                         // split phrases that occur within 3 words between or only punctuation between them
-                        '(?:v[nm](\b|[[:punct:]])|\bvoice(?:mail|message)?|audio|missed(?:\sa\s)?|left( a)?|wireless)(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:mail|message|msg|recording|received|notif|support|call\d*\b|ca[il][il](?:er)?|log|transcript(?:ion)?\b)',
+                        '(?:v[nm](\b|[[:punct:]])?|\bvoice(?:mail|message)?|audio|missed(?:\sa\s)?|left( a)?|wireless)(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:mail|message|msg|recording|received|notif|support|ca[li1][li1]\d*\b|ca[il1][il1](?:er)?|log|transcript(?:ion)?\b)',
+                        // split phrases that start with "caller" that occur within 3 words between or only punctation 
+                        'ca[li1][li1](?:er)?(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:v[nm](\b|[[:punct:]])?|\bvoice(?:mail|message)?|audio|missed(?:\sa\s)?|left( a)?)',
                         // strong phrases
-                        '(?:open mp3|audio note|\.wav|left a vm|unanswered.*call|incoming.vm|left msg|wireless caller|VM Service|voice message|missed.called|call.(?:support|service)(?: for| log)?|missed.{0,10} VM|new voicemail from|new.v.m.from.\+?\d+|new voicemail?(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}transcript(s|ion)?|message received)',
-                        'ca[li][li](?:er)?(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:playback|transcript)',
+                        '(?:open mp3|audio note|\.wav|left a vm|unanswered.*ca[li1][li1]|incoming.vm|left msg|wireless ca[li1][li1]er|VM Service|voice message|missed.ca[li1][li1]ed|ca[li1][li1].(?:support|service)(?: for| log)?|missed.{0,10} VM|new voicemail from|new.v.m.from.\+?\d+|new voicemail?(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}transcript(s|ion)?|message received)',
+                        'ca[li1][li1](?:er)?(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:playback|transcript)',
                         // obfuscated phone number with at least one digit in the area code and at least one obfuscated number in the last group
                         // 555-555-555X, 555-555-XXXX, 555-5XX-XXXX
                         '\b1?\(?(\d{3}|\d{2}[\*X]|\d[\*X]{2})\)?[^a-z0-9]{0,2}(\d{2,3}|\d{2}[\*X]|\d[\*X]{2}|[\*X]{2,3})[^a-z0-9]{0,4}(\d{3}[\*X]|\d{2}[\*X]{2}|\d[\*X]{3}|[\*X]{3,4})[^0-9]',
@@ -35,10 +37,10 @@ source: |
                        'voicemail (is )?attached',
                        'a new encrypted voicemail',
                        'Your have incoming voiceRec',
-                       "you(?:\'ve| have) a (?:new )?missed call",
+                       "you(?:\'ve| have) a (?:new )?missed ca[li1][li1]",
                        'New Voicemail Received',
                        'left you a (?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:voice(?:mail)?|audio)(?: message)?',
-                       'New missed call record',
+                       'New missed ca[li1][li1] record',
                        'voicemail transcript(?:ion)?',
                        'Listen to VoiceMail'
     )
@@ -46,7 +48,7 @@ source: |
     or strings.icontains(body.html.raw, '<title>Voicemail Notification</title>')
     or strings.icontains(body.html.raw, '<!-- Voicemail phone logo')
   )
-  
+
   and 2 of (
     (
       // the sender is a freemail


### PR DESCRIPTION
# Description

add a new regex and add `1` to char classes to cover other obfuscation methods of the letter `l` within `call`

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/64634057ff162d3ae25b67edb5ca1f31fcfb8b288c6696c924622b8f99608987)
- [Sample 2](https://platform.sublime.security/messages/476c92cf68a9b6d1484ce78460c378b6a4242897187af807063f10d8cfbbbae8)


## Associated hunts

Samples matching the updated logic that don't match the old (had to strip replace_confusables)
- [Hunt 1](https://platform.sublime.security/hunts/771fddb2-ea8b-4d87-8ca9-efb3d5e8d2d7)

