### PR TITLE
Update impersonation_chase.yml

### DIFF
--- a/detection-rules/impersonation_chase.yml
+++ b/detection-rules/impersonation_chase.yml
@@ -37,7 +37,9 @@ source: |
         )
       )
     )
-    or strings.icontains(body.current_thread.text, 'Chase Privacy Operations')
+    or regex.icontains(body.current_thread.text,
+                        '(Chase|J\.?\s?P\.?\sMorgan)\s(Privacy|Treasury)\sOperations|(Privacy|Treasury)\sOperations\s(Chase|J\.?\s?P\.?\sMorgan)'
+    )
   )
   and not (
     sender.display_name is not null and sender.display_name in~ ("chaser", "case")


### PR DESCRIPTION
# Description

adding regex to flag mentions of Chase/JP Morgan "Treasury Operations"

# Associated samples

- https://platform.sublime.security/messages/a4f9781ad4fb4918ccb722944eee97617d38725cfddcfb65c2c4b45d14f6f702?preview_id=0197a583-f783-7b66-a8f3-2e2f470b2008
