### PR TITLE
Create impersonation_sharepoint_reply_headers.yml

### DIFF
--- a/detection-rules/impersonation_sharepoint_reply_headers.yml
+++ b/detection-rules/impersonation_sharepoint_reply_headers.yml
@@ -14,6 +14,7 @@ source: |
                     "*invited you to access a file*",
                     "*received a document*",
                     "*shared a document*",
+                    "*shared a new document*",
                     "*shared this document*"
       )
   )

--- a/detection-rules/impersonation_sharepoint_reply_headers.yml
+++ b/detection-rules/impersonation_sharepoint_reply_headers.yml
@@ -7,6 +7,16 @@ source: |
   // appears to be a reply 
   and strings.istarts_with(headers.in_reply_to, '<Share-')
   and strings.ends_with(headers.in_reply_to, '@odspnotify>')
+  and any([body.current_thread.text, body.plain.raw],
+      strings.ilike(.,
+                    "*shared a file with you*",
+                    "*shared with you*",
+                    "*invited you to access a file*",
+                    "*received a document*",
+                    "*shared a document*",
+                    "*shared this document*"
+      )
+  )
   and ( // but lacks other reply elements
     not (
       strings.istarts_with(subject.subject, "RE:")
@@ -70,8 +80,7 @@ source: |
                 "message/delivery-status"
               )
   )
-  // and not a common sender
-  and profile.by_sender().prevalence != "common"
+
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/impersonation_sharepoint_reply_headers.yml
+++ b/detection-rules/impersonation_sharepoint_reply_headers.yml
@@ -9,32 +9,38 @@ source: |
   and strings.ends_with(headers.in_reply_to, '@odspnotify>')
   and ( // but lacks other reply elements
     not (
-      (
-        strings.istarts_with(subject.subject, "RE:")
-        or strings.istarts_with(subject.subject, "RES:")
-        or strings.istarts_with(subject.subject, "R:")
-        or strings.istarts_with(subject.subject, "ODG:")
-        or strings.istarts_with(subject.subject,
-                                "答复:"
-        ) // response
-        or strings.istarts_with(subject.subject,
-                                "回复:"
-        ) // reply
-        or strings.istarts_with(subject.subject, "AW:")
-        or strings.istarts_with(subject.subject, "TR:")
-        or strings.istarts_with(subject.subject, "FWD:")
-        or strings.istarts_with(subject.subject, "Resposta automática:")
-        or strings.istarts_with(subject.subject, "Automatische Antwort:")
-        or strings.istarts_with(subject.subject, "Autosvar:")
-        or regex.icontains(subject.subject,
-                           '^(?:(?:\[[^\]]+\]\s?|EXT(?:ERNAL)?\s?){0,3}|[[:punct:]]{0,3}\w+[[:punct:]]{0,3}\s)(?:r[ev]|fwd?|tr|aw|automat(ic|ed) reply)\s?:'
-        )
+      strings.istarts_with(subject.subject, "RE:")
+      or strings.istarts_with(subject.subject, "RES:")
+      or strings.istarts_with(subject.subject, "R:")
+      or strings.istarts_with(subject.subject, "ODG:")
+      or strings.istarts_with(subject.subject,
+                              "答复:"
+      ) // response
+      or strings.istarts_with(subject.subject,
+                              "回复:"
+      ) // reply
+      or strings.istarts_with(subject.subject, "AW:")
+      or strings.istarts_with(subject.subject, "TR:")
+      or strings.istarts_with(subject.subject, "FWD:")
+      or strings.istarts_with(subject.subject, "Resposta automática:")
+      or strings.istarts_with(subject.subject, "Automatische Antwort:")
+      or strings.istarts_with(subject.subject, "Autosvar:")
+      or regex.icontains(subject.subject,
+                         '^(?:(?:\[[^\]]+\]\s?|EXT(?:ERNAL)?\s?){0,3}|[[:punct:]]{0,3}\w+[[:punct:]]{0,3}\s)(?:r[ev]|fwd?|tr|aw|automat(ic|ed) reply)\s?:'
       )
     )
     // the sender is the recipient 
     // or the recipients are hidden
     or (
-      sender.email.email in map(recipients.to, .email.email)
+      (
+        sender.email.email in map(recipients.to, .email.email)
+        and sum([
+                  length(recipients.bcc),
+                  length(recipients.to),
+                  length(recipients.cc)
+                ]
+        ) == 1
+      )
       or length(recipients.to) == 0
       or all(recipients.to, .email.email is null or .email.email == "")
     )
@@ -54,7 +60,6 @@ source: |
                                   '(?:from|to|sent|date|cc|subject|wrote):.*shared with you',
                                   '(?:from|to|sent|date|cc|subject|wrote):.*shared the folder .* with you',
                                   '(?:from|to|sent|date|cc|subject|wrote):.*invited you to view a file',
-  
               )
   )
   

