### PR TITLE
Update link_secure_sharepoint_file.yml

### DIFF
--- a/detection-rules/link_secure_sharepoint_file.yml
+++ b/detection-rules/link_secure_sharepoint_file.yml
@@ -21,11 +21,16 @@ source: |
   
   // sender is uncommon
   and (
-    profile.by_sender().prevalence in ("new", "rare", "outlier")
+    (
+      profile.by_sender().prevalence in ("new", "rare", "outlier")
+      and not profile.by_sender().solicited
+    )
     // or the reply-to address has never sent an email to the org
-    or beta.profile.by_reply_to().prevalence == "new"
+    or (
+      sender.email.domain.root_domain == "sharepointonline.com"
+      and beta.profile.by_reply_to().prevalence == "new"
+    )
   )
-  and not profile.by_sender().solicited
 tags:
  - "Attack surface reduction"
 attack_types:


### PR DESCRIPTION
# Description

Adjusting sender profile snippet to account for when users have replied to a no-reply address (sharepointonline.com addresses, in this case)