### PR TITLE
Create link_cloudflare_service_abuse.yml

### DIFF
--- a/detection-rules/link_cloudflare_service_abuse.yml
+++ b/detection-rules/link_cloudflare_service_abuse.yml
@@ -8,10 +8,6 @@ source: |
           // Check root domain first 
           .href_url.domain.root_domain in ("r2.dev", "pages.dev", "workers.dev")
           // Check the specific pub-{hex}.r2.dev subdomain pattern only for r2.dev
-          or (
-              .href_url.domain.root_domain == "r2.dev"
-              and regex.icontains(.href_url.domain.subdomain, '^pub-[a-f0-9]{32}$')
-          )
   )
   // negate emails with unsubscribe links
   and not any(body.links,


### PR DESCRIPTION
# Description

Cloudflare offer a number of services that include hosting, this includes:
`r2.dev`
`pages.dev`
`workers.dev`

`r2.dev`: r2.dev is Cloudflare's object storage service. It's designed to integrate with Cloudflare's serverless platform, Workers, allowing for dynamic data manipulation through Workers.

`pages.dev`: This domain used by Cloudflare's Pages platform, which provides a service for deploying and hosting static websites
`workers.dev`: Cloudflare Workers is a serverless computing platform that allows developers to write and deploy lightweight applications and scripts directly

There is reporting on the abuse of all of these services:

1.https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/a-bucket-of-phish-attackers-shift-tactics-with-cloudflare-r2-public-buckets/
2.https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/its-raining-phish-and-scams-how-cloudflare-pages-dev-and-workers-dev-domains-get-abused/
3. https://emailsecurity.fortra.com/blog/cloudflares-pagesdev-and-workersdev-domains-increasingly-abused-phishing

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/76f9a04e7b8bd36ec6ef27ba40c3f08017c92797117f0d5838b4ad64dc3c707e?preview_id=0197084e-67f5-7ac3-b38b-5e7cddf77a3d)
- [Sample 2](https://platform.sublime.security/messages/544be982427e6950d38d974ed9bb7defcced69e83429ff9610b240ce537be833?preview_id=01977db3-8c91-7d9e-ae7b-76735f3fc3b1)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=0197a16f-7efb-7d69-bba9-ac8414980399)

---
This is a legitimate platform, however the abuse observed probably warrants a rule that can provide some hunting capacity.