### PR TITLE
Update qr_code_suspicious_indicators.yml

### DIFF
--- a/detection-rules/qr_code_suspicious_indicators.yml
+++ b/detection-rules/qr_code_suspicious_indicators.yml
@@ -41,8 +41,14 @@ source: |
                   // exclude images from WhatsApp (mobile)
                   and not regex.match(.file_name, 'WhatsApp Image \d\d\d\d-\d\d-\d\d at.*.jpe?g')
                   and not (
-                    .scan.exiftool.image_height > 3000
-                    or .scan.exiftool.image_width > 3000
+                    (
+                      .scan.exiftool.image_height > 3000
+                      and .scan.exiftool.image_height is not null
+                    )
+                    or (
+                      .scan.exiftool.image_width > 3000
+                      and .scan.exiftool.image_width is not null
+                    )
                   )
                   // exclude contact cards
                   and not strings.istarts_with(.scan.qr.data, "BEGIN:VCARD")


### PR DESCRIPTION
# Description

Adding a `not null` check to the exiftool dimensions check, as vacuous truth is causing issues. 

# Associated samples

- https://platform.sublime.security/messages/2aed0efb4a51a53b70bdfa68f142f9994f9019c7d14487664561e6e525977223
