### PR TITLE
Create attachment_suspicious_message_unscannable_cloudflare.yml

### DIFF
--- a/detection-rules/attachment_suspicious_message_unscannable_cloudflare.yml
+++ b/detection-rules/attachment_suspicious_message_unscannable_cloudflare.yml
@@ -331,3 +331,4 @@ detection_methods:
   - "Content analysis"
   - "Header analysis"
   - "Natural Language Understanding"
+id: "00f92b6f-7449-5c93-ba29-b406c57bf121"

--- a/detection-rules/attachment_suspicious_message_unscannable_cloudflare.yml
+++ b/detection-rules/attachment_suspicious_message_unscannable_cloudflare.yml
@@ -1,0 +1,333 @@
+name: "Suspicious attachment with unscannable Cloudflare link"
+description: "A PDF or Office document contains suspicious URLs that lead to Cloudflare-protected pages with turnstile CAPTCHA gates. The sender uses deceptive display names and subjects indicating urgency or authority."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(attachments,
+          (
+            .file_extension in $file_extensions_macros
+            or .file_extension == "pdf"
+            or .file_type in ("pdf", "doc", "docx", "xls", "xlsx")
+            or .content_type in ("application/pdf")
+          )
+          and any(file.explode(.),
+                  // few links
+                  0 < length(.scan.url.urls) < 20
+                  // fewer unique root domain links
+                  and length(distinct(.scan.url.urls, .domain.root_domain)) < 10
+                  // sender domain matches no body domains
+                  and all(.scan.url.urls,
+                          .domain.root_domain != sender.email.domain.root_domain
+                  )
+          )
+  )
+  
+  // negate bouncebacks and undeliverables
+  and not any(attachments,
+              .content_type in (
+                "message/global-delivery-status",
+                "message/delivery-status"
+              )
+  )
+  
+  // suspicious subject or display name
+  and (
+    regex.icontains(subject.subject,
+                    "termination.*notice",
+                    "38417",
+                    ":completed",
+                    "[il1]{2}mit.*ma[il1]{2} ?bo?x",
+                    "[il][il][il]egai[ -]",
+                    "[li][li][li]ega[li] attempt",
+                    "[ng]-?[io]n .*block",
+                    "[ng]-?[io]n .*cancel",
+                    "[ng]-?[io]n .*deactiv",
+                    "[ng]-?[io]n .*disabl",
+                    "action.*required",
+                    "abandon.*package",
+                    "about.your.account",
+                    "acc(ou)?n?t (is )?on ho[li]d",
+                    "acc(ou)?n?t.*terminat",
+                    "acc(oun)?t.*[il1]{2}mitation",
+                    "access.*limitation",
+                    "account (will be )?block",
+                    "account.*de-?activat",
+                    "account.*locked",
+                    "account.*re-verification",
+                    "account.*security",
+                    "account.*suspension",
+                    "account.has.been",
+                    "account.has.expired",
+                    "account.will.be.blocked",
+                    "account v[il]o[li]at",
+                    "activity.*acc(oun)?t",
+                    "almost.full",
+                    "app[li]e.[il]d",
+                    "authenticate.*account",
+                    "been.*suspend",
+                    "clos.*of.*account.*processed",
+                    "confirm.your.account",
+                    "courier.*able",
+                    "crediential.*notif",
+                    "deactivation.*in.*progress",
+                    "delivery.*attempt.*failed",
+                    "document.received",
+                    "documented.*shared.*with.*you",
+                    "dropbox.*document",
+                    "e-?ma[il1]+ .{010}suspen",
+                    "e-?ma[il1]{1} user",
+                    "e-?ma[il1]{2} acc",
+                    "e-?ma[il1]{2}.*up.?grade",
+                    "e.?ma[il1]{2}.*server",
+                    "e.?ma[il1]{2}.*suspend",
+                    "email.update",
+                    "faxed you",
+                    "fraud(ulent)?.*charge",
+                    "from.helpdesk",
+                    "fu[il1]{2}.*ma[il1]+[ -]?box",
+                    "has.been.*suspended",
+                    "has.been.limited",
+                    "have.locked",
+                    "he[li]p ?desk upgrade",
+                    "heipdesk",
+                    "i[il]iega[il]",
+                    "ii[il]ega[il]",
+                    "incoming e?mail",
+                    "incoming.*fax",
+                    "lock.*security",
+                    "ma[il1]{1}[ -]?box.*quo",
+                    "ma[il1]{2}[ -]?box.*fu[il1]",
+                    "ma[il1]{2}box.*[il1]{2}mit",
+                    "ma[il1]{2}box stor",
+                    "mail on.?hold",
+                    "mail.*box.*migration",
+                    "mail.*de-?activat",
+                    "mail.update.required",
+                    "mails.*pending",
+                    "messages.*pending",
+                    "missed.*shipping.*notification",
+                    "missed.shipment.notification",
+                    "must.update.your.account",
+                    "new [sl][io]g?[nig][ -]?in from",
+                    "new voice ?-?mail",
+                    "notifications.*pending",
+                    "office.*3.*6.*5.*suspend",
+                    "office365",
+                    "on google docs with you",
+                    "online doc",
+                    "password.*compromised",
+                    "periodic maintenance",
+                    "potential(ly)? unauthorized",
+                    "refund not approved",
+                    "report",
+                    "revised.*policy",
+                    "scam",
+                    "scanned.?invoice",
+                    "secured?.update",
+                    "security breach",
+                    "securlty",
+                    "signed.*delivery",
+                    "statement is ready",
+                    "status of your .{314}? ?delivery",
+                    "susp[il1]+c[il1]+ous.*act[il1]+v[il1]+ty",
+                    "suspicious.*sign.*[io]n",
+                    "suspicious.activit",
+                    "temporar(il)?y deactivate",
+                    "temporar[il1]{2}y disab[li]ed",
+                    "temporarily.*lock",
+                    "un-?usua[li].activity",
+                    "unable.*deliver",
+                    "unauthorized.*activit",
+                    "unauthorized.device",
+                    "undelivered message",
+                    "unread.*doc",
+                    "unusual.activity",
+                    "upgrade.*account",
+                    "upgrade.notice",
+                    "urgent message",
+                    "urgent.verification",
+                    "v[il1]o[li1]at[il1]on security",
+                    "va[il1]{1}date.*ma[il1]{2}[ -]?box",
+                    "verification ?-?require",
+                    "verification( )?-?need",
+                    "verify.your?.account",
+                    "web ?-?ma[il1]{2}",
+                    "web[ -]?ma[il1]{2}",
+                    "will.be.suspended",
+                    "your (customer )?account .as",
+                    "your.office.365",
+                    "your.online.access"
+    )
+    or any($suspicious_subjects, strings.icontains(subject.subject, .))
+    or regex.icontains(sender.display_name,
+                       "Admin",
+                       "Administrator",
+                       "Alert",
+                       "Assistant",
+                       "Billing",
+                       "Benefits",
+                       "Bonus",
+                       "CEO",
+                       "CFO",
+                       "CIO",
+                       "CTO",
+                       "Chairman",
+                       "Claim",
+                       "Confirm",
+                       "Critical",
+                       "Customer Service",
+                       "Deal",
+                       "Discount",
+                       "Director",
+                       "Exclusive",
+                       "Executive",
+                       "Fax",
+                       "Free",
+                       "Gift",
+                       "/bHR/b",
+                       "Helpdesk",
+                       "Human Resources",
+                       "Immediate",
+                       "Important",
+                       "Info",
+                       "Information",
+                       "Invoice",
+                       '\bIT\b',
+                       "Legal",
+                       "Lottery",
+                       "Management",
+                       "Manager",
+                       "Member Services",
+                       "Notification",
+                       "Offer",
+                       "Operations",
+                       "Order",
+                       "Partner",
+                       "Payment",
+                       "Payroll",
+                       "President",
+                       "Premium",
+                       "Prize",
+                       "Receipt",
+                       "Refund",
+                       "Registrar",
+                       "Required",
+                       "Reward",
+                       "Sales",
+                       "Secretary",
+                       "Security",
+                       "Service",
+                       "Signature",
+                       'SSA?\.gov',
+                       "Storage",
+                       "Support",
+                       "Sweepstakes",
+                       "System",
+                       "Tax",
+                       "Tech Support",
+                       "Update",
+                       "Upgrade",
+                       "Urgent",
+                       "Validate",
+                       "Verify",
+                       "VIP",
+                       "Webmaster",
+                       "Winner",
+    )
+    or any(attachments,
+           (
+             .file_extension in $file_extensions_macros
+             or .file_extension == "pdf"
+             or .file_type in ("pdf", "doc", "docx", "xls", "xlsx")
+             or .content_type in ("application/pdf")
+           )
+           and any(file.explode(.),
+                   any(.scan.url.urls, strings.ends_with(.url, ".exe"))
+                   or any(ml.nlu_classifier(.scan.ocr.raw).intents, .name == "cred_theft")
+           )
+    )
+  )
+  and any(attachments,
+          (
+            .file_extension in $file_extensions_macros
+            or .file_extension == "pdf"
+            or .file_type in ("pdf", "doc", "docx", "xls", "xlsx")
+            or .content_type in ("application/pdf")
+          )
+          and any(file.explode(.),
+                  any(.scan.url.urls,
+                      (
+                        strings.icontains(ml.link_analysis(., mode="aggressive").final_dom.display_text,
+                                          "cloudflare"
+                        )
+                        // includes the turnstile CAPTCHA
+                        or (
+                          strings.icontains(ml.link_analysis(., mode="aggressive").final_dom.raw,
+                                            'https://challenges.cloudflare.com/turnstile/'
+                          )
+                          // has a short body length indicating the page is gated behind the turnstile instead
+                          // of just including the turnstile
+                          and length((
+                                       ml.link_analysis(., mode="aggressive").final_dom.display_text
+                                     )
+                          ) < 200
+                        )
+                      )
+                      and not (
+                        ( // a Cloudflare error page
+                          strings.ilike(ml.link_analysis(., mode="aggressive").final_dom.display_text,
+                                        "*error code*"
+                          )
+                          and any(ml.link_analysis(., mode="aggressive").final_dom.links,
+                                  strings.icontains(.href_url.query_params,
+                                                    "utm_source=errorcode"
+                                  )
+                          )
+                        ) // a cookie warning mentioning Cloudflare
+                        or regex.icontains(ml.link_analysis(., mode="aggressive").final_dom.display_text,
+                                           "cookie.{0,50}Cloudflare"
+                        )
+                        or ml.link_analysis(., mode="aggressive").effective_url.domain.root_domain in (
+                          "marketbeat.com"
+                        )
+                      )
+                  )
+          )
+  )
+  
+  and (
+    not profile.by_sender().solicited
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and not profile.by_sender().any_false_positives
+    )
+  )
+  
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  and not profile.by_sender().any_messages_benign
+  
+tags:
+ - "Attack surface reduction"
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "PDF"
+  - "Social engineering"
+  - "Impersonation: Employee"
+  - "Impersonation: VIP"
+detection_methods:
+  - "File analysis"
+  - "URL analysis"
+  - "Sender analysis"
+  - "Content analysis"
+  - "Header analysis"
+  - "Natural Language Understanding"


### PR DESCRIPTION
# Description

A PDF or Office document contains suspicious URLs that lead to Cloudflare-protected pages with turnstile CAPTCHA gates. The sender uses deceptive display names and subjects indicating urgency or authority.

# Associated samples

- https://platform.sublime.security/messages/333e262d1cb41e66d85b9039d884ad73ad7a98b953f22ab80ac895d0e5d3ad4e?preview_id=01970bfe-c71d-7798-8f33-9cceef2b1a2e
