### PR TITLE
Create lookalike_domain_with_suspicious_language.yml

### DIFF
--- a/detection-rules/lookalike_domain_with_suspicious_language.yml
+++ b/detection-rules/lookalike_domain_with_suspicious_language.yml
@@ -17,8 +17,8 @@ source: |
           and not sender.email.domain.root_domain == "onmicrosoft.com"
           and ( 
             // domains are not registered or registered within 90d
-            network.whois(.href_url.domain).found == false
-            or network.whois(.href_url.domain).days_old <= 90
+            // network.whois(.href_url.domain).found == false
+            network.whois(.href_url.domain).days_old <= 90
             or network.whois(sender.email.domain).found == false
             or network.whois(sender.email.domain).days_old <= 90
           )

--- a/detection-rules/lookalike_domain_with_suspicious_language.yml
+++ b/detection-rules/lookalike_domain_with_suspicious_language.yml
@@ -1,7 +1,7 @@
 name: "Suspected Lookalike domain with suspicious language"
 description: "This rule identifies messages where links use typosquatting or lookalike domains similar to the sender domain, with at least one domain being either unregistered or recently registered (≤90 days). The messages must also contain indicators of business email compromise (BEC), credential theft, or abusive language patterns like financial terms or polite phrasing such as kindly. This layered approach targets phishing attempts combining domain deception with manipulative content"
 type: "rule"
-severity: "high"
+severity: "medium"
 source: |
   type.inbound
   

--- a/detection-rules/lookalike_domain_with_suspicious_language.yml
+++ b/detection-rules/lookalike_domain_with_suspicious_language.yml
@@ -34,7 +34,8 @@ source: |
                  )
           )
   )
-
+tags:
+ - "Attack surface reduction"
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:

--- a/detection-rules/lookalike_domain_with_suspicious_language.yml
+++ b/detection-rules/lookalike_domain_with_suspicious_language.yml
@@ -1,0 +1,48 @@
+name: "Suspected Lookalike domain with suspicious language"
+description: "This rule identifies messages where links use typosquatting or lookalike domains similar to the sender domain, with at least one domain being either unregistered or recently registered (≤90 days). The messages must also contain indicators of business email compromise (BEC), credential theft, or abusive language patterns like financial terms or polite phrasing such as "kindly." This layered approach targets phishing attempts combining domain deception with manipulative content"
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  
+  // levenshtein distance (edit distance) between the SLD of the link and the sender domain is greater than 0 and less than or equal to 2.
+  // This detects typosquatting or domains that are deceptively similar to the sender.
+  
+  and any(body.links,
+          length(.href_url.domain.sld) > 3
+          and 0 < strings.levenshtein(.href_url.domain.sld,
+                                      sender.email.domain.sld
+          ) <= 2
+          //exclude onmicrosoft.com
+          and not sender.email.domain.root_domain == "onmicrosoft.com"
+          and ( 
+            // domains are not registered or registered within 90d
+            network.whois(.href_url.domain).found == false
+            or network.whois(.href_url.domain).days_old <= 90
+            or network.whois(sender.email.domain).found == false
+            or network.whois(sender.email.domain).days_old <= 90
+          )
+  )
+  // the mesasge is intent is BEC or Cred Theft, or is talking about financial invoicing/banking language, or a request contains "kindly"
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name in ("bec", "cred_theft")
+          or any(ml.nlu_classifier(body.current_thread.text).entities,
+                 .name == "financial"
+                 and (
+                   .text in ("invoice", "banking information")
+                   or .name == "request" and strings.icontains(.text, "kindly")
+                 )
+          )
+  )
+
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Evasion"
+  - "Lookalike domain"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"
+  - "Whois"

--- a/detection-rules/lookalike_domain_with_suspicious_language.yml
+++ b/detection-rules/lookalike_domain_with_suspicious_language.yml
@@ -1,5 +1,5 @@
 name: "Suspected Lookalike domain with suspicious language"
-description: "This rule identifies messages where links use typosquatting or lookalike domains similar to the sender domain, with at least one domain being either unregistered or recently registered (≤90 days). The messages must also contain indicators of business email compromise (BEC), credential theft, or abusive language patterns like financial terms or polite phrasing such as "kindly." This layered approach targets phishing attempts combining domain deception with manipulative content"
+description: "This rule identifies messages where links use typosquatting or lookalike domains similar to the sender domain, with at least one domain being either unregistered or recently registered (≤90 days). The messages must also contain indicators of business email compromise (BEC), credential theft, or abusive language patterns like financial terms or polite phrasing such as kindly. This layered approach targets phishing attempts combining domain deception with manipulative content"
 type: "rule"
 severity: "high"
 source: |

--- a/detection-rules/lookalike_domain_with_suspicious_language.yml
+++ b/detection-rules/lookalike_domain_with_suspicious_language.yml
@@ -46,3 +46,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Sender analysis"
   - "Whois"
+id: "3674ced0-691c-5faa-9ced-922e7201dc29"


### PR DESCRIPTION
# Description

This rule identifies messages where links use typosquatting or lookalike domains similar to the sender domain, with at least one domain being either unregistered or recently registered (≤90 days). The messages must also contain indicators of business email compromise (BEC), credential theft, or abusive language patterns like financial terms or polite phrasing such as "kindly." This layered approach targets phishing attempts combining domain deception with manipulative content"

# Associated samples

Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.

- [Sample 1](https://platform.sublime.security/rules/editor?canonical_id=1a38a3b08c746a1cfd9d009dc88c0cbe1f9ddd76ca5b780a1d433ea4c5b30a9c&message_id=01939dbd-6e5d-75ba-8bf0-b08ae113f1b4)
- [Sample 2](https://platform.sublime.security/messages/44523e95935136224053e837d517dc026e7c8d646e3af92671f2a9d3d898c8ed)
