### PR TITLE
Create generic_service_abuse_reply_to.yml

### DIFF
--- a/detection-rules/generic_service_abuse_reply_to.yml
+++ b/detection-rules/generic_service_abuse_reply_to.yml
@@ -24,3 +24,4 @@ detection_methods:
   - "Header analysis"
   - "Sender analysis"
   - "Whois"
+id: "0937b4c5-72d8-5efd-834f-c80ca8336f25"

--- a/detection-rules/generic_service_abuse_reply_to.yml
+++ b/detection-rules/generic_service_abuse_reply_to.yml
@@ -1,0 +1,26 @@
+name: "Generic Service Abuse From Newly Registered Domain"
+description: "Detects messages from services that write the true sender to the reply-to field, where the sender has no prior legitimate message history and is newly registered. Indicative of service abuse."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(headers.reply_to, network.whois(.email.domain).days_old < 30)
+  and sender.email.domain.domain in $replyto_service_domains
+  // 
+  // This rule makes use of a beta feature and is subject to change without notice
+  // using the beta feature in custom rules is not suggested until it has been formally released
+  // 
+  and not beta.profile.by_reply_to().solicited
+  and not beta.profile.by_reply_to().any_messages_benign
+
+attack_types:
+  - "BEC/Fraud"
+  - "Callback Phishing"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "Header analysis"
+  - "Sender analysis"
+  - "Whois"


### PR DESCRIPTION
# Description

Detects messages from services that write the true sender to the reply-to field, where the sender has no prior legitimate message history and is newly registered. Indicative of service abuse.

# Associated samples

- https://platform.sublime.security/messages/hunt?huntId=01961678-7e78-70a6-8e94-f3cce55d4975
