### PR TITLE
Add credential phishing detection rule for generic document sharing

### DIFF
--- a/detection-rules/credential_phishing_generic_document_sharing.yml
+++ b/detection-rules/credential_phishing_generic_document_sharing.yml
@@ -7,6 +7,8 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
+  // exclude if it's a reply to an existing conversation
+  and not length(body.previous_threads) > 0
   and (
     // subject contains document sharing language
     regex.icontains(subject.subject,
@@ -90,8 +92,6 @@ source: |
     )
   )
   and not profile.by_sender().any_messages_benign
-  // exclude if it's a reply to an existing conversation
-  and not length(body.previous_threads) > 0
   
 attack_types:
   - "Credential Phishing"


### PR DESCRIPTION
# Description

This rule detects credential phishing attempts that use generic document sharing language (e.g., 'document to review', 'sent you a file') without impersonating specific brands. It identifies suspicious links that appear to be file attachments but don't point to legitimate file sharing services.

Key features:
- Detects generic document sharing language in subject and body
- Identifies suspicious link display text mimicking file attachments
- Excludes legitimate file sharing domains (SharePoint, Google Drive, etc.)
- Uses NLU to confirm credential theft intent
- Filters out legitimate senders with DMARC authentication

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/d3382cca0412226cc439ee99acdf203be669b114864a0687d6fc9f49e9f09081?preview_id=0197c713-5185-752b-8d5a-a58bb159afdb)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01983244-6e25-7a04-a417-76baaa8501be)
