### PR TITLE
Update file_sharing_link_from_suspicious_sender_domain.yml

### DIFF
--- a/detection-rules/file_sharing_link_from_suspicious_sender_domain.yml
+++ b/detection-rules/file_sharing_link_from_suspicious_sender_domain.yml
@@ -16,6 +16,7 @@ source: |
           )
   )
   and sender.email.domain.tld in $suspicious_tlds
+  and not sender.email.domain.root_domain in ("notion.so")
   and (
     not profile.by_sender().solicited
     or (

--- a/detection-rules/file_sharing_link_from_suspicious_sender_domain.yml
+++ b/detection-rules/file_sharing_link_from_suspicious_sender_domain.yml
@@ -16,7 +16,7 @@ source: |
           )
   )
   and sender.email.domain.tld in $suspicious_tlds
-  and not sender.email.domain.root_domain in ("notion.so")
+  and not sender.email.domain.root_domain in ("notion.so", "cribl.cloud")
   and (
     not profile.by_sender().solicited
     or (


### PR DESCRIPTION
# Description
Negating Notion and Cribl root domains to resolve FPs.

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/4f6689af04f428056b8c3403fc646d1310c95caf43957fcd9e0baf9b04345cda?preview_id=0198e5a2-e4b8-7621-905d-80d37ba7d7ac)
- [Sample 2](https://platform.sublime.security/messages/4f6529044b28ba70f6016521175ba257225207361aec14598c14fe77d7f00330?preview_id=0198e439-032b-731c-84b1-d6c72ab3d2c7)
- [Sample 3](https://platform.sublime.security/messages/4f520324d08e5109e9591be17edd3a9502f4b6f2e71220a3608a308b0afecd41?preview_id=0198a040-7b8a-7d91-b603-52fa3ace584b)
- [Sample 4](https://platform.sublime.security/messages/4f60f5ae6117bdfa3378d3252c350c409623ff9d5ab700512f0222ae503f3766?preview_id=0198d33f-166a-7343-b04d-c0ff842e6d01)
