### PR TITLE
rename beta.html_xpath -> html.xpath

### DIFF
--- a/detection-rules/canva_suspicious_embedded_link.yml
+++ b/detection-rules/canva_suspicious_embedded_link.yml
@@ -7,7 +7,7 @@ source: |
   and any(body.links,
           .href_url.domain.root_domain == "canva.com"
           and strings.starts_with(.href_url.path, "/design/")
-          and any(beta.html_xpath(ml.link_analysis(.).final_dom,
+          and any(html.xpath(ml.link_analysis(.).final_dom,
                                   "/html/body/script[2]"
                   ).nodes,
                   any(regex.iextract(.raw,

--- a/detection-rules/impersonation_docusign.yml
+++ b/detection-rules/impersonation_docusign.yml
@@ -225,30 +225,26 @@ source: |
                            '<span[^>]*style="[^"]*">Docu.?Sign<\/span>'
         )
   
-        // 
-        // This rule makes use of a beta feature and is subject to change without notice
-        // using the beta feature in custom rules is not suggested until it has been formally released
-        // 
-        or any(beta.html_xpath(body.html, '//h1').nodes,
+        or any(html.xpath(body.html, '//h1').nodes,
                regex.icontains(.display_text, 'Docu.?Sign')
         )
         or regex.icontains(body.html.raw,
                            '<span[^>]*style="[^"]*">(Docu|D(?:ocu?)?)<\/span>(?:<[^\>]+\>){0,2}<span[^>]*style="[^"]*">(Sign|S(?:ign?)?)<\/span>'
         )
         // any bold text contains docusign
-        or any(beta.html_xpath(body.html, '//strong').nodes,
+        or any(html.xpath(body.html, '//strong').nodes,
                regex.imatch(.display_text, 'Docu.?Sign')
         )
         // title starts with Docusign
-        or any(beta.html_xpath(body.html, '//title').nodes,
+        or any(html.xpath(body.html, '//title').nodes,
                regex.icontains(.display_text, '^docu.?sign')
         )
         // a div with a class of logo contains the display text of docusign
-        or any(beta.html_xpath(body.html, '//div[@class="logo"]').nodes,
+        or any(html.xpath(body.html, '//div[@class="logo"]').nodes,
                strings.icontains(.display_text, 'Docusign')
         )
         // image contains an alt text of docusign
-        or any(beta.html_xpath(body.html, '//img/@alt').nodes, .raw =~ "docusign")
+        or any(html.xpath(body.html, '//img/@alt').nodes, .raw =~ "docusign")
   
         // Basic variations with HTML encoding
         // use of regex extract allows 

--- a/detection-rules/link_scribd_document_cred_theft.yml
+++ b/detection-rules/link_scribd_document_cred_theft.yml
@@ -17,7 +17,7 @@ source: |
           and strings.istarts_with(.href_url.path, "/document")
           and (
             // target the embedded links via XPath
-            any(beta.html_xpath(ml.link_analysis(.).final_dom,
+            any(html.xpath(ml.link_analysis(.).final_dom,
                                 '//a[@class="ll"]/@href'
                 ).nodes,
                 strings.parse_url(.raw).domain.tld in $suspicious_tlds


### PR DESCRIPTION
# Description

https://www.notion.so/sublimesecurity/Publicly-release-html-xpath-1d504655fc9d803f9776d732c96c7304

This is a naming change to release `html.xpath` from beta

# Associated samples

there should be no change to functionality at all

## Associated hunts

# Screenshot (insights)
