### PR TITLE
Update file_sharing_link_from_suspicious_sender_domain.yml

### DIFF
--- a/detection-rules/file_sharing_link_from_suspicious_sender_domain.yml
+++ b/detection-rules/file_sharing_link_from_suspicious_sender_domain.yml
@@ -6,8 +6,14 @@ severity: "medium"
 source: |
   type.inbound
   and any(body.links,
-          .href_url.domain.domain in $free_file_hosts
-          or .href_url.domain.root_domain in $free_file_hosts
+          (
+            .href_url.domain.domain in $free_file_hosts
+            or .href_url.domain.root_domain in $free_file_hosts
+          )
+          // remove free_file_hosts used to host images as links
+          and not any($file_types_images,
+                      strings.iends_with(..href_url.url, strings.concat('.', .))
+          )
   )
   and sender.email.domain.tld in $suspicious_tlds
   and (


### PR DESCRIPTION
# Description
Remove FPs/Benign alerts caused by img src urls being parsed into body.links which are hosted on free file hosting provides. 

## Associated hunts
Samples that will no longer match this detection
- [Hunt 1](https://platform.sublime.security/hunts/019460af-0dbb-70f7-94cf-a6c62684a2c9)
