### PR TITLE
Update impersonation_ledger.yml

### DIFF
--- a/detection-rules/impersonation_ledger.yml
+++ b/detection-rules/impersonation_ledger.yml
@@ -29,6 +29,7 @@ source: |
       and (
         strings.ilike(sender.email.email, '*-ledger.com*')
         or sender.display_name =~ "ledger"
+        or strings.istarts_with(sender.display_name, "ledger")
         or strings.ilevenshtein(sender.email.domain.sld, "ledger") <= 1
       )
       and (


### PR DESCRIPTION


# Description

Updating to look for sender display name starting with ledger... Saw misses for sender display names like Ledger Wallet, Ledger Incident response, etc.

# Associated samples

- [Sample 1](https://platform.sublime.security/rules/editor?canonical_id=37001a26f4efa4235c2cb4e8100a89b6bef15f3b4fdafd1697bc39eb32dbb5e1&message_id=01942758-688d-7085-a8a1-317f872f68af)


## Associated hunts

If you ran any hunts with your rule, please link them here.

- [Hunt 1](https://platform.sublime.security/hunts/01942a84-82e7-7a4e-8ed1-d46228e35da0)
