### PR TITLE
Update attachment_eml_suspicious_indicators to expand scope

### DIFF
--- a/detection-rules/attachment_eml_suspicious_indicators.yml
+++ b/detection-rules/attachment_eml_suspicious_indicators.yml
@@ -33,11 +33,11 @@ source: |
     length(body.current_thread.text) < 300
     or body.current_thread.text is null
     or any(ml.nlu_classifier(body.current_thread.text).intents,
+               .name == "cred_theft" and .confidence != "low"
+           )
+    or any(ml.nlu_classifier(body.current_thread.text).intents,
            .name in ("cred_theft", "steal_pii")
     )
-  )
-  and not any(ml.nlu_classifier(body.current_thread.text).intents,
-              .name == "benign" and .confidence == "high"
   )
   and any(attachments,
           (.file_extension == "eml" or .content_type == "message/rfc822")


### PR DESCRIPTION
# Description

From a runner, attempting to expand coverage to include cases where cred theft is confident in a malicious message, instead of flat out negating based on confidence of current thread being benign. I'm also tossing it in an `or` statement to allow it to more fluidly compound the rule, as opposed to make it a binary `and not`

# Associated samples

- Sample 1 [4c1548a88dd8506e4049ff1d7ecc941e9c4aa25f6402a596d9e189a5d69fba7a](https://platform.sublime.security/rules/editor?canonical_id=4c1548a88dd8506e4049ff1d7ecc941e9c4aa25f6402a596d9e189a5d69fba7a&message_id=0197c17d-220e-7c96-a9c8-f8cca5558dbe)
