### PR TITLE
Update link_credential_phishing_intent_and_other_indicators.yml

### DIFF
--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -363,16 +363,17 @@ source: |
           // display text contains a request
           any(ml.nlu_classifier(.display_text).entities, .name == "request")
           and (
-          .href_url.domain.domain in $url_shorteners
-          or .href_url.domain.root_domain in $url_shorteners
-          or (
-              .href_url.domain.root_domain in ("mimecast.com", "mimecastprotect.com")
-              and any($url_shorteners,
-                      strings.icontains(..href_url.query_params,
-                                      strings.concat('domain=', .),
-                      )
+            .href_url.domain.domain in $url_shorteners
+            or .href_url.domain.root_domain in $url_shorteners
+            or (
+              .href_url.domain.root_domain in (
+                "mimecast.com",
+                "mimecastprotect.com"
               )
-          )
+              and any(regex.extract(.href_url.query_params, 'domain=([^&]+)'),
+                      any(.groups, . in $url_shorteners)
+              )
+            )
           )
       )
     )


### PR DESCRIPTION
# Description

1. Use `regex.extract` instead of looping `$url_shorteners`
1. format
# Associated samples

- [Sample 1](https://platform.sublime.security/messages/4651770a821d5b32043f4a4bba8037d35c8cbc813598f9125ee0a843c8a6ac26?preview_id=019595b7-12a2-78d9-9f2a-50378fe5ac8a)
