### PR TITLE
Create abuse_adobe_sign_unsolicited_reply-to.yml

### DIFF
--- a/detection-rules/abuse_adobe_sign_unsolicited_reply-to.yml
+++ b/detection-rules/abuse_adobe_sign_unsolicited_reply-to.yml
@@ -36,3 +36,4 @@ tactics_and_techniques:
 detection_methods:
   - "Header analysis"
   - "Sender analysis"
+id: "d00893ba-a65a-5b04-88d1-f35512eae291"

--- a/detection-rules/abuse_adobe_sign_unsolicited_reply-to.yml
+++ b/detection-rules/abuse_adobe_sign_unsolicited_reply-to.yml
@@ -1,0 +1,38 @@
+name: "Service Abuse: Adobe Sign Notification From an Unsolicited Reply-To Address"
+description: "Identifies messages appearing to come from Adobe Sign signature notifications that contain a reply-to address not previously seen in organizational communications. This tactic exploits trust in legitimate Adobe services while attempting to establish unauthorized communication channels."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  
+  // Legitimate Adobe Sign sending infratructure
+  and sender.email.email == "adobesign@adobesign.com"
+  and headers.auth_summary.spf.pass
+  and headers.auth_summary.dmarc.pass
+  and strings.icontains(subject.subject, 'signature requested')
+  
+  //
+  // This rule makes use of a beta feature and is subject to change without notice
+  // using the beta feature in custom rules is not suggested until it has been formally released
+  //
+  
+  // reply-to address has never sent an email to the org
+  and beta.profile.by_reply_to().prevalence == "new"
+  
+  // reply-to email address has never been sent an email by the org
+  and not beta.profile.by_reply_to().solicited
+  
+  // do not match if the reply_to address has been observed as a reply_to address
+  // of a message that has been classified as benign
+  and not beta.profile.by_reply_to().any_messages_benign
+
+attack_types:
+  - "BEC/Fraud"
+  - "Callback Phishing"
+  - "Spam"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Impersonation: Brand"
+detection_methods:
+  - "Header analysis"
+  - "Sender analysis"

--- a/detection-rules/abuse_adobe_sign_unsolicited_reply-to.yml
+++ b/detection-rules/abuse_adobe_sign_unsolicited_reply-to.yml
@@ -26,6 +26,8 @@ source: |
   // of a message that has been classified as benign
   and not beta.profile.by_reply_to().any_messages_benign
 
+tags:
+ - "Attack surface reduction"
 attack_types:
   - "BEC/Fraud"
   - "Callback Phishing"


### PR DESCRIPTION
# Description

Identifies messages appearing to come from Adobe Sign signature notifications that contain a reply-to address not previously seen in organizational communications. This tactic exploits trust in legitimate Adobe services while attempting to establish unauthorized communication channels.

# Associated samples
- https://platform.sublime.security/messages/0e155e76933f09cefa057f3f4ed6bcbc5cf1403be4f110a393c98447767c804f?preview_id=0196172d-157f-7918-a228-d717dcd2f0ac
- https://platform.sublime.security/messages/c6f4079feab69bd5d2270af51d9eca152ebaff3a7750352e87a8c6d87bf454c2?preview_id=0196172d-9cf0-70ad-852a-ca99817b875a
- https://platform.sublime.security/messages/9e49e4f729104858c4711f6e667296811845c489226600f86ecba97532b55dbb?preview_id=0196172e-27dc-7ef5-ba82-0ef562e81acd
- https://platform.sublime.security/messages/6f8d4f8691bdc71edfe37b92c6f1e69b38953268ab26fb0bac123d27abb7c9e0?preview_id=0196172a-7b60-7d2d-b07d-e11e507ca1a9
