### PR TITLE
Update link_fake_password_expiration.yml

### DIFF
--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -11,10 +11,9 @@ source: |
   // no attachments or suspicious attachment
   and (
     length(attachments) == 0
-    or any(attachments,
-           .file_type in ("pdf", "doc", "docx")
-           and any(file.explode(.),
-                   .scan.entropy.entropy > 7 and length(.scan.ocr.raw) < 20
+    or any(filter(attachments, .file_type in ("pdf", "doc", "docx")),
+           any(file.explode(.),
+               .scan.entropy.entropy > 7 and length(.scan.ocr.raw) < 20
            )
     )
     // or there are duplicate pdfs in name 
@@ -28,6 +27,8 @@ source: |
       or 
       // all PDFs are the same MD5
       length(distinct(filter(attachments, .file_type == "pdf"), .md5)) == 1
+      // the attachments are all images
+      or all(attachments, .file_type in $file_types_images)
     )
   )
   
@@ -65,31 +66,25 @@ source: |
     any(ml.nlu_classifier(strings.replace_confusables(body.current_thread.text)).intents,
         .name == "cred_theft" and .confidence == "high"
     )
-    or length(filter([
-                       "password",
-                       "expiration",
-                       "expire",
-                       "expiring",
-                       "kindly",
-                       "renew",
-                       "review",
-                       "click below",
-                       "kicked out",
-                       "prevent",
-                       "required now",
-                       "immediate action",
-                       "security update",
-                       "blocked",
-                       "locked",
-                       "interruption",
-                       "stay connected",
-                     ],
-                     strings.icontains(strings.replace_confusables(body.current_thread.text
-                                       ),
-                                       .
-                     )
-              )
-    ) >= 3
+    or sum([
+        strings.icount(strings.replace_confusables(body.current_thread.text), 'password'),
+        strings.icount(strings.replace_confusables(body.current_thread.text), 'expiration'),
+        strings.icount(strings.replace_confusables(body.current_thread.text), 'expire'),
+        strings.icount(strings.replace_confusables(body.current_thread.text), 'expiring'),
+        strings.icount(strings.replace_confusables(body.current_thread.text), 'kindly'),
+        strings.icount(strings.replace_confusables(body.current_thread.text), 'renew'),
+        strings.icount(strings.replace_confusables(body.current_thread.text), 'review'),
+        strings.icount(strings.replace_confusables(body.current_thread.text), 'click below'),
+        strings.icount(strings.replace_confusables(body.current_thread.text), 'kicked out'),
+        strings.icount(strings.replace_confusables(body.current_thread.text), 'required now'),
+        strings.icount(strings.replace_confusables(body.current_thread.text), 'immediate action'),
+        strings.icount(strings.replace_confusables(body.current_thread.text), 'security update'),
+        strings.icount(strings.replace_confusables(body.current_thread.text), 'blocked'),
+        strings.icount(strings.replace_confusables(body.current_thread.text), 'locked'),
+        strings.icount(strings.replace_confusables(body.current_thread.text), 'interruption'),
+        strings.icount(strings.replace_confusables(body.current_thread.text), 'access'),
+    ]) > 3
+    
   )
   
   // body length between 200 and 2000
@@ -142,7 +137,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -83,7 +83,7 @@ source: |
         strings.icount(strings.replace_confusables(body.current_thread.text), 'locked'),
         strings.icount(strings.replace_confusables(body.current_thread.text), 'interruption'),
         strings.icount(strings.replace_confusables(body.current_thread.text), 'access'),
-    ]) > 3
+    ]) >= 3
     
   )
   

--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -28,7 +28,17 @@ source: |
       // all PDFs are the same MD5
       length(distinct(filter(attachments, .file_type == "pdf"), .md5)) == 1
       // the attachments are all images and not too many attachments
-      or (all(attachments, .file_type in $file_types_images) and length(attachments) < 6)
+      or (
+        all(attachments, .file_type in $file_types_images)
+        and 0 < length(attachments) < 6
+        // any of those attachments are Microsoft branded
+        and any(attachments,
+                any(ml.logo_detect(.).brands,
+                    strings.istarts_with(.name, "Microsoft")
+                    and .confidence == "high"
+                )
+        )
+      )
     )
   )
   

