### PR TITLE
Use github event sha to validate branch

### DIFF
--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -53,7 +53,7 @@ jobs:
           fi
           
           echo "##[set-output name=head_ref;]$head_ref"
-          echo "##[set-output name=repo;]$repo"
+          echo "##[set-output name=repo;]$repo"          
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -61,6 +61,17 @@ jobs:
           repository: ${{ steps.get_head_ref.outputs.repo }}
           ref: ${{ steps.get_head_ref.outputs.head_ref }}
           fetch-depth: 0
+
+      - name: Validate Branch vs. Trigerring SHA
+        run: |
+          # If this is from a pull request validate that what we checked out is the same as the PR head.
+          # If not we'll just fail -- the workflow will be cancelled momentarily.
+          if [[ "${{ github.event_name }}" == 'pull_request_target' ]]; then
+            if [[ "${{ github.event.pull_request.head.sha }}" != "$(git rev-parse HEAD)" ]]; then
+              echo "Workflow is out of date with branch, cancelling"
+              exit 1
+            fi
+          fi
 
       - name: Get Refs
         id: get_base_ref

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -53,7 +53,7 @@ jobs:
           fi
           
           echo "##[set-output name=head_ref;]$head_ref"
-          echo "##[set-output name=repo;]$repo"          
+          echo "##[set-output name=repo;]$repo"
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description

Prevent an issue where checks run with a later commit on the branch (e.g. a merge from `main`).

I validated by opening a PR against this branch and ensuring that basic operations succeed (adding a rule ID). CI succeeded on that PR, but I did not try and simulate the race condition.
