### PR TITLE
Extending root domains in impersonation_microsoft

### DIFF
--- a/detection-rules/impersonation_microsoft.yml
+++ b/detection-rules/impersonation_microsoft.yml
@@ -56,7 +56,9 @@ source: |
     'office.com',
     'teams-events.com',
     'qualtrics-research.com',
-    'skype.com'
+    'skype.com',
+    'azureadnotifications.us',
+    'microsoftonline.us'
   )
   and (
     profile.by_sender().prevalence in ("new", "outlier")


### PR DESCRIPTION
# Description

Based on tuning POC review, this PR updates the list of root domains for Microsoft per this [link](https://learn.microsoft.com/en-us/entra/identity/authentication/concept-sspr-howitworks#notify-all-admins-when-other-admins-reset-their-passwords).

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/15ca0992cf0e226345abad08ab4af24acd48ab69918964457150006528303168?preview_id=0196fce7-18ec-77c9-9245-db6f7eff30d5
- Sample 2
