### PR TITLE
Update impersonation_recipient_domain_display_name.yml

### DIFF
--- a/detection-rules/impersonation_recipient_domain_display_name.yml
+++ b/detection-rules/impersonation_recipient_domain_display_name.yml
@@ -46,9 +46,9 @@ source: |
     strings.contains(sender.display_name, "on behalf of")
     and sender.email.domain.root_domain == "microsoftonline.com"
   )
-  // negate pageproof updates
+  // negate pageproof updates and visit notifications
   and not (
-      sender.email.email == 'team@pageproof.com'
+      sender.email.email in ("team@pageproof.com", "noreply@visitly.io")
   )
   and all(recipients.to,
           .email.email != sender.email.email


### PR DESCRIPTION
# Description
Negating legitimate domain for visit notification addressed to users.

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/9561a0a1cd609ab8ea3326532f1a9594ada7a34fc714c3b76e4f2cd790ffd540?preview_id=01973257-5ac2-745a-86f2-fa972543ffc8)
- [Sample 2](https://platform.sublime.security/messages/69e96c922ac5dbb020f7375122c1e6a5e43ea5dce793725eaf0d2805240da6a1?preview_id=01973257-5aa1-7613-b9de-70c68adfad4a)

