### PR TITLE
Update suspicious_request_for_quote_or_purchase.yml

### DIFF
--- a/detection-rules/suspicious_request_for_quote_or_purchase.yml
+++ b/detection-rules/suspicious_request_for_quote_or_purchase.yml
@@ -10,7 +10,12 @@ source: |
     (
       (
         length(recipients.to) == 0
-        or all(recipients.to, .display_name == "Undisclosed recipients")
+        or all(recipients.to,
+               .display_name in (
+                 "Undisclosed recipients",
+                 "undisclosed-recipients"
+               )
+        )
       )
       and length(recipients.cc) == 0
       and length(recipients.bcc) == 0
@@ -39,10 +44,14 @@ source: |
                         '(sign(ed?)|view).{0,10}(purchase order)|Request for a Quot(e|ation)'
         )
       ),
-      (regex.icontains(body.current_thread.text, '(please|kindly).{0,30}quot(e|ation)')),
+      (
+        regex.icontains(body.current_thread.text,
+                        '(please|kindly).{0,30}quot(e|ation)'
+        )
+      ),
       (
         regex.icontains(subject.subject,
-                        '(request for (purchase|quot(e|ation))|\bRFQ\b|\bRFP\b)'
+                        '(request for (purchase|quot(e|ation))|\bRFQ\b|\bRFP\b|bid invit(e|ation))'
         )
       ),
       (
@@ -63,6 +72,22 @@ source: |
             .name == "purchase_order" and .confidence == "high"
         )
       ),
+      (
+        0 < length(filter(body.links,
+                          (
+                            .href_url.domain.domain in $free_subdomain_hosts
+                            or .href_url.domain.domain in $free_file_hosts
+                            or network.whois(.href_url.domain).days_old < 30
+                          )
+                          and (
+                            regex.match(.display_text, '[A-Z ]+')
+                            or any(ml.nlu_classifier(.display_text).entities,
+                                   .name in ("request", "urgency")
+                            )
+                          )
+                   )
+        ) < 3
+      )
     )
     or (
       length(attachments) == 1


### PR DESCRIPTION
# Description

* Updated the condition to check for undisclosed recipients to include both "Undisclosed recipients" and "undisclosed-recipients".
* Expanded the regex pattern in the subject check to include "bid invitation".
* Added a new condition to check for suspicious links in the email body, including criteria for free subdomain hosts, free file hosts, and domains registered within the last 30 days.

# Associated samples
- https://platform.sublime.security/messages/bbb4908f8bfebb367666b9762163e2d4bb87728e10044c9f620d6b474a8e86b2
