### PR TITLE
Update attachment_docusign_suspicious_links.yml

### DIFF
--- a/detection-rules/attachment_docusign_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_suspicious_links.yml
@@ -56,7 +56,7 @@ source: |
           )
         )
         and not any(file.explode(.),
-                    strings.ilike(.scan.ocr.raw, "*DocuSign Envelope ID*")
+                    strings.ilike(.scan.ocr.raw, "*DocuSign Envelope*")
                     or strings.ilike(.scan.ocr.raw, "*Certificate Of Completion*")
                     or (
                       .depth == 0


### PR DESCRIPTION
# Description

Allow for OCR to miss the "ID" part of the attached PDFs

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/eb915828712a9935cd21039b54c3b7a86920f6a7431882076aed5daebc683047?preview_id=019519f4-82c9-73ed-aaa3-e9d961ba3743)
