### PR TITLE
Add detection rule for legal document attachments with threatening filenames

### DIFF
--- a/detection-rules/attachment_legal_document_threatening_filename.yml
+++ b/detection-rules/attachment_legal_document_threatening_filename.yml
@@ -1,0 +1,75 @@
+name: "Attachment: Legal Document with Threatening Filename"
+description: |
+  Detects malicious attachments with legal/threatening language in both the subject line 
+  and filename, often sent with minimal or no body text to appear more official.
+  Common pattern for malware delivery via legal-themed social engineering.
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and (
+    // subject contains legal/case language
+    regex.icontains(subject.subject,
+                    '\b(case\s+summary|court\s+action|legal\s+action|court\s+order|warrant|violation|fine|penalty|demand\s+notice|legal\s+notice|court\s+notice|judgment|tribunal|hearing|proceedings|prosecution|contempt|breach|default|liability|damages|settlement|injunction|summon|subpoena|lawsuit|litigation)\b'
+    )
+    or strings.icontains(subject.subject, 'case summary')
+    or strings.icontains(subject.subject, 'court action')
+    or strings.icontains(subject.subject, 'legal action')
+    or strings.icontains(subject.subject, 'court order')
+    or strings.icontains(subject.subject, 'legal notice')
+  )
+  and (
+    // external sender (not from trusted legal domains)
+    sender.email.domain.root_domain not in $org_domains
+    and sender.email.domain.root_domain not in $high_trust_sender_root_domains
+    and sender.email.domain.root_domain not in ("gov", "courts.gov", "uscourts.gov", "judiciary.gov", "co.za")
+  )
+  and length(attachments) >= 1
+  and any(attachments,
+          // Microsoft Office documents commonly used for malware
+          .file_extension in ("doc", "docx", "pdf", "xls", "xlsx")
+          and (
+            // filename contains threatening/legal language
+            regex.icontains(.file_name,
+                            '\b(court|legal|action|imminent|urgent|notice|summon|subpoena|lawsuit|litigation|judgment|warrant|violation|fine|penalty|demand|tribunal|hearing|proceedings|prosecution|contempt|breach|default|liability|damages|settlement|injunction)\b'
+            )
+            // specific patterns like "COURT-ACTION IS IMMINENT"
+            or strings.icontains(.file_name, 'court-action')
+            or strings.icontains(.file_name, 'court action')
+            or strings.icontains(.file_name, 'imminent')
+            or strings.icontains(.file_name, 'urgent')
+            or strings.icontains(.file_name, 'legal action')
+            or strings.icontains(.file_name, 'case summary')
+          )
+  )
+  and (
+    // body is minimal/empty (common in these attacks)
+    length(body.current_thread.text) < 100
+    // or contains basic threatening language
+    or regex.icontains(body.current_thread.text,
+                       '\b(urgent|immediate|action\s+required|court\s+action|legal\s+action|respond\s+immediately|deadline|expire|suspend|terminate)\b'
+    )
+  )
+  // exclude legitimate senders who pass DMARC from known legal domains
+  and not (
+    coalesce(headers.auth_summary.dmarc.pass, false)
+    and (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      or regex.icontains(sender.email.domain.root_domain, '\b(law|legal|court|attorney|barrister|solicitor|counsel)\b')
+    )
+  )
+  // exclude if recipient is explicitly addressed (reduces false positives)
+  and recipients.to[0].display_name in ("Undisclosed recipients", "", null)
+attack_types:
+  - "Malware/Ransomware"
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Malicious file"
+  - "Social engineering"
+  - "Evasion"
+  - "Impersonation: Brand"
+detection_methods:
+  - "Content analysis"
+  - "File analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description
This rule detects malicious attachments that use legal/threatening language in both subject lines and filenames to socially engineer recipients into opening malware-laden documents.

Key features:
- Detects legal terminology (court action, legal notice, warrant, etc.)
- Identifies threatening filenames on Office/PDF attachments
- Filters out legitimate legal domains and government senders
- Targets emails with minimal body content (common attack pattern)
- Excludes emails with proper recipient addressing
- High severity due to common malware delivery vector

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/98d1309e64685cf77b1c53815c5a2985352dc04fe6ebd14b2b26a3780121b5de)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01983251-8f01-7ad9-b5a5-edb4b3afefed)
