### PR TITLE
Create link_whatsapp_telegram_phishing.yml

### DIFF
--- a/detection-rules/link_whatsapp_telegram_phishing.yml
+++ b/detection-rules/link_whatsapp_telegram_phishing.yml
@@ -1,0 +1,47 @@
+name: "Brand Impersonation: Telegram and WhatsApp"
+description: "Detects when a sender's display name contains Telegram or WhatsApp messaging service names but originates from unauthorized domains with DMARC authentication failures"
+type: "rule"
+severity: "low"
+source: |
+    type.inbound
+  // Display name contains messaging app names
+  and (
+    // Telegram variations
+    strings.ilike(sender.display_name, '*telegram*')
+    or strings.ilike(strings.replace_confusables(sender.display_name),
+                     '*telegram*'
+    )
+    // WhatsApp variations
+    or strings.ilike(sender.display_name, '*whatsapp*')
+    or strings.ilike(sender.display_name, '*whats app*')
+    or strings.ilike(strings.replace_confusables(sender.display_name),
+                     '*whatsapp*'
+    )
+    or strings.ilike(strings.replace_confusables(sender.display_name),
+                     '*whats app*'
+    )
+  )
+  // Not from legitimate messaging app domains
+  and sender.email.domain.root_domain not in (
+    "telegram.org",
+    "telegram.com",
+    "t.me",
+    "whatsapp.com",
+    "whatsapp.net",
+    "fb.com",
+    "facebook.com",
+    "meta.com"
+  )
+  // Authentication validation
+  and not headers.auth_summary.dmarc.pass
+tags:
+ - "Attack surface reduction"
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Impersonation: Brand"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

Emoji laden and adult themed Telegram and WhatsApp emails using channel invites to lead to adult themed content are abusing the brands of WhatsApp & Telegram. 

These appear to be distinct from the existing brand abuse for Meta which focus on account take over and phishing, the WhatsApp one may be less high fidelity, but will monitor.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/d94437cc9882c5aeb6298132e20bd6144e749796d7c2a23dff81cb0f50aa1d82)
- [Sample 2](https://platform.sublime.security/messages/568ec4f744444d0d8ccf29116a422045015c14b24904d1db937e64ec16e0df24?preview_id=0192c00b-d1e0-7d42-89ee-2125e9c8ff2a)




- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=0197eea4-2fd7-7799-9ed8-90fb7848cc2c)

