### PR TITLE
Negating replies to DocuSign notifications

### DIFF
--- a/detection-rules/attachment_docusign_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_suspicious_links.yml
@@ -157,6 +157,9 @@ source: |
   and not any(headers.hops,
               regex.imatch(.received.server.raw, ".+.docusign.(net|com)")
   )
+
+  // negate replies to docusign notifications
+  and not any(headers.references, strings.iends_with(., '@camail.docusign.net'))
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description

Negating replies to DocuSign notifications.

# Associated samples
- https://platform.sublime.security/messages/4fe8492d8608bdc7585d8ac045e7c9d7909867f26f9a79897d0402cdb37db38f?preview_id=0197e567-d025-78ff-bf96-e3b0a7bff84a
