### PR TITLE
Updating logic to match on the sender_email

### DIFF
--- a/detection-rules/link_webflow_unsolicited.yml
+++ b/detection-rules/link_webflow_unsolicited.yml
@@ -13,10 +13,10 @@ source: |
   )
   // not solicited or from malicious/spam user with no FPs
   and (
-    not profile.by_sender().solicited
+    not profile.by_sender_email().solicited
     or (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_false_positives
+      profile.by_sender_email().any_messages_malicious_or_spam
+      and not profile.by_sender_email().any_messages_benign
     )
   )
   


### PR DESCRIPTION
# Description

Updated the logic of this rule to match on sender_email instead of the default sender_domain. Also updating deprecated function

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/ba77ebcd8ad3424a5873677a221b9c2fffdd398cf95b8e1a87c4e0d591f6f910?preview_id=01975f6e-8e6d-73e1-a1d5-f9fe715f895e)
