### PR TITLE
Modifying the DocuSign alert to exclude FPs

### DIFF
--- a/detection-rules/attachment_docusign_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_suspicious_links.yml
@@ -60,7 +60,9 @@ source: |
                                   "*DocuSigned By*",
                                   "*DocuSign Envelope ID*",
                                   "*Certificate Of Completion*",
-                                  "*Adobe Sign*"
+                                  "*Adobe Sign*",
+                                  // Additional Adobe Acrobat Sign check
+                                  "*Powered by\nAdobe\nAcrobat Sign*"
                     )
                     or (
                       .depth == 0


### PR DESCRIPTION
# Description

This tune matches legit Adobe Acrobat Sign logo found in file.explode on PDFs.

# Associated sample
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- https://platform.sublime.security/messages/af320a73229d0b59c0fefa91bd78c81872aa69d7f95847fc1bd640082ffdabfa?preview_id=0196468e-da5b-7b11-9774-6353b3e5ee2a
