### PR TITLE
Stop custom MS quarantine digest senders from flagging

### DIFF
--- a/detection-rules/credential_phishing_fake_email_quarantine_notification.yml
+++ b/detection-rules/credential_phishing_fake_email_quarantine_notification.yml
@@ -4,7 +4,6 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-
   and length(body.links) < 10
   and (
     any(ml.nlu_classifier(body.current_thread.text).intents,
@@ -69,7 +68,18 @@ source: |
   and (
     (
       sender.email.domain.root_domain in $org_domains
-      and not headers.auth_summary.dmarc.pass
+      and (
+        not headers.auth_summary.dmarc.pass
+        // MS quarantine digest emails from an org domain are router "internally" to MS, therefore, there is no authentication information
+        or not (
+          headers.auth_summary.dmarc.pass is null
+          and all(headers.domains,
+                  .root_domain in ("outlook.com", "office365.com")
+          )
+          // typical emails from freemail Outlook accounts are from prod.outlook.com
+          and strings.ends_with(headers.message_id, "protection.outlook.com>")
+        )
+      )
     )
     or sender.email.domain.root_domain not in $org_domains
   )

--- a/detection-rules/impersonation_microsoft_credential_theft.yml
+++ b/detection-rules/impersonation_microsoft_credential_theft.yml
@@ -92,6 +92,26 @@ source: |
     )
   )
   
+  // negate org domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $org_domains
+      and (
+        not headers.auth_summary.dmarc.pass
+        // MS quarantine digest emails from an org domain are router "internally" to MS, therefore, there is no authentication information
+        or not (
+          headers.auth_summary.dmarc.pass is null
+          and all(headers.domains,
+                  .root_domain in ("outlook.com", "office365.com")
+          )
+          // typical emails from freemail Outlook accounts are from prod.outlook.com
+          and strings.ends_with(headers.message_id, "protection.outlook.com>")
+        )
+      )
+    )
+    or sender.email.domain.root_domain not in $org_domains
+  )
+  
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (

--- a/detection-rules/link_content_credential_phishing.yml
+++ b/detection-rules/link_content_credential_phishing.yml
@@ -23,7 +23,8 @@ source: |
     )
   )
   and any(body.links,
-          .href_url.domain.domain != "play.google.com"
+          .href_url.domain.root_domain not in ("outlook.com")
+          and .href_url.domain.domain != "play.google.com"
           and ml.link_analysis(., mode="aggressive").effective_url.domain.domain != "play.google.com"
           and ml.link_analysis(., mode="aggressive").credphish.disposition == "phishing"
           and ml.link_analysis(., mode="aggressive").credphish.confidence in (

--- a/detection-rules/link_microsoft_low_reputation.yml
+++ b/detection-rules/link_microsoft_low_reputation.yml
@@ -370,6 +370,26 @@ source: |
    ) == 0
    and subject.subject == strings.replace_confusables(subject.subject)
  )
+
+ // negate org domains unless they fail DMARC authentication
+ and (
+   (
+     sender.email.domain.root_domain in $org_domains
+     and (
+       not headers.auth_summary.dmarc.pass
+       // MS quarantine digest emails from an org domain are router "internally" to MS, therefore, there is no authentication information
+       or not (
+         headers.auth_summary.dmarc.pass is null
+         and all(headers.domains,
+                 .root_domain in ("outlook.com", "office365.com")
+         )
+         // typical emails from freemail Outlook accounts are from prod.outlook.com
+         and strings.ends_with(headers.message_id, "protection.outlook.com>")
+       )
+     )
+   )
+   or sender.email.domain.root_domain not in $org_domains
+ )
  
  // negate highly trusted sender domains unless they fail DMARC authentication
  and (


### PR DESCRIPTION
# Description
Fixing a few rules to stop flagging on MS quarantine digests that are sent from custom org domains.
https://learn.microsoft.com/en-us/defender-office-365/quarantine-policies#customize-all-quarantine-notifications
# Associated samples

- https://platform.sublime.security/messages/bb09842d5db22734375ef645ac0bdbb1ffc73c90dd9de8c1ac4fc125ad7a5c84?preview_id=0196a24c-fd61-7151-bca1-21df4de07448
