### PR TITLE
Update impersonation_quickbooks.yml

### DIFF
--- a/detection-rules/impersonation_quickbooks.yml
+++ b/detection-rules/impersonation_quickbooks.yml
@@ -56,6 +56,12 @@ source: |
                     .href_url.domain.domain == sender.email.domain.domain
                     and (.href_url.path is null or .href_url.path == "/")
                   )
+                  // handle links to the root website when the sender uses a freemail address to send invoices
+                  or (
+                    .href_url.domain.sld == sender.email.local_part
+                    and (.href_url.path is null or .href_url.path == "/")
+                    and sender.email.domain.root_domain in $free_email_providers
+                  )
            )
     ) != length(body.links)
     // or no valid links


### PR DESCRIPTION
# Description

negating links to the sender's root website when they use a freemail address to deliver invoices

# Associated samples

- https://platform.sublime.security/messages/55cddf15508705ff9cf90500a8abe90f720ed88a40a351a70048c74892de08ce

## Associated hunts

- https://platform.sublime.security/hunts/01949679-c3e7-7f09-b38c-f62bbbbe7f35