### PR TITLE
Create brand_impersonation_gmail.yml

### DIFF
--- a/detection-rules/brand_impersonation_gmail.yml
+++ b/detection-rules/brand_impersonation_gmail.yml
@@ -21,6 +21,7 @@ source: |
                        "gmail (support|technical|help) (team)"
     )
   )
+  and not strings.icontains(sender.display_name, "for Gmail")
   and (
     any(beta.ml_topic(body.current_thread.text).topics,
         .name in ("Security and Authentication")

--- a/detection-rules/brand_impersonation_gmail.yml
+++ b/detection-rules/brand_impersonation_gmail.yml
@@ -59,3 +59,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Optical Character Recognition"
   - "Sender analysis"
+id: "17667d8e-b09d-57e1-9766-78f3eebf877d"

--- a/detection-rules/brand_impersonation_gmail.yml
+++ b/detection-rules/brand_impersonation_gmail.yml
@@ -1,7 +1,7 @@
 name: "Brand Impersonation: Gmail"
 description: "Detects incoming messages from senders using Gmail-like display names or masquerading as Gmail support teams while discussing security and authentication topics. The rule analyzes message content and screenshots for credential harvesting signals, excluding legitimate organizational domains and authenticated high-trust senders."
 type: "rule"
-severity: ""
+severity: "medium"
 source: |
   type.inbound
   and (

--- a/detection-rules/brand_impersonation_gmail.yml
+++ b/detection-rules/brand_impersonation_gmail.yml
@@ -8,7 +8,7 @@ source: |
     // display name contains gmail
     (
       strings.ilike(strings.replace_confusables(sender.display_name), '*gmail*')
-      and sender.display_name != sender.email.email
+      and not sender.display_name =~ sender.email.email
     )
     // levenshtein distance similar to gmail
     or strings.ilevenshtein(strings.replace_confusables(sender.display_name),

--- a/detection-rules/brand_impersonation_gmail.yml
+++ b/detection-rules/brand_impersonation_gmail.yml
@@ -1,0 +1,61 @@
+name: "Brand Impersonation: Gmail"
+description: "Detects incoming messages from senders using Gmail-like display names or masquerading as Gmail support teams while discussing security and authentication topics. The rule analyzes message content and screenshots for credential harvesting signals, excluding legitimate organizational domains and authenticated high-trust senders."
+type: "rule"
+severity: ""
+source: |
+  type.inbound
+  and (
+    // display name contains gmail
+    (
+      strings.ilike(strings.replace_confusables(sender.display_name), '*gmail*')
+      and sender.display_name != sender.email.email
+    )
+    // levenshtein distance similar to gmail
+    or strings.ilevenshtein(strings.replace_confusables(sender.display_name),
+                            'gmail'
+    ) <= 1
+    or regex.icontains(body.current_thread.text,
+                       "gmail (support|technical|help) (team)"
+    )
+  )
+  and (
+    any(beta.ml_topic(body.current_thread.text).topics,
+        .name in ("Security and Authentication")
+        and .confidence in ("medium", "high")
+    )
+    or any(beta.ml_topic(beta.ocr(beta.message_screenshot()).text).topics,
+           .name in ("Security and Authentication")
+           and .confidence in ("medium", "high")
+    )
+    or any(ml.nlu_classifier(body.current_thread.text).intents,
+           .name == "cred_theft" and .confidence == "high"
+    )
+    or any(ml.nlu_classifier(beta.ocr(beta.message_screenshot()).text).intents,
+           .name == "cred_theft" and .confidence == "high"
+    )
+  )
+  
+  // and the sender is not in org_domains
+  and not sender.email.domain.root_domain in $org_domains
+  
+  // and the sender is not from high trust sender root domains
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  and not profile.by_sender().solicited
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Free email provider"
+  - "Impersonation: Brand"
+detection_methods:
+  - "Content analysis"
+  - "Natural Language Understanding"
+  - "Optical Character Recognition"
+  - "Sender analysis"

--- a/detection-rules/brand_impersonation_gmail.yml
+++ b/detection-rules/brand_impersonation_gmail.yml
@@ -8,12 +8,15 @@ source: |
     // display name contains gmail
     (
       strings.ilike(strings.replace_confusables(sender.display_name), '*gmail*')
-      and not sender.display_name =~ sender.email.email
+      and sender.display_name !~ sender.email.email
     )
     // levenshtein distance similar to gmail
-    or strings.ilevenshtein(strings.replace_confusables(sender.display_name),
-                            'gmail'
-    ) <= 1
+    or (
+      strings.ilevenshtein(strings.replace_confusables(sender.display_name),
+                           'gmail'
+      ) <= 1
+      and sender.display_name !~ "email"
+    )
     or regex.icontains(body.current_thread.text,
                        "gmail (support|technical|help) (team)"
     )


### PR DESCRIPTION
# Description
Detects incoming messages from senders using Gmail-like display names or masquerading as Gmail support teams while discussing security and authentication topics. The rule analyzes message content and screenshots for credential harvesting signals, excluding legitimate organizational domains and authenticated high-trust senders.

# Associated samples
- https://platform.sublime.security/messages/72831fedc392544d7af08e852effeaa1dcd9dccfda16a77cbb2efa622f0d0018?preview_id=019590b6-d506-79ce-8011-6c3c0f1c178c
- https://platform.sublime.security/messages/hunt?huntId=0195aa58-2cf2-79c0-9c13-689830eac62e
