### PR TITLE
Create brand_impersonation_vanguard.yml

### DIFF
--- a/detection-rules/brand_impersonation_vanguard.yml
+++ b/detection-rules/brand_impersonation_vanguard.yml
@@ -65,7 +65,8 @@ source: |
         "e-vanguard.com",
         "feedback-vanguard.com",
         "m-vanguard.com",
-        "investordelivery.com"
+        "investordelivery.com",
+        "retsupport.com"
       )
       and headers.auth_summary.dmarc.pass
     )

--- a/detection-rules/brand_impersonation_vanguard.yml
+++ b/detection-rules/brand_impersonation_vanguard.yml
@@ -20,6 +20,30 @@ source: |
       )
     )
   )
+  and (
+    any(beta.ml_topic(body.current_thread.text).topics,
+        .name in (
+          "Security and Authentication",
+          "Secure Message",
+          "Reminders and Notifications"
+        )
+        and .confidence in ("medium", "high")
+    )
+    or any(beta.ml_topic(beta.ocr(beta.message_screenshot()).text).topics,
+           .name in (
+             "Security and Authentication",
+             "Secure Message",
+             "Reminders and Notifications"
+           )
+           and .confidence in ("medium", "high")
+    )
+    or any(ml.nlu_classifier(body.current_thread.text).intents,
+           .name == "cred_theft" and .confidence == "high"
+    )
+    or any(ml.nlu_classifier(beta.ocr(beta.message_screenshot()).text).intents,
+           .name == "cred_theft" and .confidence == "high"
+    )
+  )
   
   // and the sender is not in org_domains or from Vanguard domains and passes auth
   and not (
@@ -33,7 +57,11 @@ source: |
         "vanguard.co.uk",
         "vanguard.com.au",
         "vanguard.com.hk",
-        "vanguardretirement-mail.com"
+        "vanguardretirement-mail.com",
+        "e-vanguard.com",
+        "feedback-vanguard.com",
+        "m-vanguard.com",
+        "investordelivery.com"
       )
       and headers.auth_summary.dmarc.pass
     )
@@ -58,6 +86,7 @@ attack_types:
 tactics_and_techniques:
   - "Impersonation: Brand"
 detection_methods:
+  - "Natural Language Understanding"
   - "Header analysis"
   - "Sender analysis"
 id: "3bd048fe-5b3e-5050-b0d6-669653e14d9a"

--- a/detection-rules/brand_impersonation_vanguard.yml
+++ b/detection-rules/brand_impersonation_vanguard.yml
@@ -25,17 +25,17 @@ source: |
         .name in (
           "Security and Authentication",
           "Secure Message",
-          "Reminders and Notifications"
+          "Financial Communications"
         )
