### PR TITLE
Update callback_phishing_intuit.yml

### DIFF
--- a/detection-rules/callback_phishing_intuit.yml
+++ b/detection-rules/callback_phishing_intuit.yml
@@ -135,6 +135,8 @@ source: |
                           strings.icontains(.scan.ocr.raw, "ebay"),
                           strings.icontains(.scan.ocr.raw, "paypal"),
                         )
+                        // add additional logic for common language for paypal, which is a valid payment method
+                        and not regex.icontains(.scan.ocr.raw, "paypal[^\n]+accepted")
                       )
                   )
                   or any(ml.logo_detect(.).brands,


### PR DESCRIPTION
# Description
negate use of paypal in pdfs where it's listed as an acceptable form of payment

# Associated samples


- [Sample 1](https://platform.sublime.security/messages/b690e8c364e7297d7dc9f34ef95e451ed9592fb4e23d2c97b9ba921cee34d1a0)
