### PR TITLE
Create abuse_docusign_sus_names.yml

### DIFF
--- a/detection-rules/abuse_docusign_sus_names.yml
+++ b/detection-rules/abuse_docusign_sus_names.yml
@@ -1,0 +1,158 @@
+name: "Service Abuse: DocuSign Notification with Suspicious Sender or Document Name"
+description: "The detection rule is intended to match on messages sent from Docusign from a newly observed reply-to address which contains suspicious content within the document or sender display name."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and length(attachments) == 0
+  
+  // Legitimate Docusign sending infratructure
+  and sender.email.domain.root_domain == 'docusign.net'
+  and (headers.auth_summary.spf.pass or headers.auth_summary.dmarc.pass)
+  and length(headers.reply_to) > 0
+  and not any(headers.reply_to,
+              .email.domain.domain in $org_domains
+              or .email.domain.root_domain in $high_trust_sender_root_domains
+              or .email.domain.root_domain in ("docusign.net", "docusign.com")
+  )
+  
+    and length(headers.reply_to) > 0 
+    // reply-to email address has never been sent an email by the org
+    and not (
+      any(headers.reply_to, .email.email in $recipient_emails)
+      // if the reply-to email address is NOT in free_email_providers, check the domain in recipient_domains
+      or any(filter(headers.reply_to,
+                    // filter the list to only emails that are not in free_email_providers
+                    (
+                      .email.domain.domain not in $free_email_providers
+                      or .email.domain.root_domain not in $free_email_providers
+                    )
+             ),
+             .email.domain.domain in $recipient_domains
+      )
+    )
+    // reply-to address has never sent an email to the org
+    and not (
+      any(headers.reply_to, .email.email in $sender_emails)
+      // if the reply-to address is NOT in free_email_providers, check the domain in sender_domains
+      or any(filter(headers.reply_to,
+                    // filter the list to only emails that are not in free_email_providers
+                    (
+                      .email.domain.domain not in $free_email_providers
+                      or .email.domain.domain not in $free_email_providers
+                    )
+             ),
+             .email.domain.root_domain in $sender_domains
+      )
+    )
+  
+  // not a completed DocuSign
+  // reminders are sent automatically and can be just as malicious as the initial
+  // users often decline malicious ones
+  and not strings.istarts_with(subject.subject, "Completed: ")
+  and not strings.istarts_with(subject.subject, "Here is your signed document: ")
+  and not strings.istarts_with(subject.subject, "Voided: ")
+  and (
+    // contains the word docusign before the `via Docusign` part
+    regex.icontains(sender.display_name, 'Docusign.*via Docusign$')
+    or strings.icontains(subject.subject, 'sharefile')
+    or strings.icontains(subject.subject, 'helloshare')
+  
+    // sender names part of the subject
+    or (
+      // Billing Accounting
+      regex.icontains(sender.display_name,
+                      'Accounts? (?:Payable|Receivable).*via Docusign$',
+                      'Billing Support.*via Docusign$'
+      )
+  
+      // HR/Payroll/Legal/etc
+      or regex.icontains(sender.display_name, 'Compliance HR.*via Docusign$')
+      or regex.icontains(sender.display_name,
+                         '(?:Compliance|Executive|Finance|\bHR\b|Human Resources|\bIT\b|Legal|Payroll|Purchasing|Operations|Security|Training|Support).*(?:Department|Team)?.*via Docusign$'
+      )
+      or regex.icontains(sender.display_name,
+                         'Corporate Communications.*via Docusign$'
+      )
+      or regex.icontains(sender.display_name, 'Employee Relations.*via Docusign$')
+      or regex.icontains(sender.display_name, 'Office Manager.*via Docusign$')
+      or regex.icontains(sender.display_name, 'Risk Management.*via Docusign$')
+      or regex.icontains(sender.display_name,
+                         'Payroll Admin(?:istrator).*via Docusign$'
+      )
+  
+      // IT related
+      or regex.icontains(sender.display_name,
+                         'IT Support.*via Docusign$',
+                         'Information Technology.*via Docusign$',
+                         '(?:Network|System)? Admin(?:istrator).*via Docusign$',
+                         'Help Desk.*via Docusign$',
+                         'Tech(?:nical) Support.*via Docusign$'
+      )
+    )
+    // filename analysis
+    // the filename is also contained in the subject line
+    or (
+      // scanner themed
+      regex.icontains(subject.subject, 'scanne[rd]')
+      // image theme
+      or regex.icontains(subject.subject, '_IMG_')
+      or regex.icontains(subject.subject, 'IMG[_-](?:\d|\W)+')
+  
+      // Invoice Themes
+      or regex.icontains(subject.subject, 'Invoice')
+      or regex.icontains(subject.subject, 'INV\b')
+      or regex.icontains(subject.subject, 'Payment')
+      or regex.icontains(subject.subject, '\bACH\b')
+      or regex.icontains(subject.subject, 'Wire Confirmation')
+      or regex.icontains(subject.subject, 'P[O0]\W+?\d+\"')
+      or regex.icontains(subject.subject, 'P[O0](?:\W+?|\d+)')
+      or regex.icontains(subject.subject, 'receipt')
+      or regex.icontains(subject.subject, 'Billing')
+      or regex.icontains(subject.subject, 'statement')
+      or regex.icontains(subject.subject, 'Past Due')
+      or regex.icontains(subject.subject, 'Remit(?:tance)?')
+      or regex.icontains(subject.subject, 'Purchase Order')
+      or regex.icontains(subject.subject, 'Settlementt')
+  
+      // contract language
+      or regex.icontains(subject.subject, 'Pr[0o]p[0o]sal')
+      or regex.icontains(subject.subject, 'Claim Doc')
+  
+      // Payroll/HR
+      or regex.icontains(subject.subject, 'Payroll')
+      or regex.icontains(subject.subject, 'Employee Pay\b')
+      or regex.icontains(subject.subject, 'Salary')
+      or regex.icontains(subject.subject, 'Benefit Enrollment')
+      or regex.icontains(subject.subject, 'Employee Handbook')
+      or regex.icontains(subject.subject, 'Reimbursement Approved')
+  
+      // 
+      // shared files/extenstion/urgency/CTA
+      or regex.icontains(subject.subject, 'Urgent')
+      or regex.icontains(subject.subject, 'Important')
+      or regex.icontains(subject.subject, 'Secure')
+      or regex.icontains(subject.subject, 'Encrypt')
+      or regex.icontains(subject.subject, 'shared')
+      or regex.icontains(subject.subject, 'protected')
+      or regex.icontains(subject.subject, 'Validate')
+      or regex.icontains(subject.subject, 'Action Required')
+      or regex.icontains(subject.subject, 'Final Notice')
+      or regex.icontains(subject.subject, 'Review(?: and| & |\s+)?Sign')
+      or regex.icontains(subject.subject, 'Download PDF')
+  
+      // MFA theme
+      or regex.icontains(subject.subject, 'Verification Code')
+      or regex.icontains(subject.subject, '\bMFA\b')
+    )
+  )
+attack_types:
+  - "Callback Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "Sender analysis"
+  - "Header analysis"
+  - "Content analysis"

--- a/detection-rules/abuse_docusign_sus_names.yml
+++ b/detection-rules/abuse_docusign_sus_names.yml
@@ -156,3 +156,4 @@ detection_methods:
   - "Sender analysis"
   - "Header analysis"
   - "Content analysis"
+id: "5e4707cd-1953-5fe2-9a62-34e3026f0336"


### PR DESCRIPTION
# Description

Add new coverage for DocuSign abuse.  Largely from the HelloSign rule but modified to work for docusign

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/c6c347410dc7809f6fdef23e5b703867359aadec0e9fcc82fffa79c9e93a086c)
## Associated hunts

- [Hunt 1](https://platform.sublime.security/hunts/a056ede2-dacd-405c-ba32-328045e61b11)
