### PR TITLE
Adding "Threads" to logo detect blocks in Meta and Salesforce Brand Impersonation Rules

### DIFF
--- a/detection-rules/impersonation_meta.yml
+++ b/detection-rules/impersonation_meta.yml
@@ -64,7 +64,7 @@ source: |
       )
       and (
         any(ml.logo_detect(beta.message_screenshot()).brands,
-            .name in ("Facebook", "Meta", "Instagram")
+            .name in ("Facebook", "Meta", "Instagram", "Threads")
         )
         or any(ml.nlu_classifier(body.current_thread.text).intents,
                .name in ("cred_theft", "callback_scam", "steal_pii")
@@ -76,7 +76,7 @@ source: |
     or (
       sender.email.domain.root_domain == "salesforce.com"
       and any(ml.logo_detect(beta.message_screenshot()).brands,
-              .name in ("Facebook", "Meta", "Instagram")
+              .name in ("Facebook", "Meta", "Instagram", "Threads")
       )
       and any(ml.nlu_classifier(body.current_thread.text).intents,
               .name in ("cred_theft", "callback_scam", "steal_pii")

--- a/detection-rules/salesforce_infra_abuse.yml
+++ b/detection-rules/salesforce_infra_abuse.yml
@@ -29,7 +29,7 @@ source: |
                        '^(?:(?:Final|Last)?\s*Warning|(?:Final|Last|Legal|Critical|Content Violation)?\s*(?:Alert|Noti(?:ce|fication))|Appeal Required|Time.Sensitive|Critical.Alert|Important|Copyright Issue)\s*:\s*'
     )
     or any(ml.logo_detect(beta.message_screenshot()).brands,
-           .name in ("Facebook", "Meta", "Instagram") and .confidence in ("medium", "high")
+           .name in ("Facebook", "Meta", "Instagram", "Threads") and .confidence in ("medium", "high")
     )
     // any of the links are for newly registered domains
     or any(filter(body.links,


### PR DESCRIPTION
# Description

> [!WARNING]
> Waiting on Threads logo detect
 
# Associated samples

- https://platform.sublime.security/messages/6e92f4f859239b4895f8818931a2ae3e3dfa478f6ab8b28fffe5397adea49327?preview_id=0196f335-7db7-73e5-b2f1-7738577be423