### PR TITLE
Update attachment_fake_attachment_image.yml

### DIFF
--- a/detection-rules/attachment_fake_attachment_image.yml
+++ b/detection-rules/attachment_fake_attachment_image.yml
@@ -24,6 +24,20 @@ source: |
           )
         )
     )
+    // message body/screenhot
+    or (
+      any(ml.logo_detect(beta.message_screenshot()).brands,
+          .name == "FakeAttachment"
+      )
+      or (
+        length(body.current_thread.text) < 2000
+        and strings.icontains(body.current_thread.text, 'sent you')
+        // the attached image includes a filesize string
+        and regex.icontains(body.current_thread.text,
+                            '\b\d+.\d{1,2}\s?(k|m)b(\s|$)'
+        )
+      )
+    )
     // fake file attachment preview in attached EML
     or any(attachments,
            (.content_type == "message/rfc822" or .file_extension == "eml")


### PR DESCRIPTION
# Description

This pull request introduces an enhancement to the detection logic in the `detection-rules/attachment_fake_attachment_image.yml` file. The update expands the detection criteria for identifying fake attachment images by analyzing message screenshots and refining the message body checks.

Enhancements to detection logic:

* Added a new condition to detect fake attachments based on the presence of the "FakeAttachment" brand in logos detected within message screenshots.
* Improved message body analysis by adding checks for:
  - Text length being less than 2000 characters.
  - The presence of phrases like "sent you."
  - A regex pattern to identify filesize strings (e.g., "2.5 MB").

# Associated samples

- https://platform.sublime.security/messages/b69bd5f0df68e934310ecf3e7a6a18d072fc2feb004764796d32f42438e79caa?preview_id=0196a587-e715-7a71-b746-f514e4584e63