### PR TITLE
fix: attachment_encrypted_msft_office_files.yml

### DIFF
--- a/detection-rules/attachment_encrypted_msft_office_files.yml
+++ b/detection-rules/attachment_encrypted_msft_office_files.yml
@@ -12,7 +12,7 @@ source: |
               or strings.iends_with(.file_name, ".docm")
               or .content_type == "application/msword"
               or .content_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-              or .file_type == "msword"
+              or .file_type in ("doc", "docx")
               or 
     
               // Excel documents
@@ -21,7 +21,7 @@ source: |
               or strings.iends_with(.file_name, ".xlsm")
               or .content_type == "application/vnd.ms-excel"
               or .content_type == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-              or .file_type == "msexcel"
+              or .file_type in ("xls", "xlsx")
               or 
     
               // PowerPoint documents
@@ -30,7 +30,7 @@ source: |
               or strings.iends_with(.file_name, ".pptm")
               or .content_type == "application/vnd.ms-powerpoint"
               or .content_type == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-              or .file_type == "mspowerpoint"
+              or .file_type in ("ppt", "pptx")
               or 
     
               // Access documents
@@ -39,7 +39,6 @@ source: |
               or .content_type == "application/msaccess"
               or .content_type == "application/x-msaccess"
               or .content_type == "application/vnd.ms-access"
-              or .file_type == "msaccess"
             )
             and any(file.explode(.),
                     any(.scan.yara.matches, .name == 'aes_encryption_keywords')


### PR DESCRIPTION
# Description

This change fixes incorrect file.type matches for the portion of this rule that checks for MSFT docs.

Original issue: `msword`, `msexcel`, `mspowerpoint`, and `msaccess` are not supported values in `.field.type`

<img width="625" alt="mdm_allowed_file_types" src="https://github.com/user-attachments/assets/56b9d235-a304-453a-950f-3c3d5f8bc17a" />

MSFT Access files of `.mdb` and `.accdb` are not currently valid options either, and do not get returned when the MDM is rendered. The file type of `unknown` is returned instead for these file types. Removed the .file_type portion for the MSFT access files in this rule.

Custom matchers will have to be added to the EML -> MDM conversion process if matching on those magic bytes is required.




