### PR TITLE
Update and rename link_referer_anon_services.yml to link_referrer_ano…

### DIFF
--- a/detection-rules/link_referrer_anon_services.yml
+++ b/detection-rules/link_referrer_anon_services.yml
@@ -1,4 +1,4 @@
-name: "Link: Referer Anonymization Service From Untrusted Sender"
+name: "Link: Referrer Anonymization Service From Untrusted Sender"
 description: "Detects messages containing links that utilize a referrer anonymization service. The rule examines senders who are either not in a trusted domain list or have failed DMARC authentication despite being from a trusted domain."
 type: "rule"
 severity: "medium"


### PR DESCRIPTION
Quick fix for spelling (yes, this is an intentional decision to disregard RFC 1945 in favour of upholding English language continuity)