### PR TITLE
CI: Reverting action/github-script to v6

### DIFF
--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -186,7 +186,7 @@ jobs:
       - name: "Create a check run"
         # this needs to be upgraded to v7 but need to get this working now
         # actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         if: (github.event_name == 'pull_request_target' || github.event_name == 'merge_group' ) && always()
         env:
           run_url: "${{ format('https://github.com/{0}/actions/runs/{1}', steps.get_head_ref.outputs.repo, github.run_id) }}"
@@ -294,7 +294,7 @@ jobs:
       - name: "Find mql-mimic-exempt Comments"
         # this needs to be upgraded to v7 but need to get this working now
         # actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         id: find_emls_to_skip
         if: steps.find_pr_number.outputs.result != ''
         with:
@@ -346,7 +346,7 @@ jobs:
       - name: "Find Existing MQL Mimic Test Results"
         # this needs to be upgraded to v7 but need to get this working now
         # actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         id: find_mql_mimic_results
         if: ${{ github.event_name != 'merge_group' }}
         env:
@@ -397,7 +397,7 @@ jobs:
       - name: "Create MQL Mimic Check"
         # this needs to be upgraded to v7 but need to get this working now
         # actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
-        uses: actions/github-script@v4
+        uses: actions/github-script@v6
         if: ${{ github.event_name == 'merge_group' }}
         id: create_check
         env:


### PR DESCRIPTION
# Description

This is another revert of the `actions/github-script` which was reverted to v4 and I didn't review the git blame close enough. This resulted in reverting some of the actions to v4 which should have been reverted to v6.

This PR updates this action by changing the github-script to v6.

https://github.com/sublime-security/sublime-rules/pull/2795

**NOTE** We do need to upgrade to v7 at some point still.