### PR TITLE
Create fictitious_invoice_using_linkedin_address.yml

### DIFF
--- a/detection-rules/fictitious_invoice_using_linkedin_address.yml
+++ b/detection-rules/fictitious_invoice_using_linkedin_address.yml
@@ -1,0 +1,39 @@
+name: "Attachment: Fictitious invoice using LinkedIn's address"
+description: "Detects PDF attachments created with wkhtmltopdf or Qt that contain LinkedIn's headquarters address (1000 W Maude Ave) in financial communications context, but do not mention LinkedIn itself."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and 0 < length(filter(attachments, .file_type == "pdf")) < 3
+  and any(filter(attachments,
+                 .file_type == "pdf"
+                 // creator and producer of PDF seen in malicious content
+                 and (
+                   strings.starts_with(beta.parse_exif(.).creator, "wkhtmltopdf")
+                   or strings.starts_with(beta.parse_exif(.).producer, "Qt ")
+                 )
+          ),
+          any(filter(file.explode(.), .scan.ocr.raw is not null),
+              // contains LinkedIn HQ address but not from LinkedIn
+              (
+                strings.icontains(.scan.ocr.raw, "1000 W Maude Ave")
+                and any(beta.ml_topic(body.current_thread.text).topics,
+                        .name == "Financial Communications"
+                        and .confidence != "low"
+                )
+                and not strings.icontains(.scan.ocr.raw, "linkedin")
+              ),
+          )
+  )
+
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "PDF"
+  - "Social engineering"
+detection_methods:
+  - "File analysis"
+  - "Optical Character Recognition"
+  - "Natural Language Understanding"
+  - "Content analysis"
+  - "Exif analysis"


### PR DESCRIPTION
# Description
Creating a new rule to look for fictitious invoices that use LinkedIn's HQ address in them as seen in samples below. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/4f531d405fd8e64415ac93300bd74feb4be279d75f796dc4c53402c4a00af39a?preview_id=01988a72-c5e6-7108-a202-14ccf1b6bd0d)
- [Sample 2](https://platform.sublime.security/messages/4f53c485bcd3815bed1d3aa21825b543ef31bbd342de63ce7dd73dae77d60e61?preview_id=019885e0-6378-7aa3-b65b-034feff758f0)
