### PR TITLE
Add credential phishing rule for email delivery failure impersonation

### DIFF
--- a/detection-rules/credential_phishing_email_delivery_failure_impersonation.yml
+++ b/detection-rules/credential_phishing_email_delivery_failure_impersonation.yml
@@ -1,5 +1,12 @@
 name: "Credential phishing: Email delivery failure impersonation"
 description: |
+  Detects phishing emails impersonating email system notifications claiming delivery failures, 
+  rejected messages, or email system issues requiring user action to 'fix' or 'recover' email functionality.
+  These attacks typically claim incoming emails couldn't be delivered and direct users to malicious 
+  portals to harvest credentials.
+type: "rule"
+severity: "high"
+source: |
   type.inbound
   and length(body.links) < 10
   and (

--- a/detection-rules/credential_phishing_email_delivery_failure_impersonation.yml
+++ b/detection-rules/credential_phishing_email_delivery_failure_impersonation.yml
@@ -21,6 +21,13 @@ source: |
       )
     )
   )
+  and (
+    regex.icontains(subject.subject, '(e)?mail(s)?')
+    or (
+      length(body.current_thread.text) < 700
+      and strings.ilike(body.current_thread.text, '*mail*')
+    )
+  )
   and 3 of (
     strings.ilike(body.current_thread.text, "*incoming messages*"),
     strings.ilike(body.current_thread.text, "*server error*"),

--- a/detection-rules/credential_phishing_email_delivery_failure_impersonation.yml
+++ b/detection-rules/credential_phishing_email_delivery_failure_impersonation.yml
@@ -1,12 +1,5 @@
 name: "Credential phishing: Email delivery failure impersonation"
 description: |
-  Detects phishing emails impersonating email system notifications claiming delivery failures, 
-  rejected messages, or email system issues requiring user action to 'fix' or 'recover' email functionality.
-  These attacks typically claim incoming emails couldn't be delivered and direct users to malicious 
-  portals to harvest credentials.
-type: "rule"
-severity: "high"
-source: |
   type.inbound
   and length(body.links) < 10
   and (
@@ -51,6 +44,8 @@ source: |
                         "portal",
                         "connect"
         )
+        and not .display_text == "View Report"
+        and .href_url.domain.root_domain in ("gmass.co")
     )
     or (
       length(body.links) < 3
@@ -94,7 +89,7 @@ source: |
       sender.email.domain.root_domain in $org_domains
       and (
         not headers.auth_summary.dmarc.pass
-        // MS quarantine digest emails from an org domain are router "internally" to MS, therefore, there is no authentication information
+        // MS  emails from an org domain are router "internally" to MS, therefore, there is no authentication information
         or not (
           headers.auth_summary.dmarc.pass is null
           and all(headers.domains,

--- a/detection-rules/credential_phishing_email_delivery_failure_impersonation.yml
+++ b/detection-rules/credential_phishing_email_delivery_failure_impersonation.yml
@@ -121,3 +121,4 @@ detection_methods:
   - "Content analysis"
   - "Natural Language Understanding"
   - "Sender analysis"
+id: "ee318b89-0d4e-5c94-80ad-08991d3958b2"

--- a/detection-rules/credential_phishing_email_delivery_failure_impersonation.yml
+++ b/detection-rules/credential_phishing_email_delivery_failure_impersonation.yml
@@ -1,0 +1,123 @@
+name: "Credential phishing: Email delivery failure impersonation"
+description: |
+  Detects phishing emails impersonating email system notifications claiming delivery failures, 
+  rejected messages, or email system issues requiring user action to 'fix' or 'recover' email functionality.
+  These attacks typically claim incoming emails couldn't be delivered and direct users to malicious 
+  portals to harvest credentials.
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and length(body.links) < 10
+  and (
+    any(ml.nlu_classifier(body.current_thread.text).intents,
+        .name == "cred_theft" and .confidence == "high"
+    )
+    or (
+      length(body.current_thread.text) < 250
+      and any(recipients.to,
+              strings.icontains(body.current_thread.text, .email.domain.sld)
+              or strings.icontains(body.current_thread.text, .email.local_part)
+      )
+    )
+  )
+  and 3 of (
+    strings.ilike(body.current_thread.text, "*incoming messages*"),
+    strings.ilike(body.current_thread.text, "*server error*"),
+    strings.ilike(body.current_thread.text, "*blocked*"),
+    strings.ilike(body.current_thread.text, "*prevented*"),
+    strings.ilike(body.current_thread.text, "*notification*"),
+    strings.ilike(body.current_thread.text, "*fix email issues*"),
+    strings.ilike(body.current_thread.text, "*rejected*"),
+    strings.ilike(body.current_thread.text, "*recover and prevent*"),
+    strings.ilike(body.current_thread.text, "*failure*"),
+    strings.ilike(body.current_thread.text, "*rejection*"),
+    strings.ilike(body.current_thread.text, "*failed*")
+  )
+  and (
+    any(body.links,
+        regex.icontains(.display_text,
+                        "view",
+                        "messages",
+                        "recover",
+                        "fix",
+                        "portal",
+                        "connect"
+        )
+    )
+    or (
+      length(body.links) < 3
+      and any(body.links,
+              any(recipients.to,
+                  .email.domain.root_domain == ..display_url.domain.root_domain
+                  and ..mismatched
+              )
+      )
+    )
+    or (all(recipients.to, .email.local_part == sender.display_name))
+    or any(body.links,
+           any(.href_url.rewrite.encoders, . == "proofpoint")
+           and .href_url.domain.root_domain not in $tranco_50k
+           and .href_url.domain.root_domain not in $org_domains
+    )
+  )
+  and not any(body.links,
+              regex.icontains(.display_text,
+                              "view document",
+                              "review (&|and) sign document"
+              )
+  )
+  and sender.email.domain.root_domain not in (
+    "bing.com",
+    "microsoft.com",
+    "microsoftonline.com",
+    "microsoftsupport.com",
+    "microsoft365.com",
+    "office.com",
+    "office365.com",
+    "onedrive.com",
+    "sharepointonline.com",
+    "yammer.com",
+    "ppops.net"
+  )
+  
+  // negate org domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $org_domains
+      and (
+        not headers.auth_summary.dmarc.pass
+        // MS quarantine digest emails from an org domain are router "internally" to MS, therefore, there is no authentication information
+        or not (
+          headers.auth_summary.dmarc.pass is null
+          and all(headers.domains,
+                  .root_domain in ("outlook.com", "office365.com")
+          )
+          // typical emails from freemail Outlook accounts are from prod.outlook.com
+          and strings.ends_with(headers.message_id, "protection.outlook.com>")
+        )
+      )
+    )
+    or sender.email.domain.root_domain not in $org_domains
+  )
+  
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  and not profile.by_sender().solicited
+  and not profile.by_sender().any_false_positives
+  
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

Added a new detection rule specifically targeting email delivery failure impersonation attacks. These attacks claim that incoming emails couldn't be delivered and direct users to malicious portals to harvest credentials.

This rule complements the existing quarantine notification rule by focusing specifically on delivery failure patterns rather than quarantine scenarios.

# Key Features

- **NLU-based detection**: Uses credential theft intent classification
- **Delivery-specific patterns**: Targets language like "incoming messages", "rejected", "fix email issues"
- **Social engineering detection**: Catches display name spoofing (sender display name matches recipient username)
- **Link analysis**: Detects suspicious URLs including Proofpoint-wrapped malicious links
- **Comprehensive filtering**: Includes sender reputation and domain trust checks

# Associated samples

- https://platform.sublime.security/messages/c8890abbe218aef58e90b2d54a91d46e02c05cd42d975b70c3a8f73ce4905ed6

🤖 Generated with [Claude Code](https://claude.ai/code)