### PR TITLE
Update link_google_share_notificaiton_sus_comments.yml

### DIFF
--- a/detection-rules/link_google_share_notificaiton_sus_comments.yml
+++ b/detection-rules/link_google_share_notificaiton_sus_comments.yml
@@ -3,7 +3,8 @@ description: "This detection rule matches on messages which contain suspicious l
 type: "rule"
 severity: "high"
 source: |
-  type.inbound and
+  type.inbound
+  and 
   // message is from google actual
   sender.email.domain.domain == 'google.com'
   and (
@@ -41,13 +42,19 @@ source: |
     )
     and headers.auth_summary.dmarc.pass
     // but the sender display name is within org_display_names
-    and any($org_display_names,
-            strings.istarts_with(sender.display_name,
-                                 strings.concat(., " (via Google ")
-            )
-            or strings.istarts_with(sender.display_name,
-                                    strings.concat(., " (Google ")
-            )
+    and (
+      any($org_display_names,
+          strings.istarts_with(sender.display_name,
+                               strings.concat(., " (via Google ")
+          )
+          or strings.istarts_with(sender.display_name,
+                                  strings.concat(., " (Google ")
+          )
+      )
+      or (
+        length(headers.reply_to) == 1
+        and all(headers.reply_to, .email.domain.domain in $org_domains)
+      )
     )
   )
 attack_types:


### PR DESCRIPTION
# Description

negate messages where its sent by google actual and the reply-to header is within $org_domains.  This adds another element when the org_display_names aren't the same as within google.


# Associated samples

- [Sample 1](https://platform.sublime.security/messages/0aeeb0ecc054e81d108e50282f9a276caa87e01bd24773bce6163aa26bab7f44)
