### PR TITLE
Update qr_code_suspicious_indicators.yml

### DIFF
--- a/detection-rules/qr_code_suspicious_indicators.yml
+++ b/detection-rules/qr_code_suspicious_indicators.yml
@@ -377,10 +377,7 @@ source: |
   // sender profile is new or outlier
   and (
     not profile.by_sender_email().any_messages_benign
-    or (
-      profile.by_sender_email().any_messages_malicious_or_spam
-      and not profile.by_sender_email().any_messages_benign
-    )
+    or profile.by_sender_email().any_messages_malicious_or_spam
     or (
       sender.email.domain.domain in $org_domains
       and not coalesce(headers.auth_summary.dmarc.pass, false)


### PR DESCRIPTION
# Description

1. update sender profile negations to allow matching on spoofed org_dominas
2. switch sender_profile references to by_sender_email
3. collapsed negation on `any_messages_benign` into existing sender profile negation logic

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/4f4a44bfbb7258626c3b6d6f49aa9e6b878dc535c1fd793f5276d0a7d3d6ee80?preview_id=01985712-7037-7452-b605-c94cdaf82860)

