### PR TITLE
Create open_redirect_spently.yml

### DIFF
--- a/detection-rules/open_redirect_spently.yml
+++ b/detection-rules/open_redirect_spently.yml
@@ -12,8 +12,8 @@ source: |
           and strings.istarts_with(.href_url.path, '/api/spently/click')
           and strings.icontains(.href_url.query_params, 'url=')
           and strings.icontains(.href_url.query_params, 'type=')
-          and not strings.icontains(.href_url.query_params,
-                                    'url=(?:https?(?:%3a|:))?(?:%2f|\/){2}[^&]*spently\.com(?:\&|\/|$)'
+          and not regex.icontains(.href_url.query_params,
+                                    'url=(?:https?(?:%3a|:))?(?:%2f|\/){2}[^&]*spently\.com(?:\&|\/|$|%2f)'
           )
   )
   and not sender.email.domain.root_domain == "spently.com"

--- a/detection-rules/open_redirect_spently.yml
+++ b/detection-rules/open_redirect_spently.yml
@@ -13,7 +13,7 @@ source: |
           and strings.icontains(.href_url.query_params, 'url=')
           and strings.icontains(.href_url.query_params, 'type=')
           and not strings.icontains(.href_url.query_params,
-                                    'url=(?:https?(?:%3a|:))?(?:%2f|\/){2}[^&]*bubblelife\.com(?:\&|\/|$)'
+                                    'url=(?:https?(?:%3a|:))?(?:%2f|\/){2}[^&]*spently\.com(?:\&|\/|$)'
           )
   )
   and not sender.email.domain.root_domain == "spently.com"

--- a/detection-rules/open_redirect_spently.yml
+++ b/detection-rules/open_redirect_spently.yml
@@ -34,3 +34,4 @@ tactics_and_techniques:
 detection_methods:
   - "Sender analysis"
   - "URL analysis"
+id: "69740e97-265f-515b-b5ae-80ec234f07ac"

--- a/detection-rules/open_redirect_spently.yml
+++ b/detection-rules/open_redirect_spently.yml
@@ -1,0 +1,36 @@
+name: "Open Redirect: api.spently.com"
+description: |
+  Message contains use of the api.spently.com redirect. This has been exploited in the wild.
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+    // there are less than 10 unique links for api.spently.com within the body.links
+  and length(distinct(filter(body.links, .href_url.domain.domain == "api.spently.com"), .href_url.url)) < 10
+  and any(body.links,
+          .href_url.domain.domain == "api.spently.com"
+          and strings.istarts_with(.href_url.path, '/api/spently/click')
+          and strings.icontains(.href_url.query_params, 'url=')
+          and strings.icontains(.href_url.query_params, 'type=')
+          and not strings.icontains(.href_url.query_params,
+                                    'url=(?:https?(?:%3a|:))?(?:%2f|\/){2}[^&]*bubblelife\.com(?:\&|\/|$)'
+          )
+  )
+  and not sender.email.domain.root_domain == "spently.com"
+  
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+attack_types:
+  - "Credential Phishing"
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Open redirect"
+detection_methods:
+  - "Sender analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description
Add coverage for observed open redirect

There is benign use of this, however the length limit of links is designed to remove those instances. 

## Associated hunts

- [Hunt 1](https://platform.sublime.security/hunts/0194c747-ac99-7d85-b7d1-3d5711528f2e)
