### PR TITLE
Create link_genially_direct.yml

### DIFF
--- a/detection-rules/link_genially_direct.yml
+++ b/detection-rules/link_genially_direct.yml
@@ -1,0 +1,24 @@
+name: "Link: Genially Link Abuse"
+description: "Detects when a message contains a Genially link containing a 24-character hexadecimal hash in the URL path, which is a pattern associated with malicious content sharing."
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and length(body.links) < 20
+  and any(body.links,
+          (
+            .href_url.domain.domain == "view.genially.com"
+            and regex.icontains(.href_url.path, '\/[a-f0-9]{24}(?:\/|$)')
+          )
+  )
+  and length(filter(body.links, .href_url.domain.root_domain == "genially.com")) == 1
+tags:
+ - "Attack surface reduction"
+attack_types:
+  - "Credential Phishing"
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Free subdomain host"
+  - "Social engineering"
+detection_methods:
+  - "URL analysis"


### PR DESCRIPTION
Genially Link Abuse

# Description

This rule is derived from the original Gamma #2633  rule. The rule relies on logic that ensures the length of the URL contains the correct number observed, as well as the expected number of URLs in a phish. #2633 

# Associated samples

-[ Sample 1](https://platform.sublime.security/messages/d05371e261a16abac447500bb149f706d8923320e111bcce7302cad0e2fc0637?preview_id=0196f3fe-2a58-7a99-862d-a2348d8c3b36)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=0196f832-fb16-73b1-9c04-ac67f01c4ab2)