--- a/detection-rules/impersonation_sharepoint_reply_headers.yml
+++ b/detection-rules/impersonation_sharepoint_reply_headers.yml
@@ -63,13 +63,15 @@ source: |
               )
   )
   
-  // // negate bouncebacks and undeliverables
+  // negate bouncebacks and undeliverables
   and not any(attachments,
               .content_type in (
                 "message/global-delivery-status",
                 "message/delivery-status"
               )
   )
+  // and not a common sender
+  and profile.by_sender().prevalence != "common"
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/impersonation_sharepoint_reply_headers.yml
+++ b/detection-rules/impersonation_sharepoint_reply_headers.yml
@@ -27,7 +27,7 @@ source: |
         or strings.istarts_with(subject.subject, "Automatische Antwort:")
         or strings.istarts_with(subject.subject, "Autosvar:")
         or regex.icontains(subject.subject,
-                           '^(?:(?:\[[^\]]+\]\s?|EXT(?:ERNAL)?\s?){0,3}|[[:punct:]]{0,3}\w+[[:punct:]]{0,3}\s)(?:r[ev]|fwd?|automat(ic|ed) reply)\s?:'
+                           '^(?:(?:\[[^\]]+\]\s?|EXT(?:ERNAL)?\s?){0,3}|[[:punct:]]{0,3}\w+[[:punct:]]{0,3}\s)(?:r[ev]|fwd?|tr|aw|automat(ic|ed) reply)\s?:'
         )
       )
     )
@@ -54,7 +54,7 @@ source: |
                                   '(?:from|to|sent|date|cc|subject|wrote):.*shared with you',
                                   '(?:from|to|sent|date|cc|subject|wrote):.*shared the folder .* with you',
                                   '(?:from|to|sent|date|cc|subject|wrote):.*invited you to view a file',
-
+  
               )
   )
   

--- a/detection-rules/impersonation_sharepoint_reply_headers.yml
+++ b/detection-rules/impersonation_sharepoint_reply_headers.yml
@@ -52,7 +52,9 @@ source: |
               )
               and regex.icontains(.,
                                   '(?:from|to|sent|date|cc|subject|wrote):.*shared with you',
-                                  '(?:from|to|sent|date|cc|subject|wrote):.*shared the folder .* with you'
+                                  '(?:from|to|sent|date|cc|subject|wrote):.*shared the folder .* with you',
+                                  '(?:from|to|sent|date|cc|subject|wrote):.*invited you to view a file',
+
               )
   )
   

