### PR TITLE
Update link_credential_phishing_voicemail_language.yml

### DIFF
--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -436,15 +436,24 @@ source: |
     )
     and any(attachments, .content_type == "message/rfc822")
   )
-  // sender profile
+  // an impersonated high trust domain 
   and (
     (
-      profile.by_sender().prevalence not in ("common")
-      and not profile.by_sender().solicited
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
     )
+  
+    // sender profile
     or (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_false_positives
+      (
+        not sender.email.domain.root_domain in $org_domains
+        and (profile.by_sender().prevalence not in ("common"))
+        and not profile.by_sender().solicited
+      )
+      or (
+        profile.by_sender().any_messages_malicious_or_spam
+        and not profile.by_sender().any_false_positives
+      )
     )
   )
 


### PR DESCRIPTION
# Description

Adding condition to supercede sender profiles if it's a high trust domain that failed auth. 

# Sample
https://platform.sublime.security/messages/fe6d049e9b553624dc25ea09a9e5900272c45e5e9bc03feafe7c5019f883b9f9