### PR TITLE
Update suspicious_request_for_quote_or_purchase.yml

### DIFF
--- a/detection-rules/suspicious_request_for_quote_or_purchase.yml
+++ b/detection-rules/suspicious_request_for_quote_or_purchase.yml
@@ -29,6 +29,7 @@ source: |
       length(headers.reply_to) > 0
       and all(headers.reply_to,
               .email.domain.root_domain != sender.email.domain.root_domain
+              and not .email.domain.root_domain in $org_domains
       )
     )
   )


### PR DESCRIPTION
# Description

Adding tolerance for org_domains being one of the reply-to addresses. This was commonly observed in third party alerting services. 

# Associated samples

Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.

- [Sample 1](https://platform.sublime.security/messages/288e0adc2242cf3036d8eeee3f12e7c37ecffcbffc7a704604193367b53fa511)

