### PR TITLE
Update link_credential_phishing_intent_and_other_indicators.yml

### DIFF
--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -298,6 +298,8 @@ source: |
     4 of (
       any(recipients.to,
           .email.domain.valid
+          // it's not the sender (occurs when everyone is BCC'ed)
+          and not sender.email.email == .email.email
           and (
             strings.icontains(body.current_thread.text, .email.email)
             or strings.icontains(body.current_thread.text, .email.local_part)


### PR DESCRIPTION
# Description

Negate recipient detection in the body of the message when the recipient is also the sen

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/4f443a499503440e235e8bab51648e0d9783a28ad0d26f3fa066e6ef2d76e53b)
