### PR TITLE
Update link_credential_phishing_intent_and_other_indicators.yml

### DIFF
--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -303,11 +303,29 @@ source: |
             or strings.icontains(body.current_thread.text, .email.local_part)
           )
       ),
-      any(ml.nlu_classifier(body.current_thread.text).intents,
-          .name == "cred_theft" and .confidence in ("medium", "high")
+      (
+        any(ml.nlu_classifier(body.current_thread.text).intents,
+            .name == "cred_theft" and .confidence in ("medium", "high")
+        )
+        or (
+          length(body.current_thread.text) == 0
+          and any(ml.nlu_classifier(beta.ocr(beta.message_screenshot()).text).intents,
+                  .name == "cred_theft" and .confidence in ("medium", "high")
+          )
+        )
       ),
-      any(ml.nlu_classifier(body.current_thread.text).entities,
-          .name == "request"
+      // entirely an image
+      length(body.current_thread.text) == 0 and length(body.previous_threads) == 0,
+      (
+        any(ml.nlu_classifier(body.current_thread.text).entities,
+            .name == "request"
+        )
+        or (
+          length(body.current_thread.text) == 0
+          and any(ml.nlu_classifier(beta.ocr(beta.message_screenshot()).text).entities,
+                  .name == "request"
+          )
+        )
       ),
       // recipient email address base64 encoded in link
       any(body.links,
@@ -388,12 +406,14 @@ source: |
           // display text contains a request
           (
             any(ml.nlu_classifier(.display_text).entities, .name == "request")
-            or regex.match(.display_text, '^[^a-z]+$')
+            or regex.match(.display_text, '[A-Z ]+')
           )
           and (
             .href_url.domain.domain in $url_shorteners
             or .href_url.domain.root_domain in $url_shorteners
             or .href_url.domain.domain in $free_file_hosts
+            or .href_url.domain.domain in $free_subdomain_hosts
+            or .href_url.domain.root_domain in $free_subdomain_hosts
             or (
               .href_url.domain.root_domain in (
                 "mimecast.com",
@@ -444,6 +464,7 @@ source: |
           length(body.links) == 1
           and all(body.links,
                   strings.ilike(.display_text, "*click here*", "*password*")
+                  or regex.imatch(.display_text, '[A-Z ]+')
           )
         )
       )


### PR DESCRIPTION
# Description

- add message screenshot NLU analysis when current thread is blank
- added all caps link display text as a condition
- added `$free_subdomain_hosts` list as a link condition

Also needs https://github.com/sublime-security/static-files/pull/493

# Associated samples
- https://platform.sublime.security/messages/2591b783c733d1e7cea4a07beedeed1612aa73da1f9f443bd21ea0d2b73d50ce?preview_id=0197e58b-e0d5-71cf-ab4c-fd80b833346d
