### PR TITLE
Create brand_impersonation_aws.yml

### DIFF
--- a/detection-rules/brand_impersonation_aws.yml
+++ b/detection-rules/brand_impersonation_aws.yml
@@ -1,0 +1,65 @@
+name: "Brand Impersonation: Amazon Web Services (AWS)"
+description: "Detects messages impersonating AWS through similar display names combined with security-themed content and authentication failures. Excludes legitimate AWS communications and trusted senders."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and regex.icontains(strings.replace_confusables(sender.display_name),
+                      '\baws\b|amazon web services|\bses\b'
+  )
+  and (
+    // ML Topic Analysis and Credential Theft Detection
+    any(beta.ml_topic(body.current_thread.text).topics,
+        .name in (
+          "Security and Authentication",
+          "Secure Message",
+          "Reminders and Notifications"
+        )
+        and .confidence in ("medium", "high")
+    )
+    or any(beta.ml_topic(beta.ocr(beta.message_screenshot()).text).topics,
+           .name in (
+             "Security and Authentication",
+             "Secure Message",
+             "Reminders and Notifications"
+           )
+           and .confidence in ("medium", "high")
+           and beta.ocr(beta.message_screenshot()).text != ""
+    )
+    or any(ml.nlu_classifier(body.current_thread.text).intents,
+           .name == "cred_theft" and .confidence == "high"
+    )
+    or any(ml.nlu_classifier(beta.ocr(beta.message_screenshot()).text).intents,
+           .name == "cred_theft" and .confidence == "high"
+    )
+  )
+  // Not from legitimate AWS domains with DMARC pass
+  and not (
+    sender.email.domain.root_domain in $org_domains
+    or (
+      sender.email.domain.root_domain in ("amazon.com", "amazonses.com")
+      and headers.auth_summary.dmarc.pass
+    )
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  and not profile.by_sender().solicited
+  
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Optical Character Recognition"
+  - "Sender analysis"
+  - "Natural Language Understanding"


### PR DESCRIPTION
# Description

Detects messages impersonating AWS through similar display names combined with security-themed content and authentication failures. Excludes legitimate AWS communications and trusted senders.

# Associated samples
- https://platform.sublime.security/messages/0095fb8ec3a97128b536927d5938546481f69be8f0dc4914a52eeb73f049e2fd?preview_id=0192956c-777d-712e-99ce-aa58bfe5a59c