### PR TITLE
Update attachment_qr_code_suspicious_components.yml

### DIFF
--- a/detection-rules/attachment_qr_code_suspicious_components.yml
+++ b/detection-rules/attachment_qr_code_suspicious_components.yml
@@ -142,16 +142,16 @@ source: |
   )
   and (
     (
-      profile.by_sender().prevalence in ("new", "outlier")
-      and not profile.by_sender().solicited
+      profile.by_sender_email().prevalence in ("new", "outlier")
+      and not profile.by_sender_email().solicited
     )
     or (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_messages_benign
+      profile.by_sender_email().any_messages_malicious_or_spam
+      and not profile.by_sender_email().any_messages_benign
     )
     or (
         sender.email.domain.domain in $org_domains
-        and not headers.auth_summary.dmarc.pass
+        and not coalesce(headers.auth_summary.dmarc.pass, false)
     )
   )
   


### PR DESCRIPTION
# Description

1. Update org_domain spoofing logic to account for when dmarc is null
2. move sender profile elements to `by_sender_email`


# Associated samples
- [Sample 1](https://platform.sublime.security/messages/4f4a44bfbb7258626c3b6d6f49aa9e6b878dc535c1fd793f5276d0a7d3d6ee80?preview_id=01985712-7037-7452-b605-c94cdaf82860)

