### PR TITLE
Update twitter impersonation to tighten scope

### DIFF
--- a/detection-rules/impersonation_twitter.yml
+++ b/detection-rules/impersonation_twitter.yml
@@ -29,8 +29,9 @@ source: |
           strings.ilike(body.current_thread.text, '*865 FM 1209*bastrop*')
         )
         or (
-          any(ml.logo_detect(beta.message_screenshot()).brands,
-              .name == "X" and .confidence == "high"
+          length(ml.logo_detect(beta.message_screenshot()).brands) == 1
+          and any(ml.logo_detect(beta.message_screenshot()).brands,
+                  .name == "X" and .confidence == "high"
           )
           and (
             any(ml.nlu_classifier(body.current_thread.text).intents,


### PR DESCRIPTION
# Description

From a runner. The idea here is to tighten the scope of one of the "3 of's" to exclude instances where more than one brand is spotted. This will help cut back on FPs caused by social media links in the footer of emails. 

# Associated samples

- Sample 1 [4f58059b90b2f9dcfd6315bf0743778ca74c4bc26098955e2eb29cfb19dfa9bb](https://platform.sublime.security/messages/4f58059b90b2f9dcfd6315bf0743778ca74c4bc26098955e2eb29cfb19dfa9bb?ph-e6489411-a22d-4959-9ecc-30170413281d=0197ccef-504a-7db4-9c7f-e4572e0095a6&preview_id=01989fd5-7848-767a-a896-74cde15f3bda)
