### PR TITLE
Update link_credential_phishing_secure_message.yml

### DIFF
--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -21,12 +21,14 @@ source: |
       or strings.icontains(body.current_thread.text, "document portal")
       or strings.icontains(body.current_thread.text, "encrypted message")
       or strings.icontains(body.current_thread.text, "protected message")
+      or strings.icontains(body.current_thread.text, "secured by")
     )
     or any(body.previous_threads,
            regex.icontains(.text, "secure (message|directory)")
            or strings.icontains(.text, "document portal")
            or strings.icontains(.text, "encrypted message")
            or strings.icontains(.text, "protected message")
+           or strings.icontains(.text, "secured by")
     )
   )
   // todo: automated display name / human local part


### PR DESCRIPTION
# Description

Added in more keywords observed in Zix themed phish campaigns in the hunts below.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5ada49b47890ba16be56b6bb36caf8e5205e19dbe6968611ba5c229dd22e75eb?preview_id=019745d9-08b3-7d51-b3a3-75b7c96d1bae)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01988422-3ab8-786e-976f-3a538f2396d9)

# Screenshot (insights)
<!-- 
**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
-->
