### PR TITLE
Update impersonation_adobe_suspicious_language_link.yml

### DIFF
--- a/detection-rules/impersonation_adobe_suspicious_language_link.yml
+++ b/detection-rules/impersonation_adobe_suspicious_language_link.yml
@@ -105,7 +105,7 @@ source: |
         or profile.by_sender_email().days_since.last_contact > 14
       )
       and not profile.by_sender().any_messages_benign
-      and not sender.email.domain.root_domain in ("adobe-events.com", "frame.io")
+      and not sender.email.domain.root_domain in ("adobe-events.com", "frame.io", "workfront.com")
     )
     or not headers.auth_summary.spf.pass
     or headers.auth_summary.spf.pass is null


### PR DESCRIPTION
# Description

Adding negation for root domain workfront.com which is a legitimate Adobe domain.
https://www.whois.com/whois/workfront.com
https://business.adobe.com/products/workfront.html

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

[- Sample 1](https://platform.sublime.security/messages/5bea0d425f199b53b2c99393aca9acf342f4d1dbf86c36f2a40e07acafb7998f?preview_id=0197a363-fbfe-7e75-a531-53468cd390df)
