### PR TITLE
Update fake tax preparation rule to catch additional patterns

### DIFF
--- a/detection-rules/fake_tax_prep_request.yml
+++ b/detection-rules/fake_tax_prep_request.yml
@@ -19,13 +19,20 @@ source: |
     ) == length(body.links)
   )
   and length(attachments) == 0
-  and strings.ilike(subject.subject, "*tax*")
+  and (
+    strings.ilike(subject.subject, "*tax*") 
+    or strings.ilike(subject.subject, "*2024*tax*")
+  )
   and strings.icontains(body.current_thread.text, "tax")
-  and strings.like(body.current_thread.text,
-                   "*return*",
-                   "*record*",
-                   "*CPA*",
-                   "*filing*"
+  and (
+    strings.like(body.current_thread.text,
+                 "*return*",
+                 "*record*",
+                 "*CPA*",
+                 "*filing*",
+                 "*extension*"
+    )
+    or strings.ilike(body.current_thread.text, "*tax preparer*", "*tax*processing*")
   )
   and (
     strings.ilike(body.current_thread.text,
@@ -36,7 +43,12 @@ source: |
                   "*tax service*",
                   "*professional help*",
                   "*prepare*tax return*",
-                  "*service*tax return*"
+                  "*service*tax return*",
+                  "*seeking*tax preparer*",
+                  "*assist*processing*tax*",
+                  "*schedule*call*",
+                  "*zoom meeting*",
+                  "*discuss*fees*"
     )
     // suspicious patterns
     or (

--- a/detection-rules/fake_tax_prep_request.yml
+++ b/detection-rules/fake_tax_prep_request.yml
@@ -19,10 +19,7 @@ source: |
     ) == length(body.links)
   )
   and length(attachments) == 0
-  and (
-    strings.ilike(subject.subject, "*tax*") 
-    or strings.ilike(subject.subject, "*2024*tax*")
-  )
+  and strings.ilike(subject.subject, "*tax*") 
   and strings.icontains(body.current_thread.text, "tax")
   and (
     strings.like(body.current_thread.text,


### PR DESCRIPTION
## Summary
- Updated tax preparation scam detection rule to catch additional false negatives
- Expanded pattern matching for various tax preparation scam indicators
- Added support for "extension filing" and "tax preparer" language

## Test plan
Tested against the following sample that was previously a false negative:
- https://platform.sublime.security/messages/4bdbe4f220374cb5ac0e984a84bf2321a45c85c99954cfdab89f4c94325ebb7a

🤖 Generated with [Claude Code](https://claude.ai/code)