### PR TITLE
Update impersonation_sharepoint_fake_file_share.yml

### DIFF
--- a/detection-rules/impersonation_sharepoint_fake_file_share.yml
+++ b/detection-rules/impersonation_sharepoint_fake_file_share.yml
@@ -250,6 +250,11 @@ source: |
                 "sharepoint.com"
               )
   )
+  // if there is a Sharepoint link, ensure the link doesn't match any org SLDs
+  and not any(body.links,
+              .href_url.domain.root_domain == "sharepoint.com"
+              and any($org_slds, . == ..href_url.domain.subdomain)
+  )
   and sender.email.domain.root_domain not in $org_domains
   and sender.email.domain.root_domain not in (
     "bing.com",


### PR DESCRIPTION
# Description

Negating org Sharepoint links, commonly found in replies to outbound Sharepoint shares.

# Associated samples
- https://platform.sublime.security/messages/58020b2241d8324dfdf299d8e6ab6b1378cbe5514fdb17d41571146a363c918a