### PR TITLE
Create unrelated_sharepoint_link.yml

### DIFF
--- a/detection-rules/unrelated_sharepoint_link.yml
+++ b/detection-rules/unrelated_sharepoint_link.yml
@@ -66,6 +66,7 @@ source: |
             )
           )
           and not strings.icontains(.href_url.path, sender.email.local_part)
+          and not any($org_slds, strings.icontains(..href_url.domain.subdomain, .))
   
           // it is either a OneNote or PDF file, or unknown
           and (
@@ -74,8 +75,6 @@ source: |
             or strings.icontains(.href_url.path, '/:u:/p')
           )
   
-  // a future negation like this would be great
-  // and any($org_domains, .domain.subdomain != ..href_url.domain.subdomain)
   )
   
   // a way to negate long threads

--- a/detection-rules/unrelated_sharepoint_link.yml
+++ b/detection-rules/unrelated_sharepoint_link.yml
@@ -108,3 +108,4 @@ detection_methods:
   - "Sender analysis"
   - "Header analysis"
   - "HTML analysis"
+id: "6870f489-5581-53f0-a6f7-a03e259fb073"

--- a/detection-rules/unrelated_sharepoint_link.yml
+++ b/detection-rules/unrelated_sharepoint_link.yml
@@ -1,0 +1,110 @@
+name: "Sharepoint Link Likely Unrelated to Sender"
+description: "Detects when a sender links to a Sharepoint file where the subdomain significantly differs from the sender's domain. The rule checks for OneNote, PDF, or unknown file types and includes various domain validation checks."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  
+  and 0 < length(body.links) < 10
+  and any(filter(body.links, .href_url.domain.root_domain == 'sharepoint.com'),
+          // Normalize Levenshtein distance by string length (0 = identical, 0.7+ = different)
+          // Working with what we have in MQL, considering we dont have max() or any other forms of string distancing
+          (
+            (
+              strings.iends_with(.href_url.domain.subdomain,
+                                 '-my'
+              ) // common Sharepoint subdomain suffix
+              and (
+                (
+                  strings.ilevenshtein(.href_url.domain.subdomain,
+                                       sender.email.domain.sld
+                  ) - 3 // subtract aforementioned suffix for more accurate calculation
+                ) / (
+                  (
+                    (length(.href_url.domain.subdomain) - 3) + length(sender.email.domain.sld
+                    )
+   + (
+                      (
+                        (length(.href_url.domain.subdomain) - 3) - length(sender.email.domain.sld
+                        )
+                      ) + (
+                        length(sender.email.domain.sld) - (
+                          length(.href_url.domain.subdomain) - 3
+                        )
+                      )
+                    )
+                  ) / 2.0 // to ensure we keep the result as a float
+                )
+              ) > 0.7 // customizable threshold
+            )
+            or (
+              not strings.iends_with(.href_url.domain.subdomain,
+                                     '-my'
+              ) // no suffix, continue with original calculation
+              and (
+                strings.ilevenshtein(.href_url.domain.subdomain,
+                                     sender.email.domain.sld
+                ) / (
+                  (
+                    length(.href_url.domain.subdomain) + length(sender.email.domain.sld
+                    )
+   + (
+                      (
+                        length(.href_url.domain.subdomain) - length(sender.email.domain.sld
+                        )
+                      ) + (
+                        length(sender.email.domain.sld) - length(.href_url.domain.subdomain
+                        )
+                      )
+                    )
+                  ) / 2.0 // to ensure we keep the result as a float
+                )
+              ) > 0.7 // customizable threshold
+            )
+          )
+          and not strings.icontains(.href_url.path, sender.email.local_part)
+  
+          // it is either a OneNote or PDF file, or unknown
+          and (
+            strings.icontains(.href_url.path, '/:o:/')
+            or strings.icontains(.href_url.path, '/:b:/')
+            or strings.icontains(.href_url.path, '/:u:/')
+          )
+  
+          // a future negation like this would be great
+          // and any($org_domains, .domain.subdomain != ..href_url.domain.subdomain)
+  )
+  
+  // a way to negate long threads
+  // the full thread must be less than 6 times the length of the current thread
+  and length(body.html.inner_text) < 6 * length(body.current_thread.text)
+  
+  and sender.email.domain.root_domain not in (
+    "sharepoint.com",
+    "sharepointonline.com"
+  )
+  
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+tags:
+ - "Attack surface reduction"
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Employee"
+  - "Lookalike domain"
+  - "OneNote"
+  - "PDF"
+  - "Social engineering"
+detection_methods:
+  - "URL analysis"
+  - "Sender analysis"
+  - "Header analysis"
+  - "HTML analysis"

--- a/detection-rules/unrelated_sharepoint_link.yml
+++ b/detection-rules/unrelated_sharepoint_link.yml
@@ -4,8 +4,11 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  
+  and any(beta.ml_topic(body.html.display_text).topics,
+          .name == "File Sharing and Cloud Services" and .confidence == "high"
+  )
   and 0 < length(body.links) < 10
+  and length(body.html.display_text) < 2000
   and any(filter(body.links, .href_url.domain.root_domain == 'sharepoint.com'),
           // Normalize Levenshtein distance by string length (0 = identical, 0.7+ = different)
           // Working with what we have in MQL, considering we dont have max() or any other forms of string distancing
@@ -66,19 +69,18 @@ source: |
   
           // it is either a OneNote or PDF file, or unknown
           and (
-            strings.icontains(.href_url.path, '/:o:/')
-            or strings.icontains(.href_url.path, '/:b:/')
-            or strings.icontains(.href_url.path, '/:u:/')
+            strings.icontains(.href_url.path, '/:o:/p')
+            or strings.icontains(.href_url.path, '/:b:/p')
+            or strings.icontains(.href_url.path, '/:u:/p')
           )
   
-          // a future negation like this would be great
-          // and any($org_domains, .domain.subdomain != ..href_url.domain.subdomain)
+  // a future negation like this would be great
+  // and any($org_domains, .domain.subdomain != ..href_url.domain.subdomain)
   )
   
   // a way to negate long threads
   // the full thread must be less than 6 times the length of the current thread
   and length(body.html.inner_text) < 6 * length(body.current_thread.text)
-  
   and sender.email.domain.root_domain not in (
     "sharepoint.com",
     "sharepointonline.com"


### PR DESCRIPTION
# Description

> [!WARNING]
>  Requires `beta.ml_topic` to be GA; may require editing to match GA namespacing.

Detects when a sender links to a Sharepoint file where the subdomain significantly differs from the sender's domain. The rule checks for OneNote, PDF, or unknown file types and includes various domain validation checks.

# Associated samples

- https://platform.sublime.security/messages/1036717b520eae4ccb8a76add437a159a11f99d1aedbd9b6905bae62057883da
