### PR TITLE
Insight: Updating Links in Attachments to remove schema urls from common attachments

### DIFF
--- a/insights/attachments/links.yml
+++ b/insights/attachments/links.yml
@@ -1,12 +1,23 @@
 name: "Links in attachments"
 type: "query"
 source: |
-  filter(
-    map(attachments,
-        map(file.explode(.),
-            distinct(map(.scan.url.urls, .url), .)
-        )
-    ),
-    length(.) > 0
-  )
+  filter(map(attachments,
+           map(file.explode(.),
+               distinct(map(filter(.scan.url.urls,
+                                   .domain.root_domain not in~ (
+                                     "schemas.openxmlformats.org",
+                                     "schemas.microsoft.com",
+                                     "purl.org",
+                                     "www.w3.org",
+                                     "purl.oclc.org"
+                                   )
+                            ),
+                            .url
+                        ),
+                        .
+               )
+           )
+       ),
+       length(.) > 0
+)
 severity: "informational"


### PR DESCRIPTION
# Description

It has been requested to remove schema URLs from common attachment types. These are mostly focused on Microsoft docs but other variations are included as well.

* purl.org - Sometimes used for Dublin Core metadata namespaces
* www.w3.org- For standard XML, XHTML, or MathML content
* purl.oclc.org - Alternative location for Dublin Core elements
* schemas.openxmlformats.org subdomains or variations

# Associated samples


- Sample 1
- Sample 2

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- Hunt 1

# Screenshot (insights)
<!-- 
**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
-->
