### PR TITLE
Update attachment_callback_phish_with_pdf.yml

### DIFF
--- a/detection-rules/attachment_callback_phish_with_pdf.yml
+++ b/detection-rules/attachment_callback_phish_with_pdf.yml
@@ -19,14 +19,22 @@ source: |
   and length(attachments) == 1
   
   // sender is freemail
-  and sender.email.domain.root_domain in $free_email_providers
-  
+  and (
+    sender.email.domain.root_domain in $free_email_providers
+    // the sender is a common service, which has likely been sent through a DL
+    or (
+      sender.email.domain.root_domain in $tranco_50k
+      and all(recipients.to, .email.domain.domain not in $org_domains)
+    )
+  )
   // the attachment is a pdf with less than 3 pages, and at least 60 ocr chars
   and any(attachments,
           (
             .file_extension == "pdf"
             // get the length of the attached pdf
-            and any(file.explode(.), .depth == 0 and .scan.exiftool.page_count < 3)
+            and any(file.explode(.),
+                    .depth == 0 and .scan.exiftool.page_count < 3
+            )
             // check that any _single_ result in the file.explode matches these conditions
             // a second file.explode is required because the OCR is generated at a different depth within 
             // the file.explode results


### PR DESCRIPTION
# Description

allow callback with PDF to occur from non-freemail senders, if the sender is within tranco_50k and all recipients are not within the org domain

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/1f5175da3d5994423bc5c764de209a103dd6219d385df1f62545ebbcee4e9bc1?preview_id=0195ba82-65ca-7361-913e-ccff5215ac36)

## Associated hunts


- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=0195cdea-1b07-7f3b-bac3-1feb07af0f82)
