### PR TITLE
encrypted_msft_office_files.yar

### DIFF
--- a/yara/encrypted_msft_office_files.yar
+++ b/yara/encrypted_msft_office_files.yar
@@ -1,14 +1,11 @@
-rule encrypted_msaccess_database {
+rule encrypted_ms_office_aes {
   meta:
-    description = "Detects Microsoft Access Databases with AES Encryption"
+    description = "Detects Microsoft Office Documents with AES Encryption"
     author = "Sublime Security"
     severity = "medium"
-    reference = "AES-256-CBC with HMAC-SHA-256 VBScript implementation"
+    reference = "AES-256-CBC with HMAC-SHA-256 implementation in MS Office files"
   
   strings:
-    // MS Access file signature
-    $access_sig = { 00 01 00 00 53 74 61 6E 64 61 72 64 20 41 43 45 20 44 42 }
-    
     // AES Encryption indicators
     $aes1 = "AES-256-CBC" ascii wide nocase
     $aes2 = "HMAC-SHA-256" ascii wide nocase
@@ -30,17 +27,14 @@ rule encrypted_msaccess_database {
     $crypto3 = "MemoryStream" ascii wide
     
   condition:
-    $access_sig at 0 and
-    (
-      // High confidence detection - specific AES implementation
-      ($aes1 and $aes2) or
-      
-      // Medium confidence detection - crypto libraries with encryption functions
-      ($aes3 and ($enc1 or $enc2)) or
-      ($aes4 and ($enc1 or $enc2)) or
-      
-      // Lower confidence but specific patterns
-      ($vbs and $aes1) or
-      (2 of ($crypto*) and 1 of ($enc*) and $enc3 and $enc4)
-    )
+    // High confidence detection - specific AES implementation
+    ($aes1 and $aes2) or
+    
+    // Medium confidence detection - crypto libraries with encryption functions
+    ($aes3 and ($enc1 or $enc2)) or
+    ($aes4 and ($enc1 or $enc2)) or
+    
+    // Lower confidence but specific patterns
+    ($vbs and $aes1) or
+    (2 of ($crypto*) and 1 of ($enc*) and $enc3 and $enc4)
 }


### PR DESCRIPTION
encrypted_msaccess_database.yar → yara/encrypted_msft_office_files.yar

Changed the YARA to better identify more file types using the same encryption scheme than just in msft access databases.

# Description

There is an additional number of files that use AES for encryption, this YARA rule will cover those file types. Hunt will be provided once the YARA is ready to be referenced by the MQL.
