### PR TITLE
Update salesforce_infra_abuse.yml

### DIFF
--- a/detection-rules/salesforce_infra_abuse.yml
+++ b/detection-rules/salesforce_infra_abuse.yml
@@ -8,11 +8,17 @@ source: |
   // we look at the return-path because many times in the abuse
   // we've seen, the From is a custom domain
   and headers.return_path.domain.root_domain == "salesforce.com"
-  
-  // legit salesforce email addresses that haven't been observed to be abused
-  and sender.email.email not in ("support@salesforce.com")
   and length(attachments) == 0
-  and length(body.links) > 0
+  // theare are external links (not org or SF domains)
+  and length(filter(body.links,
+                    .href_url.domain.domain not in $org_domains
+                    and .href_url.domain.root_domain not in (
+                      "salesforce.com",
+                      "force.com",
+                      "site.com" // salesforce CRM 
+                    )
+             )
+  ) > 0
   and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == "cred_theft" and .confidence == "high"
   )
@@ -23,7 +29,8 @@ source: |
               .href_url.domain.root_domain != sender.email.domain.root_domain
               and .href_url.domain.root_domain not in (
                 "salesforce.com",
-                "force.com"
+                "force.com",
+                "site.com"
               )
       )
     ),
@@ -48,6 +55,7 @@ source: |
                     "account (will be )?block",
                     "account.*de-?activat",
                     "account.*locked",
+                    "account.*restrict",
                     "account.*re-verification",
                     "account.*security",
                     "account.*suspension",
@@ -151,6 +159,8 @@ source: |
                     "your (customer )?account .as",
                     "your.office.365",
                     "your.online.access",
+                    "Critical.Notice",
+                    "Restore.Access",
                     // https://github.com/sublime-security/static-files/blob/master/suspicious_subjects.txt
                     "account has been limited",
                     "action required",
@@ -215,6 +225,7 @@ source: |
                     "w2",
                     "you have notifications pending",
                     "your account",
+                    'your (?:\w+\s+){0,1}\s*account',
                     "your amazon order",
                     "your document settlement",
                     "your order with amazon",
@@ -227,10 +238,14 @@ source: |
     // otherwise, it should be from salesforce
     (
       sender.email.domain.domain == "salesforce.com"
-      and any(headers.hops,
-              any(.fields,
-                  .name == "X-SFDC-EmailCategory" and .value == "apiMassMail"
-              )
+      and (
+        any(headers.hops,
+            any(.fields,
+                .name == "X-SFDC-EmailCategory"
+                and .value in ("apiMassMail", "networksNewUser")
+            )
+        )
+        or headers.x_sender.email == "postmaster@salesforce.com"
       )
     )
     or (
@@ -255,7 +270,6 @@ source: |
       )
     )
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/salesforce_infra_abuse.yml
+++ b/detection-rules/salesforce_infra_abuse.yml
@@ -238,14 +238,11 @@ source: |
     // otherwise, it should be from salesforce
     (
       sender.email.domain.domain == "salesforce.com"
-      and (
-        any(headers.hops,
-            any(.fields,
-                .name == "X-SFDC-EmailCategory"
-                and .value in ("apiMassMail", "networksNewUser")
-            )
-        )
-        or headers.x_sender.email == "postmaster@salesforce.com"
+      and any(headers.hops,
+              any(.fields,
+                  .name == "X-SFDC-EmailCategory"
+                  and .value in ("apiMassMail", "networksNewUser")
+              )
       )
     )
     or (


### PR DESCRIPTION
# Description

1. Remove negation for support at after observing abuse in the wild.
1. Determine body links length by counting "external "domains only
1. Add negations for site.com which is also owned by salesforce
1. Add additional criteria for suspicious subjects

# Associated samples
Matched TP
- [Sample 1](https://platform.sublime.security/messages/80c804abe22ad93a42b68a976ab889d403b83ed90b57db851dd02ae1635b4d24)
- [Sample 2](https://platform.sublime.security/messages/42a4a2242dfc7df1c663731c0d8c47a32691ce3f6cb6db6883628c0d6c416e14)

FPs that will be resolved by accounting for site.com
- [Sample 1](https://platform.sublime.security/messages/c573e6e55fd87bf4dd5e1f0b05a453d20119700208ebac702ab0623eaee3b41a)
- [Sample 2](https://platform.sublime.security/messages/82070fb12e680b58aa20ad7ca79b1ad4534a4c04919cee87eb497fab67491385)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/hunts/0193c177-134f-7de7-a173-d6b265216efb)
