### PR TITLE
Update impersonation_quickbooks.yml

### DIFF
--- a/detection-rules/impersonation_quickbooks.yml
+++ b/detection-rules/impersonation_quickbooks.yml
@@ -12,8 +12,18 @@ source: |
     )
     or strings.ilike(body.current_thread.text, "*invoice*")
   )
-  and any(ml.logo_detect(beta.message_screenshot()).brands,
-          .name == "Quickbooks" and .confidence in ("medium", "high")
+  and (
+    any(ml.logo_detect(beta.message_screenshot()).brands,
+        .name == "Quickbooks" and .confidence in ("medium", "high")
+    )
+    // contains the address and copyright 
+    or 
+    (
+      strings.icontains(body.current_thread.text,
+                        '2800 E. Commerce Center Place, Tucson, AZ 85706'
+      )
+      and regex.icontains(body.current_thread.text, '©\s*(?:\d+)\s*Intuit')
+    )
   )
   and sender.email.domain.root_domain not in~ (
     'intuit.com',


### PR DESCRIPTION
# Description

add logic to match on copyright and address if logo_detect doesn't find a logo

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/68b8621573b624550b2715a575a529dfac853f7750211c413e77ce29058e7773)
## Associated hunts

If you ran any hunts with your rule, please link them here.

- [Hunt 1](https://platform.sublime.security/hunts/70713400-a782-4311-9690-98d8799d0dd1)
