### PR TITLE
Create insight for vip

### DIFF
--- a/insights/sender/sender_contains_org_vip.yml
+++ b/insights/sender/sender_contains_org_vip.yml
@@ -4,12 +4,8 @@ source: |
   type.inbound
   and any($org_vips,
           strings.icontains(sender.display_name, .display_name)
-          and (
-            (
-              not sender.email.domain.root_domain in $high_trust_sender_root_domains
-              and not sender.email.domain.root_domain in $org_domains
-            )
-            and headers.auth_summary.dmarc.pass
-          )
+          and not sender.email.domain.root_domain in $high_trust_sender_root_domains
+          and not sender.email.domain.root_domain in $org_domains
+          and headers.auth_summary.dmarc.pass
   )
 severity: "informational"

--- a/insights/sender/sender_contains_org_vip.yml
+++ b/insights/sender/sender_contains_org_vip.yml
@@ -1,4 +1,4 @@
-name: "Sender Display Name is a VIP"
+name: "Sender Display Name Contains VIP Display Name"
 type: "query"
 source: |
   type.inbound

--- a/insights/sender/sender_is_vip.yml
+++ b/insights/sender/sender_is_vip.yml
@@ -1,0 +1,15 @@
+name: "Sender Display Name is a VIP"
+type: "query"
+source: |
+  type.inbound
+  and any($org_vips,
+          strings.icontains(sender.display_name, .display_name)
+          and (
+            (
+              not sender.email.domain.root_domain in $high_trust_sender_root_domains
+              and not sender.email.domain.root_domain in $org_domains
+            )
+            and headers.auth_summary.dmarc.pass
+          )
+  )
+severity: "informational"


### PR DESCRIPTION
# Description

From https://www.notion.so/sublimesecurity/Insights-for-VIP-and-Employee-name-in-display-name-8ee47c53e7e648a388e47baf6add63ee?source=copy_link 

Adding new insight to match Sender Display Names with VIP display names. 

# Screenshot (insights)

Screenshot is not applicable for this insight, as it relies on org identities which cannot be replicated outside of client environments. 