### PR TITLE
Update callback_phishing_nlu_body_or_attachments.yml

### DIFF
--- a/detection-rules/callback_phishing_nlu_body_or_attachments.yml
+++ b/detection-rules/callback_phishing_nlu_body_or_attachments.yml
@@ -9,21 +9,26 @@ source: |
   and (
     any(attachments,
         (.file_type in $file_types_images or .file_type == "pdf")
-        and any(file.explode(.),
+        and (
+          any(ml.nlu_classifier(beta.ocr(.).text).intents,
+              .name == "callback_scam" and .confidence in ("medium", "high")
+          )
+          or any(file.explode(.),
   
-                // exclude images taken with mobile cameras and screenshots from android
-                not any(.scan.exiftool.fields,
-                        .key == "Model"
-                        or (
-                          .key == "Software"
-                          and strings.starts_with(.value, "Android")
-                        )
-                        or (.key == "UserComment" and .value == "Screenshot")
-                )
-                and any(ml.nlu_classifier(.scan.ocr.raw).intents,
-                        .name == "callback_scam"
-                        and .confidence in ("medium", "high")
-                )
+                 // exclude images taken with mobile cameras and screenshots from android
+                 not any(.scan.exiftool.fields,
+                         .key == "Model"
+                         or (
+                           .key == "Software"
+                           and strings.starts_with(.value, "Android")
+                         )
+                         or (.key == "UserComment" and .value == "Screenshot")
+                 )
+                 and any(ml.nlu_classifier(.scan.ocr.raw).intents,
+                         .name == "callback_scam"
+                         and .confidence in ("medium", "high")
+                 )
+          )
         )
         and (
           // negate noreply unless a logo is found in the attachment


### PR DESCRIPTION
# Description

Incorporating an or between file.explode's ocr and beta.scan.ocr's functionality. This will bring rule matches in line with signals. 

# Associated samples


- [Sample 1](https://platform.sublime.security/rules/editor?canonical_id=ed4d350e1b1f6d7efbb1060656b4100f9122706ea14af968b9a8d08f49f4d8a4&message_id=0192c3aa-a9ee-7e0b-92a5-60711aa48fbb)

