### PR TITLE
Updates rules to support content ids without brackets

### DIFF
--- a/detection-rules/attachment_eml_suspicious_indicators.yml
+++ b/detection-rules/attachment_eml_suspicious_indicators.yml
@@ -16,10 +16,20 @@ source: |
       ) == 1
       and length(filter(attachments,
                         .file_type in $file_types_images
-                        and any(regex.extract(.content_id, '^<(?P<cid>.*)\>$'),
-                                strings.icontains(body.html.raw,
-                                                  .named_groups["cid"]
-                                )
+                        and 
+                        (
+                          any(regex.extract(.content_id, '^<(?P<cid>.*)\>$'),
+                            strings.icontains(body.html.raw,
+                                              .named_groups["cid"]
+                            )
+                          )
+                          or
+                          // Engine doesn't support alternation, so handle stripped content ids separately
+                          any(regex.extract(.content_id, '^(?P<cid>.*)$'),
+                            strings.icontains(body.html.raw,
+                                              .named_groups["cid"]
+                            )
+                          )
                         )
                  )
       ) == length(attachments) - 1

--- a/detection-rules/attachment_microsoft_image_lure_qr_code.yml
+++ b/detection-rules/attachment_microsoft_image_lure_qr_code.yml
@@ -35,10 +35,20 @@ source: |
                      .file_type in $file_types_images
                      // image attachments that are displayed in the body
                      // when the content-id is corrected, this will be much more simple
-                     and any(regex.extract(.content_id, '^<(?P<cid>[^\>]+)\>$'),
-                             strings.icontains(body.html.raw,
-                                               .named_groups["cid"]
-                             )
+                     and 
+                     (
+                      any(regex.extract(.content_id, '^<(?P<cid>[^\>]+)\>$'),
+                              strings.icontains(body.html.raw,
+                                                .named_groups["cid"]
+                              )
+                      )
+                      or
+                      // Engine doesn't support alternation, so handle stripped content ids separately
+                      any(regex.extract(.content_id, '^(?P<cid>[^\>]+)$'),
+                              strings.icontains(body.html.raw,
+                                                .named_groups["cid"]
+                              )
+                      )
                      )
               ),
               // those images contain the wording

--- a/detection-rules/callback_aol_senders.yml
+++ b/detection-rules/callback_aol_senders.yml
@@ -66,7 +66,10 @@ source: |
               .file_type == "pdf"
               and (
                 // static content_id value for the attachments
-                .content_id == '<@yahoo.com>'
+                (
+                  .content_id == '<@yahoo.com>'
+                  or .content_id == '@yahoo.com'
+                )
                 // created by observed static PDF details
                 or (
                     

--- a/detection-rules/link_fake_fax_low_reputation.yml
+++ b/detection-rules/link_fake_fax_low_reputation.yml
@@ -78,11 +78,12 @@ source: |
         and any(attachments,
                 strings.icontains(.file_name, 'fax')
                 or (
-  
                   // or they are used in the body and OCR on them contains fax wording
                   // the image is used in the HTML body
                   .file_type in $file_types_images
-                  and any(regex.extract(.content_id, '^\<(.*)\>$'),
+                  and 
+                  (
+                    any(regex.extract(.content_id, '^\<(.*)\>$'),
                           any(.groups,
                               strings.icontains(body.html.raw,
                                                 strings.concat('src="cid:',
@@ -91,6 +92,21 @@ source: |
                                                 )
                               )
                           )
+                    )
+                    or
+                    // Engine doesn't support alternation, so handle stripped content ids separately
+                    (
+                      any(regex.extract(.content_id, '^(.*)$'),
+                            any(.groups,
+                                strings.icontains(body.html.raw,
+                                                  strings.concat('src="cid:',
+                                                                .,
+                                                                '"'
+                                                  )
+                                )
+                            )
+                        )
+                    )
                   )
                   and (
                     // and that image contains fax wording


### PR DESCRIPTION
# Description
As part of https://www.notion.so/sublimesecurity/Remove-brackets-from-Attachment-content_id-field-16004655fc9d81d3b233c4894c6ba49a , the encapsulating brackets on content ids will be stripped. To support backwards compatibility with existing MDMs, as well as ensure the same rules get triggered when the MDMs strip the brackets from content ids, the impacted rules were updated to support both formats of content ids.

# Associated samples
- https://platform.sublime.security/messages/2e10ec5477674882c95ecb6647726de650c23a6ec03dee58e79dc17951f306a3?preview_id=01970f97-e0bd-7a9c-a121-5072141d5366 (for callback_aol_senders.yml)
- https://platform.sublime.security/messages/e76186f4f6bdeac87cdd98bbe626f759cf43d4c472dc8fdec5ee9d606eb861de?preview_id=0197217c-c32c-776c-a18c-08fcd1e61d80 (for attachment_eml_suspicious_indicators.yml)
- https://platform.sublime.security/messages/ddaee9e11744937606934ce32f77e1f5f6de4b7cf5ba8ae42536b51f588e6bcf?preview_id=01971c7d-e847-782b-aba0-09ba8946560e (for link_fake_fax_low_reputation.yml)
- https://platform.sublime.security/messages/2fc38404037322237c4f46fb070a4a2f385055445be2755a75f747fa0b0850cc?preview_id=01971107-ca4e-7cd1-ab70-e91154d330b6 (for attachment_microsoft_image_lure_qr_code.yml)

For each rule, the associated .eml was tested as-is (to ensure backwards compatibility) as well as tested with the brackets stripped from the content ids (to ensure forwards compatibility when the MDMs have the brackets stripped)
