### PR TITLE
Initial commit to update impersonation stripe alert to exclude FPs

### DIFF
--- a/detection-rules/impersonation_stripe.yml
+++ b/detection-rules/impersonation_stripe.yml
@@ -11,7 +11,7 @@ source: |
       sender.display_name =~ 'stripe'
       or (
           strings.istarts_with(sender.display_name, 'stripe ')
-          and not sender.display_name in~ ('Stripe & Stare')
+          and not sender.display_name in~ ('Stripe & Stare', 'Stripe and Stare', 'Stripe Events')
       )
       or strings.replace_confusables(sender.display_name) =~ 'stripe'
     )
@@ -35,6 +35,7 @@ source: |
         "scribe",
         "straye", // a shoe company?
         "storie", // storiesbystorie.com
+        "stryke", // a cybersecurity and compliance company
         "stryve", // a food/snack company stryve.com
         "shrine", // common word
         "s.ride", // cab/taxi company


### PR DESCRIPTION
# Description

PR to update impersonation stripe alert to exclude Stryke and stripe and stare, and stripe events. Stryke is a known cybersecurity and compliance organization. Stripe and Stare is an extension of the existing tune. Also tuning out Stripe Events.

# Associated samples

Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.

- https://platform.sublime.security/messages/5c2c4a672571c605998884f3ebab67a7c0057a68cd55e3b0aff92ceb35fb3f5d?preview_id=0196464e-ec6c-7b51-aaf8-aa524fc9668c

- https://platform.sublime.security/messages/54ae0cd3952b074d8924c4d3eaafc12942577a4d9082efe7eceb96f0dee55117?preview_id=01964637-8e42-7533-b59f-c405f9754f11

- https://platform.sublime.security/messages/6a4eebd5c47efc6cf3a5b32e184a68ac950eb086d14a99a5b33ffef95fd263ad?preview_id=01967c1d-4877-704d-b9cd-b5bf728ab275