-        and .confidence in ("medium", "high")
+        and .confidence == "high"
     )
     or any(beta.ml_topic(beta.ocr(beta.message_screenshot()).text).topics,
            .name in (
              "Security and Authentication",
              "Secure Message",
-             "Reminders and Notifications"
+             "Financial Communications"
            )
-           and .confidence in ("medium", "high")
+           and .confidence == "high"
     )
     or any(ml.nlu_classifier(body.current_thread.text).intents,
            .name == "cred_theft" and .confidence == "high"

--- a/detection-rules/brand_impersonation_vanguard.yml
+++ b/detection-rules/brand_impersonation_vanguard.yml
@@ -61,6 +61,7 @@ source: |
         "vanguard.co.uk",
         "vanguard.com.au",
         "vanguard.com.hk",
+        "vanguardinvestor.co.uk",
         "vanguardretirement-mail.com",
         "e-vanguard.com",
         "feedback-vanguard.com",

--- a/detection-rules/brand_impersonation_vanguard.yml
+++ b/detection-rules/brand_impersonation_vanguard.yml
@@ -21,27 +21,31 @@ source: |
     )
   )
   and (
-    any(beta.ml_topic(body.current_thread.text).topics,
-        .name in (
-          "Security and Authentication",
-          "Secure Message",
-          "Financial Communications"
-        )
-        and .confidence == "high"
+    (
+      any(beta.ml_topic(body.current_thread.text).topics,
+          .name in (
+            "Security and Authentication",
+            "Secure Message",
+            "Financial Communications"
+          )
+          and .confidence == "high"
+      )
+      or any(beta.ml_topic(beta.ocr(beta.message_screenshot()).text).topics,
+             .name in (
+               "Security and Authentication",
+               "Secure Message",
+               "Financial Communications"
+             )
+             and .confidence == "high"
+      )
     )
-    or any(beta.ml_topic(beta.ocr(beta.message_screenshot()).text).topics,
-           .name in (
-             "Security and Authentication",
-             "Secure Message",
-             "Financial Communications"
-           )
-           and .confidence == "high"
-    )
-    or any(ml.nlu_classifier(body.current_thread.text).intents,
-           .name == "cred_theft" and .confidence == "high"
-    )
-    or any(ml.nlu_classifier(beta.ocr(beta.message_screenshot()).text).intents,
-           .name == "cred_theft" and .confidence == "high"
+    and (
+      any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "cred_theft" and .confidence == "high"
+      )
+      or any(ml.nlu_classifier(beta.ocr(beta.message_screenshot()).text).intents,
+             .name == "cred_theft" and .confidence == "high"
+      )
     )
   )
   

--- a/detection-rules/brand_impersonation_vanguard.yml
+++ b/detection-rules/brand_impersonation_vanguard.yml
@@ -60,3 +60,4 @@ tactics_and_techniques:
 detection_methods:
   - "Header analysis"
   - "Sender analysis"
+id: "3bd048fe-5b3e-5050-b0d6-669653e14d9a"

--- a/detection-rules/brand_impersonation_vanguard.yml
+++ b/detection-rules/brand_impersonation_vanguard.yml
@@ -1,0 +1,62 @@
+name: "Brand Impersonation: Vanguard"
+description: "Detects inbound messages from senders using Vanguard-like display names or domains, excluding legitimate Vanguard domains and authenticated communications. Additional checks ensure the sender is not from trusted organizational domains or high-trust sender domains with proper authentication."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+    // display name contains Vanguard
+    (
+      strings.ilike(strings.replace_confusables(sender.display_name),
+                    '*vanguard*'
+      )
+      // levenshtein distance similar to Vanguard
+      or strings.ilevenshtein(strings.replace_confusables(sender.display_name),
+                              'vanguard'
+      ) <= 1
+      // sender domain contains Vanguard
+      or strings.ilike(strings.replace_confusables(sender.email.domain.domain),
+                       '*vanguard*'
+      )
+    )
+  )
+  
+  // and the sender is not in org_domains or from Vanguard domains and passes auth
+  and not (
+    sender.email.domain.root_domain in $org_domains
+    or (
+      sender.email.domain.root_domain in (
+        "vanguard.com",
+        "vanguardcharitable.org", // philanthropic giving arm
+        "vanguardmexico.com",
+        "vanguardcanada.ca",
+        "vanguard.co.uk",
+        "vanguard.com.au",
+        "vanguard.com.hk",
+        "vanguardretirement-mail.com"
+      )
+      and headers.auth_summary.dmarc.pass
+    )
+  )
+  // and the sender is not from high trust sender root domains
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  and not profile.by_sender().solicited
+
+attack_types:
+  - "BEC/Fraud"
+  - "Callback Phishing"
+  - "Credential Phishing"
+  - "Extortion"
+  - "Malware/Ransomware"
+  - "Spam"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+detection_methods:
+  - "Header analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

Detects inbound messages from senders using Vanguard-like display names or domains, excluding legitimate Vanguard domains and authenticated communications. Additional checks ensure the sender is not from trusted organizational domains or high-trust sender domains with proper authentication.

# Associated samples
- https://platform.sublime.security/messages/57ff8d5d5dbc4894e8512aff697e511d8bfcd2585ac7f505d42fcb77ab0f50a5?preview_id=01951ffa-9f01-75e9-875e-d6663346a6ec
