### PR TITLE
Update attachment_encrypted_pdf_cred_theft.yml

### DIFF
--- a/detection-rules/attachment_encrypted_pdf_cred_theft.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft.yml
@@ -21,12 +21,12 @@ source: |
   )
   and (
     (
-      profile.by_sender().prevalence in ("new", "outlier")
-      and not profile.by_sender().solicited
+      profile.by_sender_email().prevalence in ("new", "outlier")
+      and not profile.by_sender_email().solicited
     )
     or (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_false_positives
+      profile.by_sender_email().any_messages_malicious_or_spam
+      and not profile.by_sender_email().any_false_positives
     )
   )
   // negate highly trusted sender domains unless they fail DMARC authentication


### PR DESCRIPTION
# Description

narrowing the scope of the sender profile checks to `by_sender_email`

# Associated samples
- https://platform.sublime.security/messages/021ec5d935f2eae8682be5e0c13dfed3ecc567a14a71d77960fe9183b65f13ac?preview_id=0197c776-db26-711e-b2df-a5712a3414a2
