### PR TITLE
convert to reply-to profiles

### DIFF
--- a/detection-rules/abuse_docsend_unsolicited_reply-to.yml
+++ b/detection-rules/abuse_docsend_unsolicited_reply-to.yml
@@ -10,37 +10,12 @@ source: |
   and headers.auth_summary.spf.pass
   and headers.auth_summary.dmarc.pass
 
-  // the message needs to have a reply-to address
-  and length(headers.reply_to) > 0
-
-  // reply-to email address has never been sent an email by the org
-  and not (
-    any(headers.reply_to, .email.email in $recipient_emails)
-    // if the reply-to email address is NOT in free_email_providers, check the domain in recipient_domains
-    or any(filter(headers.reply_to,
-                  // filter the list to only emails that are not in free_email_providers
-                  (
-                    .email.domain.domain not in $free_email_providers
-                    or .email.domain.root_domain not in $free_email_providers
-                  )
-           ),
-           .email.domain.domain in $recipient_domains
-    )
-  )
   // reply-to address has never sent an email to the org
-  and not (
-    any(headers.reply_to, .email.email in $sender_emails)
-    // if the reply-to address is NOT in free_email_providers, check the domain in sender_domains
-    or any(filter(headers.reply_to,
-                  // filter the list to only emails that are not in free_email_providers
-                  (
-                    .email.domain.domain not in $free_email_providers
-                    or .email.domain.root_domain not in $free_email_providers
-                  )
-           ),
-           .email.domain.domain in $sender_domains
-    )
-  )
+  and beta.profile.by_reply_to().prevalence == "new"
+  
+  // reply-to email address has never been sent an email by the org
+  and not beta.profile.by_reply_to().solicited
+
 tags:
  - "Attack surface reduction"
 attack_types:

--- a/detection-rules/abuse_docsend_unsolicited_reply-to.yml
+++ b/detection-rules/abuse_docsend_unsolicited_reply-to.yml
@@ -23,7 +23,7 @@ source: |
 
   // do not match if the reply_to address has been observed as a reply_to address
   // of a message that has been classified as benign
-  and not beta.profile.by_reply_to().any_benign_messages
+  and not beta.profile.by_reply_to().any_messages_benign
 
 tags:
  - "Attack surface reduction"

--- a/detection-rules/abuse_docsend_unsolicited_reply-to.yml
+++ b/detection-rules/abuse_docsend_unsolicited_reply-to.yml
@@ -10,11 +10,20 @@ source: |
   and headers.auth_summary.spf.pass
   and headers.auth_summary.dmarc.pass
 
+  // 
+  // This rule makes use of a beta feature and is subject to change without notice
+  // it is not suggestion to make use of this beta feature until it has been formally released
+  // 
+  
   // reply-to address has never sent an email to the org
   and beta.profile.by_reply_to().prevalence == "new"
   
   // reply-to email address has never been sent an email by the org
   and not beta.profile.by_reply_to().solicited
+
+  // do not match if the reply_to address has been observed as a reply_to address
+  // of a message that has been classified as benign
+  and not beta.profile.by_reply_to().any_benign_messages
 
 tags:
  - "Attack surface reduction"

--- a/detection-rules/abuse_docsend_unsolicited_reply-to.yml
+++ b/detection-rules/abuse_docsend_unsolicited_reply-to.yml
@@ -12,7 +12,7 @@ source: |
 
   // 
   // This rule makes use of a beta feature and is subject to change without notice
-  // it is not suggestion to make use of this beta feature until it has been formally released
+  // using the beta feature in custom rules is not suggested until it has been formally released
   // 
   
   // reply-to address has never sent an email to the org

--- a/detection-rules/abuse_docusign_sus_names.yml
+++ b/detection-rules/abuse_docusign_sus_names.yml
@@ -15,36 +15,20 @@ source: |
               or .email.domain.root_domain in $high_trust_sender_root_domains
               or .email.domain.root_domain in ("docusign.net", "docusign.com")
   )
+  // 
+  // This rule makes use of a beta feature and is subject to change without notice
+  // using the beta feature in custom rules is not suggested until it has been formally released
+  // 
   
