### PR TITLE
Create link_scribd_fullscreen.yml

### DIFF
--- a/detection-rules/link_scribd_fullscreen.yml
+++ b/detection-rules/link_scribd_fullscreen.yml
@@ -1,0 +1,33 @@
+name: "Link: Scribd Fullscreen Link From Suspicious Sender"
+description: "Detects messages containing Scribd links with fullscreen parameter modifications from senders with no prior benign communication history."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and length(body.links) < 10
+  and any(body.links,
+          (
+            .href_url.domain.root_domain == "scribd.com"
+            or strings.icontains(.href_url.query_params, 'scribd.com')
+            or strings.icontains(.href_url.query_params, 'scribd%2ecom')
+            or strings.icontains(.href_url.query_params, 'scribd%252ecom')
+          )
+          and strings.icontains(.href_url.fragment, 'fullscreen')
+  )
+  and (
+    not profile.by_sender_email().solicited
+    or profile.by_sender_email().days_since.last_contact > 14
+    or profile.by_sender_email().any_messages_malicious_or_spam
+  )
+  and not profile.by_sender_email().any_messages_benign
+tags:
+ - "Attack surface reduction"
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Free file host"
+  - "Social engineering"
+  - "Evasion"
+detection_methods:
+  - "URL analysis"
+  - "Sender analysis"

--- a/detection-rules/link_scribd_fullscreen.yml
+++ b/detection-rules/link_scribd_fullscreen.yml
@@ -31,3 +31,4 @@ tactics_and_techniques:
 detection_methods:
   - "URL analysis"
   - "Sender analysis"
+id: "9e9bc972-d4e1-5bd0-96bc-b8b10e74b02a"

--- a/detection-rules/link_scribd_fullscreen.yml
+++ b/detection-rules/link_scribd_fullscreen.yml
@@ -14,11 +14,6 @@ source: |
           )
           and strings.icontains(.href_url.fragment, 'fullscreen')
   )
-  and (
-    not profile.by_sender_email().solicited
-    or profile.by_sender_email().days_since.last_contact > 14
-    or profile.by_sender_email().any_messages_malicious_or_spam
-  )
   and not profile.by_sender_email().any_messages_benign
 tags:
  - "Attack surface reduction"

--- a/detection-rules/link_scribd_fullscreen.yml
+++ b/detection-rules/link_scribd_fullscreen.yml
@@ -1,5 +1,5 @@
 name: "Link: Scribd Fullscreen Link From Suspicious Sender"
-description: "Detects messages containing Scribd links with fullscreen parameter modifications from senders with no prior benign communication history."
+description: "Detects messages containing Scribd links with the fullscreen parameter from senders with no prior benign communication or recent history."
 type: "rule"
 severity: "medium"
 source: |


### PR DESCRIPTION
# Description

Detects messages containing Scribd links with the fullscreen parameter from senders with no prior benign communication or recent history. 
# Associated samples

- https://platform.sublime.security/messages/e9ae225a5daeff88ac029d99183efe4d90a2ee54c7c14f1c313073e612fd3b6e?preview_id=0196b4d9-197c-7ac9-be3c-b207f8aa84a1