### PR TITLE
Update spam_attendee_list_solicitation.yml

### DIFF
--- a/detection-rules/spam_attendee_list_solicitation.yml
+++ b/detection-rules/spam_attendee_list_solicitation.yml
@@ -46,10 +46,17 @@ source: |
                         '(review|drop me a line about) (my|this|it)'
         ),
         regex.icontains(body.current_thread.text,
+                        'missed it( the)? first time'
+        ),
+        regex.icontains(body.current_thread.text,
                         '(?:below|previous(ly)?|last|prior|earlier) (message|email|sent)'
         ),
         regex.icontains(body.current_thread.text,
-                        '(sent).{0,50}(e?mail|message) (?:below|previous(ly)?|last|prior)'
+                          // "the email I sent you earlier"
+                        '(e?mail|message).{0,20}(sent).{0,20}(?:below|previous(ly)?|last|prior|earlier)'
+        ),
+        regex.icontains(body.current_thread.text,
+                        '(sent).{0,50}(e?mail|message) (?:below|previous(ly)?|last|prior|earlier)'
         ),
         regex.icontains(body.current_thread.text, 'follow(?:ing)?(-| )up'),
         regex.icontains(body.current_thread.text, '(?:contact|attendee)s? list'),
@@ -87,7 +94,7 @@ source: |
                 )
                 or regex.icontains(.,
                                 '(?:from|to|sent|date|cc|subject|wrote):(.|\W)*(?:list(?:\b|[^ei])|database)(?:[[:punct:]]*s)?(\s\w*){0,9}(?:Attendee|Buyer|Contact|Decision Maker|Email|Member|Participant|Professional|Registrant|User|Visitor|Mailing)s?'
-
+  
                 )
                 or (
                   2 of (


### PR DESCRIPTION
# Description
This pull request updates the spam detection rules in `detection-rules/spam_attendee_list_solicitation.yml` to enhance the identification of spam emails. The changes primarily involve adding new patterns and refining existing ones to better match spam-related text.

### Updates to spam detection patterns:

* Added a new regex pattern to detect phrases like "missed it the first time" in email threads.
* Refined an existing regex pattern to improve detection of phrases such as "the email I sent you earlier" by adjusting the order and proximity of keywords like "email/message" and "sent."
* Added a new regex pattern to detect phrases like "sent email/message below/previously/last/prior/earlier," ensuring broader coverage.

# Associated samples

- https://platform.sublime.security/messages/ddb209eb15706a1d8f816ea006675c3ee971212a8adbc49c6e813b52b1d5f758?preview_id=01963a19-df38-76eb-abec-d22e71631539
