### PR TITLE
Create attachment_html_excessive_const_declarations.yml

### DIFF
--- a/detection-rules/attachment_html_excessive_const_declarations.yml
+++ b/detection-rules/attachment_html_excessive_const_declarations.yml
@@ -1,4 +1,4 @@
-name: "Attachment: HTML file with excessive 'const' declarations"
+name: "Attachment: HTML file with excessive 'const' declarations and abnormally long timeouts"
 description: "Detects messages with HTML attachments containing multiple 'const' declarations while excluding legitimate Gmail messages. This is evidence of potential code injection or obfuscation techniques."
 type: "rule"
 severity: "high"
@@ -14,6 +14,10 @@ source: |
                                  "<!-- saved from url=.{0,7}https://mail.google.com/mail/u/0/#inbox/"
           )
           and length(file.parse_html(.).raw) < 50000
+          // long timeouts
+          and regex.icontains(file.parse_html(.).raw,
+                              'setTimeout\(\s*function\s*\(.*?\)\s*\{[\s\S]*?\},\s*\d+\);'
+          )
   )
   
   // and the sender is not from high trust sender root domains
@@ -24,7 +28,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
 attack_types:
   - "Malware/Ransomware"
   - "Credential Phishing"

--- a/detection-rules/attachment_html_excessive_const_declarations.yml
+++ b/detection-rules/attachment_html_excessive_const_declarations.yml
@@ -15,6 +15,15 @@ source: |
           )
           and length(file.parse_html(.).raw) < 50000
   )
+  
+  // and the sender is not from high trust sender root domains
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
 
 attack_types:
   - "Malware/Ransomware"

--- a/detection-rules/attachment_html_excessive_const_declarations.yml
+++ b/detection-rules/attachment_html_excessive_const_declarations.yml
@@ -16,7 +16,10 @@ source: |
           and length(file.parse_html(.).raw) < 50000
           // long timeouts
           and regex.icontains(file.parse_html(.).raw,
-                              'setTimeout\(\s*function\s*\(.*?\)\s*\{[\s\S]*?\},\s*\d+\);'
+                              'setTimeout\(\s*(?:function\s*)?\(.*?\)\s*(?:=>\s*)?\{[\s\S]*?\},\s*\d+\);',
+                              // const delay = new Promise((resolve) => setTimeout(resolve, 100));
+                              'setTimeout\(\s*\w+\,\s*\d{3,}\)+;'
+        )
           )
   )
   

--- a/detection-rules/attachment_html_excessive_const_declarations.yml
+++ b/detection-rules/attachment_html_excessive_const_declarations.yml
@@ -19,7 +19,6 @@ source: |
                               'setTimeout\(\s*(?:function\s*)?\(.*?\)\s*(?:=>\s*)?\{[\s\S]*?\},\s*\d+\);',
                               // const delay = new Promise((resolve) => setTimeout(resolve, 100));
                               'setTimeout\(\s*\w+\,\s*\d{3,}\)+;'
-        )
           )
   )
   

--- a/detection-rules/attachment_html_excessive_const_declarations.yml
+++ b/detection-rules/attachment_html_excessive_const_declarations.yml
@@ -1,0 +1,29 @@
+name: "Attachment: HTML file with excessive 'const' declarations"
+description: "Detects messages with HTML attachments containing multiple 'const' declarations while excluding legitimate Gmail messages. This is evidence of potential code injection or obfuscation techniques."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(attachments,
+          (
+            .file_extension in~ ("html", "htm", "shtml", "dhtml")
+            or .file_type == "html"
+          )
+          and strings.count(file.parse_html(.).raw, 'const') >= 7
+          and not regex.contains(file.parse_html(.).raw,
+                                 "<!-- saved from url=.{0,7}https://mail.google.com/mail/u/0/#inbox/"
+          )
+          and length(file.parse_html(.).raw) < 50000
+  )
+
+attack_types:
+  - "Malware/Ransomware"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "HTML smuggling"
+  - "Scripting"
+  - "Evasion"
+detection_methods:
+  - "HTML analysis"
+  - "File analysis"
+  - "Content analysis"

--- a/detection-rules/attachment_html_excessive_const_declarations.yml
+++ b/detection-rules/attachment_html_excessive_const_declarations.yml
@@ -27,3 +27,4 @@ detection_methods:
   - "HTML analysis"
   - "File analysis"
   - "Content analysis"
+id: "66f8a07a-5f0f-5a99-976c-a81d2de8b406"


### PR DESCRIPTION
# Description

This rule detects inbound emails containing HTML files with an unusually high number of const declarations, which can indicate obfuscated or injected malicious scripts. By targeting files with smaller sizes, it highlights potential threats involving compact, stealthy scripts often used for credential phishing, malware delivery, or HTML smuggling attacks. Legitimate Gmail messages are excluded to reduce false positives, ensuring the focus remains on anomalous and potentially malicious behavior.


## Associated hunts

If you ran any hunts with your rule, please link them here.

- [Hunt 1](https://platform.sublime.security/hunts/0193f714-5680-74b8-b2b9-90d1865b6f72)
