### PR TITLE
Create headers_DL_unsolicited.yml

### DIFF
--- a/detection-rules/headers_DL_unsolicited.yml
+++ b/detection-rules/headers_DL_unsolicited.yml
@@ -30,7 +30,11 @@ source: |
             or .email.domain.root_domain in ("onmicrosoft.com")
           )
   )
-  
+  // if there are reply-to addresses, ensure they are also not assoicated with the org
+  and all(headers.reply_to,
+          .email.domain.domain not in $org_domains
+          and .display_name not in $org_display_names
+  )
   
   // check the return path to ensure it's not related to our sender or the mailbox at all
   and not strings.iends_with(headers.return_path.local_part,
@@ -49,7 +53,6 @@ source: |
                   )
               )
   )
-
 attack_types:
   - "Callback Phishing"
 tactics_and_techniques:

--- a/detection-rules/headers_DL_unsolicited.yml
+++ b/detection-rules/headers_DL_unsolicited.yml
@@ -1,4 +1,4 @@
-name: "Inbound Message Via Newly Observed Distribution List"
+name: "Inbound Message from Popular Service Via Newly Observed Distribution List"
 description: "Detects when a message comes through a distribution list by matching on return paths containing Sender Rewrite Scheme (SRS) from a previously unknown domain sender to a single recipient who has never interacted with the organization. This method has been observed being abused by threat actors to deliver callback phishing."
 type: "rule"
 severity: "medium"
@@ -7,10 +7,15 @@ source: |
   and length(recipients.to) == 1
   and length(recipients.cc) == 0
   and length(recipients.bcc) == 0
+  // abuse involves a popular service
+  and sender.email.domain.root_domain in $majestic_million
+
   // message is not from a free mail provider, we have only observed sevice providers abused
   and sender.email.domain.root_domain not in $free_email_providers
   and sender.email.domain.domain not in $free_email_providers
+  
   and not any(recipients.to, .email.email =~ sender.email.email)
+
   // uses Sender Rewrite Scheme indicating the message traversed a distribtion list or other automatic relay
   and strings.icontains(headers.return_path.local_part, "+SRS=")
   

--- a/detection-rules/headers_DL_unsolicited.yml
+++ b/detection-rules/headers_DL_unsolicited.yml
@@ -1,0 +1,60 @@
+name: "Inbound Message Via Newly Observed Distribution List"
+description: "Detects when a message comes through a distribution list by matching on return paths containing Sender Rewrite Scheme (SRS) from a previously unknown domain sender to a single recipient who has never interacted with the organization. This method has been observed being abused by threat actors to deliver callback phishing."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and length(recipients.to) == 1
+  and length(recipients.cc) == 0
+  and length(recipients.bcc) == 0
+  // message is not from a free mail provider, we have only observed sevice providers abused
+  and sender.email.domain.root_domain not in $free_email_providers
+  and sender.email.domain.domain not in $free_email_providers
+  and not any(recipients.to, .email.email =~ sender.email.email)
+  // uses Sender Rewrite Scheme indicating the message traversed a distribtion list or other automatic relay
+  and strings.icontains(headers.return_path.local_part, "+SRS=")
+  
+  // the sender and recipient is not in $org_domains
+  and sender.email.domain.domain not in $org_domains
+  // the recipient has never sent an email to the org
+  and all(recipients.to,
+          .email.domain.domain not in $org_domains
+          // ensure the recipient domain has never send/received an email to/from the org
+          and (
+            (
+              .email.domain.domain not in $sender_domains
+              and .email.domain.root_domain not in $sender_domains
+              and .email.domain.domain not in $recipient_domains
+              and .email.domain.root_domain not in $recipient_domains
+            )
+            or .email.domain.root_domain in ("onmicrosoft.com")
+          )
+  )
+  
+  
+  // check the return path to ensure it's not related to our sender or the mailbox at all
+  and not strings.iends_with(headers.return_path.local_part,
+                             strings.concat('@', sender.email.domain.domain)
+  )
+  and not strings.icontains(headers.return_path.local_part,
+                            mailbox.email.local_part
+  )
+  
+  // not an inbox rule or automatic forward from a Microsoft Account
+  and not any(headers.hops,
+              any(.fields,
+                  .name in (
+                    'X-MS-Exchange-ForwardingLoop',
+                    'X-MS-Exchange-Inbox-Rules-Loop'
+                  )
+              )
+  )
+
+attack_types:
+  - "Callback Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "Header analysis"
+  - "Sender analysis"

--- a/detection-rules/headers_DL_unsolicited.yml
+++ b/detection-rules/headers_DL_unsolicited.yml
@@ -58,3 +58,4 @@ tactics_and_techniques:
 detection_methods:
   - "Header analysis"
   - "Sender analysis"
+id: "8f4bc148-a6b3-5dc4-9d2b-893c38c86c48"


### PR DESCRIPTION
# Description

Add coverage for inbound messages using DLs to relay credential phishing.  This provides a generic method of detecting the technique in [this blog](https://sublime.security/blog/callback-phishing-via-invoice-abuse-and-distribution-list-relays/)

# Associated samples


- [Sample 1](https://platform.sublime.security/messages/f04c83d1d62abd1a327bcae4421d3e0cd1f220da0977281d2b6badd03ac9ec7c)
- [Sample 2](https://platform.sublime.security/messages/05899a0c66a8d88d3abca7852f017adf7d22daf4547a1561ffdf1fb6f56ab503)

## Associated hunts


- [Hunt 1](https://platform.sublime.security/hunts/0193e60c-7f2b-7b93-a718-25943afa67ed)
