### PR TITLE
Allow a single rule to be modified by multiple PRs in test-rules

### DIFF
--- a/.github/workflows/update-test-rules.yml
+++ b/.github/workflows/update-test-rules.yml
@@ -93,6 +93,22 @@ jobs:
         run: |
           export pr_num=${{ github.event.issue.number }}
           
+          # Function to generate a deterministic UUID using the DNS namespace and a seed string
+          # This simulates the Python uuid.uuid5() function using native tools
+          generate_uuid() {
+            # Use the standard DNS namespace UUID as defined in RFC 4122
+            local DNS_NAMESPACE="6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+            local seed="$1"
+            
+            # Combine namespace and seed (similar to how Python's uuid5 implementation works)
+            # Generate a deterministic hash using openssl (similar concept to UUID5)
+            local hash=$(echo -n "$DNS_NAMESPACE$seed" | openssl dgst -sha1 | awk '{print $2}')
+            
+            # Format as UUID version 5
+            # First 8 chars, then 4 chars, then 4 chars (with first nibble set to 5 for UUID v5), etc.
+            echo "${hash:0:8}-${hash:8:4}-5${hash:13:3}-${hash:16:4}-${hash:20:12}"
+          }
+                  
           # Delete any files already referencing this PR. If they're no longer included in the PR this will remove them,
           # if they're still included we'll add them back below.
           files=$(ls destination/**/*.yml) || true
@@ -105,12 +121,15 @@ jobs:
           
           # This workflow is trigerred from an issue comment so we don't automatically have context on what changed in the PR
           # TODO: We can only retrieve 100 results, we need to add pagination support.
+          # Get the repository dynamically from the context
+          REPO="${GITHUB_REPOSITORY}"
+          
           curl -L \
             -o pr_files.json \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/sublime-security/sublime-rules/pulls/$pr_num/files?per_page=100
+            "https://api.github.com/repos/${REPO}/pulls/$pr_num/files?per_page=100"
           
           # Any files added/changed/modified will be copied to test-rules
           files_changed=$(jq -r '.[] | select(.status == "added" or .status == "modified" or .status == "changed") | .filename' pr_files.json)
@@ -119,9 +138,8 @@ jobs:
           # always use the latest sha.
           export sha=${{ steps.comment_branch.outputs.head_sha }}
           
-          # Copy any file that was added/changed/modified to the destination git folder (we could do this with git checkout
-          # but it doesn't seem any simpler). And then add testing metadata.
-          # If multiple PRs modify the same file, only one can be tested. This is solveable, but not something we see often.
+          # Copy any file that was added/changed/modified to the destination git folder
+          # Now with prefixing the filename and updating the ID
           for file in $files_changed; do
             # Skip any LA rules. We'll ignore these downstream anyway, but best to keep the branch clean.
             la_count=$(grep -c 'ml.link_analysis' source/$file || true)
@@ -130,9 +148,33 @@ jobs:
               continue
             fi
             
-            cp source/$file destination/$file
-            yq -i '.testing_pr = env(pr_num)' destination/$file
-            yq -i '.testing_sha = env(sha)' destination/$file
+            # Extract the base filename
+            base_filename=$(basename "$file")
+            # Create the prefixed filename with PR number
+            prefixed_filename="${pr_num}_${base_filename}"
+            # Get the directory of the original file
+            dir_path=$(dirname "$file")
+            
+            # Ensure the destination directory exists
+            mkdir -p "destination/$dir_path"
+            
+            # Copy the file to destination with original path structure
+            cp "source/$file" "destination/$dir_path/${prefixed_filename}"
+            
+            # Generate a deterministic UUID based on the prefixed filename
+            # test-rules requires each rule to have a unique, but deterministic
+            # id.  This will be different than the auto generated one with the main branch
+            new_uuid=$(generate_uuid "${prefixed_filename}")
+            echo "Generated UUID for ${prefixed_filename}: ${new_uuid}"
+            
+            # Update the ID in the YAML file using yq
+            yq -i '.id = "'$new_uuid'"' "destination/$dir_path/${prefixed_filename}"
+            
+            # Add testing_pr and testing_sha using yq
+            yq -i '.testing_pr = env(pr_num)' "destination/$dir_path/${prefixed_filename}"
+            yq -i '.testing_sha = env(sha)' "destination/$dir_path/${prefixed_filename}"
+            
+            echo "Processed $file -> $dir_path/${prefixed_filename}"
           done
           
           echo "Sync from PR#$pr_num" > message.txt

--- a/.github/workflows/update-test-rules.yml
+++ b/.github/workflows/update-test-rules.yml
@@ -161,7 +161,7 @@ jobs:
             # Copy the file to destination with original path structure
             cp "source/$file" "destination/$dir_path/${prefixed_filename}"
 
-            # Extract the original ID if it exists
+            # Extract the original ID before we update .id to the new_uuid
             yq -i '.og_id = .id' "destination/$dir_path/${prefixed_filename}"
             
             # Generate a deterministic UUID based on the prefixed filename

--- a/.github/workflows/update-test-rules.yml
+++ b/.github/workflows/update-test-rules.yml
@@ -160,6 +160,9 @@ jobs:
             
             # Copy the file to destination with original path structure
             cp "source/$file" "destination/$dir_path/${prefixed_filename}"
+
+            # Extract the original ID if it exists
+            yq -i '.og_id = .id' "destination/$dir_path/${prefixed_filename}"
             
             # Generate a deterministic UUID based on the prefixed filename
             # test-rules requires each rule to have a unique, but deterministic


### PR DESCRIPTION
# Description

Update the `update-test-rules` GH action to allow the same file to be modified by multiple PRs. 

This is accomplished by the following changes, which are specific to the test-rules branch:
1) Prepending the PR number to the output filename
2) Replacing the `id` calculated by `generate-rule-ids/main.py` (and added by the `[Run Rule Validation]`(https://github.com/sublime-security/sublime-rules/blob/main/.github/workflows/rule-validate.yml#L92C15-L97)` step) with a deterministic UUID based on the updated filename. 

The existing `Remove Stale from test-rules Branch` action keys in on the `testing_pr` key within the file which continue to function as it currently does. 

# Testing
This has been tested here within a fork's branch via https://github.com/zoomequipd/sublime-rules/pull/2.  You can observe the [action](https://github.com/zoomequipd/sublime-rules/actions/runs/14071099381/job/39405267516?pr=2) and the associated [commit](https://github.com/zoomequipd/sublime-rules/commit/891f9dbbde45151cd631a53081b5728baa5f81e1) to the test-rules branch. 

The cleanup GH action [could not be tested](https://github.com/zoomequipd/sublime-rules/actions/runs/14071893491/job/39407672046#step:4:49) due to logic preventing it from running on forked repos. 
However, the cleanup action is unchanged. 