### PR TITLE
Wrap xpath attributes used in numeric comparisons in a `number` call

### DIFF
--- a/detection-rules/credential_phishing_esign_document_notification.yml
+++ b/detection-rules/credential_phishing_esign_document_notification.yml
@@ -157,7 +157,7 @@ source: |
     // one hyperlinked image that's not a tracking pixel
     or (
       length(html.xpath(body.html,
-                        "//a//img[(@width > 5 or not(@width)) and (@height > 5 or not(@height))]"
+                        "//a//img[(number(@width) > 5 or not(@width)) and (number(@height) > 5 or not(@height))]"
              ).nodes
       ) == 1
       and length(body.current_thread.text) < 500


### PR DESCRIPTION
# Description

The used xpath library has problems if something used in a numeric comparison can't be converted to a number. Since a width or height can have a non-numeric value like "auto", this causes something like `@width > 5` to not always process correctly. Wrapping the attribute in a `number` call prevents this, since non-numbers are converted to `NaN`, which parses/compares fine.