### PR TITLE
Update link_google_open_redirect_with_suspicious_indicators.yml

### DIFF
--- a/detection-rules/link_google_open_redirect_with_suspicious_indicators.yml
+++ b/detection-rules/link_google_open_redirect_with_suspicious_indicators.yml
@@ -15,6 +15,7 @@ source: |
   // negate auth'ed google messages
   and not (
     sender.email.domain.sld == "google"
+    and sender.email.local_part in ("googlealerts-noreply", "comments-noreply@docs.google.com")
     and headers.auth_summary.spf.pass
     and headers.auth_summary.dmarc.pass
   )

--- a/detection-rules/link_google_open_redirect_with_suspicious_indicators.yml
+++ b/detection-rules/link_google_open_redirect_with_suspicious_indicators.yml
@@ -12,10 +12,9 @@ source: |
     or length(attachments) == 0
   )
   and sender.email.domain.root_domain not in $org_domains
-  // negate auth'ed google alerts
+  // negate auth'ed google messages
   and not (
     sender.email.domain.sld == "google"
-    and sender.email.local_part == "googlealerts-noreply"
     and headers.auth_summary.spf.pass
     and headers.auth_summary.dmarc.pass
   )

--- a/detection-rules/link_google_open_redirect_with_suspicious_indicators.yml
+++ b/detection-rules/link_google_open_redirect_with_suspicious_indicators.yml
@@ -15,7 +15,7 @@ source: |
   // negate auth'ed google messages
   and not (
     sender.email.domain.sld == "google"
-    and sender.email.local_part in ("googlealerts-noreply", "comments-noreply@docs.google.com")
+    and sender.email.local_part in ("googlealerts-noreply", "comments-noreply")
     and headers.auth_summary.spf.pass
     and headers.auth_summary.dmarc.pass
   )


### PR DESCRIPTION
# Description

Negate additional sender from google where it passed auth

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/322074e3a0fed924ef72257f3e5aa8e2cadbb01815fa4388efcba35b1c606763)