### PR TITLE
Update brand_impersonation_tiktok.yml

### DIFF
--- a/detection-rules/brand_impersonation_tiktok.yml
+++ b/detection-rules/brand_impersonation_tiktok.yml
@@ -13,8 +13,12 @@ source: |
       or strings.ilevenshtein(strings.replace_confusables(sender.display_name),
                               'tiktok'
       ) <= 1
-      or any(ml.logo_detect(beta.message_screenshot()).brands,
-             .name == "TikTok" and .confidence == "high"
+      or (
+        any(ml.logo_detect(beta.message_screenshot()).brands,
+            .name == "TikTok" and .confidence == "high"
+        )
+        // ignore logo if there are links leading directly to a tiktok profile
+        and not any(body.links, strings.icontains(.href_url.url, 'tiktok.com/@'))
       )
     )
     // OR TikTok verification language
@@ -67,6 +71,11 @@ source: |
       )
       and headers.auth_summary.dmarc.pass
     )
+  )
+  // negate iCloud Private Message Relay
+  and not (
+    sender.email.domain.root_domain == "privaterelay.appleid.com"
+    or any(headers.hops, any(.fields, .name == "X-ICLOUD-HME"))
   )
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (


### PR DESCRIPTION
# Description

negating logo detect if links lead directly to a tiktok profile (commonly found in newsletters alongside links to other social media)

negating messages sent via iCloud Private Relay

# Associated samples
- https://platform.sublime.security/messages/a948a7ab1f82607b41ca9e04001c34de568fd50095b0211bed4bec24a11d7923
- https://platform.sublime.security/messages/fb4b679e06d25dd38b0efa2f9dda88d11e83aaa6df66ab6cf7fae3495e9c9645
- https://platform.sublime.security/messages/253323dc0af9f9e2a81bfab47ffe96f070d3bdf7f9f503c34b1136c9ec9500a7

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=0197f6c2-d157-7374-a0b4-5b7813de66d5