### PR TITLE
Update spam_crypto_giveaway.yml

### DIFF
--- a/detection-rules/spam_crypto_giveaway.yml
+++ b/detection-rules/spam_crypto_giveaway.yml
@@ -35,7 +35,7 @@ source: |
     or regex.contains(body.current_thread.text, '\s\$[A-Z]{3,4}\s')
   )
   and not (
-    sender.email.domain.root_domain in ("gemini.com", "ledger.com", "binance.com", "trezor.io", "kraken.com", "solana.com", "metamask.com", "ethereum.org")
+    sender.email.domain.root_domain in ("gemini.com", "ledger.com", "binance.com", "trezor.io", "kraken.com", "solana.com", "metamask.com", "ethereum.org", "bloomberg.com")
     and headers.auth_summary.dmarc.pass
   )
 attack_types:


### PR DESCRIPTION
# Description

This expands the known crypto scam names with a focus below on Trezor. I tried to identify the email domains for the crypto wallets and exchanges, this may well change as i discover them. I also checked on the current existing names used in the body and thought the logic would make additional sense to have the same domains in the `sender.email.domain.root_domain` function.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/fc065dc41531ba7528b4f711fb2c7b0aac45a0afb009db7839f571a795addcad)
- [Sample 2](https://platform.sublime.security/messages/53839f6bb69f270bbed78525c073489cdce1bf7e230eb57588bd2db901430aab)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=0198a8d9-a1da-741a-ba79-64ac9198c182)

# Screenshot (insights)
<!-- 
**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
-->
