### PR TITLE
Create malformed_ole_header rule and yara

### DIFF
--- a/detection-rules/attachment_malformed_ole.yml
+++ b/detection-rules/attachment_malformed_ole.yml
@@ -21,3 +21,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "YARA"
+id: "5aadc68f-9a67-5fd0-a825-3d7e1c5bfcb3"

--- a/detection-rules/attachment_malformed_ole.yml
+++ b/detection-rules/attachment_malformed_ole.yml
@@ -1,0 +1,23 @@
+name: "Attachment: Malformed OLE file"
+description: |
+  Attached OLE file (typically a Microsoft Office document) is malformed, possibly to evade traditional scanners and filters.
+references:
+  - "https://x.com/anyrun_app/status/1861024182210900357"
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(attachments,
+          .file_extension in $file_extensions_macros
+          and any(file.explode(.),
+                  any(.scan.yara.matches, .name == "MALFORMED_OLE_HEADER")
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Evasion"
+detection_methods:
+  - "File analysis"
+  - "YARA"

--- a/yara/malformed_ole_header.yar
+++ b/yara/malformed_ole_header.yar
@@ -1,0 +1,18 @@
+rule MALFORMED_OLE_HEADER
+{
+    meta:
+        description = "Detects files starting with PK but not PK\\x03\\x04, while containing PK\\x03\\x04 later in the file."
+        author = "Aiden Mitchell"
+        created = "2024-11-25"
+        
+    strings:
+        $pk_start = { 50 4B }
+        $normal_pk = { 50 4B 03 04 }
+        
+    condition:
+        // File must start with PK but not PK\x03\x04
+        uint16(0) == 0x4B50 and
+        not (uint32(0) == 0x04034B50) and
+        // PK\x03\x04 must appear somewhere after the start
+        $normal_pk in (2..filesize)
+}

--- a/yara/malformed_ole_header.yar
+++ b/yara/malformed_ole_header.yar
@@ -9,11 +9,6 @@ rule MALFORMED_OLE_HEADER
         $pk_start = { 50 4B }
         $normal_pk = { 50 4B 03 04 }
         
-        // Define the forbidden starting signatures
-        $pk_local = { 50 4B 03 04 }    // Local file header
-        $pk_empty = { 50 4B 05 06 }    // Empty archive marker
-        $pk_span = { 50 4B 07 08 }     // Spanned archive marker
-        
     condition:
         $pk_start at 0 and
         

--- a/yara/malformed_ole_header.yar
+++ b/yara/malformed_ole_header.yar
@@ -9,10 +9,21 @@ rule MALFORMED_OLE_HEADER
         $pk_start = { 50 4B }
         $normal_pk = { 50 4B 03 04 }
         
+        // Define the forbidden starting signatures
+        $pk_local = { 50 4B 03 04 }    // Local file header
+        $pk_empty = { 50 4B 05 06 }    // Empty archive marker
+        $pk_span = { 50 4B 07 08 }     // Spanned archive marker
+        
     condition:
-        // File must start with PK but not PK\x03\x04
-        uint16(0) == 0x4B50 and
-        not (uint32(0) == 0x04034B50) and
-        // PK\x03\x04 must appear somewhere after the start
+        $pk_start at 0 and
+        
+        // Must not start with any of the standard signatures
+        not (
+            uint32(0) == 0x04034B50 or  // PK\x03\x04 in little-endian
+            uint32(0) == 0x06054B50 or  // PK\x05\x06 in little-endian
+            uint32(0) == 0x08074B50     // PK\x07\x08 in little-endian
+        ) and
+        
+        // Must contain normal PK signature somewhere after the start
         $normal_pk in (2..filesize)
 }


### PR DESCRIPTION
# Description

Attached OLE file (typically a Microsoft Office document) is malformed, possibly to evade traditional scanners and filters.

# Associated samples

- https://play.sublime.security/?id=433175ff-a12b-4112-8086-4342952e3a47