### PR TITLE
Create brand_impersonation_wetransfer.yml

### DIFF
--- a/detection-rules/brand_impersonation_wetransfer.yml
+++ b/detection-rules/brand_impersonation_wetransfer.yml
@@ -4,61 +4,49 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and (
-    // Check for WeTransfer impersonation with suspicious indicators
+  and 2 of (
     (
-      // Display name is WeTransfer but sender domain is suspicious
-      (
-        (
-          strings.ilike(sender.display_name, '*wetransfer*')
-          or strings.ilike(sender.display_name, '*we transfer*')
-          or strings.ilike(sender.display_name, '*WE TRANSFER*')
-          or strings.ilevenshtein(sender.display_name, "wetransfer") <= 1
-        )
-        and (
-          // Check for misspelled wetransfer domains in sender email
-          regex.icontains(sender.email.email, 'nore?pl[a@]y@wetransfer')
+      strings.ilike(sender.display_name, '*wetransfer*')
+      or strings.ilike(sender.display_name, '*we transfer*')
+      or strings.ilevenshtein(sender.display_name, "wetransfer") <= 1
+    ),
   
-          // Check for non-legitimate TLDs (.fr or others)
-          or regex.icontains(sender.email.domain.domain,
-                             'wetransfer\\.[a-z]{2,4}$'
-          )
-        )
-      )
+    // Check for misspelled wetransfer domains in sender email
+    regex.icontains(sender.email.email, 'nore?pl[a@]y@wetransfer'),
   
-      // Or suspicious subject patterns
-      or regex.icontains(subject.subject,
-                         '(?:Documents?|Files?|Recieved) (?:Received|Sent|via) WeTransfer'
-      )
+    // Check for non-legitimate TLDs (.fr or others)
+    regex.icontains(sender.email.domain.root_domain, 'wetransfer\\.[a-z]{2,4}$'),
   
-      // Check for file reference numbers which are common in phishing
-      or regex.icontains(subject.subject,
-                         'WeTransfer \[(?:File No\.|)\s*:\s*[0-9-]+\s*\]'
-      )
+    // Suspicious subject patterns
+    regex.icontains(subject.subject,
+                    '(?:Documents?|Files?) (?:Received|Sent) (?:via)? WeTransfer'
+    ),
   
-      // French language patterns
-      or regex.icontains(subject.subject,
-                         'vous a envoy[ée] .{1,30} par WeTransfer'
-      )
-      or strings.ilike(subject.subject, "*TÉLÉCHARGEZ VOTRE FICHIER*")
-      or regex.icontains(body.current_thread.text, 'transfert expirera')
-      or regex.icontains(body.current_thread.text,
-                         "fichiers n'aient pas encore été téléchargés"
-      )
+    // Check for file reference numbers which are common in phishing
+    regex.icontains(subject.subject,
+                    'WeTransfer \[(?:File No\.|)\s*:\s*[0-9-]+\s*\]'
+    ),
+  
+    // French language patterns
+    regex.icontains(subject.subject, 'vous a envoy[ée] .{1,30} par WeTransfer'),
+    regex.icontains(subject.subject, "T[ÉE]L[ÉE]CHARGEZ VOTRE FICHIER"),
+    regex.icontains(body.current_thread.text, 'transfert expirera'),
+    regex.icontains(body.current_thread.text,
+                    "fichiers n'aient pas encore été téléchargés"
+    ),
+    any(body.links,
+        strings.ilike(.display_text, '*wetransfer*')
+        and .href_url.domain.root_domain not in~ ('wetransfer.com', 'we.tl')
+    ),
+    any(body.links,
+        .href_url.domain.root_domain in $free_file_hosts
+        or network.whois(.href_url.domain).days_old < 30
+        or .href_url.domain.tld in $suspicious_tlds
     )
   )
   and not (
-    // From legitimate wetransfer.com domain with passing DMARC
-    (
-      sender.email.domain.root_domain == "wetransfer.com"
-      and headers.auth_summary.dmarc.pass
-    )
-  
-    // From legitimate we.tl domain (their URL shortener) with passing DMARC
-    or (
-      sender.email.domain.root_domain == "we.tl"
-      and headers.auth_summary.dmarc.pass
-    )
+    sender.email.domain.root_domain in ("wetransfer.com", "we.tl")
+    and headers.auth_summary.dmarc.pass
   )
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (

--- a/detection-rules/brand_impersonation_wetransfer.yml
+++ b/detection-rules/brand_impersonation_wetransfer.yml
@@ -27,7 +27,6 @@ source: |
       )
   
       // Or suspicious subject patterns
-      or strings.ilike(subject.subject, '*wetransfer*', '*we transfer*')
       or regex.icontains(subject.subject,
                          '(?:Documents?|Files?|Recieved) (?:Received|Sent|via) WeTransfer'
       )

--- a/detection-rules/brand_impersonation_wetransfer.yml
+++ b/detection-rules/brand_impersonation_wetransfer.yml
@@ -39,7 +39,10 @@ source: |
         and .href_url.domain.root_domain not in~ ('wetransfer.com', 'we.tl')
     ),
     any(body.links,
-        .href_url.domain.root_domain in $free_file_hosts
+        (
+          .href_url.domain.root_domain in $free_file_hosts
+          and .href_url.domain.root_domain not in~ ('wetransfer.com', 'we.tl')
+        )
         or network.whois(.href_url.domain).days_old < 30
         or .href_url.domain.tld in $suspicious_tlds
     )

