### PR TITLE
Update impersonation_sharepoint_fake_file_share.yml

### DIFF
--- a/detection-rules/impersonation_sharepoint_fake_file_share.yml
+++ b/detection-rules/impersonation_sharepoint_fake_file_share.yml
@@ -15,7 +15,9 @@ source: |
                           "*shared a file with you*",
                           "*shared with you*",
                           "*invited you to access a file*",
-                          "*you've received a document*"
+                          "*you've received a document*",
+                          "*shared a document*",
+                          "*shared this document*"
             )
         )
         or any(file.explode(beta.message_screenshot()),
@@ -23,7 +25,9 @@ source: |
                              "*shared a file with you*",
                              "*shared with you*",
                              "*invited you to access a file*",
-                             "*you've received a document*"
+                             "*you've received a document*",
+                             "*shared a document*",
+                             "*shared this document*"
                )
         )
       )
@@ -40,8 +44,14 @@ source: |
                          "*PowerPoint*",
                          "*OneNote*"
         )
+        or any(body.links, strings.icontains(.display_text, "OPEN DOCUMENT"))
         or subject.subject is null
         or subject.subject == ""
+        // the org as determined by NLU is in the subject
+        or any(ml.nlu_classifier(body.current_thread.text).entities,
+               .name == "org" and strings.icontains(subject.subject, .text)
+        )
+       
       )
     )
     or any([
@@ -210,7 +220,7 @@ source: |
         regex.icontains(body.html.raw, 'rgb\((25[0-5]),\s?(20[0-2]),\s?([0-7])\)')
       )
       or regex.icontains(body.html.raw,
-                       '<a[^>]+style="[^"]*background-color:\s*#[0-9A-F]{2}[5-9A-F]{2}[0-9A-F]{2}[^"]*"[^>]*>[^<]*(?:open)[^<]*</a>' // blue button containing the word "open"
+                         '<a[^>]+style="[^"]*background-color:\s*#[0-9A-F]{2}[5-9A-F]{2}[0-9A-F]{2}[^"]*"[^>]*>[^<]*(?:open)[^<]*</a>' // blue button containing the word "open"
       )
       or (
         any(recipients.to,
@@ -263,14 +273,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-  and (
-    (not profile.by_sender().solicited)
-    or (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_false_positives
-    )
-  )
-  and not profile.by_sender().any_false_positives
 attack_types:
   - "Credential Phishing"
   - "Malware/Ransomware"


### PR DESCRIPTION
# Description

1. additional "sharing" keywords in body/message screenshot
1. add "Open Document" as another indicator of being a sharepoint share 


# Associated samples

- [Sample 1](https://platform.sublime.security/messages/d7caf4ce8cec4ff0d0c882e04d1a32bc3c1be7c954c61df80f15236c5d77c7b5)
- [Sample 2](https://platform.sublime.security/messages/56b614165c9849a213ca981cf7fe38a926587da2038cb2522166b6ac85c77b6b)
