### PR TITLE
Excluding disclaimers from thread length and adding doc/docx clause

### DIFF
--- a/detection-rules/attachment_fake_scan_to_email.yml
+++ b/detection-rules/attachment_fake_scan_to_email.yml
@@ -4,7 +4,19 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(body.current_thread.text) < 1500
+  and (
+    length(body.current_thread.text) < 1500
+    // body length without disclaimer is shorter than 1500 characters
+    or (
+      any(map(filter(ml.nlu_classifier(body.current_thread.text).entities,
+                     .name == "disclaimer"
+              ),
+              .text
+          ),
+          (length(body.current_thread.text) - length(.)) < 1500
+      )
+    )
+  )
   and (
     3 of (
       strings.icontains(body.current_thread.text, "Number of Images:"),
@@ -39,39 +51,44 @@ source: |
       )
     )
   )
-  and length(filter(attachments, .file_type == "pdf")) == 1
-  and any(attachments,
-          .file_type == "pdf"
-          and (
-            any(file.explode(.),
-                (
-                  strings.ilike(.scan.ocr.raw,
-                                "*scan date*",
-                                "*was sent from*",
-                                "*of pages*",
-                                "*verif*document*",
-                                "*scanned file*"
-                  )
-                  or any(ml.nlu_classifier(.scan.ocr.raw).intents,
-                         .name == "cred_theft"
-                  )
-                  or any(ml.logo_detect(..).brands,
-                         .name in ("DocuSign", "Microsoft")
-                  )
+  and (
+    (
+      length(filter(attachments, .file_type in ("pdf"))) == 1
+      and any(attachments,
+              .file_type == "pdf"
+              and (
+                any(file.explode(.),
+                    (
+                      strings.ilike(.scan.ocr.raw,
+                                    "*scan date*",
+                                    "*was sent from*",
+                                    "*of pages*",
+                                    "*verif*document*",
+                                    "*scanned file*"
+                      )
+                      or any(ml.nlu_classifier(.scan.ocr.raw).intents,
+                             .name == "cred_theft"
+                      )
+                      or any(ml.logo_detect(..).brands,
+                             .name in ("DocuSign", "Microsoft")
+                      )
+                    )
+                    and length(.scan.url.urls) == 1
                 )
-                and length(.scan.url.urls) == 1
-            )
-            // encrypted pdf
-            or any(file.explode(.),
-                   any(.scan.exiftool.fields, .key == "Encryption")
-                   or (
-                     .scan.entropy.entropy > 7
-                     and any(.scan.strings.strings,
-                             strings.icontains(., "/Encrypt")
-                     )
-                   )
-            )
-          )
+                // encrypted pdf
+                or any(file.explode(.),
+                       any(.scan.exiftool.fields, .key == "Encryption")
+                       or (
+                         .scan.entropy.entropy > 7
+                         and any(.scan.strings.strings,
+                                 strings.icontains(., "/Encrypt")
+                         )
+                       )
+                )
+              )
+      )
+    )
+    or length(filter(attachments, .file_type in ("doc", "docx"))) == 1
   )
   and sender.email.domain.domain not in~ $org_domains
   and (


### PR DESCRIPTION
# Description

Excluding disclaimers from thread length and adding doc/docx clause to ensure rule fires with one of those attachments.

# Associated samples
- https://platform.sublime.security/messages/b447ac8a219342d13b25023630f2ed55f3ad16d4ac74c5ef301e4ecb6f9a9109?preview_id=0197d58c-6c91-769a-8e1c-46144f0b8c79
