### PR TITLE
Modifying Callback Phish alert to tune out FPs caused by resume.

### DIFF
--- a/detection-rules/attachment_callback_phish_with_pdf.yml
+++ b/detection-rules/attachment_callback_phish_with_pdf.yml
@@ -89,22 +89,17 @@ source: |
                       strings.icontains(.scan.ocr.raw, "account balance"),
                     )
                   )
-                  // negate signs of resume
                   and not (
-                    5 of (
-                      strings.icontains(.scan.ocr.raw, "experience"),
-                      strings.icontains(.scan.ocr.raw, "education"),
-                      strings.icontains(.scan.ocr.raw, "skills"),
-                      strings.icontains(.scan.ocr.raw, "university"),
-                      strings.icontains(.scan.ocr.raw, "bachelor"),
-                      strings.icontains(.scan.ocr.raw, "master"),
-                      strings.icontains(.scan.ocr.raw, "employment"),
-                      strings.icontains(.scan.ocr.raw, "references"),
-                      strings.icontains(.scan.ocr.raw, "qualifications"),
-                      regex.icontains(.scan.ocr.raw, '\d{4}\s*-\s*\d{4}'),
-                      regex.icontains(.scan.ocr.raw, '\d{4}\s*-\s*present'),
+                      any(beta.ml_topic(.scan.ocr.raw).topics,
+                        .name == "Professional and Career Development"
+                        and .confidence == "high"
+                        )
                   )
-                )
+                  and 
+                    any(beta.ml_topic(body.html.display_text).topics,
+                      .name == "Professional and Career Development"
+                      and .confidence == "high"
+                    )
               )
               // this section is synced with attachment_callback_phish_with_img.yml and body_callback_phishing_no_attachment.yml
               or any(ml.logo_detect(.).brands,

--- a/detection-rules/attachment_callback_phish_with_pdf.yml
+++ b/detection-rules/attachment_callback_phish_with_pdf.yml
@@ -35,6 +35,25 @@ source: |
             and any(file.explode(.),
                     .depth == 0 and .scan.exiftool.page_count < 3
             )
+            // negate ML matches to "Professional and Career Development" - tuning resume FPs
+            and not (
+              any(beta.ml_topic(coalesce(body.html.display_text, body.plain.raw)).topics,
+                .name == "Professional and Career Development" and .confidence == "high"
+                )
+                or (
+                    (
+                    any(attachments,
+                        .file_type == 'pdf'
+                        and any(file.explode(.),
+                                any(beta.ml_topic(.scan.ocr.raw).topics,
+                                    .name == "Professional and Career Development"
+                                    and .confidence == "high"
+                                )
+                        )
+                    )
+                    )
+                )
+            )
             // check that any _single_ result in the file.explode matches these conditions
             // a second file.explode is required because the OCR is generated at a different depth within 
             // the file.explode results

--- a/detection-rules/attachment_callback_phish_with_pdf.yml
+++ b/detection-rules/attachment_callback_phish_with_pdf.yml
@@ -89,6 +89,22 @@ source: |
                       strings.icontains(.scan.ocr.raw, "account balance"),
                     )
                   )
+                  // negate signs of resume
+                  and not (
+                    5 of (
+                      strings.icontains(.scan.ocr.raw, "experience"),
+                      strings.icontains(.scan.ocr.raw, "education"),
+                      strings.icontains(.scan.ocr.raw, "skills"),
+                      strings.icontains(.scan.ocr.raw, "university"),
+                      strings.icontains(.scan.ocr.raw, "bachelor"),
+                      strings.icontains(.scan.ocr.raw, "master"),
+                      strings.icontains(.scan.ocr.raw, "employment"),
+                      strings.icontains(.scan.ocr.raw, "references"),
+                      strings.icontains(.scan.ocr.raw, "qualifications"),
+                      regex.icontains(.scan.ocr.raw, '\d{4}\s*-\s*\d{4}'),
+                      regex.icontains(.scan.ocr.raw, '\d{4}\s*-\s*present'),
+                  )
+                )
               )
               // this section is synced with attachment_callback_phish_with_img.yml and body_callback_phishing_no_attachment.yml
               or any(ml.logo_detect(.).brands,

--- a/detection-rules/attachment_callback_phish_with_pdf.yml
+++ b/detection-rules/attachment_callback_phish_with_pdf.yml
@@ -98,27 +98,6 @@ source: |
                     // suspicious attachment name from the attachment object not file.explode() output
                     or regex.icontains(..file_name, 'INV(?:_|\s)?\d+(.pdf)$')
                   )
