### PR TITLE
Create recruitee_infra_abuse.yml

### DIFF
--- a/detection-rules/recruitee_infra_abuse.yml
+++ b/detection-rules/recruitee_infra_abuse.yml
@@ -20,7 +20,8 @@ source: |
           and regex.icontains(.display_text, "apply|submit")
   )
   // use sender email, not domain, to ensure new *.recruitee.com addresses are correctly identified
-  and profile.by_sender_email().prevalence in ("new", "outlier", "rare")
+  and profile.by_sender_email().prevalence in ("new", "outlier")
+  and not profile.by_sender_email().any_false_positives
 
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/recruitee_infra_abuse.yml
+++ b/detection-rules/recruitee_infra_abuse.yml
@@ -1,0 +1,36 @@
+name: "Recruitee Infrastructure Abuse"
+description: "Identifies inbound messages from Recruitee domains containing recruitment-related topics and application links, where the sender has limited prior history. The URLs in these messages either point to recently registered domains or appear as standalone links with application-focused text."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and sender.email.domain.root_domain == "recruitee.com"
+  and any(beta.ml_topic(body.current_thread.text).topics,
+          .name in (
+            "Advertising and Promotions",
+            "Professional and Career Development"
+          )
+          and .confidence != "low"
+  )
+  and any(body.links,
+          (
+            network.whois(.href_url.domain).days_old < 30
+            or length(body.links) == 1
+          )
+          and regex.icontains(.display_text, "apply|submit")
+  )
+  // use sender email, not domain, to ensure new *.recruitee.com addresses are correctly identified
+  and profile.by_sender_email().prevalence in ("new", "outlier", "rare")
+
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"
+  - "URL analysis"
+  - "Whois"

--- a/detection-rules/recruitee_infra_abuse.yml
+++ b/detection-rules/recruitee_infra_abuse.yml
@@ -34,3 +34,4 @@ detection_methods:
   - "Sender analysis"
   - "URL analysis"
   - "Whois"
+id: "31cab83d-f279-5db4-a0e5-c81a6e6e3d68"


### PR DESCRIPTION
# Description
Identifies inbound messages from Recruitee domains containing recruitment-related topics and application links, where the sender has limited prior history. The URLs in these messages either point to recently registered domains or appear as standalone links with application-focused text.

# Associated samples

- https://platform.sublime.security/messages/14efd35aa8679c1be5d1b7b65b4fce69ed3b683b77d7b60e84140986c0eb4246?preview_id=01951ff8-989e-71fa-bf4d-e4e52e212b45
- https://platform.sublime.security/messages/hunt?huntId=019529dd-5bfe-705a-94a5-1f13eae27bc6
