### PR TITLE
Create callback_phishing_zelle.yml

### DIFF
--- a/detection-rules/callback_phishing_zelle.yml
+++ b/detection-rules/callback_phishing_zelle.yml
@@ -1,0 +1,151 @@
+name: "Callback phishing via Zelle Service Abuse"
+description: "Callback phishing campaigns have been observed abusing Zelle services to send fraudulent payment requests with callback phishing contents."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and length(attachments) == 0
+  and sender.email.domain.root_domain in ("zellepay.com")
+  and (
+    // only seeing payment requests abused
+    strings.ilike(body.html.display_text, "* requested*")
+    // phone number in subject
+    // the subject contains the seller's "name", attacks have been seen with the entire callback text in the seller's name
+    or (
+      regex.icontains(strings.replace_confusables(subject.subject),
+                      '.*\+?([ilo0-9]{1}.)?\(?[ilo0-9]{3}?\)?.[ilo0-9]{3}.?[ilo0-9]{4}.*'
+      )
+      or regex.icontains(strings.replace_confusables(subject.subject),
+                         '.*\+[ilo0-9]{1,3}[ilo0-9]{10}.*'
+      )
+      or // +12028001238
+   regex.icontains(strings.replace_confusables(subject.subject),
+                   '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*'
+      )
+      or // 202-800-1238
+   regex.icontains(strings.replace_confusables(subject.subject),
+                   '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*'
+      )
+      or // (202) 800-1238
+   regex.icontains(strings.replace_confusables(subject.subject),
+                   '.*\([ilo0-9]{3}\)\s[ilo0-9]{3}-[ilo0-9]{4}.*'
+      )
+      or // (202)-800-1238
+   regex.icontains(strings.replace_confusables(subject.subject),
+                   '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*'
+      )
+      or ( // 8123456789
+        regex.icontains(strings.replace_confusables(subject.subject),
+                        '.*8[ilo0-9]{9}.*'
+        )
+        and regex.icontains(strings.replace_confusables(subject.subject),
+                            '\+[1li]'
+        )
+      )
+    )
+  )
+  and (
+    (
+      // icontains a phone number within the memo section (wrapped in quotes)
+      (
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '\".*\+?([ilo0-9]{1}.)?\(?[ilo0-9]{3}?\)?.[ilo0-9]{3}.?[ilo0-9]{4}.*\"'
+        )
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '\".*\+[ilo0-9]{1,3}[ilo0-9]{10}.*\"'
+        )
+        or // +12028001238
+   regex.icontains(strings.replace_confusables(body.current_thread.text),
+                   '\".*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\"'
+        )
+        or // 202-800-1238
+   regex.icontains(strings.replace_confusables(body.current_thread.text),
+                   '\".*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\"'
+        )
+        or // (202) 800-1238
+   regex.icontains(strings.replace_confusables(body.current_thread.text),
+                   '\".*\([ilo0-9]{3}\)\s[ilo0-9]{3}-[ilo0-9]{4}.*\"'
+        )
+        or // (202)-800-1238
+   regex.icontains(strings.replace_confusables(body.current_thread.text),
+                   '\".*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\"'
+        )
+        or ( // 8123456789
+          regex.icontains(strings.replace_confusables(body.current_thread.text),
+                          '\".*8[ilo0-9]{9}.*\"'
+          )
+          and regex.icontains(strings.replace_confusables(body.current_thread.text
+                              ),
+                              '\".*\+[1li].*\"'
+          )
+        )
+      )
+      and (
+        (
+          4 of (
+            strings.ilike(body.html.inner_text, '*"*you did not*"*'),
+            strings.ilike(body.html.inner_text, '*"*is not for*"*'),
+            strings.ilike(body.html.inner_text, '*"*done by you*"*'),
+            regex.icontains(body.html.inner_text, "\".*didn\'t ma[kd]e this.*\""),
+            strings.ilike(body.html.inner_text, '*"*Fruad Alert*"*'),
+            strings.ilike(body.html.inner_text, '*"*Fraud Alert*"*'),
+            strings.ilike(body.html.inner_text, '*"*fraudulent*"*'),
+            strings.ilike(body.html.inner_text, '*"*Zelle*"*'),
+            strings.ilike(body.html.inner_text, '*"*subscription*"*'),
+            strings.ilike(body.html.inner_text, '*"*antivirus*"*'),
+            strings.ilike(body.html.inner_text, '*"*order*"*'),
+            strings.ilike(body.html.inner_text, '*"*support*"*'),
+            strings.ilike(body.html.inner_text, '*"*sincerely apologize*"*'),
+            strings.ilike(body.html.inner_text, '*"*receipt*"*'),
+            strings.ilike(body.html.inner_text, '*"*invoice*"*'),
+            strings.ilike(body.html.inner_text, '*"*Purchase*"*'),
+            strings.ilike(body.html.inner_text, '*"*transaction*"*'),
+            strings.ilike(body.html.inner_text, '*"*Market*Value*"*'),
+            strings.ilike(body.html.inner_text, '*"*BTC*"*'),
+            strings.ilike(body.html.inner_text, '*"*call*"*'),
+            strings.ilike(body.html.inner_text, '*"*get in touch with our*"*'),
+            strings.ilike(body.html.inner_text, '*"*quickly inform*"*'),
+            strings.ilike(body.html.inner_text, '*"*quickly reach*"*'),
+            strings.ilike(body.html.inner_text,
+                          '*"*detected unusual transactions*'
+            ),
+            strings.ilike(body.html.inner_text, '*"*without your authorization*"*'),
+            strings.ilike(body.html.inner_text, '*"*cancel*"*'),
+            strings.ilike(body.html.inner_text, '*"*renew*"*'),
+            strings.ilike(body.html.inner_text, '*"*refund*"*'),
+            strings.ilike(body.html.inner_text, '*"*+1*"*'),
+            regex.icontains(body.html.inner_text, '\"help.{0,3}desk'),
+            strings.ilike(body.html.inner_text, '*"* your funds*"*'),
+            strings.ilike(body.html.inner_text, '*"* your checking*"*'),
+            strings.ilike(body.html.inner_text, '*"* your saving*"*'),
+            strings.ilike(body.html.inner_text, '*"*transfer*"*'),
+            strings.ilike(body.html.inner_text, '*"*secure your account*"*'),
+            strings.ilike(body.html.inner_text, '*"*recover your *"*'),
+          )
+        )
+        or regex.icontains(body.current_thread.text,
+                           'note from.{0,50}(?:call|reach|contact|paypal)'
+        )
+        or any(ml.nlu_classifier(body.current_thread.text).intents,
+               .name == "callback_scam"
+        )
+        or (
+          // Unicode confusables words obfuscated in note
+          regex.icontains(body.html.inner_text,
+                          '\+𝟭|𝗽𝗮𝘆𝗺𝗲𝗻𝘁|𝗛𝗲𝗹𝗽 𝗗𝗲𝘀𝗸|𝗿𝗲𝗳𝘂𝗻𝗱|𝗮𝗻𝘁𝗶𝘃𝗶𝗿𝘂𝘀|𝗰𝗮𝗹𝗹|𝗰𝗮𝗻𝗰𝗲𝗹'
+          )
+        )
+        or strings.ilike(body.html.inner_text, '*"*kindly*"*')
+      )
+    )
+  )
+attack_types:
+  - "BEC/Fraud"
+  - "Callback Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Sender analysis"

--- a/detection-rules/callback_phishing_zelle.yml
+++ b/detection-rules/callback_phishing_zelle.yml
@@ -149,3 +149,4 @@ detection_methods:
   - "Content analysis"
   - "Header analysis"
   - "Sender analysis"
+id: "08727484-0236-5286-be04-8c6aec86bcba"


### PR DESCRIPTION
# Description
Add specific coverage for callback via Zelle, largely taken from the paypal invoice abuse and modified to meet Zelle formatting of the memo. 

## Associated hunts

If you ran any hunts with your rule, please link them here.

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=0194f627-d9f3-76c4-bb1d-d38a0341f433)
