### PR TITLE
Create sender_new_domain_less_than_30d_unsolicited

### DIFF
--- a/detection-rules/sender_new_domain_less_than_30d_unsolicited
+++ b/detection-rules/sender_new_domain_less_than_30d_unsolicited
@@ -1,0 +1,13 @@
+name: "New sender domain (<=30d) from untrusted sender"
+description: "Detects inbound emails where the sender domain is between 11 and 30 days old from an unsolicited sender."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and 10 < network.whois(sender.email.domain).days_old <= 30
+  and not profile.by_sender().solicited
+tags:
+ - "Attack surface reduction"
+detection_methods:
+  - "Sender analysis"
+  - "Whois"


### PR DESCRIPTION
Adding gap coverage for any unsolicited sender domains <=30d but greater than 10d to not duplicate rule firings.  