### PR TITLE
Create brand_impersonation_trust_wallet.yml

### DIFF
--- a/detection-rules/brand_impersonation_trust_wallet.yml
+++ b/detection-rules/brand_impersonation_trust_wallet.yml
@@ -7,7 +7,7 @@ source: |
   and length(body.links) > 0
   and (
     regex.icontains(strings.replace_confusables(sender.display_name),
-                    '\btrust wa(ll|ii)et\b'
+                    '\btrust wa[li1]{2}et\b'
     )
     or strings.ilevenshtein(strings.replace_confusables(sender.display_name),
                             'trust wallet'

--- a/detection-rules/brand_impersonation_trust_wallet.yml
+++ b/detection-rules/brand_impersonation_trust_wallet.yml
@@ -1,0 +1,43 @@
+name: "Brand Impersonation: Trust Wallet"
+description: "Detects inbound messages containing links where the sender impersonates Trust Wallet through display name manipulation and includes the MetaMask logo or suspicious language, while not being from legitimate Trust Wallet domains. The rule checks for credential theft patterns and validates sender authentication."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and length(body.links) > 0
+  and (
+    regex.icontains(strings.replace_confusables(sender.display_name),
+                    '\btrust wa(ll|ii)et\b'
+    )
+    or strings.ilevenshtein(strings.replace_confusables(sender.display_name),
+                            'trust wallet'
+    ) <= 2
+  )
+  and (
+    any(ml.nlu_classifier(body.current_thread.text).intents,
+        .name in ("cred_theft", "callback_scam", "steal_pii", "extortion")
+        and .confidence in ("high")
+    )
+  )
+  and sender.email.domain.root_domain not in~ ('trustwallet.com')
+  
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  and not profile.by_sender().any_false_positives
+
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Natural Language Understanding"
+  - "Sender analysis"
+  - "Header analysis"

--- a/detection-rules/brand_impersonation_trust_wallet.yml
+++ b/detection-rules/brand_impersonation_trust_wallet.yml
@@ -1,5 +1,5 @@
 name: "Brand Impersonation: Trust Wallet"
-description: "Detects inbound messages containing links where the sender impersonates Trust Wallet through display name manipulation and includes the MetaMask logo or suspicious language, while not being from legitimate Trust Wallet domains. The rule checks for credential theft patterns and validates sender authentication."
+description: "Detects inbound messages containing links where the sender impersonates Trust Wallet through display name manipulation and suspicious language, while not being from legitimate Trust Wallet domains. The rule checks for credential theft patterns and validates sender authentication."
 type: "rule"
 severity: "high"
 source: |

--- a/detection-rules/brand_impersonation_trust_wallet.yml
+++ b/detection-rules/brand_impersonation_trust_wallet.yml
@@ -41,3 +41,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Sender analysis"
   - "Header analysis"
+id: "e456974c-a62d-590a-b0d7-f659c9f60c8c"


### PR DESCRIPTION
# Description

Detects inbound messages containing links where the sender impersonates Trust Wallet through display name manipulation and includes suspicious language, while not being from legitimate Trust Wallet domains. The rule checks for credential theft patterns and validates sender authentication.

# Associated samples/hunts
- https://platform.sublime.security/messages/38b2d9926c5991d5b6580b6ae59c38d384322e3220458db1f139029c21d04352
- https://platform.sublime.security/hunts/0194ad9e-aef4-725a-8f98-e184a57d1289
