### PR TITLE
Update impersonation_docusign.yml

### DIFF
--- a/detection-rules/impersonation_docusign.yml
+++ b/detection-rules/impersonation_docusign.yml
@@ -319,23 +319,23 @@ source: |
         )
         and not .href_url.domain.root_domain in ("docusign.com", "docusign.net", 'docusign.co.uk')
         and not (
-        .href_url.domain.root_domain == "mimecastprotect.com"
-        and (
-          (
-            .href_url.query_params is not null
-            and (
-              regex.icontains(.href_url.query_params,
-                              'domain=(?:\w+.)?docusign.net'
-              )
-              or regex.icontains(.href_url.query_params,
-                                 'domain=(?:\w+.)?docusign.com'
+          .href_url.domain.root_domain == "mimecastprotect.com"
+          and (
+            (
+              .href_url.query_params is not null
+              and (
+                regex.icontains(.href_url.query_params,
+                                'domain=(?:\w+.)?docusign.net'
+                )
+                or regex.icontains(.href_url.query_params,
+                                   'domain=(?:\w+.)?docusign.com'
+                )
               )
             )
+            // if there isn't a domain to decode...don't include it either. 
+            or .href_url.query_params is null
           )
-          // if there isn't a domain to decode don't include it either. 
-          or .href_url.query_params is null
         )
-      )
     )
     // Suspicious attachment
     or any(attachments,

--- a/detection-rules/impersonation_docusign.yml
+++ b/detection-rules/impersonation_docusign.yml
@@ -319,8 +319,9 @@ source: |
         )
         and not .href_url.domain.root_domain in ("docusign.com", "docusign.net", 'docusign.co.uk')
         and not (
-          .href_url.domain.root_domain == "mimecastprotect.com"
-          and (
+        .href_url.domain.root_domain == "mimecastprotect.com"
+        and (
+          (
             .href_url.query_params is not null
             and (
               regex.icontains(.href_url.query_params,
@@ -331,7 +332,10 @@ source: |
               )
             )
           )
+          // if there isn't a domain to decode don't include it either. 
+          or .href_url.query_params is null
         )
+      )
     )
     // Suspicious attachment
     or any(attachments,


### PR DESCRIPTION
# Description
Additional tuning

# Associated samples

Negation for mimecast protection URLs without domain param
- [Sample 1](https://platform.sublime.security/messages/c7ad5a7891c0801fad6674c935b9294ba8e85d85b822b2ad18b384be1a1bd672?preview_id=0196d52d-6240-784a-81fa-69f1869095c8)
