### PR TITLE
Create link_sharepoint_sender_display_name.yml

### DIFF
--- a/detection-rules/link_sharepoint_sender_display_name.yml
+++ b/detection-rules/link_sharepoint_sender_display_name.yml
@@ -1,0 +1,68 @@
+name: "Link: Uncommon SharePoint Document Type With Sender's Display Name"
+description: "Detects SharePoint file shares containing personal OneNote or PDF files where the file name matches the sender's display name."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  
+  // Matches the message id observed. DKIM/SPF domains can be custom and therefore are unpredictable.
+  and (
+    (
+      strings.starts_with(headers.message_id, '<Share-')
+      and strings.ends_with(headers.message_id, '@odspnotify>')
+    )
+    or (
+      any(headers.hops,
+          any(.fields,
+              .name == "X-Google-Original-Message-ID"
+              and strings.starts_with(.value, '<Share-')
+              and strings.ends_with(.value, '@odspnotify>')
+          )
+      )
+    )
+  )
+  
+  // SharePoint email indicators
+  and strings.like(body.current_thread.text,
+                   "*shared a file with you*",
+                   "*shared with you*",
+                   "*invited you to access a file*"
+  )
+  and strings.icontains(subject.subject, "shared")
+  
+  // file name is the sender's name
+  and any(html.xpath(body.html,
+                     '//table[@role="presentation"]//tr[last()]//text()'
+          ).nodes,
+          .display_text =~ sender.display_name
+  )
+  
+  // link logic
+  and any(body.links,
+          .href_url.domain.root_domain == "sharepoint.com"
+          // it is a personal share
+          and (
+            // /g/ is only found with /personal
+            strings.icontains(.href_url.path, '/g/personal/')
+            or strings.icontains(.href_url.path, '/p/')
+          )
+          // it is either a OneNote or PDF
+          and (
+            strings.icontains(.href_url.path, '/:o:/')
+            or strings.icontains(.href_url.path, '/:b:/')
+            or strings.icontains(.href_url.path, '/:u:/')
+          )
+  )
+tags:
+ - "Attack surface reduction"
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+  - "OneNote"
+  - "PDF"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "HTML analysis"
+  - "URL analysis"

--- a/detection-rules/link_sharepoint_sender_display_name.yml
+++ b/detection-rules/link_sharepoint_sender_display_name.yml
@@ -66,3 +66,4 @@ detection_methods:
   - "Header analysis"
   - "HTML analysis"
   - "URL analysis"
+id: "02d290b2-9cf5-5699-ac0c-e1e595d74d57"


### PR DESCRIPTION
# Description

Detects SharePoint file shares containing personal OneNote or PDF files where the file name matches the sender's display name.

# Associated samples
- https://platform.sublime.security/messages/3d2ba42cbbb8fa6fc8d18717e06eb33bc2205d7efc257be8218008f47a942297
- https://platform.sublime.security/messages/hunt?huntId=0197b1db-65a9-7033-83d6-90cae7955146