### PR TITLE
Create canva_link_abuse.yml

### DIFF
--- a/detection-rules/canva_link_abuse.yml
+++ b/detection-rules/canva_link_abuse.yml
@@ -1,0 +1,44 @@
+name: "Canva Link Abuse"
+description: "Detects when a sender outside of Canva shares a single Canva link, where the sender has low historical sending volume."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(body.links,
+          strings.icontains(.href_url.domain.root_domain, 'canva.com')
+          or strings.icontains(.href_url.query_params, 'canva.com')
+  )
+  
+  // there is one unique Canva link in the message
+  and length(distinct(filter(body.links,
+                             strings.icontains(.href_url.domain.root_domain,
+                                               'canva.com'
+                             )
+                             or strings.icontains(.href_url.query_params,
+                                                  'canva.com'
+                             )
+                      ),
+                      .href_url.url
+             )
+  ) <= 1
+  
+  and not (
+    sender.email.domain.root_domain == "canva.com"
+    and headers.auth_summary.dmarc.pass
+  )
+  and profile.by_sender_email().prevalence != "common"
+tags:
+ - "Attack surface reduction"
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Free file host"
+  - "Impersonation: Brand"
+  - "Social engineering"
+  - "Evasion"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Sender analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description
Detects when a sender outside of Canva shares a single Canva link, where the sender has low historical sending volume.

# Associated samples
- https://platform.sublime.security/hunts/01961116-8dda-7642-bb03-c3f2ed39f80f