-                  // Negate bank statements
-                  and not (
-                    2 of (
-                      strings.icontains(.scan.ocr.raw, "opening balance"),
-                      strings.icontains(.scan.ocr.raw, "closing balance"),
-                      strings.icontains(.scan.ocr.raw, "direct debit"),
-                      strings.icontains(.scan.ocr.raw, "interest"),
-                      strings.icontains(.scan.ocr.raw, "account balance"),
-                    )
-                  )
-                  and not (
-                      any(beta.ml_topic(.scan.ocr.raw).topics,
-                        .name == "Professional and Career Development"
-                        and .confidence == "high"
-                        )
-                  )
-                  and 
-                    any(beta.ml_topic(body.html.display_text).topics,
-                      .name == "Professional and Career Development"
-                      and .confidence == "high"
-                    )
               )
               // this section is synced with attachment_callback_phish_with_img.yml and body_callback_phishing_no_attachment.yml
               or any(ml.logo_detect(.).brands,

--- a/detection-rules/attachment_callback_phish_with_pdf.yml
+++ b/detection-rules/attachment_callback_phish_with_pdf.yml
@@ -38,21 +38,22 @@ source: |
             // negate ML matches to "Professional and Career Development" - tuning resume FPs
             and not (
               any(beta.ml_topic(coalesce(body.html.display_text, body.plain.raw)).topics,
-                .name == "Professional and Career Development" and .confidence == "high"
+                  .name == "Professional and Career Development"
+                  and .confidence == "high"
+              )
+              or (
+                (
+                  any(attachments,
+                      .file_type == 'pdf'
+                      and any(file.explode(.),
+                              any(beta.ml_topic(.scan.ocr.raw).topics,
+                                  .name == "Professional and Career Development"
+                                  and .confidence == "high"
+                              )
+                      )
+                  )
                 )
-                or (
-                    (
-                    any(attachments,
-                        .file_type == 'pdf'
-                        and any(file.explode(.),
-                                any(beta.ml_topic(.scan.ocr.raw).topics,
-                                    .name == "Professional and Career Development"
-                                    and .confidence == "high"
-                                )
-                        )
-                    )
-                    )
-                )
+              )
             )
             // check that any _single_ result in the file.explode matches these conditions
             // a second file.explode is required because the OCR is generated at a different depth within 

--- a/detection-rules/attachment_callback_phish_with_pdf.yml
+++ b/detection-rules/attachment_callback_phish_with_pdf.yml
@@ -98,6 +98,16 @@ source: |
                     // suspicious attachment name from the attachment object not file.explode() output
                     or regex.icontains(..file_name, 'INV(?:_|\s)?\d+(.pdf)$')
                   )
+                  // Negate bank statements
+                  and not (
+                    2 of (
+                      strings.icontains(.scan.ocr.raw, "opening balance"),
+                      strings.icontains(.scan.ocr.raw, "closing balance"),
+                      strings.icontains(.scan.ocr.raw, "direct debit"),
+                      strings.icontains(.scan.ocr.raw, "interest"),
+                      strings.icontains(.scan.ocr.raw, "account balance"),
+                    )
+                  )
               )
               // this section is synced with attachment_callback_phish_with_img.yml and body_callback_phishing_no_attachment.yml
               or any(ml.logo_detect(.).brands,

--- a/detection-rules/impersonation_paypal.yml
+++ b/detection-rules/impersonation_paypal.yml
@@ -58,6 +58,7 @@ source: |
   )
   and sender.email.domain.root_domain not in (
     'google.com',
+    'paypal-brandsfeedback.com',
     'paypal-creditsurvey.com',
     'paypal-customerfeedback.com',
     'paypal-experience.com',


### PR DESCRIPTION
# Description

Modifying the Callback Phish alert to tune out FPs caused by resumes being sent. 

# Associated samples

- https://sublime.security/messages/f9baaaa776f78ec868f9757fcc40220a3a61beb37f5c1e055baced054c0d2b01?preview_id=019646e8-470f-78f1-95c2-0cec6ddaf167
- https://sublime.security/messages/f9baaaa776f78ec868f9757fcc40220a3a61beb37f5c1e055baced054c0d2b01?preview_id=019646e8-470f-78f1-95c2-0cec6ddaf167

# Associated Hunt

- https://platform.sublime.security/hunts/0197405f-fd4d-723c-a7a8-f9506b779405