-    and length(headers.reply_to) > 0 
-    // reply-to email address has never been sent an email by the org
-    and not (
-      any(headers.reply_to, .email.email in $recipient_emails)
-      // if the reply-to email address is NOT in free_email_providers, check the domain in recipient_domains
-      or any(filter(headers.reply_to,
-                    // filter the list to only emails that are not in free_email_providers
-                    (
-                      .email.domain.domain not in $free_email_providers
-                      or .email.domain.root_domain not in $free_email_providers
-                    )
-             ),
-             .email.domain.domain in $recipient_domains
-      )
-    )
-    // reply-to address has never sent an email to the org
-    and not (
-      any(headers.reply_to, .email.email in $sender_emails)
-      // if the reply-to address is NOT in free_email_providers, check the domain in sender_domains
-      or any(filter(headers.reply_to,
-                    // filter the list to only emails that are not in free_email_providers
-                    (
-                      .email.domain.domain not in $free_email_providers
-                      or .email.domain.domain not in $free_email_providers
-                    )
-             ),
-             .email.domain.domain in $sender_domains
-      )
-    )
+  // reply-to address has never sent an email to the org
+  and beta.profile.by_reply_to().prevalence == "new"
+  
+  // reply-to email address has never been sent an email by the org
+  and not beta.profile.by_reply_to().solicited
+  
+  // do not match if the reply_to address has been observed as a reply_to address
+  // of a message that has been classified as benign
+  and not beta.profile.by_reply_to().any_messages_benign
   
   // not a completed DocuSign
   // reminders are sent automatically and can be just as malicious as the initial
@@ -146,6 +130,7 @@ source: |
       or regex.icontains(subject.subject, '\bMFA\b')
     )
   )
+
 attack_types:
   - "Callback Phishing"
   - "BEC/Fraud"

--- a/detection-rules/abuse_docusign_unsolicited_reply-to.yml
+++ b/detection-rules/abuse_docusign_unsolicited_reply-to.yml
@@ -31,7 +31,7 @@ source: |
 
   // do not match if the reply_to address has been observed as a reply_to address
   // of a message that has been classified as benign
-  and not beta.profile.by_reply_to().any_benign_messages
+  and not beta.profile.by_reply_to().any_messages_benign
 
 tags:
  - "Attack surface reduction"

--- a/detection-rules/abuse_docusign_unsolicited_reply-to.yml
+++ b/detection-rules/abuse_docusign_unsolicited_reply-to.yml
@@ -17,12 +17,21 @@ source: |
   and not strings.istarts_with(subject.subject, "Completed: ")
   and not strings.istarts_with(subject.subject, "Here is your signed document: ")
   and not strings.istarts_with(subject.subject, "Voided: ")
+
+  // 
+  // This rule makes use of a beta feature and is subject to change without notice
+  // using the beta feature in custom rules is not suggested until it has been formally released
+  // 
   
   // reply-to address has never sent an email to the org
   and beta.profile.by_reply_to().prevalence == "new"
   
   // reply-to email address has never been sent an email by the org
   and not beta.profile.by_reply_to().solicited
+
+  // do not match if the reply_to address has been observed as a reply_to address
+  // of a message that has been classified as benign
+  and not beta.profile.by_reply_to().any_benign_messages
 
 tags:
  - "Attack surface reduction"

--- a/detection-rules/abuse_docusign_unsolicited_reply-to.yml
+++ b/detection-rules/abuse_docusign_unsolicited_reply-to.yml
@@ -18,35 +18,12 @@ source: |
   and not strings.istarts_with(subject.subject, "Here is your signed document: ")
   and not strings.istarts_with(subject.subject, "Voided: ")
   
-  and length(headers.reply_to) > 0 
-  // reply-to email address has never been sent an email by the org
-  and not (
-    any(headers.reply_to, .email.email in $recipient_emails)
-    // if the reply-to email address is NOT in free_email_providers, check the domain in recipient_domains
-    or any(filter(headers.reply_to,
-                  // filter the list to only emails that are not in free_email_providers
-                  (
-                    .email.domain.domain not in $free_email_providers
-                    or .email.domain.root_domain not in $free_email_providers
-                  )
-           ),
-           .email.domain.domain in $recipient_domains
-    )
-  )
   // reply-to address has never sent an email to the org
