### PR TITLE
Update qr_code_suspicious_indicators.yml

### DIFF
--- a/detection-rules/qr_code_suspicious_indicators.yml
+++ b/detection-rules/qr_code_suspicious_indicators.yml
@@ -196,7 +196,6 @@ source: |
                         "periodic maintenance",
                         "potential(ly)? unauthorized",
                         "refund not approved",
-                        "report",
                         "revised.*policy",
                         "scam",
                         "scanned.?invoice",


### PR DESCRIPTION
Suggesting to remove the word report due to a number of false positives.

# Description

Just a very small change to see about removing the word "report" from the regex in the suspicious subjects check. This has caused a few false positives for us. 

Many thanks for considering. 
