### PR TITLE
Update impersonation_dhl.yml

### DIFF
--- a/detection-rules/impersonation_dhl.yml
+++ b/detection-rules/impersonation_dhl.yml
@@ -86,7 +86,8 @@ source: |
     'dhltariff.co.uk',
     'dhlindia-kyc.com',
     'dpogroup.com',
-    '4flow-service.com'  // shipping service
+    '4flow-service.com',  // shipping service
+    'deutschepost.de' // German postal service
   )
   and (
     profile.by_sender().prevalence in ("new", "outlier")


### PR DESCRIPTION
# Description

negating deutschepost.de (German postal service, owner of DHL)

# Associated samples

- https://platform.sublime.security/messages/fdf8d65254357a806068ba08232181af50b56565072149d8214ee6ea6e17d99d