--- a/detection-rules/impersonation_sharepoint_reply_headers.yml
+++ b/detection-rules/impersonation_sharepoint_reply_headers.yml
@@ -1,0 +1,73 @@
+name: "Impersonation: SharePoint Reply Header Anomaly"
+description: "Detects messages with SharePoint reply headers that lack standard reply characteristics and contain inconsistencies in thread elements and recipient patterns"
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // appears to be a reply 
+  and strings.istarts_with(headers.in_reply_to, '<Share-')
+  and strings.ends_with(headers.in_reply_to, '@odspnotify>')
+  and ( // but lacks other reply elements
+    not (
+      (
+        strings.istarts_with(subject.subject, "RE:")
+        or strings.istarts_with(subject.subject, "R:")
+        or strings.istarts_with(subject.subject, "ODG:")
+        or strings.istarts_with(subject.subject,
+                                "答复:"
+        ) // response
+        or strings.istarts_with(subject.subject,
+                                "回复:"
+        ) // reply
+        or strings.istarts_with(subject.subject, "AW:")
+        or strings.istarts_with(subject.subject, "TR:")
+        or strings.istarts_with(subject.subject, "FWD:")
+        or strings.istarts_with(subject.subject, "Resposta automática:")
+        or regex.icontains(subject.subject,
+                           '^(\[[^\]]+\]\s?){0,3}(?:r[ev]|fwd?|automat(ic|ed) reply)\s?:'
+        )
+      )
+    )
+    // the sender is the recipient 
+    // or the recipients are hidden
+    or (
+      sender.email.email in map(recipients.to, .email.email)
+      or length(recipients.to) == 0
+      or all(recipients.to, .email.email is null or .email.email == "")
+    )
+  )
+  
+  // lack a previous thread with sharepoint stuff
+  and not any([body.current_thread.text, body.html.display_text, body.plain.raw],
+          3 of (
+          strings.icontains(., "from:"),
+          strings.icontains(., "to:"),
+          strings.icontains(., "sent:"),
+          strings.icontains(., "date:"),
+          strings.icontains(., "cc:"),
+          strings.icontains(., "subject:")
+          )
+          and regex.icontains(.,
+                                  '(?:from|to|sent|date|cc|subject|wrote):.*shared with you'
+                  )
+  )
+  
+  // // negate bouncebacks and undeliverables
+  and not any(attachments,
+              .content_type in (
+                "message/global-delivery-status",
+                "message/delivery-status"
+              )
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Impersonation: Brand"
+  - "Evasion"
+  - "Spoofing"
+detection_methods:
+  - "Header analysis"
+  - "Content analysis"
+  - "Sender analysis"

--- a/detection-rules/impersonation_sharepoint_reply_headers.yml
+++ b/detection-rules/impersonation_sharepoint_reply_headers.yml
@@ -71,3 +71,4 @@ detection_methods:
   - "Header analysis"
   - "Content analysis"
   - "Sender analysis"
+id: "78875848-71ba-5685-ba1c-00c5269cad23"

--- a/detection-rules/impersonation_sharepoint_reply_headers.yml
+++ b/detection-rules/impersonation_sharepoint_reply_headers.yml
@@ -27,7 +27,7 @@ source: |
         or strings.istarts_with(subject.subject, "Automatische Antwort:")
         or strings.istarts_with(subject.subject, "Autosvar:")
         or regex.icontains(subject.subject,
-                           '^(\[[^\]]+\]\s?){0,3}(?:r[ev]|fwd?|automat(ic|ed) reply)\s?:'
+                           '^(?:\[[^\]]+\]\s?|EXT\s?){0,3}(?:r[ev]|fwd?|automat(ic|ed) reply)\s?:'
         )
       )
     )

--- a/detection-rules/impersonation_sharepoint_reply_headers.yml
+++ b/detection-rules/impersonation_sharepoint_reply_headers.yml
@@ -51,7 +51,8 @@ source: |
                 strings.icontains(., "subject:")
               )
               and regex.icontains(.,
-                                  '(?:from|to|sent|date|cc|subject|wrote):.*shared with you'
+                                  '(?:from|to|sent|date|cc|subject|wrote):.*shared with you',
+                                  '(?:from|to|sent|date|cc|subject|wrote):.*shared the folder .* with you'
               )
   )
   

--- a/detection-rules/impersonation_sharepoint_reply_headers.yml
+++ b/detection-rules/impersonation_sharepoint_reply_headers.yml
@@ -24,6 +24,8 @@ source: |
         or strings.istarts_with(subject.subject, "TR:")
         or strings.istarts_with(subject.subject, "FWD:")
         or strings.istarts_with(subject.subject, "Resposta automática:")
+        or strings.istarts_with(subject.subject, "Automatische Antwort:")
+        or strings.istarts_with(subject.subject, "Autosvar:")
         or regex.icontains(subject.subject,
                            '^(\[[^\]]+\]\s?){0,3}(?:r[ev]|fwd?|automat(ic|ed) reply)\s?:'
         )

