### PR TITLE
New rule: Trello board abuse

### DIFF
--- a/detection-rules/link_multistage_trello.yml
+++ b/detection-rules/link_multistage_trello.yml
@@ -1,0 +1,64 @@
+name: "Link: Multistage landing - Trello board abuse"
+description: "Detects suspicious Trello board links containing malicious indicators such as credential theft content, blocked users, malicious attachments, or boards with minimal content from unsolicited senders."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(filter(body.links,
+                 .href_url.domain.root_domain == "trello.com"
+                 and strings.istarts_with(.href_url.path, "/b/")
+          ),
+          // avoid doing LinkAnalysis if the display-text has strong indications of phishing
+          (
+            // replace confusables - observed ITW
+            regex.icontains(strings.replace_confusables(.display_text),
+                            'review|proposal|document|efax|restore|[o0]pen|secure|messaging|reset|account|verify|login|notification|alert|urgent|immediate|access|support|\bupdate\b|download|attachment|service|payment|remittance|invoice|rfp|rfi|pdf|doc'
+            )
+            and not regex.icontains(strings.replace_confusables(.display_text),
+                                    'customer service'
+            )
+            // add confidence to these strings by using profile.by_sender()
+            and (
+              not profile.by_sender_email().solicited
+              and profile.by_sender_email().prevalence in ('new', 'outlier')
+            )
+          )
+          or any(ml.link_analysis(.).additional_responses,
+                 // less than 4 cards on the Trello board
+                 length(.json['cards']) < 4
+                 or any(.json['cards'],
+                        // suspicious link in a card title
+                        (
+                          strings.parse_url(.['name']).domain.valid
+                          and (
+                            ml.link_analysis(strings.parse_url(.['name'])).credphish.disposition == "phishing"
+                            or ml.link_analysis(strings.parse_url(.['name'])).credphish.contains_captcha
+                            // CF Turnstile
+                            or any(ml.link_analysis(strings.parse_url(.['name'])).unique_urls_accessed,
+                                   .domain.domain == "challenges.cloudflare.com"
+                            )
+                          )
+                        )
+                        // Trello detected a malicious card attachment
+                        or .['badges']['maliciousAttachments'] > 0
+                 )
+                 // Trello has blocked the user account
+                 or any(.json['members'], .['activityBlocked'] == true)
+                 // the user is the sole member of their Trello account and is the admin
+                 or (
+                   length(.json['memberships']) == 1
+                   and all(.json['memberships'], .['orgMemberType'] == "admin")
+                 )
+          )
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Free file host"
+  - "Social engineering"
+detection_methods:
+  - "URL analysis"
+  - "Content analysis"
+  - "Sender analysis"
+  - "URL screenshot"

--- a/detection-rules/link_multistage_trello.yml
+++ b/detection-rules/link_multistage_trello.yml
@@ -62,3 +62,4 @@ detection_methods:
   - "Content analysis"
   - "Sender analysis"
   - "URL screenshot"
+id: "14a5b23a-2432-5c58-a3c4-1f0606977dcc"


### PR DESCRIPTION
# Description

Detects suspicious Trello board links containing malicious indicators such as credential theft content, blocked users, malicious attachments, or boards with minimal content from unsolicited senders.

# Associated samples
- https://platform.sublime.security/messages/4f437d85a89ec56cb75df5ce599187a104ed380559510c0d6dc4a98bce682367?preview_id=019833e3-f1d9-7334-972c-3e9d7eb39dc8
- https://platform.sublime.security/messages/hunt?huntId=0198a9de-a3ac-777e-9ec4-d5a1ccac2bcf