### PR TITLE
Create monday_infra_abuse.yml

### DIFF
--- a/detection-rules/monday_infra_abuse.yml
+++ b/detection-rules/monday_infra_abuse.yml
@@ -94,7 +94,7 @@ source: |
     (subject.is_reply or subject.is_forward)
     and (
       length(headers.references) > 0
-      and any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+      and headers.in_reply_to is not null
     )
   )
   // negate graymail and newsletters


### PR DESCRIPTION
# Description

Detects unauthorized use of Monday.com tracking links in messages, attachments, or QR codes from unusual senders who lack proper authentication. Excludes legitimate replies and messages from trusted domains with valid DMARC.

# Associated samples

- https://platform.sublime.security/messages/07c0db33624d8579a37fbff333269e4b7ab17b5b850b09c2bcfe9c45e54f9dc1?preview_id=0196f2d2-04dc-7702-8957-48e6d4b1429e
- https://platform.sublime.security/messages/cedf5ea2dd2f777f2812eceac1139a1c8cbda0d9836f2e0e62030ad31215b9b0?preview_id=0196f2d1-d7ff-7cea-8230-92caabb789a1
- https://platform.sublime.security/messages/55859636da858ea6c9592fd05aeaab83fb49f494fdee45c53b93cee855c93347
