### PR TITLE
Update impersonation_turbotax.yml

### DIFF
--- a/detection-rules/impersonation_turbotax.yml
+++ b/detection-rules/impersonation_turbotax.yml
@@ -6,36 +6,36 @@ references:
 type: "rule"
 severity: "low"
 source: |
-type.inbound
-and (
-  strings.ilike(sender.display_name, '*turbotax*')
-  or (
-    strings.ilevenshtein(sender.display_name, 'turbotax') <= 1
-    // negates FP for company called TurboTan
-    and not (
-      sender.display_name == "TurboTan"
-      and sender.email.domain.root_domain == "brevosend.com"
-      and headers.auth_summary.spf.pass
+  type.inbound
+  and (
+    strings.ilike(sender.display_name, '*turbotax*')
+    or (
+      strings.ilevenshtein(sender.display_name, 'turbotax') <= 1
+      // negates FP for company called TurboTan
+      and not (
+        sender.display_name == "TurboTan"
+        and sender.email.domain.root_domain == "brevosend.com"
+        and headers.auth_summary.spf.pass
+      )
+    )
+    or strings.ilike(sender.email.domain.domain, '*turbotax*')
+  )
+  and sender.email.domain.root_domain not in (
+    'intuit.com',
+    'turbotax.com',
+    'intuit.ca',
+    'truist.com' // Truist partners with Intuit to provide discounts
+  )
+  and sender.email.email not in $recipient_emails
+  
+  // negates survery service used by TurboTax
+  and not (
+    sender.email.domain.root_domain in ('qemailserver.com')
+    and headers.auth_summary.spf.pass
+    and any(body.links,
+            .href_url.domain.root_domain in ("qualtrics.com", "intuit.com")
     )
   )
-  or strings.ilike(sender.email.domain.domain, '*turbotax*')
-)
-and sender.email.domain.root_domain not in (
-  'intuit.com',
-  'turbotax.com',
-  'intuit.ca',
-  'truist.com' // Truist partners with Intuit to provide discounts
-)
-and sender.email.email not in $recipient_emails
-
-// negates survery service used by TurboTax
-and not (
-  sender.email.domain.root_domain in ('qemailserver.com')
-  and headers.auth_summary.spf.pass
-  and any(body.links,
-          .href_url.domain.root_domain in ("qualtrics.com", "intuit.com")
-  )
-)
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description

This change is to address three separate cases of FPs found for this rule. It will address the survey follow up emails from TurboTax (using Qualtrics and Intuit links), hits on a company called 'TurboTan', and Truist promotion emails for their partnership with TurboTax. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->
Survey follow ups (Qualtrics and Intuit)
- https://platform.sublime.security/messages/e13cc49409ee449bea3a683a179a9877978741432ea6105184f0b7ea718655aa?preview_id=0196f44c-599e-719e-9c72-8cbe95625b86

- https://platform.sublime.security/messages/01547b49e447f779398a05dd4acbde949751078a382288b1288396aac214e59a?preview_id=019645b9-8fd7-74a4-b51d-3309d975628f

TurboTan 
- https://platform.sublime.security/messages/331a1475e918bc1ee91a8aed4e8e74394db7cab061747771353072effee8fd00?preview_id=0196a4a4-86ae-722a-98d8-ac78f577d2e0

Truist
- https://platform.sublime.security/messages/589b64945ce98bdb6c6497dcbd5167dafc5fc1d143605d5b149898b6bbe17ece?preview_id=469b4830-deb6-43e1-a5f7-9c991b3516f0

## Associated hunts

Inverse hunt showing changes no longer match survey use case:
- https://platform.sublime.security/messages/hunt?huntId=01976494-9a67-765d-8843-303f88f5aaf7

Inverse hunt showing changes no longer match TurboTan use case:
- https://platform.sublime.security/messages/hunt?huntId=01976490-da79-7dc3-970a-7f5046866f2a

Truist example older than 365 days so no hunt available, but matched changes to example email in rule editor. 


