### PR TITLE
Create impersonationa_Sublime_security_domain.yml

### DIFF
--- a/impersonationa_Sublime_security_domain.yml
+++ b/impersonationa_Sublime_security_domain.yml
@@ -1,0 +1,208 @@
+name: "Sublime Security Punycode Domain Variants"
+description: "Detects communications from domains designed to visually mimic sublime.security through punycode and character substitution techniques, including sender analysis and link inspection. Checks Levenshtein distance and maintains allowlist for legitimate domains."
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and (
+    // Check sender email domain for punycode sublime.security impersonation taken from dnstwist output 25 July 2025
+    sender.email.domain.domain in~ (
+      "xn--sublim-8ua.security",
+      "xn--sublim-gva.security",
+      "xn--sublim-nva.security",
+      "xn--sublim-uva.security",
+      "xn--sublim-u3a.security",
+      "xn--sublim-83a.security",
+      "xn--sublim-n4a.security",
+      "xn--sublim-14a.security",
+      "xn--sublim-g5a.security",
+      "xn--sublim-gpc.security",
+      "xn--sublim-gvc.security",
+      "xn--sublim-8k7b.security",
+      "xn--sublim-uh8b.security",
+      "xn--sublie-t3c.security",
+      "xn--sublie-705b.security",
+      "xn--sublie-fs7b.security",
+      "xn--sublie-ts7b.security",
+      "xn--sublie-7s7b.security",
+      "xn--sublme-zva.security",
+      "xn--sublme-6va.security",
+      "xn--sublme-lwa.security",
+      "xn--sublme-l8a.security",
+      "xn--sublme-z8a.security",
+      "xn--sublme-s9a.security",
+      "xn--sublme-6db.security",
+      "xn--sublme-l6b.security",
+      "xn--sublme-ejc.security",
+      "xn--sublme-z1c.security",
+      "xn--sublme-61c.security",
+      "xn--sublme-l2c.security",
+      "xn--sublme-zk8b.security",
+      "xn--sublme-el8b.security",
+      "xn--subime-yva.security",
+      "xn--subime-5va.security",
+      "xn--subime-kwa.security",
+      "xn--subime-k8a.security",
+      "xn--subime-y8a.security",
+      "xn--subime-r9a.security",
+      "xn--subime-5db.security",
+      "xn--subime-k6b.security",
+      "xn--subime-djc.security",
+      "xn--subime-y1c.security",
+      "xn--subime-51c.security",
+      "xn--subime-k2c.security",
+      "xn--subime-yk8b.security",
+      "xn--subime-dl8b.security",
+      "xn--sulime-qxc.security",
+      "xn--sulime-qcd.security",
+      "xn--sulime-cg7b.security",
+      "xn--sulime-qg7b.security",
+      "xn--sulime-4g7b.security",
+      "xn--sblime-iya.security",
+      "xn--sblime-pya.security",
+      "xn--sblime-wya.security",
+      "xn--sblime-3ya.security",
+      "xn--sblime-wlb.security",
+      "xn--sblime-bmb.security",
+      "xn--sblime-pmb.security",
+      "xn--sblime-3mb.security",
+      "xn--sblime-inb.security",
+      "xn--sblime-wnb.security",
+      "xn--sblime-3zb.security",
+      "xn--sblime-b7b.security",
+      "xn--sblime-blc.security",
+      "xn--sblime-plc.security",
+      "xn--sblime-i8c.security",
+      "xn--sblime-335b.security",
+      "xn--sblime-347b.security",
+      "xn--sblime-iq8b.security",
+      "xn--ublime-2ib.security",
+      "xn--ublime-hjb.security",
+      "xn--ublime-9jb.security",
+      "xn--ublime-2lc.security",
+      "xn--ublime-26c.security",
+      "xn--ublime-2y7b.security",
+      "xn--ublime-hz7b.security"
+    )
+    // Check for Levenshtein distance to sublime.security
+    or strings.ilevenshtein(sender.email.domain.domain, 'sublime.security') <= 2
+    // Check for punycode domains in any links within the email body  
+    or any(body.links,
+           .href_url.domain.domain in~ (
+             "xn--sublim-8ua.security",
+             "xn--sublim-gva.security",
+             "xn--sublim-nva.security",
+             "xn--sublim-uva.security",
+             "xn--sublim-u3a.security",
+             "xn--sublim-83a.security",
+             "xn--sublim-n4a.security",
+             "xn--sublim-14a.security",
+             "xn--sublim-g5a.security",
+             "xn--sublim-gpc.security",
+             "xn--sublim-gvc.security",
+             "xn--sublim-8k7b.security",
+             "xn--sublim-uh8b.security",
+             "xn--sublie-t3c.security",
+             "xn--sublie-705b.security",
+             "xn--sublie-fs7b.security",
+             "xn--sublie-ts7b.security",
+             "xn--sublie-7s7b.security",
+             "xn--sublme-zva.security",
+             "xn--sublme-6va.security",
+             "xn--sublme-lwa.security",
+             "xn--sublme-l8a.security",
+             "xn--sublme-z8a.security",
+             "xn--sublme-s9a.security",
+             "xn--sublme-6db.security",
+             "xn--sublme-l6b.security",
+             "xn--sublme-ejc.security",
+             "xn--sublme-z1c.security",
+             "xn--sublme-61c.security",
+             "xn--sublme-l2c.security",
+             "xn--sublme-zk8b.security",
+             "xn--sublme-el8b.security",
+             "xn--subime-yva.security",
+             "xn--subime-5va.security",
+             "xn--subime-kwa.security",
+             "xn--subime-k8a.security",
+             "xn--subime-y8a.security",
+             "xn--subime-r9a.security",
+             "xn--subime-5db.security",
+             "xn--subime-k6b.security",
+             "xn--subime-djc.security",
+             "xn--subime-y1c.security",
+             "xn--subime-51c.security",
+             "xn--subime-k2c.security",
+             "xn--subime-yk8b.security",
+             "xn--subime-dl8b.security",
+             "xn--sulime-qxc.security",
+             "xn--sulime-qcd.security",
+             "xn--sulime-cg7b.security",
+             "xn--sulime-qg7b.security",
+             "xn--sulime-4g7b.security",
+             "xn--sblime-iya.security",
+             "xn--sblime-pya.security",
+             "xn--sblime-wya.security",
+             "xn--sblime-3ya.security",
+             "xn--sblime-wlb.security",
+             "xn--sblime-bmb.security",
+             "xn--sblime-pmb.security",
+             "xn--sblime-3mb.security",
+             "xn--sblime-inb.security",
+             "xn--sblime-wnb.security",
+             "xn--sblime-3zb.security",
+             "xn--sblime-b7b.security",
+             "xn--sblime-blc.security",
+             "xn--sblime-plc.security",
+             "xn--sblime-i8c.security",
+             "xn--sblime-335b.security",
+             "xn--sblime-347b.security",
+             "xn--sblime-iq8b.security",
+             "xn--ublime-2ib.security",
+             "xn--ublime-hjb.security",
+             "xn--ublime-9jb.security",
+             "xn--ublime-2lc.security",
+             "xn--ublime-26c.security",
+             "xn--ublime-2y7b.security",
+             "xn--ublime-hz7b.security"
+           )
+    )
+  )
+  // Negate legitimate sublime.security domains
+  and sender.email.domain.root_domain not in~ (
+    "sublime.security",
+    "sublimesecurity.com"
+  )
+  // Add sender reputation checks similar to other impersonation rules
+  and (
+    not profile.by_sender().solicited
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and not profile.by_sender().any_messages_benign
+    )
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  and not profile.by_sender().any_messages_benign
+
+attack_types:
+  - "BEC/Fraud"
+  - "Callback Phishing"
+  - "Credential Phishing"
+  - "Extortion"
+  - "Malware/Ransomware"
+  - "Spam"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Lookalike domain"
+  - "Punycode"
+  - "Social engineering"
+detection_methods:
+  - "Sender analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description

A very broad attempt at attempting to catch IDN domains using both DMARC protection and ilevenshtein on `sublime.security` spoofed emails and URLs in the body of an email. I have been able to test it in the playgrounds for now. This content was taken from a [Dnstwister](https://dnstwister.report/search?ed=7375626c696d652e7365637572697479#) Its probable the nominal number of domains existing today will eventually have an IP or an MX record associated with them which will elevate the risk.

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019840f9-3ed2-716e-91dc-688b0a534269)
- [Sample 1](https://play.sublime.security/?id=01984128-c60b-78a9-9a4f-5ba4ec330252) 

# Screenshot (insights)
<!-- 
**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
-->
