### PR TITLE
Update impersonation_meta.yml

### DIFF
--- a/detection-rules/impersonation_meta.yml
+++ b/detection-rules/impersonation_meta.yml
@@ -87,7 +87,7 @@ source: |
     // or the body contains a facebook/meta footer with the address citing "community support" 
     (
       regex.icontains(body.current_thread.text,
-                      '(1 (Facebook|Meta)?\s*Way|1601 Willow Road), Menlo Park, CA 94025'
+                      '(1\s+(Facebook|Meta)?\s*Way|1601\s+Willow\s+Rd?).*Menlo\s+Park.*CA.*94025'
       )
       // and it contains a link to spawn a chat with facebook - this is not the way support operates
       and (


### PR DESCRIPTION
# Description

Adding in a additional logic for the Meta/Facebook location. There is some additional logic in here i am testing including some rebrand.ly links, but for now just the location logic is being suggested to include for this rule, which the below message matched.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/295bf131b47cee53346c9435f01d5543737862234c0a878a1d7c228e731509c8?preview_id=01979bfd-c401-7d23-b58c-a67dfaaa28da)


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01979c2a-65b4-7c41-af35-216b5bd298b0)


