### PR TITLE
Updating secure sharepoint alert to allow for common phishing wording

### DIFF
--- a/detection-rules/link_secure_sharepoint_file.yml
+++ b/detection-rules/link_secure_sharepoint_file.yml
@@ -33,7 +33,7 @@ source: |
     // or the message contains suspect language
     or (
       regex.icontains(body.current_thread.text,
-                      '(Mr|Mrs|Ms|Miss|Dr|Prof|Sir|Lady|kindly)'
+                      '(kindly)'
       )
     )
   )


### PR DESCRIPTION
# Description
Updating secure sharepoint alert to allow for common phishing wording. I want to let this sit in test rules to see if we get any false positives

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/c1356fc1460d33cf16a0e76f53b6458ef5593cc1e6543f6db2d876621eeb033c?preview_id=0197a381-0aa7-7705-ba38-68292ac2bcc7)