### PR TITLE
Create link_youtube_user_info_excessive_padding.yml

### DIFF
--- a/detection-rules/link_youtube_user_info_excessive_padding.yml
+++ b/detection-rules/link_youtube_user_info_excessive_padding.yml
@@ -1,4 +1,4 @@
-name: "Link: Obfuscation via YouTube.com user info with excessive URL padding"
+name: "Link: Obfuscation via YouTube.com User Info with Excessive URL Padding"
 description: "Identifies instances where a malicious actor leverages YouTube's domain name as a username in a URL, while the actual root domain leads elsewhere. The URL is further obfuscated using excessive URL-encoded spaces (%20) to hide the true destination in preview windows."
 type: "rule"
 severity: "medium"

--- a/detection-rules/link_youtube_user_info_excessive_padding.yml
+++ b/detection-rules/link_youtube_user_info_excessive_padding.yml
@@ -1,0 +1,35 @@
+name: "Link: Obfuscation via YouTube.com user info with excessive URL padding"
+description: "Identifies instances where a malicious actor leverages YouTube's domain name as a username in a URL, while the actual root domain leads elsewhere. The URL is further obfuscated using excessive URL-encoded spaces (%20) to hide the true destination in preview windows."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and length(body.links) < 100
+  and any(body.links,
+          (
+            // Detects cases where the URL starts with youtube.com but the root domain is not youtube.com.
+            // A browser will interpret the URL as directing to malicious-site.com, ignoring youtube.com entirely
+            // because everything before the @ symbol is treated as a username.
+            (
+              regex.match(.href_url.url,
+                          'https?:\/\/(?:www\.)?youtube.com.*'
+              ) // Matches URLs starting with youtube.com
+              or .href_url.username == "youtube.com" // Checks if youtube.com is used as a username
+            )
+            and .href_url.domain.root_domain != "youtube.com" // Verifies that the actual root domain is not youtube.com
+  
+            // Detects excessive padding (e.g., %20) used to obfuscate the malicious portion of the URL.
+            // Padding forces the malicious portion to be hidden in truncated previews (e.g., in email clients or chat apps).
+            
+            and strings.count(.href_url.url, "%20") > 30 // Flags URLs with more than 30 URL-encoded spaces
+          )
+  )
+  
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Impersonation: Brand"
+detection_methods:
+  - "URL analysis"

--- a/detection-rules/link_youtube_user_info_excessive_padding.yml
+++ b/detection-rules/link_youtube_user_info_excessive_padding.yml
@@ -33,3 +33,4 @@ tactics_and_techniques:
   - "Impersonation: Brand"
 detection_methods:
   - "URL analysis"
+id: "91b7b09a-f353-533c-a4b5-f15af3b1eb63"


### PR DESCRIPTION
# Description

This rule identifies suspicious URLs that exploit the username component in links with 'youtube.com'. Attackers use this technique to trick users into believing the link is legitimate while redirecting to a malicious domain. The rule detects:

Links where youtube.com is used as a username (e.g., youtube.com@malicious-site.com).
and where the root domain does not match youtube.com.
Excessive URL-encoded padding (%20) that obscures the malicious domain in previews, such as in email clients or chat applications.

# Associated samples

Link to samples that are affected by your change. 

## Associated hunts



- [Hunt 1](https://platform.sublime.security/hunts/019450e1-9fbf-7680-8e98-4781af68ac07)

