### PR TITLE
CI: Reverting actions/github-script to v4

### DIFF
--- a/.github/workflows/clear-old-test-rules.yml
+++ b/.github/workflows/clear-old-test-rules.yml
@@ -23,7 +23,9 @@ jobs:
 
       - name: Get Open PRs
         id: open_prs
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        # this needs to be upgraded to v7 but need to get this working now
+        # actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@v4
         with:
           script: |
             github.paginate(

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -184,7 +184,9 @@ jobs:
       # Various alternatives were explored, but all run into issues when dealing with forks. This sets a "Check" for
       # the latest commit, and we can depend on that as a required check.
       - name: "Create a check run"
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        # this needs to be upgraded to v7 but need to get this working now
+        # actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@v4
         if: (github.event_name == 'pull_request_target' || github.event_name == 'merge_group' ) && always()
         env:
           run_url: "${{ format('https://github.com/{0}/actions/runs/{1}', steps.get_head_ref.outputs.repo, github.run_id) }}"
@@ -290,7 +292,9 @@ jobs:
 
 
       - name: "Find mql-mimic-exempt Comments"
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        # this needs to be upgraded to v7 but need to get this working now
+        # actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@v4
         id: find_emls_to_skip
         if: steps.find_pr_number.outputs.result != ''
         with:
@@ -340,7 +344,9 @@ jobs:
             return allEMLsToSkip.join(" ")
 
       - name: "Find Existing MQL Mimic Test Results"
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        # this needs to be upgraded to v7 but need to get this working now
+        # actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@v4
         id: find_mql_mimic_results
         if: ${{ github.event_name != 'merge_group' }}
         env:
@@ -389,7 +395,9 @@ jobs:
           ignoreIDs: ${{ steps.find_mql_mimic_results.outputs.result }}
 
       - name: "Create MQL Mimic Check"
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        # this needs to be upgraded to v7 but need to get this working now
+        # actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@v4
         if: ${{ github.event_name == 'merge_group' }}
         id: create_check
         env:


### PR DESCRIPTION
# Description

This is reverting our `actions/github-script` to v4. We need to upgrade to v7 but in order to get this working now we are just reverting these actions.

