### PR TITLE
Create abuse_google_shortlinks_services.yml

### DIFF
--- a/detection-rules/abuse_google_shortlinks_services.yml
+++ b/detection-rules/abuse_google_shortlinks_services.yml
@@ -1,0 +1,29 @@
+name: "Google Services Using G.co Shortlinks"
+description: "Identifies messages from authenticated Google domains containing g.co shortened URLs with a subdomain in either the message body links or thread text."
+references: 
+  - "https://gist.github.com/zachlatta/f86317493654b550c689dc6509973aa4"
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // allow for multiple google TLDs
+  and sender.email.domain.sld == "google"
+  and headers.auth_summary.spf.pass
+  // g.co url shortner in links or the current thread to identify the workspace name
+  and (
+    any(body.links, .href_url.domain.root_domain == 'g.co' and .href_url.domain.subdomain is not null)
+    or (
+      strings.icontains(body.current_thread.text, '.g.co')
+      and regex.icontains(body.current_thread.text, '[^\s]+\.g\.co\b')
+    )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Free email provider"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Sender analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description

Add coverage for abuse of subdomains of `g.co` to send messages from google which lend credibility to actors. 
