### PR TITLE
Negate direct-to-VIP messages

### DIFF
--- a/detection-rules/vip_impersonation_subject.yml
+++ b/detection-rules/vip_impersonation_subject.yml
@@ -16,6 +16,17 @@ source: |
           strings.contains(subject.subject, .display_name)
           and strings.contains(.display_name, " ")
   )
+  // not being sent to said VIP
+  and not (
+    length(recipients.to) == 1
+    and all(recipients.to,
+            any($org_vips,
+                .email == ..email.email
+                and strings.contains(subject.subject, .display_name)
+                and strings.contains(.display_name, " ")
+            )
+    )
+  )
   and (
     // ignore personal <> work emails
     // where the sender and mailbox's display name are the same


### PR DESCRIPTION
# Description

Negating messages that are directly sent to the VIP being "impersonated" in the subject.

# Associated samples
- https://platform.sublime.security/messages/672726abc80fdaf78338e1538c474becd85dd8ddbdecc9c11e6fca8846abc7b3?preview_id=0197d738-d8fe-7b4d-96c3-e939159c141c
