### PR TITLE
Update attachment_adobe_image_lure.yml

### DIFF
--- a/detection-rules/attachment_adobe_image_lure.yml
+++ b/detection-rules/attachment_adobe_image_lure.yml
@@ -79,13 +79,13 @@ source: |
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
   and (
-    not profile.by_sender().solicited
+    not profile.by_sender_email().solicited
     or (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_false_positives
+      profile.by_sender_email().any_messages_malicious_or_spam
+      and not profile.by_sender_email().any_false_positives
     )
   )
-  and not profile.by_sender().any_false_positives
+  and not profile.by_sender_email().any_false_positives
 
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/attachment_adobe_image_lure.yml
+++ b/detection-rules/attachment_adobe_image_lure.yml
@@ -80,6 +80,7 @@ source: |
   )
   and (
     not profile.by_sender_email().solicited
+    or profile.by_sender_email().prevalence == "new"
     or (
       profile.by_sender_email().any_messages_malicious_or_spam
       and not profile.by_sender_email().any_false_positives

--- a/detection-rules/attachment_adobe_image_lure.yml
+++ b/detection-rules/attachment_adobe_image_lure.yml
@@ -70,7 +70,8 @@ source: |
   // not a newsletter or advertisement
   and not any(headers.hops, any(.fields, .name == "List-Unsubscribe-Post"))
   and not any(beta.ml_topic(body.current_thread.text).topics,
-        .name in ("Advertising and Promotions", "Newsletters and Digests")
+              .name in ("Advertising and Promotions", "Newsletters and Digests")
+              and .confidence == "high"
   )
   
   // negate highly trusted sender domains unless they fail DMARC authentication
@@ -90,6 +91,7 @@ source: |
     )
   )
   and not profile.by_sender_email().any_false_positives
+
 
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/attachment_adobe_image_lure.yml
+++ b/detection-rules/attachment_adobe_image_lure.yml
@@ -67,8 +67,11 @@ source: |
     or length(headers.references) == 0
   )
   
-  // not a newsletter
+  // not a newsletter or advertisement
   and not any(headers.hops, any(.fields, .name == "List-Unsubscribe-Post"))
+  and not any(beta.ml_topic(body.current_thread.text).topics,
+        .name in ("Advertising and Promotions", "Newsletters and Digests")
+  )
   
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (


### PR DESCRIPTION
# Description

use `by_sender_email()` for sender profiles instead of `by_sender`

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/639ae612ee0b33c01b8f5bb3d8aa435014504c3f7b0be7a02ea3560afaa26eb3?preview_id=0195d47e-b95f-79d5-aefc-41c247498cf3)