### PR TITLE
Update link_credential_phishing_secure_message.yml

### DIFF
--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -82,7 +82,16 @@ source: |
       )
     )
     and not (
-      any(headers.hops, any(.fields, .name == 'X-ZixNet'))
+      any(headers.hops,
+          any(.fields,
+              .name in (
+                'X-ZixNet',
+                'X-VPM-MIV',
+                'X-VPM-ActionCode',
+                'X-VPM-SmtpTo'
+              )
+          )
+      )
       and any(headers.domains,
               .root_domain in (
                 "zixport.com",


### PR DESCRIPTION
# Description

The previous suggestion of a simple text rule was too broad to be reliable, the sending architecture from ZixGateway rely on a number of `X-Headers` being present. These are as follows:

The previous pr is: https://github.com/sublime-security/sublime-rules/pull/3057

X-Headers used in ZixDirect replies and forwards:

- X-VPM-EncryptionAlgo
- X-VPM-KeyData
- X-VPM-ZixVersion
- X-VPM-KeyRequestHash
- X-VPM-SmtpFrom
- X-VPM-BrandCode
- X-VPM-SmtpTo
- X-VPM-ActionCode
- X-VPM-MIV


The ZixGateway servers and ZixMail clients add several kinds of X-headers to the mail message:

- X-VPM: = marks any message that is sent Gateway-to-Gateway.
- X-VPM-FROM:  = gives the original MAIL-FROM address for an encrypted message.
- X-VPM-RECIPIENTS:  = gives the list of the original recipients in RCPT-TOs for an encrypted message.
- x-smg-security-info: = Provides information about S/MIME encryption, if enabled.
- X-Mailer: ZixMail 1.0 = Identifies the ZixMail client, if used.


I've chosen to add in a small portion of these as a test for the potential addition of the broader number of `X-Headers`


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=0198cd4a-31f1-7104-b818-5df2b2f795fe)

# Screenshot (insights)
<!-- 
**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
-->
