### PR TITLE
Create encrypted_msaccess_database.yar

### DIFF
--- a/detection-rules/attachment_encrypted_msft_access_database.yml
+++ b/detection-rules/attachment_encrypted_msft_access_database.yml
@@ -13,7 +13,7 @@ source: |
             or .file_type == "msaccess"
           )
           and any(file.explode(.),
-                  any(.flavors.yara, . == 'encrypted_msaccess_database')
+                  any(.scan.yara.matches, .name == 'encrypted_msaccess_database')
           )
   )
   // Negating high-trust sender domains unless they fail DMARC authentication

--- a/detection-rules/attachment_encrypted_msft_access_database.yml
+++ b/detection-rules/attachment_encrypted_msft_access_database.yml
@@ -36,3 +36,4 @@ detection_methods:
   - "Header analysis"
   - "Sender analysis"
   - "YARA"
+id: "e6bc23e5-b8bf-57b7-8c2d-45ba48cca34f"

--- a/detection-rules/attachment_encrypted_msft_access_database.yml
+++ b/detection-rules/attachment_encrypted_msft_access_database.yml
@@ -1,0 +1,38 @@
+name: "Attachment: Encrypted Microsoft Access Database from Non-Trusted Sources"
+description: "Detects encrypted Microsoft Access database files (.accdb) from senders outside trusted domains or from trusted domains that fail DMARC authentication"
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and any(attachments,
+          (
+            strings.iends_with(.file_name, ".accdb")
+            or .content_type == "application/msaccess"
+            or .content_type == "application/x-msaccess"
+            or .content_type == "application/vnd.ms-access"
+            or .file_type == "msaccess"
+          )
+          and any(file.explode(.),
+                  any(.flavors.yara, . == 'encrypted_msaccess_database')
+          )
+  )
+  // Negating high-trust sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+tags:
+ - "Attack surface reduction"
+attack_types:
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Encryption"
+  - "Evasion"
+detection_methods:
+  - "File analysis"
+  - "Header analysis"
+  - "Sender analysis"
+  - "YARA"

--- a/yara/encrypted_msaccess_database.yar
+++ b/yara/encrypted_msaccess_database.yar
@@ -1,0 +1,46 @@
+rule encrypted_msaccess_database {
+  meta:
+    description = "Detects Microsoft Access Databases with AES Encryption"
+    author = "Sublime Security"
+    severity = "medium"
+    reference = "AES-256-CBC with HMAC-SHA-256 VBScript implementation"
+  
+  strings:
+    // MS Access file signature
+    $access_sig = { 00 01 00 00 53 74 61 6E 64 61 72 64 20 41 43 45 20 44 42 }
+    
+    // AES Encryption indicators
+    $aes1 = "AES-256-CBC" ascii wide nocase
+    $aes2 = "HMAC-SHA-256" ascii wide nocase
+    $aes3 = "RijndaelManaged" ascii wide
+    $aes4 = "System.Security.Cryptography" ascii wide
+    
+    // Encryption functions and parameters
+    $enc1 = "Encrypt" ascii wide
+    $enc2 = "Decrypt" ascii wide
+    $enc3 = "aesKey" ascii wide nocase
+    $enc4 = "Base64" ascii wide nocase
+    
+    // VBScript implementation
+    $vbs = "aes.vbs" ascii wide nocase
+    
+    // Crypto library fragments
+    $crypto1 = "FromBase64Transform" ascii wide
+    $crypto2 = "ToBase64Transform" ascii wide
+    $crypto3 = "MemoryStream" ascii wide
+    
+  condition:
+    $access_sig at 0 and
+    (
+      // High confidence detection - specific AES implementation
+      ($aes1 and $aes2) or
+      
+      // Medium confidence detection - crypto libraries with encryption functions
+      ($aes3 and ($enc1 or $enc2)) or
+      ($aes4 and ($enc1 or $enc2)) or
+      
+      // Lower confidence but specific patterns
+      ($vbs and $aes1) or
+      (2 of ($crypto*) and 1 of ($enc*) and $enc3 and $enc4)
+    )
+}


### PR DESCRIPTION
This rule covers detection for the following file, AES-256-CBC with HMAC-SHA-256 VBScript implementation inside `accdb` file types. This YARA rule will be called from within an upcoming rule i have that relies on YARA to detect the logic contained in the `encrypt` & `decrypt` functions, the additional YARA coverage for Crypto library fragments are also required.
