### PR TITLE
Update link_notion_file_share.yml

### DIFF
--- a/detection-rules/link_notion_file_share.yml
+++ b/detection-rules/link_notion_file_share.yml
@@ -8,7 +8,7 @@ severity: "medium"
 source: |
   type.inbound
   and any(body.links,
-          .href_url.domain.root_domain =~ 'notion.so'
+          .href_url.domain.root_domain in~ ("notion.so", "notion.site")
           and (
             strings.ilike(.href_url.url,
                           '*shared*',


### PR DESCRIPTION
# Description

Adding in the additional notion domain of notion.site which is responsible for some of the true positive hunt results, the abuse of the domain is present in the following hunts.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/7afaf23f890dc1eeb79cf38fedbf523a4058a2dd8ace9fd9d8118993764a54fc?preview_id=0197cfb4-ab66-71e7-8539-cd3f19d559de)
- [Sample 2](https://platform.sublime.security/messages/f598e320fa79e8797e8ecb294ade05e94b563877b3931f418a0e9e5b51a3c9c2?preview_id=019779b8-0efb-7d34-9591-9cb21f35e14b)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=0197d165-d2bd-7f2c-ad26-c51cf84aaf72)

# Screenshot (insights)
<!-- 
**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
-->
