### PR TITLE
Insight: Remove common schema domains from Links with low reputation in attachments

### DIFF
--- a/insights/attachments/links_low_reputation.yml
+++ b/insights/attachments/links_low_reputation.yml
@@ -6,7 +6,7 @@ source: |
         map(file.explode(.),
             distinct(map(filter(.scan.url.urls, .domain.root_domain not in $tranco_1m
             and .domain.root_domain not in $org_domains
-            and .domain.root_domain != "sublimesecurity.com"), .url), .)
+            and .domain.root_domain not in ("sublimesecurity.com", "openxmlformats.org"), .url), .)
         )
     ),
     length(.) > 0

--- a/insights/attachments/links_low_reputation.yml
+++ b/insights/attachments/links_low_reputation.yml
@@ -24,5 +24,5 @@ source: |
            )
        ),
        length(.) > 0
-)
+  )
 severity: "low"

--- a/insights/attachments/links_low_reputation.yml
+++ b/insights/attachments/links_low_reputation.yml
@@ -15,7 +15,8 @@ source: |
                                      "schemas.microsoft.com",
                                      "purl.org",
                                      "www.w3.org",
-                                     "purl.oclc.org"
+                                     "purl.oclc.org",
+                                     "schemas.apple.com"
                                    )
                             ),
                             .url

--- a/insights/attachments/links_low_reputation.yml
+++ b/insights/attachments/links_low_reputation.yml
@@ -1,14 +1,49 @@
 name: "Links with low reputation in attachments"
 type: "query"
 source: |
-  filter(
-    map(attachments,
-        map(file.explode(.),
-            distinct(map(filter(.scan.url.urls, .domain.root_domain not in $tranco_1m
-            and .domain.root_domain not in $org_domains
-            and .domain.root_domain not in ("sublimesecurity.com", "openxmlformats.org"), .url), .)
-        )
-    ),
-    length(.) > 0
-  )
+  filter(map(attachments,
+           map(file.explode(.),
+               distinct(map(filter(.scan.url.urls,
+                                   .domain.root_domain not in $tranco_1m
+                                   and .domain.root_domain not in $org_domains
+                                   and .domain.root_domain not in (
+                                     "sublimesecurity.com"
+                                   )
+                                   and .domain.domain not in~ (
+                                     "schemas.openxmlformats.org",
+                                     "schemas.microsoft.com",
+                                     "purl.org",
+                                     "www.w3.org",
+                                     "purl.oclc.org"
+                                   )
+                            ),
+                            .url
+                        ),
+                        .
+               )
+           )
+       ),
+       length(.) > 0
+)
 severity: "low"
+
+
+filter(map(attachments,
+           map(file.explode(.),
+               distinct(map(filter(.scan.url.urls,
+                                   .domain.domain not in~ (
+                                     "schemas.openxmlformats.org",
+                                     "schemas.microsoft.com",
+                                     "purl.org",
+                                     "www.w3.org",
+                                     "purl.oclc.org"
+                                   )
+                            ),
+                            .url
+                        ),
+                        .
+               )
+           )
+       ),
+       length(.) > 0
+  )

--- a/insights/attachments/links_low_reputation.yml
+++ b/insights/attachments/links_low_reputation.yml
@@ -8,6 +8,7 @@ source: |
                                    and .domain.root_domain not in $org_domains
                                    and .domain.root_domain not in (
                                      "sublimesecurity.com"
+                                     "wps.cn"
                                    )
                                    and .domain.domain not in~ (
                                      "schemas.openxmlformats.org",

--- a/insights/attachments/links_low_reputation.yml
+++ b/insights/attachments/links_low_reputation.yml
@@ -7,7 +7,7 @@ source: |
                                    .domain.root_domain not in $tranco_1m
                                    and .domain.root_domain not in $org_domains
                                    and .domain.root_domain not in (
-                                     "sublimesecurity.com"
+                                     "sublimesecurity.com",
                                      "wps.cn"
                                    )
                                    and .domain.domain not in~ (

--- a/insights/attachments/links_low_reputation.yml
+++ b/insights/attachments/links_low_reputation.yml
@@ -26,24 +26,3 @@ source: |
        length(.) > 0
 )
 severity: "low"
-
-
-filter(map(attachments,
-           map(file.explode(.),
-               distinct(map(filter(.scan.url.urls,
-                                   .domain.domain not in~ (
-                                     "schemas.openxmlformats.org",
-                                     "schemas.microsoft.com",
-                                     "purl.org",
-                                     "www.w3.org",
-                                     "purl.oclc.org"
-                                   )
-                            ),
-                            .url
-                        ),
-                        .
-               )
-           )
-       ),
-       length(.) > 0
-  )


### PR DESCRIPTION
# Description

This PR removes common schema domains from attachments which have common doc attachments. These schema urls are common and can be filtered out within this insight. Please see screenshots below showing it working as expected.

Removing the following `root_domains`:

* "wps.cn"

Removing the following `domain`s:

*  "schemas.openxmlformats.org"
* "schemas.microsoft.com"
* "purl.org"
* "www.w3.org"
* "purl.oclc.org"
* "schemas.apple.com"

# Screenshot (insights)

<img width="1446" height="889" alt="484623769-7cfc3235-dfb1-42fd-9517-a69c43684b1e" src="https://github.com/user-attachments/assets/a0b70572-94d6-4ee5-8c98-a181c459139b" />

<img width="1458" height="882" alt="484623812-4c9124df-cb7c-484e-a71c-a8875b6bc5e9" src="https://github.com/user-attachments/assets/db357354-04e2-4b96-b116-d02876247ecc" />


