### PR TITLE
Update brand_impersonation_booking_com.yml

### DIFF
--- a/detection-rules/brand_impersonation_booking_com.yml
+++ b/detection-rules/brand_impersonation_booking_com.yml
@@ -17,6 +17,7 @@ source: |
     any(ml.nlu_classifier(body.current_thread.text).entities,
         .name == "org" and .text == "Booking.com"
         or strings.icontains(body.current_thread.text, ' booking.com ')
+        or strings.icontains(sender.display_name, "booking.com")
     )
   )
   and (
@@ -35,10 +36,17 @@ source: |
            or network.whois(.href_url.domain).days_old < 30
            or strings.icontains(.href_url.path, "/redir")
     )
+    // check for text strings that betray intent
+    or strings.icontains(body.current_thread.text, "book a room", )
+    or strings.ilike(body.current_thread.text, "* availab*", )
     // two seperate HTML elements impersonating the logo
     or (
-      any(html.xpath(body.html, '//*[text()[normalize-space()]]').nodes, .display_text =~ "Booking")
-      and any(html.xpath(body.html, '//*[text()[normalize-space()]]').nodes, .display_text =~ ".com")
+      any(html.xpath(body.html, '//*[text()[normalize-space()]]').nodes,
+          .display_text =~ "Booking"
+      )
+      and any(html.xpath(body.html, '//*[text()[normalize-space()]]').nodes,
+              .display_text =~ ".com"
+      )
     )
   )
   and sender.email.domain.root_domain not in~ ('booking.com')


### PR DESCRIPTION
# Description

Added code to catch sender displays claiming to be Booking.com but not matching domain; also added text strings to catch things that are outside of links. Cleaned formatting.

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/4f4add381bbf19c87e11c3000dd5323bd4d30a99d6bfbdea4568f39170ad901c?preview_id=0198569f-dfea-77aa-89c2-fcc2fa4b96c7)
- [Sample 2](https://platform.sublime.security/messages/4f4a1eb74d4c7a45d419fc578aa8193dd3ac54b9631c11791a61bfb1d8410b01?preview_id=0198568b-c042-70f3-9355-82d928f5411b)
- [Sample 3](https://platform.sublime.security/messages/4f4ac192882058cc615612d78c36b941f81f09a166568434831ae63f5da8eaf9?preview_id=01985689-f663-7aa0-83e8-2172e2a1feb7)

## Associated hunts
- [Hunt 1]
(https://platform.sublime.security/messages/hunt?huntId=019856cf-68ad-79a2-a9b1-b10d027f6181)

