### PR TITLE
Update link_display_text_matches_subject.yml

### DIFF
--- a/detection-rules/link_display_text_matches_subject.yml
+++ b/detection-rules/link_display_text_matches_subject.yml
@@ -74,6 +74,7 @@ source: |
            .name == "cred_theft"
     )
   )
+  
   // the display text of a link is the subject
   and subject.subject in map(body.links, .display_text)
   

--- a/detection-rules/link_display_text_matches_subject.yml
+++ b/detection-rules/link_display_text_matches_subject.yml
@@ -68,7 +68,6 @@ source: |
         or ml.link_analysis(.).final_dom.display_text == "Verify you are human"
         or .href_url.domain.domain in $self_service_creation_platform_domains
         or .href_url.domain.domain in $url_shorteners
-        or .href_url.domain.domain in $free_file_hosts
     )
     // or the body is cred_theft
     or any(ml.nlu_classifier(body.current_thread.text).intents,

--- a/detection-rules/link_display_text_matches_subject.yml
+++ b/detection-rules/link_display_text_matches_subject.yml
@@ -66,15 +66,15 @@ source: |
         // when visited is phishing
         ml.link_analysis(.).credphish.disposition == "phishing"
         or ml.link_analysis(.).final_dom.display_text == "Verify you are human"
+        or .href_url.domain.domain in $self_service_creation_platform_domains
+        or .href_url.domain.domain in $url_shorteners
+        or .href_url.domain.domain in $free_file_hosts
     )
     // or the body is cred_theft
     or any(ml.nlu_classifier(body.current_thread.text).intents,
            .name == "cred_theft"
     )
-    // or sender address same as recipient address
-    or any(recipients.to, .email.email =~ sender.email.email)
   )
-  
   // the display text of a link is the subject
   and subject.subject in map(body.links, .display_text)
   

--- a/detection-rules/link_display_text_matches_subject.yml
+++ b/detection-rules/link_display_text_matches_subject.yml
@@ -71,6 +71,8 @@ source: |
     or any(ml.nlu_classifier(body.current_thread.text).intents,
            .name == "cred_theft"
     )
+    // or sender address same as recipient address
+    or any(recipients.to, .email.email =~ sender.email.email)
   )
   
   // the display text of a link is the subject


### PR DESCRIPTION
# Description

adding failsafe to flag messages with links leading to self service creation platforms, free file hosting services, and url shorterners

# Associated samples
- Original sample was not shared through the platform (it was provided to us as a raw .EML)

Other samples w/ sender and recipient address match that fire on existing logic:
- https://platform.sublime.security/messages/4f5eb715832625f0a35390c496434347d704dc927a85bb080d45d16f90f4caa7
- https://platform.sublime.security/messages/4f5fa0d1478ac05af49372e728a508e968dae4be4919a015af19ec0d575386a6

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=0198f457-a98a-754f-ae9c-435cc42e5fbe