### PR TITLE
Updating SendGrid rule to match on Twilio and expanding base coverage

### DIFF
--- a/detection-rules/brand_impersonation_sendgrid.yml
+++ b/detection-rules/brand_impersonation_sendgrid.yml
@@ -1,11 +1,11 @@
-name: "Brand Impersonation: SendGrid and Twilio"
-description: "Detects inbound messages that impersonate SendGrid or Twilio through display name or domain manipulation, combined with security or authentication-themed content, while failing authentication checks and originating from untrusted sources."
+name: "Brand Impersonation: Twilio/SendGrid"
+description: "Detects inbound messages that impersonate Twilio/SendGrid through display name or domain manipulation, combined with security or authentication-themed content, while failing authentication checks and originating from untrusted sources."
 type: "rule"
 severity: "medium"
 source: |
   type.inbound
   and (
-    // Brand impersonation detection for SendGrid and Twilio
+    // Brand impersonation detection for Twilio/SendGrid
     (
       // SendGrid impersonation patterns
       strings.ilike(strings.replace_confusables(sender.display_name), '*sendgrid*')
@@ -77,10 +77,10 @@ source: |
     )
   )
   
-  // Enhanced authentication verification
+  // message was not sent from Twilio/Sendgrid infrastructure
   and (
     not (
-      // Look for valid SPF or DKIM pass for SendGrid/Twilio in delivery hops
+      // Look for valid SPF or DKIM pass for Twilio/SendGrid in delivery hops
       any(headers.hops,
           // SendGrid authentication checks
           (

--- a/detection-rules/brand_impersonation_sendgrid.yml
+++ b/detection-rules/brand_impersonation_sendgrid.yml
@@ -1,34 +1,44 @@
-name: "Brand Impersonation: SendGrid"
-description: "Detects inbound messages that impersonate SendGrid through display name or domain manipulation, combined with security or authentication-themed content, while failing authentication checks and originating from untrusted sources."
+name: "Brand Impersonation: SendGrid and Twilio"
+description: "Detects inbound messages that impersonate SendGrid or Twilio through display name or domain manipulation, combined with security or authentication-themed content, while failing authentication checks and originating from untrusted sources."
 type: "rule"
 severity: "medium"
 source: |
   type.inbound
   and (
-    // display name contains sendgrid
+    // Brand impersonation detection for SendGrid and Twilio
     (
-      strings.ilike(strings.replace_confusables(sender.display_name),
-                    '*sendgrid*'
-      )
-      // levenshtein distance similar to sendgrid
-      or strings.ilevenshtein(strings.replace_confusables(sender.display_name),
-                              'sendgrid'
-      ) <= 1
-      // no display name, local_part contains sendgrid 
+      // SendGrid impersonation patterns
+      strings.ilike(strings.replace_confusables(sender.display_name), '*sendgrid*')
+      or strings.ilevenshtein(strings.replace_confusables(sender.display_name), 'sendgrid') <= 1
       or (
-        strings.ilike(strings.replace_confusables(sender.email.local_part),
-                      '*sendgrid*'
-        )
+        strings.ilike(strings.replace_confusables(sender.email.local_part), '*sendgrid*')
         and (
           sender.display_name is null
-          or strings.ilike(strings.replace_confusables(subject.subject),
-                           '*sendgrid*'
-          )
+          or strings.ilike(strings.replace_confusables(subject.subject), '*sendgrid*')
         )
+      )
+      or any(ml.logo_detect(beta.message_screenshot()).brands,
+           .name == "SendGrid" and .confidence == "high"
+      )
+    )
+    or (
+      // Twilio impersonation patterns
+      strings.ilike(strings.replace_confusables(sender.display_name), '*twilio*')
+      or strings.ilevenshtein(strings.replace_confusables(sender.display_name), 'twilio') <= 1
+      or (
+        strings.ilike(strings.replace_confusables(sender.email.local_part), '*twilio*')
+        and (
+          sender.display_name is null
+          or strings.ilike(strings.replace_confusables(subject.subject), '*twilio*')
+        )
+      )
+      or any(ml.logo_detect(beta.message_screenshot()).brands,
+           .name == "Twilio" and .confidence == "high"
       )
     )
   )
   and (
+    // Content analysis using ML/NLU
     any(beta.ml_topic(body.current_thread.text).topics,
         .name in (
           "Security and Authentication",
@@ -53,17 +63,50 @@ source: |
     or any(ml.nlu_classifier(beta.ocr(beta.message_screenshot()).text).intents,
            .name == "cred_theft" and .confidence == "high"
     )
-  )
-  
-  // and the sender is not in org_domains or from sendgrid domains and passes auth
-  and not (
-    sender.email.domain.root_domain in $org_domains
+    // Infrastructure analysis for behavioral patterns
     or (
-      sender.email.domain.root_domain in ("sendgrid.com")
-      and headers.auth_summary.dmarc.pass
+      any(body.links,
+        (.href_url.path =~ "/ls/click" or .href_url.path =~ "/wf/open" or strings.contains(.href_url.query_params, "upn="))
+        and .href_url.domain.root_domain not in ("sendgrid.com", "twilio.com", "mailchimp.com", "constantcontact.com")
+      )
+      and (
+        any(body.links, length(.href_url.query_params) > 150)
+        or any(body.links, .display_url.domain.root_domain in ("sendgrid.com", "twilio.com"))
+        or body.current_thread.text =~ "(?i)(update.*billing|declined|api.*issue|misconfigured.*headers)"
+      )
     )
   )
-  // and the sender is not from high trust sender root domains
+  
+  // Enhanced authentication verification
+  and (
+    not (
+      // Look for valid SPF or DKIM pass for SendGrid/Twilio in delivery hops
+      any(headers.hops,
+          // SendGrid authentication checks
+          (
+              strings.ilike(.authentication_results.spf, "*pass*")
+              and strings.ilike(.authentication_results.spf, "*sendgrid.net*")
+          )
+          or (
+              strings.ilike(.authentication_results.dkim, "*pass*")
+              and strings.ilike(.authentication_results.dkim, "*sendgrid.net*")
+          )
+          // Twilio authentication checks
+          or (
+              strings.ilike(.authentication_results.spf, "*pass*")
+              and strings.ilike(.authentication_results.spf, "*twilio.com*")
+          )
+          or (
+              strings.ilike(.authentication_results.dkim, "*pass*")
+              and strings.ilike(.authentication_results.dkim, "*twilio.com*")
+          )
+      )
+      // Envelope sender domain verification
+      or sender.email.domain.domain in ('sendgrid.net', 'sendgrid.com', 'twilio.com')
+    )
+    and sender.email.domain.root_domain not in $org_domains
+  )
+  // Exclude high trust domains with valid auth and solicited senders
   and (
     (
       sender.email.domain.root_domain in $high_trust_sender_root_domains

--- a/detection-rules/brand_impersonation_sendgrid.yml
+++ b/detection-rules/brand_impersonation_sendgrid.yml
@@ -1,4 +1,4 @@
-name: "Brand Impersonation: Twilio/SendGrid"
+name: "Brand Impersonation: SendGrid"
 description: "Detects inbound messages that impersonate Twilio/SendGrid through display name or domain manipulation, combined with security or authentication-themed content, while failing authentication checks and originating from untrusted sources."
 type: "rule"
 severity: "medium"


### PR DESCRIPTION
# Description

Expanding coverage of the SendGrid rule to match on Twilio in the display name. As well as expanding authentication / verifying legitimacy of the senders.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/4f43530855ce535e1edf78dd0a85713efce3a3f40244a0612b4dddcad7475daf?preview_id=019833cd-8247-785b-9c20-5f4d4c7166dc)

## Associated hunts

- Hunt 1

