### PR TITLE
Create link_ludus_presentation_cred_theft.yml

### DIFF
--- a/detection-rules/link_ludus_presentation_cred_theft.yml
+++ b/detection-rules/link_ludus_presentation_cred_theft.yml
@@ -1,0 +1,103 @@
+name: "Link: Ludus Presentation With Credential Phishing Indicators"
+description: "Detects when a standalone Ludus document link contains embedded links that are suspicious, particularly those targeting Microsoft services through various evasion techniques. The rule analyzes both the presentation content and linked destinations for suspicious patterns and redirects."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // only one link to Ludus
+  and length(distinct(filter(body.links,
+                             .href_url.domain.root_domain in ("ludus.one")
+                      ),
+                      .href_url.url
+             )
+  ) == 1
+  and any(body.links,
+          .href_url.domain.root_domain in ("ludus.one")
+          and (
+            any(ml.link_analysis(.).final_dom.links,
+                .href_url.domain.root_domain != "ludus.com"
+                // once we have additional responses, add # of slides == 1 logic
+                and (
+                  .href_url.domain.tld in $suspicious_tlds
+                  or .href_url.domain.domain in $free_subdomain_hosts
+                  or .href_url.domain.root_domain in $free_subdomain_hosts
+                  // observed pattern in credential theft URLs
+                  or strings.ilike(.href_url.path,
+                                   "*o365*",
+                                   "*office365*",
+                                   "*microsoft*"
+                  )
+                  // observed pattern in credential theft URLs
+                  or strings.ilike(.href_url.query_params,
+                                   "*o365*",
+                                   "*office365*",
+                                   "*microsoft*"
+                  )
+                  // observed pattern in credential theft URLs
+                  or any(beta.scan_base64(.href_url.query_params),
+                         strings.ilike(., "*o365*", "*office365*", "*microsoft*")
+                  )
+                  or ml.link_analysis(.href_url, mode="aggressive").credphish.disposition == "phishing"
+                  or ml.link_analysis(.href_url, mode="aggressive").credphish.contains_captcha
+                  or strings.icontains(ml.link_analysis(.href_url,
+                                                        mode="aggressive"
+                                       ).final_dom.display_text,
+                                       "I'm Human"
+                  )
+                  // bails out to a well-known domain, seen in evasion attempts
+                  or (
+                    length(ml.link_analysis(.href_url, mode="aggressive").redirect_history
+                    ) > 0
+                    and ml.link_analysis(.href_url, mode="aggressive").effective_url.domain.root_domain in $tranco_10k
+                  )
+                )
+            )
+            // credential theft language on the main Scribd page
+            or any(ml.nlu_classifier(beta.ocr(ml.link_analysis(.,
+                                                               mode="aggressive"
+                                              ).screenshot
+                                     ).text
+                   ).intents,
+                   .name == "cred_theft" and .confidence != "low"
+            )
+          )
+  )
+  and (
+    (
+      headers.auth_summary.spf.pass
+      and headers.auth_summary.dmarc.pass
+      and (
+        not profile.by_sender().solicited
+        or profile.by_sender().any_messages_malicious_or_spam
+        or profile.by_sender_email().days_since.last_contact > 14
+      )
+      and not profile.by_sender().any_messages_benign
+    )
+    or not headers.auth_summary.spf.pass
+    or headers.auth_summary.spf.pass is null
+    or not headers.auth_summary.dmarc.pass
+    or headers.auth_summary.dmarc.pass is null
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+  - "Impersonation: Brand"
+detection_methods:
+  - "Header analysis"
+  - "URL analysis"
+  - "Computer Vision"
+  - "URL screenshot"
+  - "Natural Language Understanding"
+  - "Optical Character Recognition"
+  - "Sender analysis"

--- a/detection-rules/link_ludus_presentation_cred_theft.yml
+++ b/detection-rules/link_ludus_presentation_cred_theft.yml
@@ -1,4 +1,4 @@
-name: "Link: Ludus Presentation With Credential Phishing Indicators"
+name: "Link: Multistage Landing - Ludus Presentation"
 description: "Detects when a standalone Ludus document link contains embedded links that are suspicious, particularly those targeting Microsoft services through various evasion techniques. The rule analyzes both the presentation content and linked destinations for suspicious patterns and redirects."
 type: "rule"
 severity: "medium"

--- a/detection-rules/link_ludus_presentation_cred_theft.yml
+++ b/detection-rules/link_ludus_presentation_cred_theft.yml
@@ -101,3 +101,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Optical Character Recognition"
   - "Sender analysis"
+id: "a8b3c311-5cb8-513f-9b5e-7d8849f8fc41"

--- a/detection-rules/link_ludus_presentation_cred_theft.yml
+++ b/detection-rules/link_ludus_presentation_cred_theft.yml
@@ -62,22 +62,6 @@ source: |
             )
           )
   )
-  and (
-    (
-      headers.auth_summary.spf.pass
-      and headers.auth_summary.dmarc.pass
-      and (
-        not profile.by_sender().solicited
-        or profile.by_sender().any_messages_malicious_or_spam
-        or profile.by_sender_email().days_since.last_contact > 14
-      )
-      and not profile.by_sender().any_messages_benign
-    )
-    or not headers.auth_summary.spf.pass
-    or headers.auth_summary.spf.pass is null
-    or not headers.auth_summary.dmarc.pass
-    or headers.auth_summary.dmarc.pass is null
-  )
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (


### PR DESCRIPTION
# Description
Detects when a standalone Ludus document link contains embedded links that are suspicious, particularly those targeting Microsoft services through various evasion techniques. The rule analyzes both the presentation content and linked destinations for suspicious patterns and redirects.

# Associated samples

- https://platform.sublime.security/messages/43a47b65d1ebc90469107175831d273eaa481acac4813605dd48798ebe1cdba6?preview_id=0196c59e-df9f-7bc9-88e6-8df8e97fb567