-  and not (
-    any(headers.reply_to, .email.email in $sender_emails)
-    // if the reply-to address is NOT in free_email_providers, check the domain in sender_domains
-    or any(filter(headers.reply_to,
-                  // filter the list to only emails that are not in free_email_providers
-                  (
-                    .email.domain.domain not in $free_email_providers
-                    or .email.domain.root_domain not in $free_email_providers
-                  )
-           ),
-           .email.domain.domain in $sender_domains
-    )
-  )
+  and beta.profile.by_reply_to().prevalence == "new"
+  
+  // reply-to email address has never been sent an email by the org
+  and not beta.profile.by_reply_to().solicited
+
 tags:
  - "Attack surface reduction"
 attack_types:

--- a/detection-rules/abuse_dropbox_new_domain.yml
+++ b/detection-rules/abuse_dropbox_new_domain.yml
@@ -16,15 +16,21 @@ source: |
   
   // the message needs to have a reply-to address
   and length(headers.reply_to) > 0
+
+  // 
+  // This rule makes use of a beta feature and is subject to change without notice
+  // using the beta feature in custom rules is not suggested until it has been formally released
+  // 
   
-  // reply-to email address has never received an email from your org
-  and not any(headers.reply_to, .email.email in $recipient_emails)
+  // reply-to email address has never been sent an email by the org
+  and not beta.profile.by_reply_to().solicited
+  
+  // do not match if the reply_to address has been observed as a reply_to address
+  // of a message that has been classified as benign
+  and not beta.profile.by_reply_to().any_messages_benign
   
   // new reply-to domain
-  and any(filter(headers.reply_to,
-                  // negate .com.au which doesn't provide created date for domains
-                  .email.domain.tld not in ('com.au')
-          ),
+  and any(headers.reply_to,
           network.whois(.email.domain).days_old < 30
   )
 tags:

--- a/detection-rules/abuse_dropbox_unsolicited_reply-to.yml
+++ b/detection-rules/abuse_dropbox_unsolicited_reply-to.yml
@@ -15,11 +15,21 @@ source: |
   and strings.icontains(subject.subject, 'shared')
   and strings.icontains(subject.subject, 'with you')
   
+  //
+  // This rule makes use of a beta feature and is subject to change without notice
+  // using the beta feature in custom rules is not suggested until it has been formally released
+  //
+  
   // reply-to address has never sent an email to the org
   and beta.profile.by_reply_to().prevalence == "new"
   
   // reply-to email address has never been sent an email by the org
   and not beta.profile.by_reply_to().solicited
+
+  // do not match if the reply_to address has been observed as a reply_to address
+  // of a message that has been classified as benign
+  and not beta.profile.by_reply_to().any_messages_benign
+  
 tags:
  - "Attack surface reduction"
 attack_types:

--- a/detection-rules/abuse_dropbox_unsolicited_reply-to.yml
+++ b/detection-rules/abuse_dropbox_unsolicited_reply-to.yml
@@ -15,35 +15,11 @@ source: |
   and strings.icontains(subject.subject, 'shared')
   and strings.icontains(subject.subject, 'with you')
   
-  and length(headers.reply_to) > 0
-  // reply-to email address has never been sent an email by the org
-  and not (
-    any(headers.reply_to, .email.email in $recipient_emails)
-    // if the reply-to email address is NOT in free_email_providers, check the domain in recipient_domains
-    or any(filter(headers.reply_to,
-                  // filter the list to only emails that are not in free_email_providers
-                  (
-                    .email.domain.domain not in $free_email_providers
-                    or .email.domain.root_domain not in $free_email_providers
-                  )
-           ),
-           .email.domain.domain in $recipient_domains
-    )
-  )
   // reply-to address has never sent an email to the org
-  and not (
-    any(headers.reply_to, .email.email in $sender_emails)
-    // if the reply-to address is NOT in free_email_providers, check the domain in sender_domains
-    or any(filter(headers.reply_to,
-                  // filter the list to only emails that are not in free_email_providers
-                  (
-                    .email.domain.domain not in $free_email_providers
-                    or .email.domain.root_domain not in $free_email_providers
-                  )
-           ),
-           .email.domain.domain in $sender_domains
-    )
-  )
+  and beta.profile.by_reply_to().prevalence == "new"
+  
+  // reply-to email address has never been sent an email by the org
+  and not beta.profile.by_reply_to().solicited
 tags:
  - "Attack surface reduction"
 attack_types:

--- a/detection-rules/abuse_google_drive_unsolicited_reply-to.yml
+++ b/detection-rules/abuse_google_drive_unsolicited_reply-to.yml
@@ -10,37 +10,12 @@ source: |
   )
   and not any(headers.reply_to, .email.domain.domain in $org_domains)
   
