### PR TITLE
Create suspicious_sender_display_name_procedurally_generated_blob.yml

### DIFF
--- a/detection-rules/suspicious_sender_display_name_procedurally_generated_blob.yml
+++ b/detection-rules/suspicious_sender_display_name_procedurally_generated_blob.yml
@@ -25,6 +25,7 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
+  and not profile.by_sender_email().any_false_positives
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/suspicious_sender_display_name_procedurally_generated_blob.yml
+++ b/detection-rules/suspicious_sender_display_name_procedurally_generated_blob.yml
@@ -5,6 +5,8 @@ severity: "medium"
 source: |
   type.inbound
   and regex.icontains(sender.display_name, '\b[\w\p{L}\p{N}]{35,}\b')
+  and not regex.icontains(sender.display_name, '_bot_[a-f0-9]{32}\)')
+  
   // negate org domains unless they fail DMARC authentication
   and (
     (
@@ -22,7 +24,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/suspicious_sender_display_name_procedurally_generated_blob.yml
+++ b/detection-rules/suspicious_sender_display_name_procedurally_generated_blob.yml
@@ -6,6 +6,7 @@ source: |
   type.inbound
   and regex.icontains(sender.display_name, '\b[\w\p{L}\p{N}]{35,}\b')
   and not regex.icontains(sender.display_name, '_bot_[a-f0-9]{32}\)')
+  and not regex.match(sender.display_name, '\b[\w\p{L}\p{N}]{35,}\b')
   
   // negate org domains unless they fail DMARC authentication
   and (

--- a/detection-rules/suspicious_sender_display_name_procedurally_generated_blob.yml
+++ b/detection-rules/suspicious_sender_display_name_procedurally_generated_blob.yml
@@ -7,7 +7,7 @@ source: |
   and regex.icontains(sender.display_name, '\b[\w\p{L}\p{N}]{35,}\b')
   and not regex.icontains(sender.display_name, '_bot_[a-f0-9]{32}\)')
   and not regex.match(sender.display_name, '\b[\w\p{L}\p{N}]{35,}\b')
-  
+  and not (sender.email.email == "" or sender.email.domain.valid == false)
   // negate org domains unless they fail DMARC authentication
   and (
     (

--- a/detection-rules/suspicious_sender_display_name_procedurally_generated_blob.yml
+++ b/detection-rules/suspicious_sender_display_name_procedurally_generated_blob.yml
@@ -1,0 +1,32 @@
+name: "Suspicious sender display name with long procedurally generated text blob"
+description: "This rule identifies sender display names containing long strings of nonsensical or procedurally generated characters,which are often used in phishing or spam campaigns for campaign tracking and identification, as well as to bypass detection filters."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and regex.icontains(sender.display_name, '\b[\w\p{L}\p{N}]{35,}\b')
+  // negate org domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $org_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $org_domains
+  )
+  
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+detection_methods:
+  - "Content analysis"
+  - "Sender analysis"

--- a/detection-rules/suspicious_sender_display_name_procedurally_generated_blob.yml
+++ b/detection-rules/suspicious_sender_display_name_procedurally_generated_blob.yml
@@ -1,5 +1,5 @@
 name: "Suspicious sender display name with long procedurally generated text blob"
-description: "This rule identifies sender display names containing long strings of nonsensical or procedurally generated characters,which are often used in phishing or spam campaigns for campaign tracking and identification, as well as to bypass detection filters."
+description: "This rule identifies sender display names containing long strings of nonsensical or procedurally generated characters, which are often used in phishing or spam campaigns for campaign tracking and identification, as well as to bypass detection filters."
 type: "rule"
 severity: "medium"
 source: |

--- a/detection-rules/suspicious_sender_display_name_procedurally_generated_blob.yml
+++ b/detection-rules/suspicious_sender_display_name_procedurally_generated_blob.yml
@@ -30,3 +30,4 @@ tactics_and_techniques:
 detection_methods:
   - "Content analysis"
   - "Sender analysis"
+id: "2a40b043-52dc-59ca-8519-3793e8817d07"


### PR DESCRIPTION
# Description

New rule to test generated blobs of text in the sender display name. This has been observed in several campaigns, most likely for tracking purposes or obfuscation. 

## Associated hunts



- [Hunt 1](https://platform.sublime.security/hunts/f016e89a-ff4c-41ce-b8a2-f797941b6369)
