### PR TITLE
Update attachment_docusign_suspicious_links.yml

### DIFF
--- a/detection-rules/attachment_docusign_suspicious_links.yml
+++ b/detection-rules/attachment_docusign_suspicious_links.yml
@@ -43,7 +43,7 @@ source: |
                    or (
                      regex.icontains(.scan.ocr.raw,
                                      "((re)?view|access|complete(d)?) document(s)?",
-                                     '[^d][^o][^cd][^ue]sign(?:\b|ature)',
+                                     '[^d][^o][^cd][^ue][^\-]sign(?:\b|ature)',
                                      "important edocs",
                                      // German (Document (check|check|sign|sent))
                                      "Dokument (überprüfen|prüfen|unterschreiben|geschickt)",
@@ -142,7 +142,11 @@ source: |
     )
   )
   and not profile.by_sender_email().any_messages_benign
-  
+  // negate resume related messages
+  and not any(ml.nlu_classifier(body.current_thread.text).topics,
+              .name == "Professional and Career Development"
+              and .confidence == "high"
+  )
   // negate docusign 'via' messages
   and not (
     any(headers.hops,
@@ -157,9 +161,10 @@ source: |
   and not any(headers.hops,
               regex.imatch(.received.server.raw, ".+.docusign.(net|com)")
   )
-
+  
   // negate replies to docusign notifications
   and not any(headers.references, strings.iends_with(., '@camail.docusign.net'))
+
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description
Adding negation for resume related messages where DocuSign may be mentioned.

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/72ac42f3b32f7801092242f5062478ba7f63e1051b146765e85cca6be7332bb9?preview_id=01976b9e-26e3-78b5-b7cd-42efb7b0f75d)