-  // the message needs to have a reply-to address
-  and length(headers.reply_to) > 0
+  // reply-to address has never sent an email to the org
+  and beta.profile.by_reply_to().prevalence == "new"
   
   // reply-to email address has never been sent an email by the org
-  and not (
-    any(headers.reply_to, .email.email in $recipient_emails)
-    // if the reply-to email address is NOT in free_email_providers, check the domain in recipient_domains
-    or any(filter(headers.reply_to,
-                  // filter the list to only emails that are not in free_email_providers
-                  (
-                    .email.domain.domain not in $free_email_providers
-                    or .email.domain.root_domain not in $free_email_providers
-                  )
-           ),
-           .email.domain.domain in $recipient_domains
-    )
-  )
-  // reply-to address has never sent an email to the org
-  and not (
-    any(headers.reply_to, .email.email in $sender_emails)
-    // if the reply-to address is NOT in free_email_providers, check the domain in sender_domains
-    or any(filter(headers.reply_to,
-                  // filter the list to only emails that are not in free_email_providers
-                  (
-                    .email.domain.domain not in $free_email_providers
-                    or .email.domain.root_domain not in $free_email_providers
-                  )
-           ),
-           .email.domain.domain in $sender_domains
-    )
-  )
+  and not beta.profile.by_reply_to().solicited
+
 tags:
  - "Attack surface reduction"
 attack_types:

--- a/detection-rules/abuse_google_drive_unsolicited_reply-to.yml
+++ b/detection-rules/abuse_google_drive_unsolicited_reply-to.yml
@@ -10,10 +10,10 @@ source: |
   )
   and not any(headers.reply_to, .email.domain.domain in $org_domains)
 
-  // 
+  //
   // This rule makes use of a beta feature and is subject to change without notice
-  // it is not suggestion to make use of this beta feature until it has been formally released
-  // 
+  // using the beta feature in custom rules is not suggested until it has been formally released
+  //
   
   // reply-to address has never sent an email to the org
   and beta.profile.by_reply_to().prevalence == "new"
@@ -23,7 +23,7 @@ source: |
 
   // do not match if the reply_to address has been observed as a reply_to address
   // of a message that has been classified as benign
-  and not beta.profile.by_reply_to().any_benign_messages
+  and not beta.profile.by_reply_to().any_messages_benign
 
 tags:
  - "Attack surface reduction"

--- a/detection-rules/abuse_google_drive_unsolicited_reply-to.yml
+++ b/detection-rules/abuse_google_drive_unsolicited_reply-to.yml
@@ -9,12 +9,21 @@ source: |
     'drive-shares-noreply@google.com',
   )
   and not any(headers.reply_to, .email.domain.domain in $org_domains)
+
+  // 
+  // This rule makes use of a beta feature and is subject to change without notice
+  // it is not suggestion to make use of this beta feature until it has been formally released
+  // 
   
   // reply-to address has never sent an email to the org
   and beta.profile.by_reply_to().prevalence == "new"
   
   // reply-to email address has never been sent an email by the org
   and not beta.profile.by_reply_to().solicited
+
+  // do not match if the reply_to address has been observed as a reply_to address
+  // of a message that has been classified as benign
+  and not beta.profile.by_reply_to().any_benign_messages
 
 tags:
  - "Attack surface reduction"

--- a/detection-rules/abuse_quickbooks_new_domain.yml
+++ b/detection-rules/abuse_quickbooks_new_domain.yml
@@ -19,14 +19,20 @@ source: |
   // the message needs to have a reply-to address
   and length(headers.reply_to) > 0
   
