### PR TITLE
Negate legitimate Google reCAPTCHA badge

### DIFF
--- a/detection-rules/link_credential_phishing.yml
+++ b/detection-rules/link_credential_phishing.yml
@@ -9,10 +9,21 @@ source: |
   and any(body.links,
           ml.link_analysis(.).credphish.disposition == "phishing"
           and (
-             ml.link_analysis(.).credphish.confidence in ("medium", "high")
-             or ml.link_analysis(.).credphish.contains_captcha
+            ml.link_analysis(.).credphish.confidence in ("medium", "high")
+            or ml.link_analysis(.).credphish.contains_captcha
           )
           and length(ml.link_analysis(.).final_dom.links) < 50
+          // negate legitimate use of Google reCAPTCHA embedded badge
+          and not (
+            (
+              ml.link_analysis(.).credphish.brand.name == "Captcha"
+              or ml.link_analysis(.).credphish.contains_captcha
+            )
+            and length(html.xpath(ml.link_analysis(.).final_dom,
+                                  "//div[@class='grecaptcha-badge' and @data-style='bottomright']"
+                       ).nodes
+            ) == 1
+          )
   )
   and (
     (


### PR DESCRIPTION
# Description

Negating legitimate Google reCAPTCHA badge in LA results.

# Associated samples
- https://platform.sublime.security/messages/3b37ec8d73b5d18a3e7eb1d044429f8b2d1353c89cd7a360f2eec12ace8531f6?preview_id=0197d515-ce1a-7c85-aec6-36120ad91b50