### PR TITLE
Update cc_infra_abuse.yml

### DIFF
--- a/detection-rules/cc_infra_abuse.yml
+++ b/detection-rules/cc_infra_abuse.yml
@@ -56,8 +56,7 @@ source: |
     or (
       (
         any(headers.hops,
-            .index == 0
-            and any(.authentication_results.dkim_details,
+            any(.authentication_results.dkim_details,
                     .domain == "auth.ccsend.com"
             )
         )


### PR DESCRIPTION
# Description

Removing hops index check to widen `auth.ccsend.com` negation.

# Associated samples

- https://platform.sublime.security/messages/5dfa86382e166ea65e7be31dde597d9f6b188a9fe6e1e1aa689623ed9996752f
