### PR TITLE
Create open_redirect_predictiveresponse.yml

### DIFF
--- a/detection-rules/open_redirect_predictiveresponse.yml
+++ b/detection-rules/open_redirect_predictiveresponse.yml
@@ -37,3 +37,4 @@ tactics_and_techniques:
 detection_methods:
   - "Sender analysis"
   - "URL analysis"
+id: "3474bb1b-8840-53b5-9582-3c9baf1b2d63"

--- a/detection-rules/open_redirect_predictiveresponse.yml
+++ b/detection-rules/open_redirect_predictiveresponse.yml
@@ -1,0 +1,39 @@
+name: "Open Redirect: predictiveresponse.net"
+description: |
+  Message contains use of the predictiveresponse.net open redirect. This has been exploited in the wild.
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(body.links,
+          .href_url.domain.root_domain == "predictiveresponse.net"
+          and strings.icontains(.href_url.query_params, 'redirect=')
+          and not regex.icontains(.href_url.query_params,
+                                  'redirect=(?:https?(?:%3a|:))?(?:%2f|\/){2}[^&]*predictiveresponse\.net(?:\&|\/|$)'
+          )
+  )
+  and not sender.email.domain.root_domain == "predictiveresponse.net"
+  // negate use of predictiveresponse infra
+  and not any(headers.domains, .root_domain == "predictiveresponse.net")
+  and not any(headers.hops,
+              any(.fields,
+                  .name == "List-Unsubscribe"
+                  and strings.iends_with(.value, '@predictiveresponse.net>')
+              )
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+attack_types:
+  - "Credential Phishing"
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Open redirect"
+detection_methods:
+  - "Sender analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description
Add coverage for observed open redirect

This does appear to be used legit as well, but the negation on header.domains and the list-unsub header addressed the observed benign use. 
## Associated hunts


- [Hunt 1](https://platform.sublime.security/hunts/0194a4a0-afe6-7020-a487-655026e72f0a)
