### PR TITLE
standardize docusign auth check

### DIFF
--- a/detection-rules/callback_phishing_docusign_comment.yml
+++ b/detection-rules/callback_phishing_docusign_comment.yml
@@ -8,11 +8,20 @@ source: |
   and length(attachments) == 0
   
   // Legitimate Docusign sending infratructure
+  and sender.email.domain.root_domain == 'docusign.net'
+  and headers.auth_summary.spf.pass
   and (
-    sender.email.domain.root_domain in ('docusign.net', 'docusign.com')
-    // check for SPF or DMARC passed
-    and (headers.auth_summary.spf.pass or headers.auth_summary.dmarc.pass)
+    headers.auth_summary.spf.details.designator == 'docusign.net'
+    // observed subdomains of docusign being used (camail.docusign.net)
+    or strings.ends_with(headers.auth_summary.spf.details.designator,
+                         '.docusign.net'
+    )
+    // "domain of dse_na4@docusign.net"
+    or strings.ends_with(headers.auth_summary.spf.details.designator,
+                         '@docusign.net'
+    )
   )
+  and headers.auth_summary.dmarc.pass
   
   // Docusign Logo 
   and any(ml.logo_detect(beta.message_screenshot()).brands, .name == "DocuSign")

--- a/detection-rules/callback_phishing_docusign_comment.yml
+++ b/detection-rules/callback_phishing_docusign_comment.yml
@@ -9,19 +9,7 @@ source: |
   
   // Legitimate Docusign sending infratructure
   and sender.email.domain.root_domain == 'docusign.net'
-  and headers.auth_summary.spf.pass
-  and (
-    headers.auth_summary.spf.details.designator == 'docusign.net'
-    // observed subdomains of docusign being used (camail.docusign.net)
-    or strings.ends_with(headers.auth_summary.spf.details.designator,
-                         '.docusign.net'
-    )
-    // "domain of dse_na4@docusign.net"
-    or strings.ends_with(headers.auth_summary.spf.details.designator,
-                         '@docusign.net'
-    )
-  )
-  and headers.auth_summary.dmarc.pass
+  and (headers.auth_summary.spf.pass or headers.auth_summary.dmarc.pass)
   
   // Docusign Logo 
   and any(ml.logo_detect(beta.message_screenshot()).brands, .name == "DocuSign")

--- a/detection-rules/docusign_new_sender_domain.yml
+++ b/detection-rules/docusign_new_sender_domain.yml
@@ -13,19 +13,7 @@ source: |
   
   // message is from docusign actual
   and sender.email.domain.root_domain == 'docusign.net'
-  and headers.auth_summary.spf.pass
-  and (
-    headers.auth_summary.spf.details.designator == 'docusign.net'
-    // observed subdomains of docusign being used (camail.docusign.net)
-    or strings.ends_with(headers.auth_summary.spf.details.designator,
-                         '.docusign.net'
-    )
-    // "domain of dse_na4@docusign.net"
-    or strings.ends_with(headers.auth_summary.spf.details.designator,
-                         '@docusign.net'
-    )
-  )
-  and headers.auth_summary.dmarc.pass
+  and (headers.auth_summary.spf.pass or headers.auth_summary.dmarc.pass)
   
   // not a completed DocuSign
   and not strings.istarts_with(subject.subject, "Completed:")

--- a/detection-rules/link_multistage_docusign.yml
+++ b/detection-rules/link_multistage_docusign.yml
@@ -10,19 +10,7 @@ source: |
   
   // message is from docusign actual
   and sender.email.domain.root_domain == 'docusign.net'
-  and headers.auth_summary.spf.pass
-  and (
-    headers.auth_summary.spf.details.designator == 'docusign.net'
-    // observed subdomains of docusign being used (camail.docusign.net)
-    or strings.ends_with(headers.auth_summary.spf.details.designator,
-                         '.docusign.net'
-    )
-    // "domain of dse_na4@docusign.net"
-    or strings.ends_with(headers.auth_summary.spf.details.designator,
-                         '@docusign.net'
-    )
-  )
-  and headers.auth_summary.dmarc.pass
+  and (headers.auth_summary.spf.pass or headers.auth_summary.dmarc.pass)
   
   // filter out all the links, keeping only the links of interest
   and any(filter(body.links,

--- a/detection-rules/link_multistage_docusign.yml
+++ b/detection-rules/link_multistage_docusign.yml
@@ -17,6 +17,10 @@ source: |
     or strings.ends_with(headers.auth_summary.spf.details.designator,
                          '.docusign.net'
     )
+    // "domain of dse_na4@docusign.net"
+    or strings.ends_with(headers.auth_summary.spf.details.designator,
+                         '@docusign.net'
+    )
   )
   and headers.auth_summary.dmarc.pass
   


### PR DESCRIPTION
# Description

standardize auth check for docusign - source : https://github.com/sublime-security/sublime-rules/blob/main/detection-rules/callback_phishing_docusign_comment.yml#L14
