### PR TITLE
Create link_suspicious_message_unscannable_vercel.yml

### DIFF
--- a/detection-rules/link_suspicious_message_unscannable_vercel.yml
+++ b/detection-rules/link_suspicious_message_unscannable_vercel.yml
@@ -1,0 +1,271 @@
+name: "Suspicious message with unscannable Vercel link"
+description: "This rule detects messages with unscannable links to Vercel infrastructure with suspicious indicators in the subject or display name from an unsolicited sender."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+    // few links
+    0 < length(body.links) < 20
+    // fewer unique root domain links
+    and length(distinct(body.links, .href_url.domain.root_domain)) < 10
+    // sender domain matches no body domains
+    and all(body.links,
+            .href_url.domain.root_domain != sender.email.domain.root_domain
+            // sender email addtess in body looks like this
+            or .href_url.url == sender.email.domain.root_domain
+    )
+  )
+  
+  // negate bouncebacks and undeliverables
+  and not any(attachments,
+              .content_type in (
+                "message/global-delivery-status",
+                "message/delivery-status"
+              )
+  )
+  
+  // suspicious subject or display name
+  and (
+    regex.icontains(subject.subject,
+                    "termination.*notice",
+                    "38417",
+                    ":completed",
+                    "[il1]{2}mit.*ma[il1]{2} ?bo?x",
+                    "[il][il][il]egai[ -]",
+                    "[li][li][li]ega[li] attempt",
+                    "[ng]-?[io]n .*block",
+                    "[ng]-?[io]n .*cancel",
+                    "[ng]-?[io]n .*deactiv",
+                    "[ng]-?[io]n .*disabl",
+                    "action.*required",
+                    "abandon.*package",
+                    "about.your.account",
+                    "acc(ou)?n?t (is )?on ho[li]d",
+                    "acc(ou)?n?t.*terminat",
+                    "acc(oun)?t.*[il1]{2}mitation",
+                    "access.*limitation",
+                    "account (will be )?block",
+                    "account.*de-?activat",
+                    "account.*locked",
+                    "account.*re-verification",
+                    "account.*security",
+                    "account.*suspension",
+                    "account.has.been",
+                    "account.has.expired",
+                    "account.will.be.blocked",
+                    "account v[il]o[li]at",
+                    "activity.*acc(oun)?t",
+                    "almost.full",
+                    "app[li]e.[il]d",
+                    "authenticate.*account",
+                    "been.*suspend",
+                    "clos.*of.*account.*processed",
+                    "confirm.your.account",
+                    "courier.*able",
+                    "crediential.*notif",
+                    "deactivation.*in.*progress",
+                    "delivery.*attempt.*failed",
+                    "document.received",
+                    "documented.*shared.*with.*you",
+                    "dropbox.*document",
+                    "e-?ma[il1]+ .{010}suspen",
+                    "e-?ma[il1]{1} user",
+                    "e-?ma[il1]{2} acc",
+                    "e-?ma[il1]{2}.*up.?grade",
+                    "e.?ma[il1]{2}.*server",
+                    "e.?ma[il1]{2}.*suspend",
+                    "email.update",
+                    "faxed you",
+                    "fraud(ulent)?.*charge",
+                    "from.helpdesk",
+                    "fu[il1]{2}.*ma[il1]+[ -]?box",
+                    "has.been.*suspended",
+                    "has.been.limited",
+                    "have.locked",
+                    "he[li]p ?desk upgrade",
+                    "heipdesk",
+                    "i[il]iega[il]",
+                    "ii[il]ega[il]",
+                    "incoming e?mail",
+                    "incoming.*fax",
+                    "lock.*security",
+                    "ma[il1]{1}[ -]?box.*quo",
+                    "ma[il1]{2}[ -]?box.*fu[il1]",
+                    "ma[il1]{2}box.*[il1]{2}mit",
+                    "ma[il1]{2}box stor",
+                    "mail on.?hold",
+                    "mail.*box.*migration",
+                    "mail.*de-?activat",
+                    "mail.update.required",
+                    "mails.*pending",
+                    "messages.*pending",
+                    "missed.*shipping.*notification",
+                    "missed.shipment.notification",
+                    "must.update.your.account",
+                    "new [sl][io]g?[nig][ -]?in from",
+                    "new voice ?-?mail",
+                    "notifications.*pending",
+                    "office.*3.*6.*5.*suspend",
+                    "office365",
+                    "on google docs with you",
+                    "online doc",
+                    "password.*compromised",
+                    "periodic maintenance",
+                    "potential(ly)? unauthorized",
+                    "refund not approved",
+                    "report",
+                    "revised.*policy",
+                    "scam",
+                    "scanned.?invoice",
+                    "secured?.update",
+                    "security breach",
+                    "securlty",
+                    "signed.*delivery",
+                    "statement is ready",
+                    "status of your .{314}? ?delivery",
+                    "susp[il1]+c[il1]+ous.*act[il1]+v[il1]+ty",
+                    "suspicious.*sign.*[io]n",
+                    "suspicious.activit",
+                    "temporar(il)?y deactivate",
+                    "temporar[il1]{2}y disab[li]ed",
+                    "temporarily.*lock",
+                    "un-?usua[li].activity",
+                    "unable.*deliver",
+                    "unauthorized.*activit",
+                    "unauthorized.device",
+                    "undelivered message",
+                    "unread.*doc",
+                    "unusual.activity",
+                    "upgrade.*account",
+                    "upgrade.notice",
+                    "urgent message",
+                    "urgent.verification",
+                    "v[il1]o[li1]at[il1]on security",
+                    "va[il1]{1}date.*ma[il1]{2}[ -]?box",
+                    "verification ?-?require",
+                    "verification( )?-?need",
+                    "verify.your?.account",
+                    "web ?-?ma[il1]{2}",
+                    "web[ -]?ma[il1]{2}",
+                    "will.be.suspended",
+                    "your (customer )?account .as",
+                    "your.office.365",
+                    "your.online.access"
+    )
+    or any($suspicious_subjects, strings.icontains(subject.subject, .))
+    or regex.icontains(sender.display_name,
+                       "Admin",
+                       "Administrator",
+                       "Alert",
+                       "Assistant",
+                       "Billing",
+                       "Benefits",
+                       "Bonus",
+                       "CEO",
+                       "CFO",
+                       "CIO",
+                       "CTO",
+                       "Chairman",
+                       "Claim",
+                       "Confirm",
+                       "Critical",
+                       "Customer Service",
+                       "Deal",
+                       "Discount",
+                       "Director",
+                       "Exclusive",
+                       "Executive",
+                       "Fax",
+                       "Free",
+                       "Gift",
+                       "/bHR/b",
+                       "Helpdesk",
+                       "Human Resources",
+                       "Immediate",
+                       "Important",
+                       "Info",
+                       "Information",
+                       "Invoice",
+                       '\bIT\b',
+                       "Legal",
+                       "Lottery",
+                       "Management",
+                       "Manager",
+                       "Member Services",
+                       "Notification",
+                       "Offer",
+                       "Operations",
+                       "Order",
+                       "Partner",
+                       "Payment",
+                       "Payroll",
+                       "President",
+                       "Premium",
+                       "Prize",
+                       "Receipt",
+                       "Refund",
+                       "Registrar",
+                       "Required",
+                       "Reward",
+                       "Sales",
+                       "Secretary",
+                       "Security",
+                       "Service",
+                       "Signature",
+                       "SSA",
+                       "Storage",
+                       "Support",
+                       "Sweepstakes",
+                       "System",
+                       "Tax",
+                       "Tech Support",
+                       "Update",
+                       "Upgrade",
+                       "Urgent",
+                       "Validate",
+                       "Verify",
+                       "VIP",
+                       "Webmaster",
+                       "Winner",
+    )
+    or any(body.links, strings.ends_with(.href_url.url, ".exe"))
+  )
+  
+  // link can't be scanned due to Vercel block page
+  and any(body.links,
+          strings.icontains(ml.link_analysis(., mode="aggressive").final_dom.display_text,
+                            "Vercel Security Checkpoint"
+          )
+          or strings.icontains(ml.link_analysis(., mode="aggressive").final_dom.raw,
+                               'https://vercel.link/security-checkpoint'
+          )
+  )
+  and (
+    not profile.by_sender_email().solicited
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and not profile.by_sender().any_false_positives
+    )
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  and not profile.by_sender().any_false_positives
+  
+tags:
+ - "Attack surface reduction"
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Sender analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description

This rule detects messages with unscannable links to Vercel infrastructure with suspicious indicators in the subject or display name from an unsolicited sender.

# Associated samples

- https://platform.sublime.security/messages/d24e942b5de1508a13dd9c7441576eb815dd3c4287ffbb5152c7ce5ccb23d80f?preview_id=019740a5-dc52-71c1-8f80-254c6aa6acc5