### PR TITLE
Update body_extortion.yml

### DIFF
--- a/detection-rules/body_extortion.yml
+++ b/detection-rules/body_extortion.yml
@@ -41,7 +41,7 @@ source: |
                       "po[rŗ]n|adult (web)?site|webcam|mastu[rŗ]bating|je[rŗ]king off|pleasu[rŗ]ing you[rŗ]self|getting off"
       ),
       regex.icontains(strings.replace_confusables(body.current_thread.text),
-                      "perver[rŗ]|perve[rŗ]sion|mastu[rŗ]bat"
+                      "pe[rŗ]ve[rŗ]t|pe[rŗ]ve[rŗ]sion|mastu[rŗ]bat"
       ),
       // a timeframe to pay
       regex.icontains(strings.replace_confusables(body.current_thread.text),

--- a/detection-rules/body_extortion.yml
+++ b/detection-rules/body_extortion.yml
@@ -34,32 +34,32 @@ source: |
     or 3 of (
       // malware terms
       regex.icontains(strings.replace_confusables(body.current_thread.text),
-                      "((spy|mal)ware|trojan|remote control)"
+                      "((spy|mal)ware|t[rŗ]ojan|remote control)"
       ),
       // actions recorded
       regex.icontains(strings.replace_confusables(body.current_thread.text),
-                      "porn|adult (web)?site|webcam|masturbating|jerking off|pleasuring yourself|getting off"
+                      "po[rŗ]n|adult (web)?site|webcam|mastu[rŗ]bating|je[rŗ]king off|pleasu[rŗ]ing you[rŗ]self|getting off"
       ),
       regex.icontains(strings.replace_confusables(body.current_thread.text),
-                      "pervert|perversion|masturbat"
+                      "perver[rŗ]|perve[rŗ]sion|mastu[rŗ]bat"
       ),
       // a timeframe to pay
       regex.icontains(strings.replace_confusables(body.current_thread.text),
-                      '\d\d (?:hours|uur)',
-                      '(?:one|two|three|\d) days?'
+                      '[ilo0-9]{2} (?:hou[rŗ]s|uu[rŗ])',
+                      '(?:one|two|th[rŗ]ee|\d) days?'
       ),
       // a promise from the actor
       regex.icontains(strings.replace_confusables(body.current_thread.text),
-                      'permanently delete|(remove|destroy) (?:\w+\s*){0,4} (?:data|evidence|videos?)'
+                      '(?:pe[rŗ]manently|will) delete|([rŗ]emove|destroy) (?:\w+\s*){0,4} (?:data|evidence|videos?)'
       ),
       // a threat from the actor
       regex.icontains(strings.replace_confusables(body.current_thread.text),
-                      'sen[dt]\s*(?:\w+\s*){0,2}\s*to\s*(?:\w+\s*){0,3}\s*your contacts'
+                      'sen[dt]\s*(?:\w+\s*){0,2}\s*to\s*(?:\w+\s*){0,3}\s*you[rŗ] contacts'
       ),
       // bitcoin language (excluding newsletters)
       (
         regex.icontains(strings.replace_confusables(body.current_thread.text),
-                        'bitcoin|\bbtc\b|blockchain'
+                        'bitc[oöة]+in|\bbtc\b|blockchain'
         )
         // negate cryptocurrency newsletters
         and not (
@@ -117,8 +117,6 @@ source: |
     )
   )
   and length(body.current_thread.text) < 6000
-
-
 attack_types:
   - "Extortion"
 tactics_and_techniques:


### PR DESCRIPTION
# Description

- Update to address evasion in some letters which aren't currently replaced by `strings.replace_confusables`
- allow for `ilo` in addition to numbers when detecting the "duration" (hours) 

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/304b97dce2738a0333bdb0d47f2623c90f5e5979470e8f17dcda636cfb800e88?preview_id=01943c42-8f07-7959-86d3-d8fac525b623)

