### PR TITLE
Update impersonation_sharepoint_body_credential_theft.yml

### DIFF
--- a/detection-rules/impersonation_sharepoint_body_credential_theft.yml
+++ b/detection-rules/impersonation_sharepoint_body_credential_theft.yml
@@ -84,6 +84,11 @@ source: |
         strings.starts_with(headers.message_id, '<Share-')
         and strings.ends_with(headers.message_id, '@odspnotify>')
       )
+      or // negate legitimate access request to file
+      (
+        strings.starts_with(headers.message_id, '<Sharing')
+        and strings.ends_with(headers.message_id, '@odspnotify>')
+      )
       // deal with Google thinking the message ID is "broke"
       or (
         strings.icontains(headers.message_id, 'SMTPIN_ADDED_BROKEN')


### PR DESCRIPTION
# Description

Adding a negation for when someone legitimately requests access to a SharePoint file. 

# Associated samples

[- Sample 1](https://na-west.platform.sublime.security/messages/5a83761786d55f6c3fec667988d6983c4bde1b47788a271176382d9a714f9992?preview_id=01977bc2-b293-77e3-9b63-f376f1e5e604)
[- Sample 2](https://na-west.platform.sublime.security/messages/f823598953360f535b37e11b5d090829ef5f4d81b789f1b0545d6d4e70cfffb4?preview_id=01977ba5-3496-79ef-ae68-9bea9d9a0ce6)
[- Sample 3](https://na-west.platform.sublime.security/messages/6891f031af8de9c063fe76b493ed7fb1a8574fdd3abb6abb16511cdab0fdae4b?preview_id=0197aac3-5eb2-7aaa-b00b-f96ed7f6e6b8)
[- Sample 4](https://na-west.platform.sublime.security/messages/61e42002ea8fef272f8a09a4ca839feeca2c2a93916b41962066369a413d3a1a?preview_id=0197aafb-a0c9-712b-9fe0-88c24292176d)

