### PR TITLE
Update attachment_qr_code_suspicious_components.yml

### DIFF
--- a/detection-rules/attachment_qr_code_suspicious_components.yml
+++ b/detection-rules/attachment_qr_code_suspicious_components.yml
@@ -28,8 +28,9 @@ source: |
                  )
           ) > 3
         )
+        // the attachment name contains the SLD of a recipient
         or any(filter(attachments, .file_extension in ('pdf', 'docx')),
-               any(recipients.to,
+               any(filter(recipients.to, .email.domain.valid),
                    strings.icontains(..file_name, .email.domain.sld)
                )
         )
@@ -89,8 +90,9 @@ source: |
                                      )
                                  )
                       )
+                      // the QR code contains the email address of a recipient
                       or (
-                        any(recipients.to,
+                        any(filter(recipients.to, .email.domain.valid),
                             strings.icontains(..scan.qr.url.url, .email.email)
                         )
                       )
@@ -120,8 +122,10 @@ source: |
                     and strings.starts_with(.scan.qr.url.query_params,
                                             "type=dataset&url=http"
                     )
+                    // the QR code contains the email address of a recipient
+                    // allowing for base64 encoded variants
                     or (
-                      any(recipients.to,
+                      any(filter(recipients.to, .email.domain.valid),
                           strings.icontains(..scan.qr.url.url, .email.email)
                           or any(beta.scan_base64(..scan.qr.url.url,
                                                   ignore_padding=true


### PR DESCRIPTION
Re-opened from #3011 -
# Description

In situations where an email contains an attachment with a QR code, but the recipients.to is only "undisclosed-recipients" the sections like

```
any(recipients.to,
    strings.icontains(..scan.qr.url.url, .email.email)
)
```

always evaluate to true. I tried setting the filter for where email isn't null, but that seemed to not work either, so I went with where length of email.email > 0.

After this change, the false positive that I have with "undisclosed-recipients" and a benign URL bearing QR code in an attachment is no longer flagged by this message.

# Associated samples

The Sublime team may find a sample I shared in the platform with the comment `PR - Attachment: QR code with credential phishing indicators`

