### PR TITLE
adding dmarc and spf checks for attachment smuggling

### DIFF
--- a/detection-rules/attachment_small_html_recipient_address.yml
+++ b/detection-rules/attachment_small_html_recipient_address.yml
@@ -63,13 +63,17 @@ source: |
     and any(attachments, .content_type == "message/rfc822")
   )
   and (
-    not profile.by_sender_email().solicited
-    or (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_messages_benign
+    (not headers.auth_summary.dmarc.pass or not headers.auth_summary.spf.pass)
+    and (
+      not profile.by_sender_email().solicited
+      or (
+        profile.by_sender().any_messages_malicious_or_spam
+        and not profile.by_sender().any_messages_benign
+      )
+      or (
+        not headers.auth_summary.dmarc.pass or not headers.auth_summary.spf.pass
+      )
     )
-    or not headers.auth_summary.dmarc.pass
-    or not headers.auth_summary.spf.pass
   )
 tags:
   - "Attack surface reduction"

--- a/detection-rules/attachment_small_html_recipient_address.yml
+++ b/detection-rules/attachment_small_html_recipient_address.yml
@@ -43,10 +43,10 @@ source: |
     )
   )
   and not any(attachments,
-            any(file.parse_eml(.).attachments,
-                .content_type == "message/delivery-status"
-            )
-      )
+              any(file.parse_eml(.).attachments,
+                  .content_type == "message/delivery-status"
+              )
+  )
   // bounce-back negations
   and not (
     any(attachments,
@@ -75,6 +75,7 @@ source: |
       )
     )
   )
+
 tags:
   - "Attack surface reduction"
 attack_types:

--- a/detection-rules/attachment_small_html_recipient_address.yml
+++ b/detection-rules/attachment_small_html_recipient_address.yml
@@ -68,6 +68,8 @@ source: |
       profile.by_sender().any_messages_malicious_or_spam
       and not profile.by_sender().any_messages_benign
     )
+    or not headers.auth_summary.dmarc.pass
+    or not headers.auth_summary.spf.pass
   )
 tags:
   - "Attack surface reduction"

--- a/detection-rules/attachment_small_html_recipient_address.yml
+++ b/detection-rules/attachment_small_html_recipient_address.yml
@@ -62,18 +62,29 @@ source: |
     )
     and any(attachments, .content_type == "message/rfc822")
   )
+  // unsolicited or fails authentation
   and (
-    (not headers.auth_summary.dmarc.pass or not headers.auth_summary.spf.pass)
-    and (
-      not profile.by_sender_email().solicited
-      or (
-        profile.by_sender().any_messages_malicious_or_spam
-        and not profile.by_sender().any_messages_benign
-      )
-      or (
-        not headers.auth_summary.dmarc.pass or not headers.auth_summary.spf.pass
-      )
+    (
+      profile.by_sender_email().prevalence in ("new", "outlier")
+      and not profile.by_sender_email().solicited
     )
+    or (
+      profile.by_sender_email().any_messages_malicious_or_spam
+      and not profile.by_sender_email().any_messages_benign
+    )
+    or (
+      sender.email.domain.domain in $org_domains
+      and not coalesce(headers.auth_summary.dmarc.pass, false)
+    )
+  )
+  
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not coalesce(headers.auth_summary.dmarc.pass, false)
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
 
 tags:


### PR DESCRIPTION
# Description

From a runner request. Negating sender profiling if sender fails dmarc or spf auth.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/4f3f07ff470416eb38f61390c8c3e0069a4857acfcfc47cf70d814e035238e79?preview_id=019837bc-e23b-71a7-8ded-52d50cf47372)
- [Sample 2](https://platform.sublime.security/messages/4f3f53ef62bce8269a8ffdb9436307170d197971a989f7a19e8afc4191e98f79?preview_id=019837ba-f01a-70de-b927-5548267e0339)
- [Sample 3](https://platform.sublime.security/messages/4f40433dda448f8f388b788c604fac07da3cf23c786a86e3b135528e04afff6d?preview_id=019837ba-dda5-76ab-9dcb-5fab4a0433a1)
- [Sample 4](https://platform.sublime.security/messages/4f406880fcc06bf07b2bcd9dbb64756ff99096fbb26bcffcb195032581d47a01?preview_id=019837ba-d958-7b78-aa21-b81d662fa8b9) 
