### PR TITLE
Create free_file_share_with_mismatched_links.yml

### DIFF
--- a/detection-rules/free_file_share_with_mismatched_links.yml
+++ b/detection-rules/free_file_share_with_mismatched_links.yml
@@ -1,0 +1,56 @@
+name: "Mismatched Links: Free File Share With Urgent Language"
+description: "Detects messages from first-time senders containing free file sharing links, multiple urgent language indicators, and mismatched link text."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  
+  // Unsolicited + new sender
+  and (
+    profile.by_sender_email().prevalence in ("new", "outlier")
+    and not profile.by_sender_email().solicited
+  )
+  and not profile.by_sender_email().any_messages_benign
+  
+  // Free file share
+  and any(body.links, .href_url.domain.domain in $free_file_hosts)
+  
+  // urgent language
+  and 3 of (
+    any(ml.nlu_classifier(body.current_thread.text).entities, .name == "urgency"),
+    any(ml.nlu_classifier(subject.subject).entities, .name == "urgency"),
+    regex.icontains(body.current_thread.text,
+                    'immediate|urgent|expire|suspend|action.{0,20}required|time.{0,10}sensitive|verify.{0,20}immediately|complete.{0,20}requested'
+    ),
+    regex.icontains(subject.subject,
+                    'immediate|urgent|expire|suspend|action.{0,20}required|important.{0,20}announcement'
+    ),
+    regex.icontains(body.current_thread.text,
+                    'deadline|expires?.{0,10}(today|soon)|act.{0,10}now|time.{0,10}running.{0,10}out|limited.{0,10}time'
+    )
+  )
+  
+  // Mismatched link
+  and any(body.links,
+          .mismatched == true
+          and length(body.links) <= 3
+          and not .href_url.domain.root_domain in (
+            "mimecast.com",
+            "mimecastprotect.com"
+          )
+  )
+attack_types:
+  - "BEC/Fraud"
+  - "Callback Phishing"
+  - "Credential Phishing"
+  - "Extortion"
+  - "Malware/Ransomware"
+  - "Spam"
+tactics_and_techniques:
+  - "Free file host"
+  - "Social engineering"
+detection_methods:
+  - "Natural Language Understanding"
+  - "Sender analysis"
+  - "URL analysis"
+id: "478334c8-66be-5cc2-8bd5-3422cc8d2e9d"


### PR DESCRIPTION
# Description
Creating free file share rule with mismatched links and urgent language. This came from a runner ping, Aiden also updated one of the rules that is directly in the client env. This is expanding coverage.

# Associated samples
[Sample 1](https://platform.sublime.security/messages/9136517b7c15a44c9fb771550d168a374489f6449359f535e826a508b3a25c43?preview_id=01977b67-4ae9-72f7-b733-c938278d8aac)

# Associated hunts
[Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01977f45-b2d6-77f0-a5d9-10eeb06fe3c4)