### PR TITLE
Add generic security login alert phishing detection rule

### DIFF
--- a/detection-rules/link_fake_security_login_alert_generic.yml
+++ b/detection-rules/link_fake_security_login_alert_generic.yml
@@ -1,0 +1,100 @@
+name: "Credential Phishing: Fake Security Login Alert (Generic)"
+description: "Detects phishing attempts that claim suspicious login activity or unusual sign-in attempts regardless of brand"
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  
+  // Subject contains security alert language
+  and regex.icontains(subject.subject,
+                     "unusual login|unusual sign|login attempt|sign.?in attempt|suspicious sign|unusual activity|security alert")
+  
+  // Body contains security alert language
+  and regex.icontains(body.current_thread.text,
+                     "detect.*login|unusual.*login|suspicious.*login|login attempt|unusual sign|IP Address|Location|don't recognize|security|verify.*account|suspicious activity")
+  
+  // Link with suspicious display text
+  and any(body.links,
+         regex.icontains(.display_text, 
+                        "sign in|log in|login|verify|continue|account|confirm")
+  )
+  
+  // Link domains don't match sender
+  and any(body.links,
+         .href_url.domain.root_domain != sender.email.domain.root_domain
+         and .href_url.domain.root_domain not in $org_domains
+  )
+  
+  // Check for NLU credential theft intent
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "cred_theft" and .confidence in ("medium", "high")
+  )
+  
+  // Explicit negations for known legitimate security alert senders
+  and not (
+    regex.icontains(sender.email.domain.domain, 
+                   "lastpass.com|teachable.com|accountprotection.microsoft.com|notificationservices.org")
+    and headers.auth_summary.spf.pass
+  )
+  
+  // Sender profile checks
+  and (
+    (
+      profile.by_sender().prevalence in ("new", "outlier")
+      and not profile.by_sender().solicited
+    )
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and not profile.by_sender().any_false_positives
+    )
+  )
+  
+  // Stricter negation for high trust domains - must pass both SPF and DMARC
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and (
+        not headers.auth_summary.dmarc.pass
+        or not headers.auth_summary.spf.pass
+      )
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  
+  // Stronger senders of concern - limit to these patterns for common phishing sources
+  and (
+    regex.icontains(sender.display_name, 
+                   "Amazon|Microsoft|Meta|Facebook|Twitter|X|Chase|Wells Fargo|Bank|Metamask|Coinbase|AWS|Adobe|Navan|MEXC|Google")
+    or regex.icontains(sender.email.local_part, 
+                      "support|security|no[-_]?reply|secure|alert|service|admin|help|info|account")
+    or (
+      regex.icontains(sender.email.domain.domain, 
+                      "service|security|support|alert|secure|admin|google|microsoft|amazon")
+      and not regex.icontains(sender.email.domain.domain, "notificationservice")
+    )
+  )
+  
+  // Make sure the link URL pattern is suspicious (not just matching domain mismatch)
+  and any(body.links,
+         (
+           regex.icontains(.href_url.url, 
+                          "login|auth|sign|verify|account|secure|confirm|token|session|password")
+           or .href_url.domain.root_domain in $url_shorteners
+         )
+         or regex.icontains(.display_text, "log into my account")
+  )
+  
+  // Negate replies
+  and (
+    length(headers.references) == 0
+    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"
+  - "URL analysis"

--- a/detection-rules/link_fake_security_login_alert_generic.yml
+++ b/detection-rules/link_fake_security_login_alert_generic.yml
@@ -98,3 +98,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Sender analysis"
   - "URL analysis"
+id: "9fbdd60b-8f1b-52b2-9a55-c3f0b5e86c6d"


### PR DESCRIPTION
# Description

This PR adds a new rule for detecting login security alert phishing attempts that is brand-agnostic. Current phishing detection rules are often specific to particular brands (Microsoft, Chase, Meta, etc.), but attackers frequently use the same tactics across different brands. This rule provides a generic layer of detection for all login security alert phishing, regardless of which brand is being impersonated.

Features:
- Detects suspicious login/security alert language in subject and body
- Uses NLU for credential theft intent detection
- Checks for URL shorteners in links through the $url_shorteners list
- Includes smart sender pattern detection for common security alert impersonations
- Has explicit negations for legitimate security alert providers to reduce FPs
- Requires both SPF and DMARC failures for high trust sender domains

# Associated samples

- https://platform.sublime.security/messages/4651770a821d5b32043f4a4bba8037d35c8cbc813598f9125ee0a843c8a6ac26 (Navan phishing)
- Multiple AWS/MEXC/Meta security alert phishing samples detected in hunt

## Associated hunts

- https://platform.sublime.security/hunts/01959647-5ddb-74d2-837e-8abcca4163c6

🤖 Generated with [Claude Code](https://claude.ai/code)