### PR TITLE
Adding new SFDC-EmailCategory value

### DIFF
--- a/detection-rules/salesforce_infra_abuse.yml
+++ b/detection-rules/salesforce_infra_abuse.yml
@@ -292,7 +292,7 @@ source: |
       and any(headers.hops,
               any(.fields,
                   .name == "X-SFDC-EmailCategory"
-                  and .value in ("apiMassMail", "networksNewUser")
+                  and .value in ("apiMassMail", "networksNewUser", "Not Specified")
               )
       )
     )


### PR DESCRIPTION
# Description

Adding `Not Specified` to the `X-SFDC-EmailCategory` header check.

# Associated samples
- https://platform.sublime.security/messages/4f58c0b9ea0b725efbe2b5c547853318fa17dd289735fdae293ee4ef313361c7?preview_id=0198a3ce-2463-78ec-9e3b-67875f8b634e
