### PR TITLE
Update link_credential_phishing_intent_and_other_indicators.yml

### DIFF
--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -348,7 +348,15 @@ source: |
       (
         // recipient's email address is in the body
         any(recipients.to,
-            strings.icontains(body.current_thread.text, .email.email)
+            // use count to ensure the email address is not part of a disclaimer
+            strings.icount(body.current_thread.text, .email.email) > 
+            // sum allows us to add more logic as needed
+            sum([
+                  strings.icount(body.current_thread.text,
+                                 strings.concat('was sent to ', .email.email)
+                  )
+                ]
+            )
         )
         // suspicious display text
         or (


### PR DESCRIPTION
# Description

add logic to consider when the email.email is part of the disclaimer in the message

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/e96292f41032c7d41a15ec918865c7ac41b0a842fec6153080499e17ff68a69d)
