### PR TITLE
Update attachment_docusign_suspicious_links.yml

### DIFF
--- a/detection-rules/attachment_docusign_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_suspicious_links.yml
@@ -56,12 +56,27 @@ source: |
           )
         )
         and not any(file.explode(.),
-                    strings.ilike(.scan.ocr.raw, "*DocuSign Envelope*")
-                    or strings.ilike(.scan.ocr.raw, "*Certificate Of Completion*")
+                    strings.ilike(.scan.ocr.raw,
+                                  "*DocuSigned By*",
+                                  "*DocuSign Envelope ID*",
+                                  "*Certificate Of Completion*",
+                                  "*Adobe Sign*"
+                    )
                     or (
                       .depth == 0
-                      and .scan.exiftool.page_count > 10
-                      and length(.scan.strings.strings) > 8000
+                      and (
+                        (
+                          .scan.exiftool.page_count > 10
+                          and length(.scan.strings.strings) > 8000
+                        )
+                        or (
+                          .scan.exiftool.producer == "Acrobat Sign"
+                          and any(.scan.exiftool.fields,
+                                  .key == "SigningReason"
+                                  and .value == "Certified by Adobe Acrobat Sign"
+                          )
+                        )
+                      )
                     )
         )
     )
@@ -106,14 +121,11 @@ source: |
           )
         )
         and not any(file.explode(beta.message_screenshot()),
-                    (
-                      strings.ilike(.scan.ocr.raw, "*DocuSigned By*")
-                      and not strings.ilike(.scan.ocr.raw,
-                                            "*DocuSign Envelope ID*"
-                      )
-                      and not strings.ilike(.scan.ocr.raw,
-                                            "*Certificate Of Completion*"
-                      )
+                    strings.ilike(.scan.ocr.raw,
+                                  "*DocuSigned By*",
+                                  "*DocuSign Envelope ID*",
+                                  "*Certificate Of Completion*",
+                                  "*Adobe Sign*"
                     )
         )
       )


### PR DESCRIPTION
# Description

Negating Adobe Signed documents.

# Associated samples

- https://platform.sublime.security/messages/1f1f5d8c074223e57c60cb095b2f9110367a4ef3c08df12bd77636262ab5164c?preview_id=019669d0-00fe-7cb8-92b5-346f01c8ee4c
- https://platform.sublime.security/messages/eed7bf5f1fc551cce60463b0d5f4264d9a4684adf9e84ad3c443dba43284e47d?preview_id=019669d0-0dbf-7bb8-a13e-5b92d6508ee0