### PR TITLE
Create impersonation_box_file_share.yml

### DIFF
--- a/detection-rules/impersonation_box_file_share.yml
+++ b/detection-rules/impersonation_box_file_share.yml
@@ -35,6 +35,13 @@ source: |
   )
   // not a forward or reply
   and (headers.in_reply_to is null or length(headers.references) == 0)
+  // negation for messages traversing box.com
+  // happens with custom sender domains
+  and not (
+    any(headers.domains, .root_domain == "box.com")
+    and headers.auth_summary.spf.pass
+    and headers.auth_summary.dmarc.pass
+  )
 
 attack_types:
   - "Credential Phishing"


### PR DESCRIPTION
# Description
Detects messages impersonating Box file sharing service by identifying Box logos, collaboration-related language, or Box company address information from senders not associated with the legitimate box.com domain.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/4f65fa368cdb5b0506540610ba409c2ca8b8d54fde2330d71a1965aaf5d1eaf8)
- [Sample 2](https://platform.sublime.security/messages/4f62ce363b3cf12dbb771c1f02c75a96fbdab61391885288e446b7efcf755097)

## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01994dec-ddcf-7bad-b0e9-515802e460ea)
