### PR TITLE
Update link_adobe_share_suspicious.yml

### DIFF
--- a/detection-rules/link_adobe_share_suspicious.yml
+++ b/detection-rules/link_adobe_share_suspicious.yml
@@ -42,6 +42,15 @@ source: |
     // the NLU detected "sender" is included within the body wrapped with new lines indicating it's a "signature"
     or any(filter(ml.nlu_classifier(body.current_thread.text).entities,
                   .name == "sender" and .text not in ('Customer Support', 'SHARED ON')
+                  // in some cases the filename is detected as the sender
+                  // we can filter out this case when the detected "sender"
+                  // text is the file shared
+                  and not strings.icontains(body.current_thread.text,
+                                            strings.concat("invited you to edit\n",
+                                                           .text,
+                                                           "\nOpen"
+                                            )
+                  )
            ),
            strings.icontains(body.current_thread.text,
                              strings.concat("\n", .text, "\n")


### PR DESCRIPTION
# Description
add negation for when the filename being shared is detected as a sender

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/a0d7355103422e0bf02b34c65a73a555696704d306d72e40f8c84802a381b631)
