### PR TITLE
Update link_google_share_notificaiton_sus_comments.yml

### DIFF
--- a/detection-rules/link_google_share_notificaiton_sus_comments.yml
+++ b/detection-rules/link_google_share_notificaiton_sus_comments.yml
@@ -43,13 +43,10 @@ source: |
     and headers.auth_summary.dmarc.pass
     // but the sender display name is within org_display_names
     and (
-      any($org_display_names,
-          strings.istarts_with(sender.display_name,
-                               strings.concat(., " (via Google ")
-          )
-          or strings.istarts_with(sender.display_name,
-                                  strings.concat(., " (Google ")
-          )
+      any(regex.iextract(sender.display_name,
+                                 '^(?P<sender_display_name>.*)\((?:via )?Google'
+                  ),
+                  .named_groups["sender_display_name"] in $org_display_names
       )
       or (
         length(headers.reply_to) == 1

--- a/detection-rules/link_google_share_notificaiton_sus_comments.yml
+++ b/detection-rules/link_google_share_notificaiton_sus_comments.yml
@@ -46,7 +46,7 @@ source: |
       any(regex.iextract(sender.display_name,
                                  '^(?P<sender_display_name>.*)\((?:via )?Google'
                   ),
-                  .named_groups["sender_display_name"] in $org_display_names
+                  .named_groups["sender_display_name"] in~ $org_display_names
       )
       or (
         length(headers.reply_to) == 1


### PR DESCRIPTION
# Description

Use regex extract to extract the sender display and check the value in the list instead of looping through $org_display_names
