### PR TITLE
Adding new brand impersonation rule for Experian

### DIFF
--- a/detection-rules/impersonation_experian.yml
+++ b/detection-rules/impersonation_experian.yml
@@ -1,0 +1,46 @@
+name: "Brand impersonation: Experian"
+description: |
+  Impersonation of Experian
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+    strings.ilike(sender.display_name, '*experian*')
+    or strings.ilevenshtein(sender.display_name, 'experian') <= 1
+  )
+  and sender.email.domain.root_domain not in~ ('experian.com')
+  
+  // and not if the sender.display.name contains "via" and dmarc pass from venmo.com
+  and not (
+    (
+      headers.auth_summary.dmarc.pass
+      and headers.auth_summary.dmarc.details.from.root_domain == "experian.com"
+    )
+    and strings.contains(sender.display_name, "via")
+  )
+
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+
+  // and no false positives and not solicited
+  and (
+    not profile.by_sender().any_false_positives
+    and not profile.by_sender().solicited
+  )
+  
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Lookalike domain"
+  - "Social engineering"
+detection_methods:
+  - "Sender analysis"
+id: "7e5c04dd-e324-53de-b1e1-91f0bdc680cd"


### PR DESCRIPTION
# Description

This is a new rule titled `Brand impersonation: Experian` that mimics the `Brand impersonation: Venmo` rule by modifying the domains.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/e69ca0fee96c5b21fcb220fae03ab5246caa8c4857922f91cdff44381b05a126?preview_id=0196e48d-e924-78fd-a9f3-6012c75e2b1c)
- Sample 2

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- Hunt 1
