### PR TITLE
Create govdelivery_compromise.yml

### DIFF
--- a/detection-rules/govdelivery_compromise.yml
+++ b/detection-rules/govdelivery_compromise.yml
@@ -1,5 +1,6 @@
 name: "Vendor Compromise: GovDelivery Message With Suspicious Link"
 description: "Detects messages from GovDelivery that contain links to non-government domains, URL shorteners, newly registered domains, or domains with suspicious redirects. GovDelivery is a digital communications system that lets government agencies send updates via email, text, and social media. We have observed compromised American municipal and county GovDelivery delivering phishing emails."
+type: "rule"
 severity: "high"
 source: |
   type.inbound

--- a/detection-rules/govdelivery_compromise.yml
+++ b/detection-rules/govdelivery_compromise.yml
@@ -1,6 +1,5 @@
 name: "Vendor Compromise: GovDelivery Message With Suspicious Link"
-description: "Detects messages from GovDelivery that contain links to non-government domains, URL shorteners, newly registered domains, or domains with suspicious redirects. GovDelivery is a digital communications system that lets government agencies send updates via email, text, and social media. We have observed American municipal and county GovDelivery accounts being compromised."
-type: "rule"
+description: "Detects messages from GovDelivery that contain links to non-government domains, URL shorteners, newly registered domains, or domains with suspicious redirects. GovDelivery is a digital communications system that lets government agencies send updates via email, text, and social media. We have observed compromised American municipal and county GovDelivery delivering phishing emails."
 severity: "high"
 source: |
   type.inbound

--- a/detection-rules/govdelivery_compromise.yml
+++ b/detection-rules/govdelivery_compromise.yml
@@ -1,0 +1,57 @@
+name: "Vendor Compromise: GovDelivery Message With Suspicious Link"
+description: "Detects messages from GovDelivery that contain links to non-government domains, URL shorteners, newly registered domains, or domains with suspicious redirects. GovDelivery is a digital communications system that lets government agencies send updates via email, text, and social media. We have observed American municipal and county GovDelivery accounts being compromised."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and sender.email.domain.domain == "public.govdelivery.com"
+  and headers.auth_summary.spf.pass
+  and headers.auth_summary.dmarc.pass
+  and length(body.links) < 10
+  and any(body.links,
+          any(filter(regex.extract(.href_url.path, '/CL0/(?P<url>.*?)/1/'),
+                     strings.parse_url(.named_groups["url"]).domain.root_domain not in (
+                       "google.com",
+                       "govdelivery.com",
+                       "granicus.com"
+                     )
+                     and strings.parse_url(.named_groups["url"]).domain.tld not in (
+                       "gov"
+                     )
+              ),
+              // this is inside the filter to avoid flagging this condition on known link domains, as listed above
+              any(ml.nlu_classifier(..display_text).intents,
+                  .name == "cred_theft"
+              )
+              or strings.parse_url(.named_groups["url"]).domain.domain in $url_shorteners
+              or strings.parse_url(.named_groups["url"]).domain.root_domain in $url_shorteners
+              or strings.parse_url(.named_groups["url"]).domain.domain in $free_subdomain_hosts
+              or strings.parse_url(.named_groups["url"]).domain.root_domain in $free_subdomain_hosts
+              or network.whois(strings.parse_url(.named_groups["url"]).domain).days_old < 30
+              or any(ml.link_analysis(strings.parse_url(.named_groups["url"])).redirect_history,
+                     network.whois(.domain).days_old < 30
+                     or strings.icontains(.domain.domain, "ipfs")
+                     or regex.icontains(.query_params, '[\.-/]ipfs[\.-/]')
+              )
+              // page redirects to common website, observed when evasion happens
+              or (
+                length(ml.link_analysis(strings.parse_url(.named_groups["url"])).redirect_history
+                ) > 1
+                and ml.link_analysis(strings.parse_url(.named_groups["url"])).effective_url.domain.root_domain in $tranco_10k
+              )
+          )
+  )
+
+attack_types:
+  - "Credential Phishing"
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Free subdomain host"
+  - "IPFS"
+  - "Social engineering"
+  - "Evasion"
+  - "Impersonation: Brand"
+detection_methods:
+  - "Natural Language Understanding"
+  - "URL analysis"
+  - "Whois"

--- a/detection-rules/govdelivery_compromise.yml
+++ b/detection-rules/govdelivery_compromise.yml
@@ -55,3 +55,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "URL analysis"
   - "Whois"
+id: "0d2d5172-de93-5452-872e-68db64b089ce"


### PR DESCRIPTION
# Description

> [!NOTE]
> Being tested in https://github.com/sublime-security/sublime-rules/pull/2668 without LinkAnalysis. 

Detects messages from GovDelivery that contain links to non-government domains, URL shorteners, newly registered domains, or domains with suspicious redirects. GovDelivery is a digital communications system that lets government agencies send updates via email, text, and social media. We have observed American municipal and county GovDelivery accounts being compromised.

# Associated samples
- https://platform.sublime.security/messages/hunt?huntId=01968d5e-f0b7-7388-b4ca-496711a95f7e