### PR TITLE
Add voice note pattern to fake voicemail rule

### DIFF
--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -24,7 +24,7 @@ source: |
                         // split phrases that start with "caller" that occur within 3 words between or only punctation 
                         'ca[li1][li1](?:er)?(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:v[nm](\b|[[:punct:]])?|\bvoice(?:mail|message)?|audi[o0]|missed(?:\sa\s)?|left( a)?)',
                         // strong phrases
-                        '(?:open mp3|audi[o0] note|\.wav|left a vm|[^\s]+voip[^\s]*|unanswered.*ca[li1][li1]|incoming.vm|left msg|wireless ca[li1][li1]er|VM Service|voice message|missed.ca[li1][li1](?:e[rd])?|\bca[li1][li1].(?:support|service)(?: for| log)?|missed.{0,10} VM|new voicemail from|new.v.m.from.\+?\d+|new voicemail?(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}transcript(s|ion)?|message received|incoming transmission)',
+                        '(?:open mp3|audi[o0] note|\.wav|left a vm|[^\s]+voip[^\s]*|unanswered.*ca[li1][li1]|incoming.vm|left msg|wireless ca[li1][li1]er|VM Service|voice message|missed.ca[li1][li1](?:e[rd])?|\bca[li1][li1].(?:support|service)(?: for| log)?|missed.{0,10} VM|new voicemail from|new.v.m.from.\+?\d+|new voicemail?(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}transcript(s|ion)?|message received|incoming transmission|voice note)',
                         // starts in the format of `(4)` and contains some voicemail keywords
                         '^\(\d\)\s(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:message|voip|voice|unread|call)',
                         'ca[li1][li1](?:er)?(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:playback|transcript)',
@@ -51,7 +51,8 @@ source: |
                        'New missed ca[li1][li1] record',
                        '\bvoicemail transcript\b',
                        'Listen to VoiceMail',
-                       'New voicemail from'
+                       'New voicemail from',
+                       'voice note'
     )
     // pull out two regexes that could benefit from negations
     or (
@@ -102,7 +103,8 @@ source: |
                               'New missed ca[li1][li1] record',
                               'voicemail transcript(?:ion)?',
                               'Listen to VoiceMail',
-                              'New voicemail from'
+                              'New voicemail from',
+                              'voice note'
               )
               or (
                 regex.icontains(.scan.ocr.raw,
@@ -349,7 +351,7 @@ source: |
       any(body.links,
           regex.contains(.display_text, '[^a-z]*[A-Z][^a-z]*')
           and regex.icontains(.display_text,
-                              '(v[nm]|voice|audi[o0]|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|audi[o0] note|listen|playback|\(?(?:\*\*\*|[0-9]{3})?.(?:\*\*\*|[0-9]{3})[^a-z]{0,2}(?:\*{4}|\d+\*+)|play'
+                              '(v[nm]|voice|audi[o0]|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|audi[o0] note|listen|playback|\(?(?:\*\*\*|[0-9]{3})?.(?:\*\*\*|[0-9]{3})[^a-z]{0,2}(?:\*{4}|\d+\*+)|play|voice note'
           )
           // negate FP terms in link display texts
           and not strings.icontains(.display_text, 'voice call center')
@@ -359,7 +361,7 @@ source: |
       any(body.links,
           .href_url.path == "/ctt"
           and regex.icontains(.display_text,
-                              '(v[nm]|voice|audi[o0]|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|audi[o0] note|listen|playback|\(?(?:\*\*\*|[0-9]{3})?.(?:\*\*\*|[0-9]{3})[^a-z]{0,2}(?:\*{4}|\d+\*+)|play'
+                              '(v[nm]|voice|audi[o0]|call|missed|caii)(\s?|-)(mail|message|recording|call|caii)|transcription|open mp3|audi[o0] note|listen|playback|\(?(?:\*\*\*|[0-9]{3})?.(?:\*\*\*|[0-9]{3})[^a-z]{0,2}(?:\*{4}|\d+\*+)|play|voice note'
           )
           // negate FP terms in link display texts
           and not strings.icontains(.display_text, 'voice call center')


### PR DESCRIPTION
# Description

Added 'voice note' keyword to existing regex patterns in the fake voicemail rule to capture samples using this terminology instead of traditional voicemail language.

# Associated samples

- https://platform.sublime.security/messages/42822b8df05b87ec6314d6976fd5cae03ed202bb8d92e022174ab62969588334

🤖 Generated with [Claude Code](https://claude.ai/code)