### PR TITLE
Update impersonation_adobe_suspicious_language_link.yml

### DIFF
--- a/detection-rules/impersonation_adobe_suspicious_language_link.yml
+++ b/detection-rules/impersonation_adobe_suspicious_language_link.yml
@@ -21,7 +21,7 @@ source: |
       strings.icontains(body.current_thread.text, "adobe")
       and length(beta.ml_topic(body.current_thread.text).topics) == 1
       and all(beta.ml_topic(body.current_thread.text).topics,
-              .name == "File Sharing and Cloud Services"
+              .name == "File Sharing and Cloud Services" and .confidence == "high"
       )
       and length(body.current_thread.text) < 2000
     )

--- a/detection-rules/impersonation_adobe_suspicious_language_link.yml
+++ b/detection-rules/impersonation_adobe_suspicious_language_link.yml
@@ -23,6 +23,7 @@ source: |
       and all(beta.ml_topic(body.current_thread.text).topics,
               .name == "File Sharing and Cloud Services"
       )
+      and length(body.current_thread.text) < 2000
     )
   )
   and (
@@ -74,7 +75,7 @@ source: |
           or strings.istarts_with(subject.subject, "TR:")
           or strings.istarts_with(subject.subject, "FWD:")
           or regex.imatch(subject.subject,
-                        '(\[[^\]]+\]\s?){0,3}(re|fwd?|automat.*)\s?:.*'
+                        '^\[?/{0,2}(EXT|EXTERNAL)\]?/{0,2}[: ]\s*(RE|FWD?|FW|AW|TR|ODG|答复):.*'
         )
         )
       )
@@ -91,6 +92,7 @@ source: |
         or profile.by_sender_email().days_since.last_contact > 14
       )
       and not profile.by_sender().any_messages_benign
+      and not sender.email.domain.root_domain in ("adobe-events.com", "frame.io")
     )
     or not headers.auth_summary.spf.pass
     or headers.auth_summary.spf.pass is null

--- a/detection-rules/impersonation_adobe_suspicious_language_link.yml
+++ b/detection-rules/impersonation_adobe_suspicious_language_link.yml
@@ -82,11 +82,21 @@ source: |
     or length(headers.references) == 0
   )
   and (
-    not profile.by_sender().solicited
-    or profile.by_sender().any_messages_malicious_or_spam
-    or profile.by_sender_email().days_since.last_contact > 14
+    (
+      headers.auth_summary.spf.pass
+      and headers.auth_summary.dmarc.pass
+      and (
+        not profile.by_sender().solicited
+        or profile.by_sender().any_messages_malicious_or_spam
+        or profile.by_sender_email().days_since.last_contact > 14
+      )
+      and not profile.by_sender().any_messages_benign
+    )
+    or not headers.auth_summary.spf.pass
+    or headers.auth_summary.spf.pass is null
+    or not headers.auth_summary.dmarc.pass
+    or headers.auth_summary.dmarc.pass is null
   )
-  and not profile.by_sender().any_messages_benign
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (

--- a/detection-rules/impersonation_adobe_suspicious_language_link.yml
+++ b/detection-rules/impersonation_adobe_suspicious_language_link.yml
@@ -13,8 +13,17 @@ source: |
     or length(attachments) == 0
   )
   and length(body.links) > 0
-  and any(ml.logo_detect(beta.message_screenshot()).brands,
-          .name == "Adobe" and .confidence in ("high")
+  and (
+    any(ml.logo_detect(beta.message_screenshot()).brands,
+        .name == "Adobe" and .confidence in ("high")
+    )
+    or (
+      strings.icontains(body.current_thread.text, "adobe")
+      and length(beta.ml_topic(body.current_thread.text).topics) == 1
+      and all(beta.ml_topic(body.current_thread.text).topics,
+              .name == "File Sharing and Cloud Services"
+      )
+    )
   )
   and (
     any(file.explode(beta.message_screenshot()),
@@ -74,11 +83,10 @@ source: |
   )
   and (
     not profile.by_sender().solicited
-    or (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_false_positives
-    )
+    or profile.by_sender().any_messages_malicious_or_spam
+    or profile.by_sender_email().days_since.last_contact > 14
   )
+  and not profile.by_sender().any_messages_benign
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (


### PR DESCRIPTION
# Description
This pull request updates the detection logic in the `impersonation_adobe_suspicious_language_link.yml` rule to enhance its accuracy and reduce false positives. The changes focus on refining conditions for detecting Adobe-related impersonation attempts by incorporating additional checks and improving sender profile evaluation.

### Enhancements to detection logic:
* Added a new condition to check if the email body contains the term "adobe" and matches a specific machine-learned topic ("File Sharing and Cloud Services"). This complements the existing logo detection logic for identifying Adobe-related content.

### Improvements to sender profile evaluation:
* Updated the logic to include a condition that flags emails if the sender's email has not been in contact for more than 14 days (`profile.by_sender_email().days_since.last_contact > 14`).
* Added a condition to exclude senders with any benign message history (`not profile.by_sender().any_messages_benign`) to reduce false positives.

# Associated samples
- https://platform.sublime.security/messages/e9ae225a5daeff88ac029d99183efe4d90a2ee54c7c14f1c313073e612fd3b6e?preview_id=0196b4d9-197c-7ac9-be3c-b207f8aa84a1