### PR TITLE
Create link_scribd_document_cred_theft.yml

### DIFF
--- a/detection-rules/link_scribd_document_cred_theft.yml
+++ b/detection-rules/link_scribd_document_cred_theft.yml
@@ -41,7 +41,7 @@ source: |
                 )
                 or ml.link_analysis(strings.parse_url(.raw), mode="aggressive").credphish.disposition == "phishing"
                 or ml.link_analysis(strings.parse_url(.raw), mode="aggressive").credphish.contains_captcha
-                or strings.icontains(ml.link_analysis(.href_url,
+                or strings.icontains(ml.link_analysis(strings.parse_url(.raw),
                                                       mode="aggressive"
                                      ).final_dom.display_text,
                                      "I'm Human"

--- a/detection-rules/link_scribd_document_cred_theft.yml
+++ b/detection-rules/link_scribd_document_cred_theft.yml
@@ -1,4 +1,4 @@
-name: "Link: Scribd Document With Credential Phishing Indicators"
+name: "Link: Multistage Landing - Scribd Document"
 description: "Detects when a Scribd document contains embedded links that are suspicious, particularly those targeting Microsoft services through various evasion techniques. The rule analyzes both the document content and linked destinations for suspicious patterns and redirects."
 type: "rule"
 severity: "medium"

--- a/detection-rules/link_scribd_document_cred_theft.yml
+++ b/detection-rules/link_scribd_document_cred_theft.yml
@@ -60,6 +60,30 @@ source: |
             )
           )
   )
+  and (
+    (
+      headers.auth_summary.spf.pass
+      and headers.auth_summary.dmarc.pass
+      and (
+        not profile.by_sender().solicited
+        or profile.by_sender().any_messages_malicious_or_spam
+        or profile.by_sender_email().days_since.last_contact > 14
+      )
+      and not profile.by_sender().any_messages_benign
+    )
+    or not headers.auth_summary.spf.pass
+    or headers.auth_summary.spf.pass is null
+    or not headers.auth_summary.dmarc.pass
+    or headers.auth_summary.dmarc.pass is null
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
   
 
 attack_types:

--- a/detection-rules/link_scribd_document_cred_theft.yml
+++ b/detection-rules/link_scribd_document_cred_theft.yml
@@ -65,22 +65,6 @@ source: |
             )
           )
   )
-  and (
-    (
-      headers.auth_summary.spf.pass
-      and headers.auth_summary.dmarc.pass
-      and (
-        not profile.by_sender().solicited
-        or profile.by_sender().any_messages_malicious_or_spam
-        or profile.by_sender_email().days_since.last_contact > 14
-      )
-      and not profile.by_sender().any_messages_benign
-    )
-    or not headers.auth_summary.spf.pass
-    or headers.auth_summary.spf.pass is null
-    or not headers.auth_summary.dmarc.pass
-    or headers.auth_summary.dmarc.pass is null
-  )
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (

--- a/detection-rules/link_scribd_document_cred_theft.yml
+++ b/detection-rules/link_scribd_document_cred_theft.yml
@@ -41,6 +41,11 @@ source: |
                 )
                 or ml.link_analysis(strings.parse_url(.raw), mode="aggressive").credphish.disposition == "phishing"
                 or ml.link_analysis(strings.parse_url(.raw), mode="aggressive").credphish.contains_captcha
+                or strings.icontains(ml.link_analysis(.href_url,
+                                                      mode="aggressive"
+                                     ).final_dom.display_text,
+                                     "I'm Human"
+                )
                 // bails out to a well-known domain, seen in evasion attempts
                 or (
                   length(ml.link_analysis(strings.parse_url(.raw),

--- a/detection-rules/link_scribd_document_cred_theft.yml
+++ b/detection-rules/link_scribd_document_cred_theft.yml
@@ -1,0 +1,78 @@
+name: "Link: Scribd Document With Credential Phishing Indicators"
+description: "Detects when a Scribd document contains embedded links that are suspicious, particularly those targeting Microsoft services through various evasion techniques. The rule analyzes both the document content and linked destinations for suspicious patterns and redirects."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // only one link to Scribd
+  and length(distinct(filter(body.links,
+                             .href_url.domain.root_domain in ("scribd.com")
+                             and strings.istarts_with(.href_url.path, "/document")
+                      ),
+                      .href_url.url
+             )
+  ) == 1
+  and any(body.links,
+          .href_url.domain.root_domain == "scribd.com"
+          and strings.istarts_with(.href_url.path, "/document")
+          and (
+            // target the embedded links via XPath
+            any(beta.html_xpath(ml.link_analysis(.).final_dom,
+                                '//a[@class="ll"]/@href'
+                ).nodes,
+                strings.parse_url(.raw).domain.tld in $suspicious_tlds
+                or strings.parse_url(.raw).domain.domain in $free_subdomain_hosts
+                or strings.parse_url(.raw).domain.root_domain in $free_subdomain_hosts
+                // observed pattern in credential theft URLs
+                or strings.ilike(strings.parse_url(.raw).path,
+                                 "*o365*",
+                                 "*office365*",
+                                 "*microsoft*"
+                )
+                // observed pattern in credential theft URLs
+                or strings.ilike(strings.parse_url(.raw).query_params,
+                                 "*o365*",
+                                 "*office365*",
+                                 "*microsoft*"
+                )
+                // observed pattern in credential theft URLs
+                or any(beta.scan_base64(strings.parse_url(.raw).query_params),
+                       strings.ilike(., "*o365*", "*office365*", "*microsoft*")
+                )
+                or ml.link_analysis(strings.parse_url(.raw), mode="aggressive").credphish.disposition == "phishing"
+                or ml.link_analysis(strings.parse_url(.raw), mode="aggressive").credphish.contains_captcha
+                // bails out to a well-known domain, seen in evasion attempts
+                or (
+                  length(ml.link_analysis(strings.parse_url(.raw),
+                                          mode="aggressive"
+                         ).redirect_history
+                  ) > 0
+                  and ml.link_analysis(strings.parse_url(.raw), mode="aggressive").effective_url.domain.root_domain in $tranco_10k
+                )
+            )
+            // credential theft language on the main Scribd page
+            or any(ml.nlu_classifier(beta.ocr(ml.link_analysis(.,
+                                                               mode="aggressive"
+                                              ).screenshot
+                                     ).text
+                   ).intents,
+                   .name == "cred_theft" and .confidence != "low"
+            )
+          )
+  )
+  
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+  - "Impersonation: Brand"
+  - "Free file host"
+detection_methods:
+  - "URL analysis"
+  - "HTML analysis"
+  - "Natural Language Understanding"
+  - "Computer Vision"
+  - "Optical Character Recognition"
+  - "URL screenshot"

--- a/detection-rules/link_scribd_document_cred_theft.yml
+++ b/detection-rules/link_scribd_document_cred_theft.yml
@@ -76,3 +76,4 @@ detection_methods:
   - "Computer Vision"
   - "Optical Character Recognition"
   - "URL screenshot"
+id: "afa9807d-c70f-5af6-91ef-284c72d01cab"


### PR DESCRIPTION
# Description

Detects when a Scribd document contains embedded links that are suspicious, particularly those targeting Microsoft services through various evasion techniques. The rule analyzes both the document content and linked destinations for suspicious patterns and redirects.

# Associated samples

- https://platform.sublime.security/hunts/0196c5b2-25fb-7041-ad26-a716ecc70986