### PR TITLE
Creating detection for deceptive dropbox mentioning

### DIFF
--- a/detection-rules/deceptive_dropbox_mention.yml
+++ b/detection-rules/deceptive_dropbox_mention.yml
@@ -1,0 +1,59 @@
+name: "Deceptive Dropbox Mention"
+description: "Detects when an actor mentions Dropbox but includes links to non-Dropbox domains, displays email address discrepancies, and exhibits suspicious language patterns according to machine learning analysis"
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and strings.icontains(body.current_thread.text, 'dropbox')
+  
+  // Email address discrepancy detection - body contains email different from sender
+  and (
+    regex.icontains(body.current_thread.text,
+                    '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'
+    )
+    and not strings.icontains(body.current_thread.text, sender.email.email)
+    and not regex.icontains(body.current_thread.text,
+                            'recipient:\s*[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'
+    )
+  )
+  
+  // Not from legitimate Dropbox infrastructure
+  and sender.email.domain.root_domain not in~ (
+    'dropbox.com',
+    'docsend.com',
+    // tuning: exlude hellosign emails that are covered in another rule
+    'hellosign.com'
+    'box.com'
+  )
+  
+  // Contains suspicious links to non-Dropbox/file-sharing domains
+  and any(body.links,
+          (.href_url.domain.root_domain in~ $free_subdomain_hosts
+          or .href_url.domain.root_domain in~ $free_file_hosts)
+          and .href_url.domain.valid
+  )
+  
+  // ML indicates potential credential theft
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "cred_theft" and .confidence in~ ("medium", "high")
+  )
+  
+  // Exclude legitimate file sharing services already covered by other rules
+  and sender.email.domain.root_domain not in~ (
+    'docsend.com',
+    'box.com',
+    'wetransfer.com'
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Free file host"
+  - "Free subdomain host"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"
+  - "URL analysis"

--- a/detection-rules/deceptive_dropbox_mention.yml
+++ b/detection-rules/deceptive_dropbox_mention.yml
@@ -57,3 +57,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Sender analysis"
   - "URL analysis"
+id: "58a107bc-dd68-5fdd-9813-4a05411aafd9"

--- a/detection-rules/deceptive_dropbox_mention.yml
+++ b/detection-rules/deceptive_dropbox_mention.yml
@@ -21,9 +21,9 @@ source: |
   and sender.email.domain.root_domain not in~ (
     'dropbox.com',
     'docsend.com',
+    'box.com',
     // tuning: exlude hellosign emails that are covered in another rule
     'hellosign.com'
-    'box.com'
   )
   
   // Contains suspicious links to non-Dropbox/file-sharing domains


### PR DESCRIPTION
# Description

Creating detection for deceptive dropbox mentioning. This came from a Detection Runner ask. 

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/0ce86d2199211f80d561066f1231c007d4af1dac7884f84be3065095a1ad472d?preview_id=01975bee-4679-7630-a376-bfbdb6f3173d)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01976080-9a7c-70e2-80a1-b91cf834336e)
