### PR TITLE
Update suspicious_request_for_quote_or_purchase.yml

### DIFF
--- a/detection-rules/suspicious_request_for_quote_or_purchase.yml
+++ b/detection-rules/suspicious_request_for_quote_or_purchase.yml
@@ -37,60 +37,52 @@ source: |
     )
   )
   and (
-    3 of (
-      (
-        regex.icontains(body.current_thread.text,
-                        '(discuss.{0,15}purchas(e|ing))'
+    // Group the language patterns that specifically indicate RFQ/RFP
+    (
+      1 of (
+        // RFQ/RFP specific language patterns
+        regex.icontains(body.current_thread.text, '(discuss.{0,15}purchas(e|ing))'),
+        regex.icontains(body.current_thread.text, '(sign(ed?)|view).{0,10}(purchase order)|Request for a Quot(e|ation)'),
+        regex.icontains(body.current_thread.text, '(please|kindly).{0,30}quot(e|ation)'),
+        regex.icontains(subject.subject, '(request for (purchase|quot(e|ation))|\bRFQ\b|\bRFP\b|bid invit(e|ation))'),
+        any(attachments, regex.icontains(.file_name, "(purchase.?order|Quot(e|ation))")),
+        any(ml.nlu_classifier(body.current_thread.text).tags, .name == "purchase_order" and .confidence == "high")
+      )
+      // Required: at least one RFQ/RFP language pattern
+      
+      // Optional: at least one additional indicator (can be another language pattern or a non-language indicator)
+      and (
+        2 of (
+          // RFQ/RFP language patterns (same as above)
+          regex.icontains(body.current_thread.text, '(discuss.{0,15}purchas(e|ing))'),
+          regex.icontains(body.current_thread.text, '(sign(ed?)|view).{0,10}(purchase order)|Request for a Quot(e|ation)'),
+          regex.icontains(body.current_thread.text, '(please|kindly).{0,30}quot(e|ation)'),
+          regex.icontains(subject.subject, '(request for (purchase|quot(e|ation))|\bRFQ\b|\bRFP\b|bid invit(e|ation))'),
+          any(attachments, regex.icontains(.file_name, "(purchase.?order|Quot(e|ation))")),
+          any(ml.nlu_classifier(body.current_thread.text).tags, .name == "purchase_order" and .confidence == "high"),
+          
+          // Non-language indicators
+          (
+            any(ml.nlu_classifier(body.current_thread.text).entities, .name == "request")
+            and any(ml.nlu_classifier(body.current_thread.text).entities, .name == "urgency")
+          ),
+          (
+            0 < length(filter(body.links,
+                              (
+                                .href_url.domain.domain in $free_subdomain_hosts
+                                or .href_url.domain.domain in $free_file_hosts
+                                or network.whois(.href_url.domain).days_old < 30
+                              )
+                              and (
+                                regex.match(.display_text, '[A-Z ]+')
+                                or any(ml.nlu_classifier(.display_text).entities,
+                                       .name in ("request", "urgency")
+                                )
+                              )
+                       )
+            ) < 3
+          )
         )
-      ),
-      (
-        regex.icontains(body.current_thread.text,
-                        '(sign(ed?)|view).{0,10}(purchase order)|Request for a Quot(e|ation)'
-        )
-      ),
-      (
-        regex.icontains(body.current_thread.text,
-                        '(please|kindly).{0,30}quot(e|ation)'
-        )
-      ),
-      (
-        regex.icontains(subject.subject,
-                        '(request for (purchase|quot(e|ation))|\bRFQ\b|\bRFP\b|bid invit(e|ation))'
-        )
-      ),
-      (
-        any(attachments,
-            regex.icontains(.file_name, "(purchase.?order|Quot(e|ation))")
-        )
-      ),
-      (
-        any(ml.nlu_classifier(body.current_thread.text).entities,
-            .name == "request"
-        )
-        and any(ml.nlu_classifier(body.current_thread.text).entities,
-                .name == "urgency"
-        )
-      ),
-      (
-        any(ml.nlu_classifier(body.current_thread.text).tags,
-            .name == "purchase_order" and .confidence == "high"
-        )
-      ),
-      (
-        0 < length(filter(body.links,
-                          (
-                            .href_url.domain.domain in $free_subdomain_hosts
-                            or .href_url.domain.domain in $free_file_hosts
-                            or network.whois(.href_url.domain).days_old < 30
-                          )
-                          and (
-                            regex.match(.display_text, '[A-Z ]+')
-                            or any(ml.nlu_classifier(.display_text).entities,
-                                   .name in ("request", "urgency")
-                            )
-                          )
-                   )
-        ) < 3
       )
     )
     or (

--- a/detection-rules/suspicious_request_for_quote_or_purchase.yml
+++ b/detection-rules/suspicious_request_for_quote_or_purchase.yml
@@ -37,7 +37,7 @@ source: |
     )
   )
   and (
-    2 of (
+    3 of (
       (
         regex.icontains(body.current_thread.text,
                         '(discuss.{0,15}purchas(e|ing))'


### PR DESCRIPTION
# Description

Fixing logic error where a sample with no RFP/RFQ language could flag.
Instead of simply requiring 2 of any indicators, this change ensures that:
1. At least one specific RFQ/RFP language pattern must be present
2. At least two indicators total must be present
3. If at least two language patterns are present, the rule will fire
4. Non-language indicators alone won't trigger the rule

This maintains detection effectiveness while preventing false positives from non-RFQ/RFP content.


![Screenshot 2025-03-05 at 12 47 59 PM](https://github.com/user-attachments/assets/e26f271d-9810-4686-9d2d-fb2cce5d7c79)

# Associated samples
- https://platform.sublime.security/messages/25f70ab736f292245ba505e615986da0a67ff1fa0cabf69d448e62dee4afce5d?preview_id=01953dc2-f213-7eef-8998-e90f6612bf27
