### PR TITLE
Update spam_attendee_list_solicitation.yml

### DIFF
--- a/detection-rules/spam_attendee_list_solicitation.yml
+++ b/detection-rules/spam_attendee_list_solicitation.yml
@@ -37,7 +37,7 @@ source: |
                           "(?:interest(s|ed)|accessing|purchas|obtain|acuir|sample|provide.{0,10}samples|counts|pricing)"
       )
       and not regex.icontains(body.current_thread.text,
-                              "(?:debit card|transaction.{0,20}processed|receipt)"
+                              "(?:debit card|transaction.{0,20}processed)"
       )
     )
     // if there are indicators of a previous thread, also inspect the previous thread


### PR DESCRIPTION
# Description

Removing 'receipt' from negations to provide additional coverage where this rule should have fired.

# Associated samples


[- Sample 1](https://platform.sublime.security/messages/4f383ec4479b94d85f9583252b03791dae5685fb345130646f67ea18e5924fb3?preview_id=0197fa63-9526-7431-b529-0e5d5d5f241b)
[- Sample 2](https://platform.sublime.security/messages/413115e5a8de5516ac05ab4563fb6fe6cca1b64d6bd1b3f7780d6ea62c93b797?preview_id=0196d132-1534-75c1-8d8a-5bfa34f99ecb)
