### PR TITLE
Update impersonation_linkedin.yml

### DIFF
--- a/detection-rules/impersonation_linkedin.yml
+++ b/detection-rules/impersonation_linkedin.yml
@@ -44,6 +44,12 @@ source: |
   )
   and sender.email.email not in $recipient_emails
   and not strings.iends_with(headers.message_id, "linkedin.com>")
+  
+  // LinkedIn corporate uses DocuSign
+  and not (
+    sender.email.domain.root_domain in~ ('docusign.net', 'docusign.com')
+    and all(headers.reply_to, .email.domain.root_domain == 'linkedin.com')
+  )
 
 attack_types:
   - "Credential Phishing"


### PR DESCRIPTION
# Description

Negating DocuSign notifications originating from linkedin.com reply-to addresses

# Associated samples

- https://platform.sublime.security/messages/b84451f11ad89dd9ca41fe65b87340e308d00d33c95801c678344133cd4bb68a?preview_id=019571f1-f45b-75fc-935b-fcce30e818be
