### PR TITLE
Update attachment_svg_embedded_js.yml

### DIFF
--- a/detection-rules/attachment_svg_embedded_js.yml
+++ b/detection-rules/attachment_svg_embedded_js.yml
@@ -1,4 +1,4 @@
-name: "Attachment: Embedded Javascript in SVG file (unsolicited)"
+name: "Attachment: Embedded Javascript in SVG file"
 description: |
   Javascript inside SVG files can be used to smuggle malicious payloads or execute scripts.
 references:

--- a/detection-rules/attachment_svg_embedded_js.yml
+++ b/detection-rules/attachment_svg_embedded_js.yml
@@ -79,8 +79,9 @@ source: |
                                           "*window.location.href*",
                                           "*onerror*",
                                           "*CDATA*",
-                                          "*<script*>*",
-                                          "*</script>*",
+                                          "*<script*",
+                                          "*</script*",
+                                          "*atob*",
                                           "*location.assign*",
                                           "*decodeURIComponent*"
                             )

--- a/detection-rules/attachment_svg_embedded_js.yml
+++ b/detection-rules/attachment_svg_embedded_js.yml
@@ -6,43 +6,86 @@ references:
   - "https://delivr.to/payloads?id=28178b12-766d-44d5-8654-d372a94ff961"
   - "https://delivr.to/payloads?id=3dce858d-7be3-412e-85d9-84f3b9845275"
   - "https://delivr.to/payloads?id=a0a38332-21b6-4394-b901-3697008e3440"
+  - "https://delivr.to/payloads?id=e30f12f2-de69-4e86-8b14-3c9b4e466bea"
+  - "https://delivr.to/payloads?id=9e1b64c8-748d-44f3-aaeb-3efbce9f84e3"
+  - "https://delivr.to/payloads?id=802a25c6-4a3d-468b-81d5-fc7313efd878"
+
 type: "rule"
 severity: "high"
 source: |
   type.inbound
   and any(attachments,
-          .file_extension =~ "svg"
-          and (
-            strings.ilike(file.parse_text(., encodings=["ascii", "utf8", "utf16-le"]).text,
-                          "*onload*",
-                          "*window.location.href*",
-                          "*onerror*",
-                          "*CDATA*",
-                          "*<script>*",
-                          "*</script>*"
+          (
+            .file_extension in~ ("svg", "svgz")
+            and (
+              strings.ilike(file.parse_text(.,
+                                            encodings=[
+                                              "ascii",
+                                              "utf8",
+                                              "utf16-le"
+                                            ]
+                            ).text,
+                            "*onload*",
+                            "*window.location.href*",
+                            "*onerror*",
+                            "*CDATA*",
+                            "*<script*>*",
+                            "*</script>*",
+                            "*location.assign*",
+                            "*decodeURIComponent*"
+              )
+              or regex.icontains(file.parse_text(.,
+                                                 encodings=[
+                                                   "ascii",
+                                                   "utf8",
+                                                   "utf16-le"
+                                                 ]
+                                 ).text,
+                                 '<iframe[^\>]+src\s*=\s*\"data:[^\;]+;base64,'
+              )
+              or any(beta.scan_base64(file.parse_text(.).text,
+                                      encodings=["ascii", "utf8", "utf16-le"]
+                     ),
+                     strings.ilike(.,
+                                   "*onload*",
+                                   "*window.location.href*",
+                                   "*onerror*",
+                                   "*CDATA*",
+                                   "*<script*>*",
+                                   "*</script>*",
+                                   "*location.assign*",
+                                   "*decodeURIComponent*"
+                     )
+              )
             )
-            or regex.icontains(file.parse_text(., encodings=["ascii", "utf8", "utf16-le"]).text,
-                               '<iframe[^\>]+src\s*=\s*\"data:[^\;]+;base64,'
+          )
+          or (
+            (
+              .file_extension in $file_extensions_common_archives
+              or .file_type == "gz"
+              or .content_type == "application/x-gzip"
             )
-            or any(beta.scan_base64(file.parse_text(.).text, encodings=["ascii", "utf8", "utf16-le"]),
-                   strings.ilike(.,
-                                 "*onload*",
-                                 "*window.location.href*",
-                                 "*onerror*",
-                                 "*CDATA*",
-                                 "*<script>*",
-                                 "*</script>*"
-                   )
+            and any(file.explode(.),
+                    (
+                      .file_extension in~ ("svg", "svgz")
+                      or .flavors.mime == "image/svg+xml"
+                    )
+                    and any(.scan.strings.strings,
+                            strings.ilike(.,
+                                          "*onload*",
+                                          "*window.location.href*",
+                                          "*onerror*",
+                                          "*CDATA*",
+                                          "*<script*>*",
+                                          "*</script>*",
+                                          "*location.assign*",
+                                          "*decodeURIComponent*"
+                            )
+                    )
             )
           )
   )
-  and (
-    not profile.by_sender().solicited
-    or (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_false_positives
-    )
-  )
+ 
 attack_types:
   - "Malware/Ransomware"
 tactics_and_techniques:

--- a/detection-rules/attachment_svg_embedded_js.yml
+++ b/detection-rules/attachment_svg_embedded_js.yml
@@ -52,8 +52,10 @@ source: |
                                    "*window.location.href*",
                                    "*onerror*",
                                    "*CDATA*",
-                                   "*<script*>*",
-                                   "*</script>*",
+                                   "*<script*",
+                                   "*</script*", 
+                                   "*atob*",
+
                                    "*location.assign*",
                                    "*decodeURIComponent*"
                      )

--- a/detection-rules/attachment_svg_embedded_js.yml
+++ b/detection-rules/attachment_svg_embedded_js.yml
@@ -29,8 +29,9 @@ source: |
                             "*window.location.href*",
                             "*onerror*",
                             "*CDATA*",
-                            "*<script*>*",
-                            "*</script>*",
+                            "*<script*",
+                            "*</script*",
+                            "*atob*",
                             "*location.assign*",
                             "*decodeURIComponent*"
               )


### PR DESCRIPTION
# Description

Adding coverage for 
  - "https://delivr.to/payloads?id=e30f12f2-de69-4e86-8b14-3c9b4e466bea"
  - "https://delivr.to/payloads?id=9e1b64c8-748d-44f3-aaeb-3efbce9f84e3"
  - "https://delivr.to/payloads?id=802a25c6-4a3d-468b-81d5-fc7313efd878"
  
  Also incorporating new strings from #2619 
  Adding archive support ++ gz/svgz
  Expanding <script> to <script*> the core is hardly ever <script> but more frequently something like <script type="text/javascript">

