### PR TITLE
make instructions be comments pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,24 +1,30 @@
 # Description
 
+<!-- 
 Explain your change and why. For example, "negating legitimate replies," or "adding additional credential theft keywords."
 
 If it's a new rule or insight, explain what the rule is designed to catch/what the insight should fire on.
+-->
 
 # Associated samples
-
+<!-- 
 Link to samples that are affected by your change. 
 
 For example, samples you are negating, samples you are including, or samples your new insight should fire on.
+-->
 
 - Sample 1
 - Sample 2
 
 ## Associated hunts
+<!-- 
 
 If you ran any hunts with your rule, please link them here.
+-->
 
 - Hunt 1
 
 # Screenshot (insights)
-
+<!-- 
 **For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
+-->


### PR DESCRIPTION
use Github markdown comments for the instructions so they don't appear within the PR comment
