### PR TITLE
Update link_fake_password_expiration.yml

### DIFF
--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -5,8 +5,8 @@ severity: "medium"
 source: |
   type.inbound
   
-  // few links
-  and 0 < length(body.links) < 10
+  // few links which are not in $org_domains
+  and 0 < length(filter(body.links, .href_url.domain.domain not in $org_domains)) <= 10
   
   // no attachments or suspicious attachment
   and (
@@ -16,6 +16,18 @@ source: |
            and any(file.explode(.),
                    .scan.entropy.entropy > 7 and length(.scan.ocr.raw) < 20
            )
+    )
+    // or there are duplicate pdfs in name 
+    or (
+      length(filter(attachments, .file_type == "pdf")) > length(distinct(filter(attachments,
+                                                                                .file_type == "pdf"
+                                                                         ),
+                                                                         .file_name
+                                                                )
+      )
+      or 
+      // all PDFs are the same MD5
+      length(distinct(filter(attachments, .file_type == "pdf"), .md5)) == 1
     )
   )
   
@@ -93,11 +105,13 @@ source: |
       )
       or regex.icontains(body.html.raw, '(?:<p>\s*&nbsp;\s*</p>\s*){7,}')
       or regex.icontains(body.html.raw, '(?:<p>\s*&nbsp;\s*</p>\s*<br>\s*){7,}')
-      or regex.icontains(body.html.raw, '(?:<p[^>]*>\s*&nbsp;\s*<br>\s*</p>\s*){5,}')
+      or regex.icontains(body.html.raw,
+                         '(?:<p[^>]*>\s*&nbsp;\s*<br>\s*</p>\s*){5,}'
+      )
       or regex.icontains(body.html.raw, '(?:<p[^>]*>&nbsp;</p>\s*){7,}')
     )
   )
-
+  
   // a body link does not match the sender domain
   and any(body.links,
           .href_url.domain.root_domain != sender.email.domain.root_domain


### PR DESCRIPTION
# Description

change body.links limit check to use only domains not in the org_domains (avoid domains captured from emails)
additional logic for PDF detection based on duplicate PDF attachments

# Associated samples

Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.

- [Sample 1](https://platform.sublime.security/messages/b25101cd39deb75a145b42a856644a9053c37665d407c4134cef366dcaf6bf1f)
- [Sample 2](https://platform.sublime.security/messages/f233cd4b090858d7ebc92cf007c9d9d61804463cce4207b847b06f95c00b34d5)

## Associated hunts

If you ran any hunts with your rule, please link them here.

- [Hunt 1](https://platform.sublime.security/hunts/0193b922-a495-7a4a-9c7b-16d585fc6901)

# Screenshot (insights)

**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
