### PR TITLE
Checking current thread text mentions follow up

### DIFF
--- a/detection-rules/spam_attendee_list_solicitation.yml
+++ b/detection-rules/spam_attendee_list_solicitation.yml
@@ -39,6 +39,7 @@ source: |
       and not regex.icontains(body.current_thread.text,
                               "(?:debit card|transaction.{0,20}processed|receipt)"
       )
+      and regex.icontains(body.current_thread.text, 'follow(?:ing)?(-| )up')
     )
     // if there are indicators of a previous thread, also inspect the previous thread
     or (


### PR DESCRIPTION
# Description

Extending rule to check if mentioning if a follow up from a previous email / thread. 

# Associated samples

- [Sample 1](https://na-east-2.platform.sublime.security/messages/31c655cc53af7b7c920b84af0a92d41cdc299849f98a8f450c00a2e13dd3f7ca?preview_id=0196fce7-b1f5-7052-87f5-e8cecc20f0a1)
- Sample 2

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- Hunt 1

