### PR TITLE
Update link_credential_phishing_intent_and_other_indicators.yml

### DIFF
--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -117,6 +117,7 @@ source: |
                     "undelivered message",
                     "unread.*doc",
                     "unusual.activity",
+                    "(?:unrecognized|Unusual|suspicious|unknown) (?:log|sign).?[io]n attempt",
                     "upgrade.*account",
                     "upgrade.notice",
                     "urgent message",
@@ -357,6 +358,22 @@ source: |
       and any(body.links,
               // display text contains a request
               any(ml.nlu_classifier(.display_text).entities, .name == "request")
+      ),
+      any(body.links,
+          // display text contains a request
+          any(ml.nlu_classifier(.display_text).entities, .name == "request")
+          and (
+          .href_url.domain.domain in $url_shorteners
+          or .href_url.domain.root_domain in $url_shorteners
+          or (
+              .href_url.domain.root_domain in ("mimecast.com", "mimecastprotect.com")
+              and any($url_shorteners,
+                      strings.icontains(..href_url.query_params,
+                                      strings.concat('domain=', .),
+                      )
+              )
+          )
+          )
       )
     )
     or (


### PR DESCRIPTION
# Description
1. add condition for suspicious subject.
1. Add body links with a "request" that link to a url_shortner domains
 

Note: This section could benefit from regex extract to extract the domain from the mimecast url query param and do a more typical `in $url_shortners`
```
              and any($url_shorteners,
                      strings.icontains(..href_url.query_params,
                                      strings.concat('domain=', .),
                      )
              )
```

# Associated samples


- [Sample 1](https://platform.sublime.security/messages/4651770a821d5b32043f4a4bba8037d35c8cbc813598f9125ee0a843c8a6ac26?preview_id=019595b7-12a2-78d9-9f2a-50378fe5ac8a)
