### PR TITLE
Updating suspicious comment rule

### DIFF
--- a/detection-rules/attachment_web_suspicious_comments.yml
+++ b/detection-rules/attachment_web_suspicious_comments.yml
@@ -34,7 +34,14 @@ source: |
               // targeting comments that pad the file with sayings
               // examples: "<!-- <span> No gain without pain. </span> -->", "<!-- <p> Beauty is only skin deep. </p> -->", "<!-- <span> Actions speak louder than words. </span> -->"
               regex.count(file.parse_text(.).text,
-                          '<!-- +[A-Z][ a-z ]+\. +-->'
+                          '<!-- *(<[a-z]+>)? [A-Z].*\. *(</[a-z]+>)? -->'
+              )
+            ) > 2
+            or (
+              // targeting comments inside hidden HTML elements
+              // example: "<h1 style="display:none;"> Self-confidence inspires others to believe in you. </h1>"
+              regex.count(file.parse_text(.).text,
+                          '<[a-z0-9]+ style="display:none;">(<[a-z]+>)? [A-Z].*\. </[a-z0-9]+>'
               )
             ) > 2
           )

--- a/detection-rules/attachment_web_suspicious_comments.yml
+++ b/detection-rules/attachment_web_suspicious_comments.yml
@@ -1,5 +1,5 @@
-name: "Attachment: HTML With Suspicious Comments"
-description: "Detects HTML files under 100KB that contain duplicate or padding text in the form of literary quotes or common sayings within HTML comments."
+name: "Attachment: Web Files With Suspicious Comments"
+description: "Detects HTML or SVG files under 100KB that contain duplicate or padding text in the form of literary quotes or common sayings within code comments."
 type: "rule"
 severity: "high"
 source: |
@@ -8,8 +8,8 @@ source: |
           (
             (
               .file_type == "html"
-              or .file_extension in ("html", "xhtml", "mhtml")
-              or .content_type == "text/html"
+              or .file_extension in ("html", "xhtml", "mhtml", "svg")
+              or .content_type in ("text/html", "text/plain")
             )
             and .size < 100000
           )
@@ -34,7 +34,7 @@ source: |
               // targeting comments that pad the file with sayings
               // examples: "<!-- <span> No gain without pain. </span> -->", "<!-- <p> Beauty is only skin deep. </p> -->", "<!-- <span> Actions speak louder than words. </span> -->"
               regex.count(file.parse_text(.).text,
-                          '<!-- <[a-z]+> [A-Z][ a-z ]+\. </[a-z]+> -->'
+                          '<!-- +[A-Z][ a-z ]+\. +-->'
               )
             ) > 2
           )

--- a/detection-rules/attachment_web_suspicious_comments.yml
+++ b/detection-rules/attachment_web_suspicious_comments.yml
@@ -34,7 +34,7 @@ source: |
               // targeting comments that pad the file with sayings
               // examples: "<!-- <span> No gain without pain. </span> -->", "<!-- <p> Beauty is only skin deep. </p> -->", "<!-- <span> Actions speak louder than words. </span> -->"
               regex.count(file.parse_text(.).text,
-                          '<!-- *(<[a-z]+>)? [A-Z].*\. *(</[a-z]+>)? -->'
+                          '<!-- +(<[a-z]+>)? [A-Z][ a-z ]+\. (</[a-z]+>)? +-->'
               )
             ) > 2
             or (


### PR DESCRIPTION
# Description
This pull request updates the detection rule for suspicious comments in web file attachments, expanding its scope and refining its logic. The changes include renaming the rule, broadening file type support, and simplifying the regex used for detection.

### Rule renaming and description update:
* Renamed the file from `attachment_html_suspicious_comments.yml` to `attachment_web_suspicious_comments.yml` and updated the rule name and description to include both HTML and SVG files.

### Expanded file type support:
* Added support for `svg` files by including `.file_extension == "svg"` and `.content_type == "text/plain"` in the detection logic.

### Refined detection logic:
* Simplified the regex used to detect suspicious comments by removing HTML tag-specific patterns and focusing on general comment structures.

# Associated samples
- https://platform.sublime.security/messages/b1e7852047027839d130bbdfc8eced0eea335b7c522b16ab611527261c43456f?preview_id=01961ae2-b49e-7a52-b384-e86e7708f1ec
