### PR TITLE
Update link_fake_password_expiration.yml

### DIFF
--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -45,14 +45,14 @@ source: |
   // body contains expire, expiration, loose, lose 
   and (
     regex.icontains(body.current_thread.text,
-                    '(expir(e)?(ation|s)|\blo(o)?se\b|(?:offices?|microsoft).365|re.{0,3}confirm)|due for update'
+                    '(expir(e(d|s)?|ation|s)?|\blo(o)?se\b|(?:offices?|microsoft).365|re.{0,3}confirm)|due for update'
     )
     and not strings.icontains(body.current_thread.text, 'link expires in ')
   )
   and (
     // subject or body contains account or access
     any([subject.subject, body.current_thread.text],
-        regex.icontains(., "account|access|your email")
+        regex.icontains(., "account|access|your email|mailbox")
     )
     // suspicious use of recipients email address
     or any(recipients.to,


### PR DESCRIPTION
# Description

Fixing regex to capture `expire`, and adding additional keyword to account words list.

# Associated samples
- https://platform.sublime.security/messages/e6fa19fbae1cda6605641cc6db42f82709ee170a8e4ed463d92eb9210daaf863?preview_id=019322b6-9925-7ba4-b774-9df878243ea8