--- a/detection-rules/brand_impersonation_wetransfer.yml
+++ b/detection-rules/brand_impersonation_wetransfer.yml
@@ -91,3 +91,4 @@ detection_methods:
   - "Content analysis"
   - "Header analysis"
   - "Sender analysis"
+id: "e37885ad-1099-58f9-a428-0910c666d119"

--- a/detection-rules/brand_impersonation_wetransfer.yml
+++ b/detection-rules/brand_impersonation_wetransfer.yml
@@ -1,0 +1,93 @@
+name: "Brand Impersonation: WeTransfer"
+description: "Detects messages claiming to be from WeTransfer that contain suspicious indicators, including misspelled domains, non-standard TLDs, suspicious file reference numbers, and French language variations. Excludes legitimate WeTransfer traffic with valid DMARC authentication."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and (
+    // Check for WeTransfer impersonation with suspicious indicators
+    (
+      // Display name is WeTransfer but sender domain is suspicious
+      (
+        (
+          strings.ilike(sender.display_name, '*wetransfer*')
+          or strings.ilike(sender.display_name, '*we transfer*')
+          or strings.ilike(sender.display_name, '*WE TRANSFER*')
+          or strings.ilevenshtein(sender.display_name, "wetransfer") <= 1
+        )
+        and (
+          // Check for misspelled wetransfer domains in sender email
+          regex.icontains(sender.email.email, 'nore?pl[a@]y@wetransfer')
+  
+          // Check for non-legitimate TLDs (.fr or others)
+          or regex.icontains(sender.email.domain.domain,
+                             'wetransfer\\.[a-z]{2,4}$'
+          )
+        )
+      )
+  
+      // Or suspicious subject patterns
+      or strings.ilike(subject.subject, '*wetransfer*', '*we transfer*')
+      or regex.icontains(subject.subject,
+                         '(?:Documents?|Files?|Recieved) (?:Received|Sent|via) WeTransfer'
+      )
+  
+      // Check for file reference numbers which are common in phishing
+      or regex.icontains(subject.subject,
+                         'WeTransfer \[(?:File No\.|)\s*:\s*[0-9-]+\s*\]'
+      )
+  
+      // French language patterns
+      or regex.icontains(subject.subject,
+                         'vous a envoy[ée] .{1,30} par WeTransfer'
+      )
+      or strings.ilike(subject.subject, "*TÉLÉCHARGEZ VOTRE FICHIER*")
+      or regex.icontains(body.current_thread.text, 'transfert expirera')
+      or regex.icontains(body.current_thread.text,
+                         "fichiers n'aient pas encore été téléchargés"
+      )
+    )
+  )
+  and not (
+    // From legitimate wetransfer.com domain with passing DMARC
+    (
+      sender.email.domain.root_domain == "wetransfer.com"
+      and headers.auth_summary.dmarc.pass
+    )
+  
+    // From legitimate we.tl domain (their URL shortener) with passing DMARC
+    or (
+      sender.email.domain.root_domain == "we.tl"
+      and headers.auth_summary.dmarc.pass
+    )
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  and (
+    not profile.by_sender().solicited
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and not profile.by_sender().any_false_positives
+    )
+  )
+  and not profile.by_sender().any_false_positives
+
+attack_types:
+  - "BEC/Fraud"
+  - "Callback Phishing"
+  - "Credential Phishing"
+  - "Extortion"
+  - "Malware/Ransomware"
+  - "Spam"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description
Detects messages claiming to be from WeTransfer that contain suspicious indicators, including misspelled domains, non-standard TLDs, suspicious file reference numbers, and French language variations. Excludes legitimate WeTransfer traffic with valid DMARC authentication.

# Associated samples

- https://platform.sublime.security/messages/739b9cab11132677d6f18429ea89b2998cfcb5efad9a66d3231fed7c08765d53?preview_id=0194fd01-ac77-7d57-a0f4-8f97b7746f65
- https://platform.sublime.security/messages/hunt?huntId=019568a9-f736-76a4-9491-b37c3c20357e
