### PR TITLE
Create brand_impersonation_mastercard.yml

### DIFF
--- a/detection-rules/brand_impersonation_mastercard.yml
+++ b/detection-rules/brand_impersonation_mastercard.yml
@@ -1,0 +1,72 @@
+name: "Brand Impersonation: Mastercard"
+description: "Detects messages impersonating mastercard through similar display names, combined with security-themed content and authentication failures. Excludes legitimate Mastercard communications and trusted senders."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+    // Mastercard Brand Detection 
+    (
+      // display name contains mastercard
+      strings.ilike(strings.replace_confusables(sender.display_name), '*mastercard*')
+      // levenshtein distance similar to mastercard
+      or strings.ilevenshtein(strings.replace_confusables(sender.display_name),
+                              'mastercard'
+      ) <= 1
+    )
+    // OR Mastercard related language
+    or (
+      strings.icontains(body.current_thread.text, "mastercard")
+      and (
+        strings.icontains(body.current_thread.text, "unusual activity")
+        or strings.icontains(body.current_thread.text, "transaction")
+      )
+    )
+  )
+  and (
+    // ML Topic Analysis and Credential Theft Detection
+    any(beta.ml_topic(body.current_thread.text).topics,
+        .name in (
+          "Security and Authentication",
+          "Secure Message",
+          "Reminders and Notifications"
+        )
+        and .confidence in ("medium", "high")
+    )
+    or any(ml.nlu_classifier(body.current_thread.text).intents,
+           .name == "cred_theft" and .confidence == "high"
+    )
+  )
+  // Not from legitimate Mastercard domains with DMARC pass
+  and not (
+    sender.email.domain.root_domain in $org_domains
+    or (
+      sender.email.domain.root_domain in (
+        "mastercard.com"
+      )
+      and headers.auth_summary.dmarc.pass
+    )
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  and not profile.by_sender().solicited
+  
+
+attack_types:
+  - "Callback Phishing"
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"

--- a/detection-rules/brand_impersonation_mastercard.yml
+++ b/detection-rules/brand_impersonation_mastercard.yml
@@ -1,5 +1,5 @@
 name: "Brand Impersonation: Mastercard"
-description: "Detects messages impersonating mastercard through similar display names, combined with security-themed content and authentication failures. Excludes legitimate Mastercard communications and trusted senders."
+description: "Detects messages impersonating Mastercard through similar display names, combined with security-themed content and authentication failures. Excludes legitimate Mastercard communications and trusted senders."
 type: "rule"
 severity: "medium"
 source: |


### PR DESCRIPTION
# Description

Detects messages impersonating Mastercard through similar display names, combined with security-themed content and authentication failures. Excludes legitimate Mastercard communications and trusted senders.

# Associated samples
- https://platform.sublime.security/messages/7c885948fc0214bf7b67d77843ddea86ec5edf7448c53a38794f346266fd4001?preview_id=01927206-9894-7ed8-b711-a9b478fb304d