### PR TITLE
Create link_screenconnect.yml

### DIFF
--- a/detection-rules/link_screenconnect.yml
+++ b/detection-rules/link_screenconnect.yml
@@ -1,0 +1,43 @@
+name: "Link: ScreenConnect Installer With Suspicious Relay Domain"
+description: "Detects when a link leads to a ConnectWise ScreenConnect installer and references a relay domain that doesn't match sender or organizational domains."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(body.links,
+          strings.ends_with(.href_url.url, ".exe")
+          and any(ml.link_analysis(., mode="aggressive").files_downloaded,
+                  any(file.explode(.),
+                      any(.scan.strings.strings,
+                          strings.icontains(., "ScreenConnect")
+                      )
+                      and any(filter(.scan.strings.strings,
+                                     strings.icontains(., "h=") // relay domain
+                                     and strings.icontains(., "k=") // encoded encryption key
+                              ),
+                              any(regex.extract(., 'h=(?P<url>[^&]+)'),
+                                  strings.parse_url(strings.concat("https://",
+                                                                   .named_groups["url"]
+                                                    )
+                                  ).domain.root_domain not in $org_domains
+                                  and strings.parse_url(strings.concat("https://",
+                                                                       .named_groups["url"]
+                                                        )
+                                  ).domain.root_domain != sender.email.domain.root_domain
+                              )
+                      )
+                  )
+          )
+  )
+  and not profile.by_sender_email().any_messages_benign
+
+attack_types:
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Evasion"
+  - "Out of band pivot"
+  - "Social engineering"
+detection_methods:
+  - "URL analysis"
+  - "File analysis"
+  - "Content analysis"


### PR DESCRIPTION
# Description
Detects when a link leads to a ConnectWise ScreenConnect installer and references a relay domain that doesn't match sender or organizational domains.

# Associated samples
- https://platform.sublime.security/messages/917b2fa5197a275b4075f93dad31661bd690776c2099c5c2e4fb4c1d22e2d420?preview_id=0196820a-b03b-74bc-9124-735b45032b31