### PR TITLE
Update abuse_docusign_sus_names.yml

### DIFF
--- a/detection-rules/abuse_docusign_sus_names.yml
+++ b/detection-rules/abuse_docusign_sus_names.yml
@@ -42,7 +42,7 @@ source: |
                       or .email.domain.domain not in $free_email_providers
                     )
              ),
-             .email.domain.root_domain in $sender_domains
+             .email.domain.domain in $sender_domains
       )
     )
   


### PR DESCRIPTION
# Description

use reply_to .email.domain.domain instead of .email.domain.root_domain to avoid FPs

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/858b6bcf899bf4b3165c26f911d5371b1c5e91ca97b89b7f771cd3e0d5f8ff71)
