### PR TITLE
Update impersonation_microsoft_credential_theft.yml

### DIFF
--- a/detection-rules/impersonation_microsoft_credential_theft.yml
+++ b/detection-rules/impersonation_microsoft_credential_theft.yml
@@ -48,7 +48,7 @@ source: |
   and not (
     sender.email.domain.domain == "planner.office365.com"
     and headers.return_path.email == "noreply@planner.office365.com"
-    and headers.auth_summary.dmarc.details.from.domain == "planner.office365.com"
+    and headers.auth_summary.dmarc.details.from.root_domain == "office365.com"
   )
   // Microsoft has some legit onmicrosoft domains...
   and not (


### PR DESCRIPTION
# Description

widening the scope of the DMARC-based negation to include all messages from the root domain

# Associated samples

- https://platform.sublime.security/messages/093b5086f0982f68081ffc4ec97cf39734f8eda7797571b427f757f06069ed99
- https://na-east-2.platform.sublime.security/messages/c5947b297c0d464a85c708969ccf8ff63f21218aa69affcb1e1af00236f4a547