### PR TITLE
Update link_credential_phishing_suspicious_sender_tld_and_signals.yml

### DIFF
--- a/detection-rules/link_credential_phishing_suspicious_sender_tld_and_signals.yml
+++ b/detection-rules/link_credential_phishing_suspicious_sender_tld_and_signals.yml
@@ -5,45 +5,60 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-
+  
   // we don't do a suspicious link check here
   // because we are seeing abuse of mass marketing tools
   // like campaign[.]adobe[.]com
   // once we roll out better support for unfurling those,
   // we can update this logic
   and length(body.links) > 0
-
+  
   // commonly abused sender TLD
   and strings.ilike(sender.email.domain.tld, "*.jp")
   and 3 of (
     // language attempting to engage
     any(ml.nlu_classifier(body.current_thread.text).entities, .name == "request"),
-
+  
     // financial request
-    any(ml.nlu_classifier(body.current_thread.text).entities, .name == "financial"),
-
+    any(ml.nlu_classifier(body.current_thread.text).entities,
+        .name == "financial"
+    ),
+  
     // urgency request
     any(ml.nlu_classifier(body.current_thread.text).entities, .name == "urgency"),
-
+  
     // known suspicious pattern in the URL path
     any(body.links, regex.match(.href_url.path, '\/[a-z]{3}\d[a-z]')),
-
+  
     // suspicious image that's most likely cred_theft
     any(attachments,
         .file_type in $file_types_images
         and any(file.explode(.),
-                any(ml.nlu_classifier(.scan.ocr.raw).intents, .name == "cred_theft")
-                or any(ml.nlu_classifier(.scan.ocr.raw).entities, .name == "financial")
+                any(ml.nlu_classifier(.scan.ocr.raw).intents,
+                    .name == "cred_theft"
+                )
+                or any(ml.nlu_classifier(.scan.ocr.raw).entities,
+                       .name == "financial"
+                )
         )
     ),
-
+  
     // recipient's SLD is in the sender's display name
-    any(recipients.to, strings.icontains(sender.display_name, .email.domain.sld) and (.email.domain.valid or strings.icontains(.display_name, "undisclosed"))),
+    any(recipients.to,
+        strings.icontains(sender.display_name, .email.domain.sld)
+        and (
+          .email.domain.valid or strings.icontains(.display_name, "undisclosed")
+        )
+    ),
   
     // recipient's email address in the subject
-    any(recipients.to, strings.icontains(subject.subject, .email.email) and (.email.domain.valid or strings.icontains(.display_name, "undisclosed"))),
+    any(recipients.to,
+        strings.icontains(subject.subject, .email.email)
+        and (
+          .email.domain.valid or strings.icontains(.display_name, "undisclosed")
+        )
+    ),
   )
-
   and (
     not profile.by_sender().solicited
     or (
@@ -51,8 +66,8 @@ source: |
       and not profile.by_sender().any_messages_benign
     )
   )
-
-    // negate highly trusted sender domains unless they fail DMARC authentication
+  and not sender.email.domain.root_domain in ("amazon.co.jp")
+  // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (
       sender.email.domain.root_domain in $high_trust_sender_root_domains
@@ -60,6 +75,7 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
+
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description
Adding negation for legitimate Amazon .co.jp domain. 

# Associated samples


[- Sample 1](https://platform.sublime.security/messages/4f78384ae1103700a913157540c25e64211bc38f95340b377d899837b735661a?preview_id=01976ae0-0e74-7da5-aea0-9a31ff9f01ba)
