### PR TITLE
Create link_userinfo_excessive_padding.yml

### DIFF
--- a/detection-rules/link_user_info_excessive_padding.yml
+++ b/detection-rules/link_user_info_excessive_padding.yml
@@ -1,0 +1,19 @@
+name: "Link: Obfuscation via userinfo with Excessive URL Padding"
+description: "Identifies instances where a malicious actor leverages an excessively padded username within the userinfo portion of the URL to hide the true destination in preview windows."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and 0 < length(body.links) < 100
+  and any(body.links,
+          regex.icontains(coalesce(.href_url.rewrite.original, .href_url.url),
+                       'https?(?:(?:%3a|\:)?(?:\/|%2f){2})[^\/]+(?:%(?:25)?[a-f0-9]{2}){30,}(?:@|%(?:25)?40)[^\/]+(?:\/|%(?:25)2f)'
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Impersonation: Brand"
+detection_methods:
+  - "URL analysis"

--- a/detection-rules/link_userinfo_excessive_padding.yml
+++ b/detection-rules/link_userinfo_excessive_padding.yml
@@ -6,6 +6,12 @@ source: |
   type.inbound
   and 0 < length(body.links) < 100
   and any(body.links,
+          // Detects deceptive URLs where the URL appears to start with a trusted domain (e.g., youtube.com@),
+          // but the actual destination domain is something else (e.g., malicious-site.com).
+          // In such cases, browsers interpret the portion before the '@' symbol as a username (e.g., youtube.com),
+          // and the URL resolves to the domain after the '@' symbol (malicious-site.com).
+          // This technique is often used in phishing attacks to trick users into trusting the link by showing a familiar domain.
+          // (?:%(?:25)?[a-f0-9]{2}){30,} is the key part which detects 30 or more URL encoded values before an @ (or a URL encoded @)
           regex.icontains(coalesce(.href_url.rewrite.original, .href_url.url),
                        'https?(?:(?:%3a|\:)?(?:\/|%2f){2})[^\/]+(?:%(?:25)?[a-f0-9]{2}){30,}(?:@|%(?:25)?40)[^\/]+(?:\/|%(?:25)?2f)'
           )

--- a/detection-rules/link_userinfo_excessive_padding.yml
+++ b/detection-rules/link_userinfo_excessive_padding.yml
@@ -17,3 +17,4 @@ tactics_and_techniques:
   - "Impersonation: Brand"
 detection_methods:
   - "URL analysis"
+id: "806317a3-d931-501c-9505-d2e08c646565"

--- a/detection-rules/link_userinfo_excessive_padding.yml
+++ b/detection-rules/link_userinfo_excessive_padding.yml
@@ -7,7 +7,7 @@ source: |
   and 0 < length(body.links) < 100
   and any(body.links,
           regex.icontains(coalesce(.href_url.rewrite.original, .href_url.url),
-                       'https?(?:(?:%3a|\:)?(?:\/|%2f){2})[^\/]+(?:%(?:25)?[a-f0-9]{2}){30,}(?:@|%(?:25)?40)[^\/]+(?:\/|%(?:25)2f)'
+                       'https?(?:(?:%3a|\:)?(?:\/|%2f){2})[^\/]+(?:%(?:25)?[a-f0-9]{2}){30,}(?:@|%(?:25)?40)[^\/]+(?:\/|%(?:25)?2f)'
           )
   )
 attack_types:


### PR DESCRIPTION
# Description

A generic approach to #2297 
> This rule identifies suspicious URLs that exploit the username component in links with 'youtube.com'. Attackers use this technique to trick users into believing the link is legitimate while redirecting to a malicious domain. The rule detects:
>
> Links where youtube.com is used as a username (e.g., [youtube.com@malicious-site.com](mailto:youtube.com@malicious-site.com)).
and where the root domain does not match youtube.com.
Excessive URL-encoded padding (%20) that obscures the malicious domain in previews, such as in email clients or chat applications.

# Associated samples
- [facebook](https://platform.sublime.security/messages/b4ccda6673c5de313a99a92538dc84dd378e9d0f8a661aba3d7ed50f548bd8a9)
- [linkedin](https://platform.sublime.security/messages/9c97dd69878d95aa647056377a2d8243cb3ca3b9f31fce72a80d1c631c5c1861)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/hunts/01945157-45ff-70fb-93e9-24ad60ec84fd)
