### PR TITLE
Create attachment_ics_file_non_rfc_compliant.yml

### DIFF
--- a/detection-rules/attachment_ics_file_non_rfc_compliant.yml
+++ b/detection-rules/attachment_ics_file_non_rfc_compliant.yml
@@ -1,7 +1,9 @@
 name: "Non-RFC Compliant Calendar Files from unsolicited sender"
 description: "Detects calendar (.ics) files that do not follow RFC standards by lacking required UID identifiers while containing specific calendar components (VTODO, VJOURNAL, VFREEBUSY, or VEVENT)."
 type: "rule"
-severity: ""
+severity: "medium"
+references:
+  - "https://mrd0x.com/spoofing-calendar-invites-using-ics-files/"
 source: |
   type.inbound
   and any(attachments,

--- a/detection-rules/attachment_ics_file_non_rfc_compliant.yml
+++ b/detection-rules/attachment_ics_file_non_rfc_compliant.yml
@@ -1,0 +1,38 @@
+name: "Non-RFC Compliant Calendar Files from unsolicited sender"
+description: "Detects calendar (.ics) files that do not follow RFC standards by lacking required UID identifiers while containing specific calendar components (VTODO, VJOURNAL, VFREEBUSY, or VEVENT)."
+type: "rule"
+severity: ""
+source: |
+  type.inbound
+  and any(attachments,
+          (
+            .file_type in $file_extensions_common_archives
+            or .file_extension == "ics"
+            or .content_type == "text/calendar"
+          )
+          and any(file.explode(.),
+                  (.file_extension == "ics" or .flavors.mime == "text/calendar")
+                  and not any(.scan.strings.strings,
+                              strings.starts_with(., "UID:")
+                  )
+                  and any(.scan.strings.strings,
+                          strings.ilike(.,
+                                        "*VTODO*",
+                                        "*VJOURNAL*",
+                                        "*VFREEBUSY*",
+                                        "*VEVENT*"
+                          )
+                  )
+          )
+  )
+  and not profile.by_sender().solicited
+tags:
+ - "Attack surface reduction"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "Archive analysis"
+  - "Content analysis"
+  - "File analysis"
+  - "Sender analysis"

--- a/detection-rules/attachment_ics_file_non_rfc_compliant.yml
+++ b/detection-rules/attachment_ics_file_non_rfc_compliant.yml
@@ -8,7 +8,7 @@ source: |
   type.inbound
   and any(attachments,
           (
-            .file_type in $file_extensions_common_archives
+            .file_extension in $file_extensions_common_archives
             or .file_extension == "ics"
             or .content_type == "text/calendar"
           )

--- a/detection-rules/attachment_ics_file_non_rfc_compliant.yml
+++ b/detection-rules/attachment_ics_file_non_rfc_compliant.yml
@@ -36,3 +36,4 @@ detection_methods:
   - "Content analysis"
   - "File analysis"
   - "Sender analysis"
+id: "9859f100-5fa5-5bb5-9ca6-bce8925afe6d"

--- a/detection-rules/attachment_ics_file_non_rfc_compliant.yml
+++ b/detection-rules/attachment_ics_file_non_rfc_compliant.yml
@@ -1,5 +1,5 @@
 name: "Non-RFC Compliant Calendar Files from unsolicited sender"
-description: "Detects calendar (.ics) files that do not follow RFC standards by lacking required UID identifiers while containing specific calendar components (VTODO, VJOURNAL, VFREEBUSY, or VEVENT)."
+description: "Detects calendar (.ics) files that do not follow RFC standards by lacking required UID identifiers while containing specific calendar components (VTODO, VJOURNAL, VFREEBUSY, or VEVENT). Forged ICS calendar invites can be spoofed to seemingly originate from any sender."
 type: "rule"
 severity: "medium"
 references:


### PR DESCRIPTION
# Description

Detects calendar (.ics) as a direct attachment or archive, that do not follow RFC standards by lacking required UID identifiers while containing specific calendar components (VTODO, VJOURNAL, VFREEBUSY, or VEVENT).

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/a3844eddd73dbc3088ff5741b3d50fb98db3966ba5dfd698a7ce5403621d814a)