### PR TITLE
Update impersonation_microsoft_credential_theft.yml

### DIFF
--- a/detection-rules/impersonation_microsoft_credential_theft.yml
+++ b/detection-rules/impersonation_microsoft_credential_theft.yml
@@ -5,11 +5,13 @@ severity: "high"
 source: |
   type.inbound
   and (
-    length(attachments) > 0
-    and (
-      all(attachments, .file_type in $file_types_images or .file_type == "pdf")
-      or length(attachments) == 0
+    (
+      length(attachments) > 0
+      and all(attachments,
+              .file_type in $file_types_images or .file_type == "pdf"
+      )
     )
+    or length(attachments) == 0
   )
   and any(ml.logo_detect(beta.message_screenshot()).brands,
           strings.starts_with(.name, "Microsoft")

--- a/detection-rules/impersonation_microsoft_credential_theft.yml
+++ b/detection-rules/impersonation_microsoft_credential_theft.yml
@@ -4,12 +4,28 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and length(attachments) == 0
+  and (
+    length(attachments) > 0
+    and (
+      all(attachments, .file_type in $file_types_images or .file_type == "pdf")
+      or length(attachments) == 0
+    )
+  )
   and any(ml.logo_detect(beta.message_screenshot()).brands,
           strings.starts_with(.name, "Microsoft")
   )
-  and any(ml.nlu_classifier(body.current_thread.text).intents,
-          .name == "cred_theft" and .confidence in ("medium", "high")
+  and (
+    any(ml.nlu_classifier(body.current_thread.text).intents,
+        .name == "cred_theft" and .confidence in ("medium", "high")
+    )
+    or (
+      length(body.current_thread.text) == 0
+      and any(file.explode(beta.message_screenshot()),
+              any(ml.nlu_classifier(.scan.ocr.raw).intents,
+                  .name == "cred_theft" and .confidence in ("medium", "high")
+              )
+      )
+    )
   )
   and (
     not (


### PR DESCRIPTION
# Description

Adding tolerance for all attachments are images or pdfs and if the body is null use message screenshot to run the NLU intent. 

# Associated samples

Link to samples that are affected by your change. 


- [Sample 1](https://platform.sublime.security/rules/editor?canonical_id=bc4cc67ec16a31c51d2afa175e69571a3b0d849cbf505468c717a30595275d7e&message_id=01932258-7b57-78f9-b521-7505e4879a47)

## Associated hunts

If you ran any hunts with your rule, please link them here.

- [Hunt 1](https://platform.sublime.security/hunts/5ca726ea-a0fb-45bc-abb3-66539bae6c1d)

