### PR TITLE
Update high_trust_auth_fail.yml

### DIFF
--- a/insights/sender/high_trust_auth_fail.yml
+++ b/insights/sender/high_trust_auth_fail.yml
@@ -5,14 +5,8 @@ source: |
        sender.email.domain.root_domain in $high_trust_sender_root_domains
        and (
          (
-           any(distinct(headers.hops, .authentication_results.dmarc is not null),
-               strings.ilike(.authentication_results.dmarc, "*fail")
-           )
-         )
-         or (
-           any(distinct(headers.hops, .authentication_results.spf is not null),
-               strings.ilike(.authentication_results.spf, "*fail")
-           )
+           not headers.auth_summary.dmarc.pass
+           or not headers.auth_summary.spf.pass
          )
        )
   )


### PR DESCRIPTION


# Description

Updating to use headers.auth_summary vs distinct legacy auth evals.
