### PR TITLE
Update impersonation_quickbooks.yml

### DIFF
--- a/detection-rules/impersonation_quickbooks.yml
+++ b/detection-rules/impersonation_quickbooks.yml
@@ -8,7 +8,7 @@ source: |
     (
       strings.ilike(sender.display_name, 'quickbook*')
       or strings.ilevenshtein(sender.display_name, 'quickbooks') <= 1
-      or strings.ilike(sender.email.domain.domain, '*quickbooks*')
+      or strings.ilike(sender.email.domain.domain, '*quickbook*')
     )
     or strings.ilike(body.current_thread.text, "*invoice*")
   )


### PR DESCRIPTION
# Description
Expanding scope of sender display name to account for non plural use in malicious messages.

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/4f68c0391c8864475e5da0c15fccc3725441d6bf6228845d4d6848c6dae7a68a?preview_id=0198f0e3-f5f3-707a-9896-662d8e767df3)

