### PR TITLE
Update attachment_file_scheme_link_to_executable_filetype.yml

### DIFF
--- a/detection-rules/attachment_file_scheme_link_to_executable_filetype.yml
+++ b/detection-rules/attachment_file_scheme_link_to_executable_filetype.yml
@@ -21,13 +21,18 @@ source: |
                   and regex.icontains(.target_url.path,
                                       '\.(action|ahk|apk|app|appimage|applescript|bat|bin|cab|cmd|command|cpl|dll|dmg|exe|gadget|hta|inf|ins|ipa|isu|jar|job|js|jse|lnk|msi|msp|paf|pif|ps1|rgs|run|scr|sct|sh|shb|vb|vbe|vbs)($|[^\w])'
                   )
+                  // avoid flagging on internal/network drives mappings
+                  and not (
+                    strings.starts_with(.target_url.scheme, "file")
+                    and not regex.imatch(.target_url.path, '/?[a-z]:/')
+                  )
           )
   )
   and (
     not profile.by_sender().any_false_positives
     or profile.by_sender().any_messages_malicious_or_spam
   )
-  
+
 tags:
   - "Attack surface reduction"
   - "PikaBot"


### PR DESCRIPTION
# Description

Adding negations for internal pathing eg. 

/C:/M:/Users/user/Library/Containers/com.microsoft.Excel/Data/Documents/C:/Applications/Microsoft Excel.app/M:/Users/user Mac/Library/Caches/TemporaryItems/Outlook Temp/file_name.xls

Was previously flagging on the excel.app.. due to the way windows store names apps now. 


# Associated samples

- ad483fa119f94e82b0e3b91ed3bb293168f9289a673354a87609c4b4ad0cf8d6 1

