### PR TITLE
Create link_squarespace_abuse.yml

### DIFF
--- a/detection-rules/link_squarespace_abuse.yml
+++ b/detection-rules/link_squarespace_abuse.yml
@@ -5,7 +5,7 @@ severity: "medium"
 source: |
   type.inbound
   and any(body.links, .href_url.domain.domain == "engage.squarespace-mail.com")
-  // there is one unique Klaviyo Link in the message
+  // there is one unique Squarespace Link in the message
   and length(distinct(filter(body.links,
                              .href_url.domain.domain == "engage.squarespace-mail.com"
                       ),

--- a/detection-rules/link_squarespace_abuse.yml
+++ b/detection-rules/link_squarespace_abuse.yml
@@ -5,6 +5,7 @@ severity: "medium"
 source: |
   type.inbound
   and any(body.links, .href_url.domain.domain == "engage.squarespace-mail.com")
+  and length(body.links) < 10
   // there is one unique Squarespace Link in the message
   and length(distinct(filter(body.links,
                              .href_url.domain.domain == "engage.squarespace-mail.com"

--- a/detection-rules/link_squarespace_abuse.yml
+++ b/detection-rules/link_squarespace_abuse.yml
@@ -13,6 +13,7 @@ source: |
              )
   ) == 1
   and not headers.return_path.domain.root_domain == "squarespace-mail.com"
+  and not any(headers.domains, .root_domain == "squarespace-mail.com")
   and profile.by_sender_email().prevalence != "common"
 
 attack_types:

--- a/detection-rules/link_squarespace_abuse.yml
+++ b/detection-rules/link_squarespace_abuse.yml
@@ -25,3 +25,4 @@ detection_methods:
   - "Header analysis"
   - "URL analysis"
   - "Sender analysis"
+id: "a8fe9d30-e64e-50e8-95d8-720e90676409"

--- a/detection-rules/link_squarespace_abuse.yml
+++ b/detection-rules/link_squarespace_abuse.yml
@@ -1,0 +1,27 @@
+name: "Link: Squarespace Infrastructure Abuse"
+description: "Detects inbound messages containing exactly one Squarespace tracking link but lacking authentic Squarespace email headers and sender patterns."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(body.links, .href_url.domain.domain == "engage.squarespace-mail.com")
+  // there is one unique Klaviyo Link in the message
+  and length(distinct(filter(body.links,
+                             .href_url.domain.domain == "engage.squarespace-mail.com"
+                      ),
+                      .href_url.url
+             )
+  ) == 1
+  and not headers.return_path.domain.root_domain == "squarespace-mail.com"
+  and profile.by_sender_email().prevalence != "common"
+
+attack_types:
+  - "Credential Phishing"
+  - "Spam"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Header analysis"
+  - "URL analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description
Detects inbound messages containing exactly one Squarespace tracking link but lacking authentic Squarespace email headers and sender patterns.

# Associated samples

- https://platform.sublime.security/messages/72831fedc392544d7af08e852effeaa1dcd9dccfda16a77cbb2efa622f0d0018?preview_id=019590b6-d506-79ce-8011-6c3c0f1c178c
- https://platform.sublime.security/messages/hunt?huntId=0195aa58-2cf2-79c0-9c13-689830eac62e
