### PR TITLE
fix: Add zoom-x.de for Zoom Germany to legitimate Zoom domains

### DIFF
--- a/detection-rules/brand_impersonation_zoom.yml
+++ b/detection-rules/brand_impersonation_zoom.yml
@@ -103,7 +103,8 @@ source: |
       "zoom.us",
       "zuora.com",
       "zoomgov.com",
-      "zoom.com"
+      "zoom.com",
+      "zoom-x.de"
     )
     and headers.auth_summary.dmarc.pass
   )


### PR DESCRIPTION
# Description

<!-- 
Explain your change and why. For example, "negating legitimate replies," or "adding additional credential theft keywords."

If it's a new rule or insight, explain what the rule is designed to catch/what the insight should fire on.
-->

Having co-workers in Germany, we keep getting false positives for Zoom brand impersonation for zoom-x.de despite that being an official zoom domain, per this [Zoom blog post](https://www.zoom.com/en/blog/zoom-and-deutsche-telekom/). 

Updating this rule, so other Sublime users with Germany co-workers don't get these false positives. 

Reference 1: https://www.zoom.com/en/blog/zoom-and-deutsche-telekom/

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/e38413fa7a9d14d9d25b04171e569106ec05bb23e5b277f60666d8bf1c979b13)
