### PR TITLE
Fix false positives in brand impersonation rules

### DIFF
--- a/detection-rules/impersonation_mailgun.yml
+++ b/detection-rules/impersonation_mailgun.yml
@@ -30,6 +30,7 @@ source: |
       sender.email.domain.root_domain in (
         'mailgun.com',
         'mailgun.net', // official mailgun domains
+        'sinch.com', // parent company of Mailgun
         'mailgunwarmup.com', // an unrelated b2b firm
         'emailonacid.com', // another sinch email product 
         'elior-na.com', // a domain with a simliar logo that catches on logo_detect

--- a/detection-rules/impersonation_microsoft.yml
+++ b/detection-rules/impersonation_microsoft.yml
@@ -71,7 +71,10 @@ source: |
     all(attachments,
         .content_type in ("message/delivery-status", "message/rfc822")
     )
-    and (sender.email.local_part in ('postmaster', 'mailer-daemon'))
+    and (
+      sender.email.local_part in ('postmaster', 'mailer-daemon')
+      or strings.starts_with(sender.email.local_part, 'microsoftexchange')
+    )
     and strings.contains(subject.subject, 'Undeliverable:')
   )
   


### PR DESCRIPTION
# Description

Fixed false positives in Mailgun and Microsoft brand impersonation rules by:
- Adding sinch.com to trusted domains in Mailgun rule (parent company)
- Expanding Microsoft Exchange sender negation for undeliverable reports

# Associated samples

- Legitimate Sinch employee email about Mailgun services
- Microsoft Exchange undeliverable report with microsoftexchange sender

🤖 Generated with [Claude Code](https://claude.ai/code)