--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -67,22 +67,27 @@ source: |
         .name == "cred_theft" and .confidence == "high"
     )
     or 3 of (
-        strings.icount(strings.replace_confusables(body.current_thread.text), 'password'),
-        strings.icount(strings.replace_confusables(body.current_thread.text), 'expiration'),
-        strings.icount(strings.replace_confusables(body.current_thread.text), 'expire'),
-        strings.icount(strings.replace_confusables(body.current_thread.text), 'expiring'),
-        strings.icount(strings.replace_confusables(body.current_thread.text), 'kindly'),
-        strings.icount(strings.replace_confusables(body.current_thread.text), 'renew'),
-        strings.icount(strings.replace_confusables(body.current_thread.text), 'review'),
-        strings.icount(strings.replace_confusables(body.current_thread.text), 'click below'),
-        strings.icount(strings.replace_confusables(body.current_thread.text), 'kicked out'),
-        strings.icount(strings.replace_confusables(body.current_thread.text), 'required now'),
-        strings.icount(strings.replace_confusables(body.current_thread.text), 'immediate action'),
-        strings.icount(strings.replace_confusables(body.current_thread.text), 'security update'),
-        strings.icount(strings.replace_confusables(body.current_thread.text), 'blocked'),
-        strings.icount(strings.replace_confusables(body.current_thread.text), 'locked'),
-        strings.icount(strings.replace_confusables(body.current_thread.text), 'interruption'),
-        strings.icount(strings.replace_confusables(body.current_thread.text), 'access'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'password'),
+        regex.icontains(strings.replace_confusables(body.current_thread.text), 'password\s*(?:\w+\s+){0,4}\s*reconfirm'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'keep password'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'password is due'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'expiration'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'expire'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'expiring'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'kindly'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'renew'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'review'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'click below'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'kicked out'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'required now'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'immediate action'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'security update'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'blocked'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'locked'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'interruption'),
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'access'),
+        
+
     )
     
   )

--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -27,8 +27,8 @@ source: |
       or 
       // all PDFs are the same MD5
       length(distinct(filter(attachments, .file_type == "pdf"), .md5)) == 1
-      // the attachments are all images
-      or all(attachments, .file_type in $file_types_images)
+      // the attachments are all images and not too many attachments
+      or (all(attachments, .file_type in $file_types_images) and length(attachments) < 6)
     )
   )
   

--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -69,7 +69,7 @@ source: |
     or 3 of (
         strings.icontains(strings.replace_confusables(body.current_thread.text), 'password'),
         regex.icontains(strings.replace_confusables(body.current_thread.text), 'password\s*(?:\w+\s+){0,4}\s*reconfirm'),
-        strings.icontains(strings.replace_confusables(body.current_thread.text), 'keep password'),
+        regex.icontains(strings.replace_confusables(body.current_thread.text), 'keep\s*(?:\w+\s+){0,4}\s*password'),
         strings.icontains(strings.replace_confusables(body.current_thread.text), 'password is due'),
         strings.icontains(strings.replace_confusables(body.current_thread.text), 'expiration'),
         strings.icontains(strings.replace_confusables(body.current_thread.text), 'expire'),
@@ -86,10 +86,9 @@ source: |
         strings.icontains(strings.replace_confusables(body.current_thread.text), 'locked'),
         strings.icontains(strings.replace_confusables(body.current_thread.text), 'interruption'),
         strings.icontains(strings.replace_confusables(body.current_thread.text), 'access'),
-        
-
+        strings.icontains(strings.replace_confusables(body.current_thread.text), 'action is not taken'),
+  
     )
-    
   )
   
   // body length between 200 and 2000

--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -85,7 +85,6 @@ source: |
         strings.icontains(strings.replace_confusables(body.current_thread.text), 'blocked'),
         strings.icontains(strings.replace_confusables(body.current_thread.text), 'locked'),
         strings.icontains(strings.replace_confusables(body.current_thread.text), 'interruption'),
-        strings.icontains(strings.replace_confusables(body.current_thread.text), 'access'),
         strings.icontains(strings.replace_confusables(body.current_thread.text), 'action is not taken'),
   
     )

--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -66,7 +66,7 @@ source: |
     any(ml.nlu_classifier(strings.replace_confusables(body.current_thread.text)).intents,
         .name == "cred_theft" and .confidence == "high"
     )
-    or sum([
+    or 3 of (
         strings.icount(strings.replace_confusables(body.current_thread.text), 'password'),
         strings.icount(strings.replace_confusables(body.current_thread.text), 'expiration'),
         strings.icount(strings.replace_confusables(body.current_thread.text), 'expire'),
@@ -83,7 +83,7 @@ source: |
         strings.icount(strings.replace_confusables(body.current_thread.text), 'locked'),
         strings.icount(strings.replace_confusables(body.current_thread.text), 'interruption'),
         strings.icount(strings.replace_confusables(body.current_thread.text), 'access'),
-    ]) >= 3
+    )
     
   )
   


### PR DESCRIPTION
# Description

address FN by allowing for all attachments to be image types
refactor the entropy logic to display in the rule editor more cleanly
refactor goofy "3 of" into a `3 of` and add additional keywords

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/37c43733274680671258850ac5575b38c43a3cffc295ce2946cc65f91b6f4984)

## Associated hunts

FNs resolved
- [Hunt 1](https://platform.sublime.security/hunts/0194cec0-9dcd-77f8-98b9-3a2e505224f6)