--- a/detection-rules/impersonation_sharepoint_reply_headers.yml
+++ b/detection-rules/impersonation_sharepoint_reply_headers.yml
@@ -27,9 +27,8 @@ source: |
         or strings.istarts_with(subject.subject, "Automatische Antwort:")
         or strings.istarts_with(subject.subject, "Autosvar:")
         or regex.icontains(subject.subject,
-                           '^(?:\[[^\]]+\]\s?|EXT(?:ERNAL)?\s?){0,3}(?:r[ev]|fwd?|automat(ic|ed) reply)\s?:'
+                           '^(?:(?:\[[^\]]+\]\s?|EXT(?:ERNAL)?\s?){0,3}|\w+\s)(?:r[ev]|fwd?|automat(ic|ed) reply)\s?:'
         )
-      )
     )
     // the sender is the recipient 
     // or the recipients are hidden

--- a/detection-rules/impersonation_sharepoint_reply_headers.yml
+++ b/detection-rules/impersonation_sharepoint_reply_headers.yml
@@ -11,6 +11,7 @@ source: |
     not (
       (
         strings.istarts_with(subject.subject, "RE:")
+        or strings.istarts_with(subject.subject, "RES:")
         or strings.istarts_with(subject.subject, "R:")
         or strings.istarts_with(subject.subject, "ODG:")
         or strings.istarts_with(subject.subject,

--- a/detection-rules/impersonation_sharepoint_reply_headers.yml
+++ b/detection-rules/impersonation_sharepoint_reply_headers.yml
@@ -27,8 +27,9 @@ source: |
         or strings.istarts_with(subject.subject, "Automatische Antwort:")
         or strings.istarts_with(subject.subject, "Autosvar:")
         or regex.icontains(subject.subject,
-                           '^(?:(?:\[[^\]]+\]\s?|EXT(?:ERNAL)?\s?){0,3}|\w+\s)(?:r[ev]|fwd?|automat(ic|ed) reply)\s?:'
+                           '^(?:(?:\[[^\]]+\]\s?|EXT(?:ERNAL)?\s?){0,3}|[[:punct:]]{0,3}\w+[[:punct:]]{0,3}\s)(?:r[ev]|fwd?|automat(ic|ed) reply)\s?:'
         )
+      )
     )
     // the sender is the recipient 
     // or the recipients are hidden
@@ -41,17 +42,17 @@ source: |
   
   // lack a previous thread with sharepoint stuff
   and not any([body.current_thread.text, body.html.display_text, body.plain.raw],
-          3 of (
-          strings.icontains(., "from:"),
-          strings.icontains(., "to:"),
-          strings.icontains(., "sent:"),
-          strings.icontains(., "date:"),
-          strings.icontains(., "cc:"),
-          strings.icontains(., "subject:")
-          )
-          and regex.icontains(.,
+              3 of (
+                strings.icontains(., "from:"),
+                strings.icontains(., "to:"),
+                strings.icontains(., "sent:"),
+                strings.icontains(., "date:"),
+                strings.icontains(., "cc:"),
+                strings.icontains(., "subject:")
+              )
+              and regex.icontains(.,
                                   '(?:from|to|sent|date|cc|subject|wrote):.*shared with you'
-                  )
+              )
   )
   
   // // negate bouncebacks and undeliverables
@@ -61,7 +62,6 @@ source: |
                 "message/delivery-status"
               )
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/impersonation_sharepoint_reply_headers.yml
+++ b/detection-rules/impersonation_sharepoint_reply_headers.yml
@@ -27,7 +27,7 @@ source: |
         or strings.istarts_with(subject.subject, "Automatische Antwort:")
         or strings.istarts_with(subject.subject, "Autosvar:")
         or regex.icontains(subject.subject,
-                           '^(?:\[[^\]]+\]\s?|EXT\s?){0,3}(?:r[ev]|fwd?|automat(ic|ed) reply)\s?:'
+                           '^(?:\[[^\]]+\]\s?|EXT(?:ERNAL)?\s?){0,3}(?:r[ev]|fwd?|automat(ic|ed) reply)\s?:'
         )
       )
     )


### PR DESCRIPTION
# Description

Coverage for fake SharePoint file shares which contain reply headers but do not contain reply characteristics.

## Associated hunts

- [Hunt 1](https://platform.sublime.security/hunts/01946179-e83c-7521-acf4-8fe48e8eb4f9)
