### PR TITLE
Update impersonation_human_resources.yml

### DIFF
--- a/detection-rules/impersonation_human_resources.yml
+++ b/detection-rules/impersonation_human_resources.yml
@@ -33,8 +33,11 @@ source: |
     or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
   )
   // Negate common marketing mailers
-  and not regex.icontains(sender.display_name,
-                          'HR (?:Events|Expert|Support Center|Studies|Knowledge Cloud|News Library|Crowd|Solutions|Interests)|HR and People Operations'
+  and not (
+    sender.display_name is not null
+    and regex.icontains(sender.display_name,
+                        'HR (?:Events|Expert|Support Center|Studies|Knowledge Cloud|News Library|Crowd|Solutions|Interests)|HR and People Operations'
+    )
   )
   and not (
     any(headers.hops,
@@ -157,7 +160,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
 attack_types:
   - "BEC/Fraud"
   - "Credential Phishing"


### PR DESCRIPTION
# Description

Handle cases when the sender display name might be null, and thus regex.icontains returned null instead of false.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/328f492d55d80ddd0878c623e6e56743aed6e3b4fcc66c7ef15ee17fc77ef1a4?from_canonical_id=d5b376e18a4bc7517b6c428c295dd76e25c0dc10b91c837ae8f4e71d60e65f39&preview_id=0195f1ef-ca5a-78d0-9179-b625344c966c)