-  // reply-to email address has never received an email from your org
-  and not any(headers.reply_to, .email.email in $recipient_emails)
+  // 
+  // This rule makes use of a beta feature and is subject to change without notice
+  // using the beta feature in custom rules is not suggested until it has been formally released
+  // 
+  
+  // reply-to email address has never been sent an email by the org
+  and not beta.profile.by_reply_to().solicited
+  
+  // do not match if the reply_to address has been observed as a reply_to address
+  // of a message that has been classified as benign
+  and not beta.profile.by_reply_to().any_messages_benign
   
   // new reply-to
-  and any(filter(headers.reply_to,
-                 // negate .com.au which doesn't provide created date for domains
-                 .email.domain.tld not in ('com.au')
-          ),
+  and any(headers.reply_to,
           network.whois(.email.domain).days_old < 30
   )
 tags:

--- a/detection-rules/docusign_new_sender_domain.yml
+++ b/detection-rules/docusign_new_sender_domain.yml
@@ -4,17 +4,22 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  
-  // reply-to email address has never received an email from your org
-  and not any(headers.reply_to, .email.email in $recipient_emails)
-  
-  // new reply-to
-  and any(headers.reply_to, network.whois(.email.domain).days_old < 30)
-  
+
   // message is from docusign actual
   and sender.email.domain.root_domain == 'docusign.net'
   and (headers.auth_summary.spf.pass or headers.auth_summary.dmarc.pass)
-  
+
+  // 
+  // This rule makes use of a beta feature and is subject to change without notice
+  // using the beta feature in custom rules is not suggested until it has been formally released
+  // 
+
+  // reply-to email address has never been sent an email by the org
+  and not beta.profile.by_reply_to().solicited
+
+  // new reply-to
+  and any(headers.reply_to, network.whois(.email.domain).days_old < 30)
+
   // not a completed DocuSign
   and not strings.istarts_with(subject.subject, "Completed:")
 tags:

--- a/detection-rules/headers_replyto_new_domain_nlu_request.yml
+++ b/detection-rules/headers_replyto_new_domain_nlu_request.yml
@@ -28,7 +28,13 @@ source: |
   )
   and (
     not profile.by_sender().solicited
+    
+    // 
+    // This rule makes use of a beta feature and is subject to change without notice
+    // using the beta feature in custom rules is not suggested until it has been formally released
+    // 
     or not beta.profile.by_reply_to().solicited
+    
     or (
       profile.by_sender().any_messages_malicious_or_spam
       and not profile.by_sender().any_false_positives

--- a/detection-rules/headers_replyto_new_domain_nlu_request.yml
+++ b/detection-rules/headers_replyto_new_domain_nlu_request.yml
@@ -28,11 +28,7 @@ source: |
   )
   and (
     not profile.by_sender().solicited
-    or (
-      length(headers.reply_to) > 0
-      // reply-to email address as never been sent an email by the org
-      and all(headers.reply_to, .email.email not in $recipient_emails)
-    )
+    or not beta.profile.by_reply_to().solicited
     or (
       profile.by_sender().any_messages_malicious_or_spam
       and not profile.by_sender().any_false_positives

--- a/detection-rules/link_multistage_docusign.yml
+++ b/detection-rules/link_multistage_docusign.yml
@@ -5,8 +5,17 @@ severity: "high"
 source: |
   type.inbound
   
-  // reply-to email address as never been sent an email by the org
-  and not any(headers.reply_to, .email.email in $recipient_emails)
+  //
+  // This rule makes use of a beta feature and is subject to change without notice
+  // using the beta feature in custom rules is not suggested until it has been formally released
+  //
+    
+  // reply-to email address has never been sent an email by the org
+  and not beta.profile.by_reply_to().solicited
+
+  // do not match if the reply_to address has been observed as a reply_to address
+  // of a message that has been classified as benign
+  and not beta.profile.by_reply_to().any_messages_benign
   
   // message is from docusign actual
   and sender.email.domain.root_domain == 'docusign.net'

--- a/detection-rules/link_multistage_google_drive.yml
+++ b/detection-rules/link_multistage_google_drive.yml
@@ -34,7 +34,7 @@ source: |
   and not any(regex.iextract(sender.display_name,
                              '^(?P<sender_display_name>.*)\((?:via )?Google'
               ),
-              .named_groups["sender_display_name"] in $org_display_names
+              .named_groups["sender_display_name"] in~ $org_display_names
   )
   
   // threat actors dont want others to edit the share

--- a/detection-rules/link_multistage_google_drive.yml
+++ b/detection-rules/link_multistage_google_drive.yml
@@ -5,8 +5,18 @@ severity: "high"
 source: |
   type.inbound
   
-  // reply-to email address as never been sent an email by the org
-  and not any(headers.reply_to, .email.email in $recipient_emails)
+  //
+  // This rule makes use of a beta feature and is subject to change without notice
+  // using the beta feature in custom rules is not suggested until it has been formally released
+  //
+  // the reply-to address is new or unsolicited
+  and ( 
+    // reply-to address has never sent an email to the org
+     beta.profile.by_reply_to().prevalence == "new"
+  
+    // reply-to email address has never been sent an email by the org
+    or not beta.profile.by_reply_to().solicited
+  )
   
   // message is from google actual
   and sender.email.domain.domain == 'google.com'
@@ -21,9 +31,10 @@ source: |
   and headers.auth_summary.dmarc.pass
   
   // not where the sender display name is within org_display_names
-  and not any($org_display_names,
-      strings.istarts_with(sender.display_name, strings.concat(., " (via Google "))
-      or strings.istarts_with(sender.display_name, strings.concat(., " (Google "))
+  and not any(regex.iextract(sender.display_name,
+                             '^(?P<sender_display_name>.*)\((?:via )?Google'
+              ),
+              .named_groups["sender_display_name"] in $org_display_names
   )
   
   // threat actors dont want others to edit the share

--- a/detection-rules/link_secure_sharepoint_file.yml
+++ b/detection-rules/link_secure_sharepoint_file.yml
@@ -23,19 +23,7 @@ source: |
   and (
     profile.by_sender().prevalence in ("new", "rare", "outlier")
     // or the reply-to address has never sent an email to the org
-    or (
-      any(headers.reply_to, .email.email not in $sender_emails)
-      // if the reply-to address is NOT in free_email_providers, check the domain in sender_domains
-      or any(filter(headers.reply_to,
-                    // filter the list to only emails that are not in free_email_providers
-                    (
-                      .email.domain.domain not in $free_email_providers
-                      or .email.domain.root_domain not in $free_email_providers
-                    )
-             ),
-             .email.domain.domain in $sender_domains
-      )
-    )
+    or profile.by_sender().prevalence in ("new")
   )
   and not profile.by_sender().solicited
 tags:

--- a/detection-rules/suspicious_sharepoint_file_shared.yml
+++ b/detection-rules/suspicious_sharepoint_file_shared.yml
@@ -44,7 +44,7 @@ source: |
         )
   
         // no outbound emails 
-        or all(headers.reply_to, .email.email not in $recipient_emails)
+        or not beta.profile.by_reply_to().solicited
       )
     )
   )

--- a/detection-rules/suspicious_sharepoint_file_shared.yml
+++ b/detection-rules/suspicious_sharepoint_file_shared.yml
@@ -42,10 +42,18 @@ source: |
         or all(headers.reply_to,
                .email.domain.root_domain in $free_email_providers
         )
-  
+
+        //
+        // This rule makes use of a beta feature and is subject to change without notice
+        // using the beta feature in custom rules is not suggested until it has been formally released
+        //
+        
         // no outbound emails 
         or not beta.profile.by_reply_to().solicited
       )
+      // do not match if the reply_to address has been observed as a reply_to address
+      // of a message that has been classified as benign
+      and not beta.profile.by_reply_to().any_messages_benign
     )
   )
   // link logic


### PR DESCRIPTION
# Description
Convert rules to use the reply-to profiles - single PR for multiple rules

> [!WARNING]
> This PR makes use of a beta feature `beta.profile.by_reply_to()`.  This feature is subject to change without notice and is not suggested for use within custom rules.  