### PR TITLE
Update impersonation_wells_fargo.yml

### DIFF
--- a/detection-rules/impersonation_wells_fargo.yml
+++ b/detection-rules/impersonation_wells_fargo.yml
@@ -38,6 +38,7 @@ source: |
       and not headers.auth_summary.dmarc.pass
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+    or sender.email.email == "drive-shares-noreply@google.com"  // Google Drive abuse has been observed
   )
 
 attack_types:

--- a/detection-rules/impersonation_wells_fargo.yml
+++ b/detection-rules/impersonation_wells_fargo.yml
@@ -10,8 +10,8 @@ source: |
   type.inbound
   and (
     sender.display_name =~ 'wellsfargo'
-    or strings.ilevenshtein(sender.display_name, 'wellsfargo') <= 1
-    or regex.icontains(sender.display_name, "wells?fargo")
+    or strings.ilevenshtein(strings.replace_confusables(sender.display_name), 'wellsfargo') <= 1
+    or regex.icontains(strings.replace_confusables(sender.display_name), 'wells?\s?farg(o|o͙)')
     or strings.ilike(sender.email.domain.domain, '*wellsfargo*')
     or strings.ilike(subject.subject, '*wells fargo security*')
     or strings.ilike(body.plain.raw, '*wells fargo security team*')

--- a/detection-rules/impersonation_wells_fargo.yml
+++ b/detection-rules/impersonation_wells_fargo.yml
@@ -38,7 +38,7 @@ source: |
       and not headers.auth_summary.dmarc.pass
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
-    or sender.email.email == "drive-shares-noreply@google.com"  // Google Drive abuse has been observed
+    or sender.email.email in ("drive-shares-noreply@google.com", "drive-shares-dm-noreply@google.com")  // Google Drive abuse has been observed
   )
 
 attack_types:

--- a/detection-rules/impersonation_wells_fargo.yml
+++ b/detection-rules/impersonation_wells_fargo.yml
@@ -11,7 +11,7 @@ source: |
   and (
     sender.display_name =~ 'wellsfargo'
     or strings.ilevenshtein(strings.replace_confusables(sender.display_name), 'wellsfargo') <= 1
-    or regex.icontains(strings.replace_confusables(sender.display_name), 'wells?\s?farg(o|o͙)')
+    or regex.icontains(strings.replace_confusables(sender.display_name), 'we(ll|ii)s?\s?farg(o|o͙)')
     or strings.ilike(sender.email.domain.domain, '*wellsfargo*')
     or strings.ilike(subject.subject, '*wells fargo security*')
     or strings.ilike(body.plain.raw, '*wells fargo security team*')


### PR DESCRIPTION
# Description
Adding `replace_confusables`, additional permutations of the regex check, and an inclusion of Google Drive as the sender, bypassing the high trust check.

# Associated samples
- https://platform.sublime.security/messages/bd8ce8de2311398fbdd8c9fa3b63c8ccef1f5f9762f4d7508cd089e0f2a98146
- https://platform.sublime.security/messages/4e583c4e97ed67dd8671c4c6799e9936c68d5e538bca2d24c9705b4f4c5ec4f5
