### PR TITLE
Create open_redirect_bangkoksync.yml

### DIFF
--- a/detection-rules/open_redirect_bangkoksync.yml
+++ b/detection-rules/open_redirect_bangkoksync.yml
@@ -33,3 +33,4 @@ tactics_and_techniques:
 detection_methods:
   - "Sender analysis"
   - "URL analysis"
+id: "e1449ccd-566e-5218-8bfe-269afc4182e7"

--- a/detection-rules/open_redirect_bangkoksync.yml
+++ b/detection-rules/open_redirect_bangkoksync.yml
@@ -1,0 +1,35 @@
+name: "Open Redirect: bangkoksync.com"
+description: |
+  Message contains use of the bangkoksync.com open redirect. This has been exploited in the wild.
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(body.links,
+          .href_url.domain.root_domain == "bangkoksync.com"
+          and strings.icontains(.href_url.path, '/goto.php')
+          and regex.icontains(.href_url.query_params,
+                              'url=(?:https?|(?:\/|%2f)(?:\/|%2f))'
+          )
+          and any(.href_url.query_params_decoded["url"],
+                  strings.parse_url(.).domain.root_domain != "bangkoksync.com"
+          )
+  )
+  and not sender.email.domain.root_domain == "bangkoksync.com"
+  
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+attack_types:
+  - "Credential Phishing"
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Open redirect"
+detection_methods:
+  - "Sender analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description

This rule is designed to detect the open redirect abuse used to forward to some observed click-fix domains.

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=0197172b-7232-7701-aa59-db0399170f80)
 
