### PR TITLE
Update abuse_zoom_docs_unsolicited_sender.yml

### DIFF
--- a/detection-rules/abuse_zoom_docs_unsolicited_sender.yml
+++ b/detection-rules/abuse_zoom_docs_unsolicited_sender.yml
@@ -5,7 +5,7 @@ severity: "low"
 source: |
   type.inbound
   and sender.email.domain.root_domain == "zoom.us"
-  and sender.display_name == "Zoom Docs"
+  and strings.ends_with(sender.display_name, "Zoom Docs")
   and any(html.xpath(body.html, '//h2').nodes,
           // extract the sender email out of the message body
           any(regex.iextract(.display_text,


### PR DESCRIPTION
# Description

adding `ends.with` condition to account for `via Zoom Docs` sender display name

# Associated samples

- https://platform.sublime.security/messages/ebfb85d061056051a9af77fe42d7fb7deaa200ecb284442aaefce131ced3bb1a?preview_id=01981d75-baa8-7bf5-a1f1-cc2e6e87a8ce