### PR TITLE
Modifying PayPal Brand Impersonation excluding FP

### DIFF
--- a/detection-rules/impersonation_paypal.yml
+++ b/detection-rules/impersonation_paypal.yml
@@ -58,6 +58,7 @@ source: |
   )
   and sender.email.domain.root_domain not in (
     'google.com',
+    'paypal-brandsfeedback.com',
     'paypal-creditsurvey.com',
     'paypal-customerfeedback.com',
     'paypal-experience.com',


### PR DESCRIPTION
# Description

PR to modify the PayPal Brand Impersonation alert to exclude known feedback survey. Analysis found here -> https://www.paypal.com/us/cshelp/article/does-paypal-ask-its-customers-to-participate-in-surveys-and-research-studies%E2%80%AF--help334  

*As a side note; paypal-experience.com (also found in analysis) is already excluded in this alert.*

# Associated sample

- https://platform.sublime.security/messages/de8e7d3dda2d2d109ee30389ecdded86e350c7c53177d4152e59f6339e4dfdc4?preview_id=0196468e-a613-7356-8918-decf9c02c828
