### PR TITLE
Updating nlu cred theft alert to allow one bcc

### DIFF
--- a/detection-rules/recipients_undisclosed_nlu_cred_theft_low_rep_links.yml
+++ b/detection-rules/recipients_undisclosed_nlu_cred_theft_low_rep_links.yml
@@ -4,9 +4,9 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and (length(recipients.to) == 0 or all(recipients.to, .display_name == "Undisclosed recipients"))
+  and (length(recipients.to) == 0 or all(recipients.to, strings.ilike(.display_name, "undisclosed?recipients")))
   and length(recipients.cc) == 0
-  and length(recipients.bcc) == 0
+  and 0 <= length(recipients.bcc) <= 1
   and any(body.links, .href_url.domain.root_domain not in $tranco_1m)
   and (
     any(body.links,


### PR DESCRIPTION
also changing undisclosed recipient callout for better matching

# Description
also changing undisclosed recipient callout for better matching

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/26ba8f91c54284ae2dbe92c27854ac3109e74478f28d4b7051d12c299530fbf5?preview_id=0197a796-cd5e-7a30-a7dd-08c1712ecf1f)
- [Sample 2](https://platform.sublime.security/messages/22494908e0288071016730db6fd6e84f4603e763a097ea76d6181d3a6e4d3b31?preview_id=0197a389-6ae3-749f-b22f-c66f65cf6f91)
