### PR TITLE
Update govdelivery_compromise.yml

### DIFF
--- a/detection-rules/govdelivery_compromise.yml
+++ b/detection-rules/govdelivery_compromise.yml
@@ -4,9 +4,11 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and sender.email.domain.domain == "public.govdelivery.com"
-  and headers.auth_summary.spf.pass
-  and headers.auth_summary.dmarc.pass
+  and (
+    sender.email.domain.domain == "public.govdelivery.com"
+    or any(headers.domains, .root_domain == "govdelivery.com")
+  )
+  and (headers.auth_summary.spf.pass or headers.auth_summary.dmarc.pass)
   and length(body.links) < 10
   and any(body.links,
           any(filter(regex.extract(.href_url.path, '/CL0/(?P<url>.*?)/1/'),
@@ -39,7 +41,6 @@ source: |
               )
           )
   )
-
 attack_types:
   - "Credential Phishing"
   - "Malware/Ransomware"


### PR DESCRIPTION
# Description

handle cases where govdelivery.com isn't the sender but is the delivery infra and where dmarc is missing.

# Associated samples


- [Sample 1](https://platform.sublime.security/messages/82c5912f8bc011dd0c8957954daafb7342b491e43c46720e68afd42e200eadcf?preview_id=01970f27-f639-742f-8c37-d430d1774887)
