### PR TITLE
Create link_display_text_matches_subject.yml

### DIFF
--- a/detection-rules/link_display_text_matches_subject.yml
+++ b/detection-rules/link_display_text_matches_subject.yml
@@ -1,0 +1,98 @@
+name: "Link: Display Text Matches Subject Line"
+description: "Message with short body text contains a single link where the display text matches the subject line. The link is deceptive and the recipient patterns are unusual, such as the recipient's address appearing in the body or undisclosed recipients being used."
+type: "rule"
+severity: ""
+source: |
+  type.inbound
+  
+  // short body
+  and length(body.current_thread.text) < 1500
+  
+  // suspicious recipient patterns
+  and (
+    // recipient email is contained within the body
+    (
+      length(recipients.to) == 1
+      and all(recipients.to,
+              strings.icontains(body.current_thread.text, .email.email)
+      )
+    )
+    // the sender is the recipient
+    or sender.email.email in map(recipients.to, .email.email)
+    // none of the recipients are valid (generally undisclosed recipients)
+    or not all(recipients.to, .email.domain.valid)
+  )
+  // few overall links
+  and length(body.links) < 10
+  // none of the links are unsubscribe links
+  and not any(body.links,
+              strings.icontains(.display_text, 'unsub')
+              or strings.icontains(.href_url.url, 'unsub')
+              or strings.icontains(.display_text, 'optout')
+              or strings.icontains(.href_url.url, 'optout')
+              or strings.icontains(.display_text, 'subscription')
+              // google confidential email use the subject as a link
+              or .href_url.domain.domain == "confidential-mail.google.com"
+  )
+  
+  // even fewer links which are
+  and 0 < length(filter(body.links,
+                        // not related to the sender domain
+                        .href_url.domain.root_domain != sender.email.domain.root_domain
+                        // not related to the recipient domain
+                        and not any(recipients.to,
+                                    .email.domain.root_domain == ..href_url.domain.root_domain
+                        )
+                        // filter out links common in signatures
+                        and not .href_url.domain.root_domain in (
+                          "facebook.com",
+                          "instagram.com",
+                          'twitter.com',
+                          'x.com'
+                        )
+                        // do not contain a display_text (TP samples have the display_text of the subject)
+                        // // this removes domains found in signatures
+                        and .display_text is not null
+                        // not the aka.ms in warning banners
+                        and not .href_url.domain.domain == "aka.ms"
+                 )
+  ) <= 3
+  
+  // exactly one link with display text that matches the subject
+  and length(filter(body.links, subject.subject =~ .display_text)) == 1
+  and (
+    // the link with the display_text of the subject
+    any(filter(body.links, subject.subject =~ .display_text),
+        // when visited is phishing
+        ml.link_analysis(.).credphish.disposition == "phishing"
+        or ml.link_analysis(.).final_dom.display_text == "Verify you are human"
+    )
+    // or the body is cred_theft
+    or any(ml.nlu_classifier(body.current_thread.text).intents,
+           .name == "cred_theft"
+    )
+  )
+  
+  // the display text of a link is the subject
+  and subject.subject in map(body.links, .display_text)
+  
+  // exclude common in signup links/password resets which are observed in links all the time
+  and not (
+    strings.icontains(subject.subject, 'confirm')
+    or strings.icontains(subject.subject, 'activate')
+    or strings.icontains(subject.subject, 'reset')
+    or strings.icontains(subject.subject, 'unlock')
+    or strings.icontains(subject.subject, 'login')
+    or strings.icontains(subject.subject, 'log in')
+  )
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Evasion"
+detection_methods:
+  - "Header analysis"
+  - "Content analysis"
+  - "Natural Language Understanding"
+  - "URL analysis"

--- a/detection-rules/link_display_text_matches_subject.yml
+++ b/detection-rules/link_display_text_matches_subject.yml
@@ -96,3 +96,4 @@ detection_methods:
   - "Content analysis"
   - "Natural Language Understanding"
   - "URL analysis"
+id: "ba722cf0-b94e-55d2-b29a-df6fab80a164"

--- a/detection-rules/link_display_text_matches_subject.yml
+++ b/detection-rules/link_display_text_matches_subject.yml
@@ -1,7 +1,7 @@
 name: "Link: Display Text Matches Subject Line"
 description: "Message with short body text contains a single link where the display text matches the subject line. The link is deceptive and the recipient patterns are unusual, such as the recipient's address appearing in the body or undisclosed recipients being used."
 type: "rule"
-severity: ""
+severity: "medium"
 source: |
   type.inbound
   


### PR DESCRIPTION
# Description

Coverage for credential theft messages leveraging subjects and display_text for links. 

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/718f9dd8e28724bca84647f6f3b1ae80abbc5155d6236c5da487a32ccd97ff8f?preview_id=01964963-1bc2-77fd-ba72-0a590656db23)

## Associated hunts

If you ran any hunts with your rule, please link them here.

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01965a51-6bad-7a45-b631-4771d402f2dc)
