### PR TITLE
Update brand_impersonation_siriusxm.yml

### DIFF
--- a/detection-rules/brand_impersonation_siriusxm.yml
+++ b/detection-rules/brand_impersonation_siriusxm.yml
@@ -14,14 +14,16 @@ source: |
       'siriusxm.com',
       'siriusxmmedia.com',
       'siriusxm.ca',
-      'engagement360.net' // SiriusXM survey vendor
+      'engagement360.net', // SiriusXM survey vendor
+      'sciquest.com' // SiriusXM Procurement
     )
     or (
       sender.email.domain.root_domain in (
         'siriusxm.com',
         'siriusxmmedia.com',
         'siriusxm.ca',
-        'engagement360.net' // SiriusXM survey vendor
+        'engagement360.net', // SiriusXM survey vendor
+        'sciquest.com' // SiriusXM Procurement
       )
       and not headers.auth_summary.dmarc.pass
     )


### PR DESCRIPTION
# Description

negating `sciquest.com` (used by siriusxm for procurement)

# Associated samples

- https://na-west.platform.sublime.security/messages/5634b907865afa9871ebe42f65f9f85c11b2040198bb896ed5143598260b10f3?preview_id=01977be3-3b59-7eb0-a6a9-fa07d78db1d1
- https://na-west.platform.sublime.security/messages/37020a3838961a2ff795e54e0be68b918d0d993a106c0476bd0e8faa49a5b7ed?preview_id=01977ba8-27d8-7e91-9808-e28aa2d90a48
- https://na-west.platform.sublime.security/messages/a90a3c21de7a4e0761c7afda2f1d18967b82f8ab2b4a52ce4edb9c6c3a494616?preview_id=01977c60-9fc4-7b5e-8368-f69212c838e5