### PR TITLE
Update open_redirect_emp-eduyield.yml

### DIFF
--- a/detection-rules/open_redirect_emp-eduyield.yml
+++ b/detection-rules/open_redirect_emp-eduyield.yml
@@ -9,7 +9,7 @@ source: |
           .href_url.domain.domain == "emp.eduyield.com"
           // the redirect field
           and strings.icontains(.href_url.query_params, "&dest=")
-          and regex.icontains(.href_url.query_params, '&dest=(?:https?)?(?:(?:%3a|\:)?(?:\/|%2f){2})?google\.com[^\&]+\/+amp\/+s\/+')
+          and regex.icontains(.href_url.query_params, '&dest=(?:https?)?(?:(?:%3a|\:)?(?:\/|%2f){2})?google\.com[^\&]*\/+amp\/+s\/+')
   )
   and (
     not profile.by_sender().solicited


### PR DESCRIPTION
handle google urls that don't include anything between `google.com` and `/amp/`