### PR TITLE
Enhance spam_attendee_list_solicitation.yml to detect grocery store list solicitations

### DIFF
--- a/detection-rules/spam_attendee_list_solicitation.yml
+++ b/detection-rules/spam_attendee_list_solicitation.yml
@@ -12,7 +12,7 @@ source: |
         any([subject.subject, body.current_thread.text],
             (
               regex.icontains(.,
-                              '(?:Attendee|Buyer|Contact|Decision Maker|Email|Member|Participant|Professional|Registrant|User|Visitor)(?:[[:punct:]]*s)?(?:\s\w*){0,9}(?:list(?:\b|[^ei])|database)'
+                              '(?:Attendee|Buyer|Contact|Decision Maker|Email|Member|Participant|Professional|Registrant|User|Visitor|Store|Grocer)(?:[[:punct:]]*s)?(?:\s\w*){0,9}(?:list(?:\b|[^ei])|database)'
               )
               and not (
                 regex.icount(., '(email|contact)(?:[[:punct:]]*s)?(?:\s\w*){0,9}list') == 1
@@ -23,12 +23,12 @@ source: |
               )
             )
             or regex.icontains(.,
-                               '\b(?:list|database)(?:[[:punct:]]*s)?\b(\s\w*){0,9}(?:Attendee|Buyer|Contact|Decision Maker|Email|Member|Participant|Professional|Registrant|User|Visitor)s?'
+                               '\b(?:list|database)(?:[[:punct:]]*s)?\b(\s\w*){0,9}(?:Attendee|Buyer|Contact|Decision Maker|Email|Member|Participant|Professional|Registrant|User|Visitor|Store|Grocer)s?'
             )
         )
       )
       and regex.icontains(body.current_thread.text,
-                          "(?:interest(s|ed)|accessing|purchas|obtain|acuir|sample)"
+                          "(?:interest(s|ed)|accessing|purchas|obtain|acuir|sample|provide.{0,10}samples|counts|pricing)"
       )
       and not regex.icontains(body.current_thread.text,
                               "(?:debit card|transaction.{0,20}processed|receipt)"


### PR DESCRIPTION
## Summary
- Add "Store|Grocer" to entity types to detect grocery store list solicitations
- Expand pattern to detect phrases like "provide samples", "counts", and "pricing"
- These changes help detect emails offering lists of grocery stores and similar business entities

## Test plan
- Verify rule detects emails similar to:
  - Subject: "Grocery Stores- Need Samples?"
  - Body containing offers for "list of USA-based Grocery Stores" with "Samples", "Counts and Pricing"
- https://platform.sublime.security/messages/365c579cc168f6e881561b443bb62dde7f72b5bf50d07d3608911cd04780a091?preview_id=0195254f-bd47-7021-b3e2-c32ee1e24d21

🤖 Generated with Claude Code