### PR TITLE
Apply `format=url` to scan_base64

### DIFF
--- a/detection-rules/attachment_adobe_image_lure_qr_code.yml
+++ b/detection-rules/attachment_adobe_image_lure_qr_code.yml
@@ -55,7 +55,7 @@ source: |
                               .email.domain.valid
                               and (
                                 strings.icontains(..scan.qr.data, .email.email)
-                                or any(beta.scan_base64(..scan.qr.data),
+                                or any(beta.scan_base64(..scan.qr.data, format="url"),
                                        strings.icontains(., ..email.email)
                                 )
                               )

--- a/detection-rules/attachment_qr_link_b64_recipient.yml
+++ b/detection-rules/attachment_qr_link_b64_recipient.yml
@@ -16,7 +16,7 @@ source: |
           and any(file.explode(.),
                   any(recipients.to,
                       .email.domain.valid
-                      and any(beta.scan_base64(..scan.qr.url.url, ignore_padding=true),
+                      and any(beta.scan_base64(..scan.qr.url.url, format=url, ignore_padding=true),
                           strings.icontains(., ..email.email)
                       )
                   )

--- a/detection-rules/attachment_qr_link_b64_recipient.yml
+++ b/detection-rules/attachment_qr_link_b64_recipient.yml
@@ -16,7 +16,7 @@ source: |
           and any(file.explode(.),
                   any(recipients.to,
                       .email.domain.valid
-                      and any(beta.scan_base64(..scan.qr.url.url, format=url, ignore_padding=true),
+                      and any(beta.scan_base64(..scan.qr.url.url, format="url", ignore_padding=true),
                           strings.icontains(., ..email.email)
                       )
                   )

--- a/detection-rules/impersonation_meta.yml
+++ b/detection-rules/impersonation_meta.yml
@@ -95,17 +95,14 @@ source: |
           )
         )
         or any(recipients.to,
-               any(body.links,
-                   (strings.icontains(.href_url.url, ..email.email) and ..email.domain.valid)
-                   or any(beta.scan_base64(.href_url.url, format="url" ignore_padding=true),
+               .email.domain.valid 
+               and any(body.links,
+                   strings.icontains(.href_url.url, ..email.email
+                   or any(beta.scan_base64(.href_url.url, format="url", ignore_padding=true),
                           strings.icontains(., ...email.email)
-                          and ...email.domain.valid
                    )
-                   or any(beta.scan_base64(.href_url.fragment,
-                                           ignore_padding=true
-                          ),
+                   or any(beta.scan_base64(.href_url.fragment, ignore_padding=true),
                           strings.icontains(., ...email.email)
-                          and ...email.domain.valid
                    )
                )
         )

--- a/detection-rules/impersonation_meta.yml
+++ b/detection-rules/impersonation_meta.yml
@@ -96,14 +96,16 @@ source: |
         )
         or any(recipients.to,
                any(body.links,
-                   strings.icontains(.href_url.url, ..email.email)
-                   or any(beta.scan_base64(.href_url.url, ignore_padding=true),
+                   (strings.icontains(.href_url.url, ..email.email) and ..email.domain.valid)
+                   or any(beta.scan_base64(.href_url.url, format="url" ignore_padding=true),
                           strings.icontains(., ...email.email)
+                          and ...email.domain.valid
                    )
                    or any(beta.scan_base64(.href_url.fragment,
                                            ignore_padding=true
                           ),
                           strings.icontains(., ...email.email)
+                          and ...email.domain.valid
                    )
                )
         )

--- a/detection-rules/impersonation_meta.yml
+++ b/detection-rules/impersonation_meta.yml
@@ -97,7 +97,7 @@ source: |
         or any(recipients.to,
                .email.domain.valid 
                and any(body.links,
-                   strings.icontains(.href_url.url, ..email.email
+                   strings.icontains(.href_url.url, ..email.email)
                    or any(beta.scan_base64(.href_url.url, format="url", ignore_padding=true),
                           strings.icontains(., ...email.email)
                    )

--- a/detection-rules/link_qr_code_suspicious_language_fts.yml
+++ b/detection-rules/link_qr_code_suspicious_language_fts.yml
@@ -23,7 +23,7 @@ source: |
                           strings.icontains(..scan.qr.data, .email.email)
                           or (
                           // recipient email found in qr data base64 encoded
-                            any(beta.scan_base64(..scan.qr.data),
+                            any(beta.scan_base64(..scan.qr.data, format="url"),
                                 strings.icontains(., ..email.email)
                             )
                           )

--- a/insights/attachments/links_qr_contains_recipient_email.yml
+++ b/insights/attachments/links_qr_contains_recipient_email.yml
@@ -12,7 +12,7 @@ source: |
                          .email.domain.valid
                          and (
                            strings.icontains(..scan.qr.url.url, .email.email)
-                           or any(beta.scan_base64(..scan.qr.url.url),
+                           or any(beta.scan_base64(..scan.qr.url.url, format="url"),
                                   strings.icontains(., ..email.email)
                            )
                          )


### PR DESCRIPTION
# Description
Update the uses of scan_base64 to include `format=url` where the scan_base64 object is a url. 
