### PR TITLE
Update attachment_adobe_image_lure_qr_code.yml

### DIFF
--- a/detection-rules/attachment_adobe_image_lure_qr_code.yml
+++ b/detection-rules/attachment_adobe_image_lure_qr_code.yml
@@ -16,7 +16,13 @@ source: |
                  .name == "Adobe"
           )
           or any(file.explode(.),
-               any(.scan.strings.strings, regex.icontains(., "adobe (acrobat|sign)"))
+                 any(.scan.strings.strings,
+                     regex.icontains(., "adobe (acrobat|sign)")
+                     // negate PDF data, like "xmp:CreatorTool>Adobe Acrobat Pro (64-bit) 24.4.20272</xmp:CreatorTool>"
+                     and not regex.icontains(.,
+                                             "(creatortool|producer|creator).{1,5}adobe acrobat"
+                     )
+                 )
           )
         )
     )


### PR DESCRIPTION
# Description

Negating strings in PDFs denoting the PDF creator/producer as Adobe Acrobat.

# Associated samples

- https://platform.sublime.security/messages/e2837a5f62cb4356af4a1db105a0d6cfc83355a0ee7f8024536c2519d0ce0e00
