### PR TITLE
Negating other types of MS notifications

### DIFF
--- a/detection-rules/impersonation_microsoft.yml
+++ b/detection-rules/impersonation_microsoft.yml
@@ -80,6 +80,20 @@ source: |
     )
     and strings.contains(subject.subject, 'Undeliverable:')
   )
+
+  // negate other legitimate MS notifications
+  and not (
+    length(body.links) > 0
+    and all(body.links,
+            .href_url.domain.root_domain in (
+              "aka.ms",
+              "microsoftonline.com",
+              "microsoft.com"
+            )
+            or .href_url.domain.tld == "microsoft"
+    )
+    and headers.auth_summary.dmarc.pass
+  )
   
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (


### PR DESCRIPTION
# Description

Negating authenticated messages containing only MS links.

# Associated samples
- https://platform.sublime.security/messages/274f29472867540248ec513ad6892dfd87a9b92ceb166c9fb874319a66b5ab94?preview_id=0197d657-9dfe-758f-afe2-a1ab8fc0d7d5
