### PR TITLE
Update body_extortion.yml

### DIFF
--- a/detection-rules/body_extortion.yml
+++ b/detection-rules/body_extortion.yml
@@ -117,6 +117,15 @@ source: |
     )
   )
   and length(body.current_thread.text) < 6000
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  
 attack_types:
   - "Extortion"
 tactics_and_techniques:


### PR DESCRIPTION
# Description
Adding negation for high trust sender domains unless they fail authentication to resolve FPs.

# Associated samples

[- Sample 1](https://platform.sublime.security/messages/62d63a228e19cbdd190579ac5ab61a67c27dbe312fca86f98b2484b6fbb71b4c?preview_id=0197f2fa-d037-7983-a1a6-a2dd28eee4a8)
[- Sample 2](https://platform.sublime.security/messages/4f452b06af26255138d32426fe5c3cb602f9ae4938c816af76a01ce3fe3734ba?preview_id=01983e27-318c-788c-92dc-c50129b3f03e)
[- Sample 3](https://platform.sublime.security/messages/b29315071550c642848baa1dd2fbe324830b479690c6bf5196abd12a8c6f34e8?preview_id=01976bbd-a42a-7297-a1f8-7fee2233a29f)
