### PR TITLE
Adding logic to .ms check

### DIFF
--- a/detection-rules/impersonation_sharepoint_body_credential_theft.yml
+++ b/detection-rules/impersonation_sharepoint_body_credential_theft.yml
@@ -14,8 +14,12 @@ source: |
     or any(ml.logo_detect(beta.message_screenshot()).brands,
            .name == "Microsoft SharePoint"
     )
-    or strings.istarts_with(strings.replace_confusables(body.current_thread.text), "Sharepoint")
-    or regex.icontains(body.html.raw, '<img.*(title=|alt=).share.*src=""')  // broken Sharepoint logo
+    or strings.istarts_with(strings.replace_confusables(body.current_thread.text),
+                            "Sharepoint"
+    )
+    or regex.icontains(body.html.raw,
+                       '<img.*(title=|alt=).share.*src=""'
+    ) // broken Sharepoint logo
   )
   and (
     (
@@ -32,9 +36,8 @@ source: |
            .name == "urgency" and strings.ilike(.text, "*encrypted*")
     )
   )
-
   and not (
-     (
+    (
       (
         strings.istarts_with(subject.subject, "RE:")
         or strings.istarts_with(subject.subject, "R:")
@@ -49,10 +52,7 @@ source: |
         )
       )
       and (
-        (
-          length(headers.references) > 0
-          or headers.in_reply_to is not null
-        )
+        (length(headers.references) > 0 or headers.in_reply_to is not null)
         // ensure that there are actual threads
         and (
           length(body.previous_threads) > 0
@@ -61,7 +61,6 @@ source: |
       )
     )
   )
-  
   and (
     profile.by_sender_email().prevalence != 'common'
     or not profile.by_sender_email().solicited
@@ -77,7 +76,7 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
+  
   // negate sharepoint file share
   and not (
     // based on the message id format
@@ -87,7 +86,7 @@ source: |
         and strings.ends_with(headers.message_id, '@odspnotify>')
       )
       or // negate legitimate access request to file
-      (
+   (
         strings.starts_with(headers.message_id, '<Sharing')
         and strings.ends_with(headers.message_id, '@odspnotify>')
       )
@@ -109,7 +108,18 @@ source: |
                    or .display_text == "Open"
             ),
             .href_url.domain.root_domain in ("sharepoint.com")
-            or .href_url.domain.tld == "ms"
+            or (
+              .href_url.domain.tld == "ms"
+              // Microsoft does not own the .ms TLD, this checks to ensure it is one of their domains
+              and (
+                network.whois(.href_url.domain).registrant_company == "Microsoft Corporation"
+                or strings.ilike(network.whois(.href_url.domain).registrar_name,
+                                 "*MarkMonitor*",
+                                 "*CSC Corporate*",
+                                 "*com laude*"
+                )
+              )
+            )
     )
   )
 

--- a/detection-rules/link_multistage_microsoft_forms.yml
+++ b/detection-rules/link_multistage_microsoft_forms.yml
@@ -104,7 +104,18 @@ source: |
                                   and .href_url.domain.root_domain =~ 'microsoft.com'
                                 )
                                 or .href_url.domain.root_domain =~ sender.email.domain.root_domain
-                                or .href_url.domain.tld == "ms"
+                                or (
+                                  .href_url.domain.tld == "ms"
+                                  // Microsoft does not own the .ms TLD, this checks to ensure it is one of their domains
+                                  and (
+                                    network.whois(.href_url.domain).registrant_company == "Microsoft Corporation"
+                                    or strings.ilike(network.whois(.href_url.domain).registrar_name,
+                                                     "*MarkMonitor*",
+                                                     "*CSC Corporate*",
+                                                     "*com laude*"
+                                    )
+                                  )
+                                )
                               )
                        )
             ) <= 2


### PR DESCRIPTION
# Description

Tightening `.ms` TLD check to prevent potential detection bypasses.
