### PR TITLE
Update impersonation_meta.yml

### DIFF
--- a/detection-rules/impersonation_meta.yml
+++ b/detection-rules/impersonation_meta.yml
@@ -142,6 +142,27 @@ source: |
               .name == "urgency"
       )
     )
+    // utilize enrichments to surface legal notices & negate mismatched display text phishing links, while not depending on sender specific signals or lack of display name.
+    or (
+      any(beta.ml_topic(body.html.display_text).topics,
+          .name == "Legal and Compliance" and .confidence in ("medium", "high")
+      )
+      and regex.icontains(body.current_thread.text,
+                          '\bFacebook\b',
+                          '\bInstagram\b',
+                          '\bMeta\b',
+                          '\bThreads\b'
+      )
+      // negate footer social links
+      and not any(body.links,
+                  regex.icontains(.display_text,
+                                  '\bFacebook\b',
+                                  '\bInstagram\b',
+                                  '\bMeta\b',
+                                  '\bThreads\b'
+                  )
+      )
+    )
   )
   and sender.email.domain.root_domain not in~ (
     'facebook.com',


### PR DESCRIPTION
# Description

Adding enrichment coverage for legal & specific brand mentions, negating footer social links & display text altered phishing links, separate of all other scopes to mitigate FP's.

# Associated samples

Samples are skewed due to client sending incorrect .eml. Providing two links that we received and added to Analyzer. The forwarded one will not apply as current thread body is not the original message. Second example will apply, but is a modified version of first sample to mimic a real message. These links may or may not work. See POC channel for sender for reference if this is the case.

[- Sample 1](https://platform.sublime.security/rules/editor?canonical_id=e4f963cc95f669e8018f6bfdd7b0820098f20c6574f85ea9e7a0858a90348b5c&message_id=019837c4-617e-7198-a3ca-7192e43b1305)
[- Sample 2](https://platform.sublime.security/rules/editor?canonical_id=ba161d1f9aa5a278e2245d825c454a045ba7cf34c4723f12f0a7355200ec01b6&message_id=019837c6-0460-7542-ab77-7ea9c5f32ed3)

## Associated hunts

[- Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019838b7-af84-7ece-a356-e1cb995ef0f4)