### PR TITLE
Negating legit Sharepoint messages from fake attachment

### DIFF
--- a/detection-rules/attachment_fake_attachment_image.yml
+++ b/detection-rules/attachment_fake_attachment_image.yml
@@ -84,6 +84,10 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
+  and (
+    sender.email.domain.root_domain not in ("sharepointonline.com")
+    or not headers.auth_summary.dmarc.pass
+  )
 tags:
   - "Suspicious attachment"
   - "Suspicious content"


### PR DESCRIPTION
# Description

Negating `sharepointonline.com` as a sender.
# Associated samples
- https://platform.sublime.security/messages/423b06527b7e050c0ce00441d61af614f9eab702204c6ccab548d5e21c6f1740?preview_id=0197d27d-fb23-797f-827a-7bc1707667fd