### PR TITLE
BI Meta: Convert display name list to regex.icontains

### DIFF
--- a/detection-rules/impersonation_meta.yml
+++ b/detection-rules/impersonation_meta.yml
@@ -14,6 +14,7 @@ source: |
       regex.icontains(sender.display_name,
                     'facebook ?ads',
                     'facebook ?business',
+                    'meta ?account',
                     'meta ?support',
                     'meta ?business',
                     'meta ?for ?business',

--- a/detection-rules/impersonation_meta.yml
+++ b/detection-rules/impersonation_meta.yml
@@ -11,20 +11,20 @@ source: |
     // sender display name is a strong enough indicator
     // that it can be used without any other impersonation logic
     (
-      strings.ilike(sender.display_name,
-                    '*facebook ads*',
-                    '*facebook business*',
-                    '*meta support*',
-                    '*meta business*',
-                    '*meta for business*',
-                    '*meta policy*',
-                    '*page ads support*',
-                    'Instagram Not*',
-                    'Instagram Policies*',
-                    'Instagram Report*',
-                    'Instagram Helpdesk*',
-                    'Instagram Support*',
-                    '*Ads Team'
+      regex.icontains(sender.display_name,
+                    'facebook ?ads',
+                    'facebook ?business',
+                    'meta ?support',
+                    'meta ?business',
+                    'meta ?for ?business',
+                    'meta ?policy',
+                    'page ?ads ?support',
+                    'Instagram ?Not',
+                    'Instagram ?Policies',
+                    'Instagram ?Report',
+                    'Instagram ?Helpdesk',
+                    'Instagram ?Support',
+                    'Ads ?Team'
       )
       or strings.ilevenshtein(sender.display_name, 'facebook ads') <= 2
       or strings.ilevenshtein(sender.display_name, 'facebook business') <= 2


### PR DESCRIPTION
# Description

Converted display name check to `regex.icontains` and made all spaces optional.

# Associated samples
- https://platform.sublime.security/messages/a24a22362daee74c0e2274bf6a2b559f3fe42d6cdcbccc471ed56a62a9a22a0a?preview_id=0197d111-95ed-73e1-86d3-c971c406792b
