### PR TITLE
Update link_credential_phishing_voicemail_language.yml

### DIFF
--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -17,7 +17,9 @@ source: |
                         // split phrases that start with "caller" that occur within 3 words between or only punctation 
                         'ca[li1][li1](?:er)?(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:v[nm](\b|[[:punct:]])?|\bvoice(?:mail|message)?|audio|missed(?:\sa\s)?|left( a)?)',
                         // strong phrases
-                        '(?:open mp3|audio note|\.wav|left a vm|\bvoip\b|unanswered.*ca[li1][li1]|incoming.vm|left msg|wireless ca[li1][li1]er|VM Service|voice message|missed.ca[li1][li1](?:e[rd])?|ca[li1][li1].(?:support|service)(?: for| log)?|missed.{0,10} VM|new voicemail from|new.v.m.from.\+?\d+|new voicemail?(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}transcript(s|ion)?|message received)',
+                        '(?:open mp3|audio note|\.wav|left a vm|[^\s]+voip[^\s]*|unanswered.*ca[li1][li1]|incoming.vm|left msg|wireless ca[li1][li1]er|VM Service|voice message|missed.ca[li1][li1](?:e[rd])?|ca[li1][li1].(?:support|service)(?: for| log)?|missed.{0,10} VM|new voicemail from|new.v.m.from.\+?\d+|new voicemail?(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}transcript(s|ion)?|message received)',
+                        // starts in the format of `(4)` and contains some voicemail keywords
+                        '^\(\d\)\s(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:message|voip|voice|unread|call)',
                         'ca[li1][li1](?:er)?(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:playback|transcript)',
 
                         // obfuscated phone number with at least one digit in the area code and at least one obfuscated number in the last group

--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -335,16 +335,6 @@ source: |
       or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
     )
   )
-  and (
-    (
-      profile.by_sender().prevalence in ("new", "outlier")
-      and not profile.by_sender().solicited
-    )
-    or (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_false_positives
-    )
-  )
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (


### PR DESCRIPTION
# Description

1. Remove sender profile checking due to FNs.  The rest of the rule should be tight enough to avoid them.
1. Tighten logic around "voip" to avoid FP
1. Add additional logic to continue matching on samples after reducing FPs

# Associated samples

- [Sample 1](https://platform.sublime.security/rules/editor?canonical_id=8dc7f71933b981914a5bba094e70612869f531f7270fd308192f7b8c73eb7ae2)

FP sample that doesn't match after VOIP changes
- [Sample 1](https://platform.sublime.security/messages/1958b83412c1ab8694ab25b5eb8668250887e57ccb589c777949a73220931212)

TP Sample that continues to match on additional logic after VOIP changes 
- [Sample 1](https://platform.sublime.security/messages/7537c458d8ea7fde3338e6473a25f55a1014e840be11e66a72ec859d70d9881a)