### PR TITLE
Updating suspicious indicator alert to remove NLU check

### DIFF
--- a/detection-rules/attachment_eml_suspicious_indicators.yml
+++ b/detection-rules/attachment_eml_suspicious_indicators.yml
@@ -36,9 +36,6 @@ source: |
            .name in ("cred_theft", "steal_pii")
     )
   )
-  and not any(ml.nlu_classifier(body.current_thread.text).intents,
-              .name == "benign" and .confidence == "high"
-  )
   and any(attachments,
           (.file_extension == "eml" or .content_type == "message/rfc822")
           and (


### PR DESCRIPTION
# Description
From a runner, removing NLU classify to try

# Associated samples

- [Sample 1](https://uk.platform.sublime.security/messages/4c1548a88dd8506e4049ff1d7ecc941e9c4aa25f6402a596d9e189a5d69fba7a?preview_id=0197c138-99b6-78b4-9a7a-d2563de2ee3b)