### PR TITLE
Update impersonation_schwab.yml

### DIFF
--- a/detection-rules/impersonation_schwab.yml
+++ b/detection-rules/impersonation_schwab.yml
@@ -38,6 +38,7 @@ source: |
           "proxyvote.com", // sends shareholder voting information with subject of company name
           "boheme-schwabing.de", // steakhouse
           "lesschwab.com", // tire sales
+          "schwab-marketing.com" // German Marketing Agency
        )
         or sender.email.domain.domain in ("schwabebooks.ccsend.com")
       )


### PR DESCRIPTION
Added schwab-marketing.com that looks similar but is owned for +24 years by a German Marketing Agency.