### PR TITLE
Update recon_recipients_bccd_undisclosed.yml

### DIFF
--- a/detection-rules/recon_recipients_bccd_undisclosed.yml
+++ b/detection-rules/recon_recipients_bccd_undisclosed.yml
@@ -16,7 +16,7 @@ source: |
     length(subject.subject) <= 10
     // extract the "real subject" (strip off any external warning keywords)
     or any(regex.iextract(subject.subject,
-                          '\[[^\]]+\]\s?){0,3} ?(?P<real_subject>.*)'
+                          '^(\[[^\]]+\]\s?){0,3} ?(?P<real_subject>.*)'
            ),
            length(.named_groups['real_subject']) <= 10
     )

--- a/detection-rules/recon_recipients_bccd_undisclosed.yml
+++ b/detection-rules/recon_recipients_bccd_undisclosed.yml
@@ -14,6 +14,12 @@ source: |
   )
   and (
     length(subject.subject) <= 10
+    // extract the "real subject" (strip off any external warning keywords)
+    or any(regex.iextract(subject.subject,
+                          '^\[?(?:EXT|EXTERNAL)\]? ?(?P<real_subject>.*)'
+           ),
+           length(.named_groups['real_subject']) <= 10
+    )
     or (
       strings.ilike(subject.subject, "*checking*", "*testing*")
       and length(subject.subject) <= 25

--- a/detection-rules/recon_recipients_bccd_undisclosed.yml
+++ b/detection-rules/recon_recipients_bccd_undisclosed.yml
@@ -16,7 +16,7 @@ source: |
     length(subject.subject) <= 10
     // extract the "real subject" (strip off any external warning keywords)
     or any(regex.iextract(subject.subject,
-                          '^\[?(?:EXT|EXTERNAL)\]? ?(?P<real_subject>.*)'
+                          '\[[^\]]+\]\s?){0,3} ?(?P<real_subject>.*)'
            ),
            length(.named_groups['real_subject']) <= 10
     )


### PR DESCRIPTION
# Description

Adding logic to evaluate the subject length without considering "external" warning keywords.

# Associated samples

- https://platform.sublime.security/messages/a029f24b079560ae8d01220ba86329918b49114ae48c74d44842ec7f921c73db?preview_id=0196f7ee-bcf7-71e4-9488-2ddc38b5f91d