### PR TITLE
Create link_discord_notification.yml

### DIFF
--- a/detection-rules/link_discord_notification.yml
+++ b/detection-rules/link_discord_notification.yml
@@ -1,0 +1,72 @@
+name: "Discord Notification Impersonation"
+description: "Detects inbound messages that impersonate Discord's notification system through display name spoofing, domain lookalikes, or logo usage in attachments. The messages contain typical Discord-style notification language in the subject line while failing authentication checks."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+    strings.ilike(sender.display_name, '*discord*')
+    or strings.ilevenshtein(sender.display_name, 'discord') <= 2
+    or strings.ilike(sender.email.domain.domain, '*discord*')
+    // Discord logo detection in image attachments
+    or any(attachments,
+           .file_type in $file_types_images
+           and any(ml.logo_detect(.).brands,
+                   strings.starts_with(.name, "Discord")
+           )
+    )
+    // Discord logo detection in message screenshot
+    or any(ml.logo_detect(beta.message_screenshot()).brands,
+           strings.starts_with(.name, "Discord") and .confidence != "low"
+    )
+  )
+  and (
+    regex.icontains(subject.subject, 'you have received a new notification')
+    or regex.icontains(subject.subject,
+                       'new (?:message|notification|alert|activity)'
+    )
+    or regex.icontains(subject.subject,
+                       '(?:message|notification|alert|activity) (?:from|waiting|pending)'
+    )
+    or regex.icontains(subject.subject, 'unread (?:message|notification)s?')
+    or regex.icontains(subject.subject,
+                       '(?:missed|pending) (?:message|notification|call)s?'
+    )
+    or regex.icontains(subject.subject, 'friend request')
+    or regex.icontains(subject.subject, 'server invitation')
+    or regex.icontains(subject.subject, 'mentioned you')
+    or regex.icontains(subject.subject, 'direct message')
+    or regex.icontains(subject.subject, 'discord (?:notification|alert|message)')
+  )
+  and not (
+    sender.email.domain.root_domain == "discord.com"
+    and any(headers.hops, .authentication_results.dmarc == "pass")
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  and (
+    (
+      profile.by_sender().prevalence in ("new", "outlier")
+      and not profile.by_sender().solicited
+    )
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and not profile.by_sender().any_false_positives
+    )
+  )
+  and not profile.by_sender().any_false_positives
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Computer Vision"
+  - "Content analysis"


### PR DESCRIPTION
Identifies incoming messages that mimic Discord's notification system by using spoofed display names, lookalike domains, or Discord logos in attachments. These messages often feature subject lines written in the style of Discord notifications but fail standard authentication checks.


- [Sample 1](https://platform.sublime.security/messages/36ccc5d5df4b1ae6c568b31a34058f5321aa53735d5ba7669f25910b6651644a?preview_id=019745c0-41e9-7ca4-9b67-663bf16f3250)
- [Sample 2](https://platform.sublime.security/messages/c08f05ec61493774b3662680430e65c4e280020b8111223d89fcc11b411d2393?preview_id=0195e6dc-3b7d-7d43-8a9d-d7f026863255)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=0197848c-4258-7806-b9b6-4dd22b26013e)

