### PR TITLE
Creating detection for deceptive dropbox mentioning

### DIFF
--- a/detection-rules/deceptive_dropbox_mention.yml
+++ b/detection-rules/deceptive_dropbox_mention.yml
@@ -51,3 +51,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Sender analysis"
   - "URL analysis"
+id: "58a107bc-dd68-5fdd-9813-4a05411aafd9"


### PR DESCRIPTION
# Description
New rule from a runner FN. This alert detects deceptive dropbox techniques that might fall outside of the broad category of Dropbox Impersonation. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/0ce86d2199211f80d561066f1231c007d4af1dac7884f84be3065095a1ad472d?preview_id=01975bee-4679-7630-a376-bfbdb6f3173d)

## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01976463-2fbc-7a7d-b55f-18e0b0afcf4a)
