### PR TITLE
Insight: Filtering out common schema domains in Domains in Attachments

### DIFF
--- a/insights/attachments/links_domains.yml
+++ b/insights/attachments/links_domains.yml
@@ -4,7 +4,6 @@ source: |
   filter(map(attachments,
            map(file.explode(.),
                distinct(map(filter(.scan.url.urls,
-                                   .domain.root_domain not in $tranco_1m
                                    and .domain.root_domain not in $org_domains
                                    and .domain.root_domain not in (
                                      "sublimesecurity.com",

--- a/insights/attachments/links_domains.yml
+++ b/insights/attachments/links_domains.yml
@@ -1,12 +1,25 @@
 name: "Domains in attachments"
 type: "query"
 source: |
-  filter(
-    map(attachments,
-        map(file.explode(.),
-            distinct(map(.scan.url.urls, .domain.domain), .)
-        )
-    ),
-    length(.) > 0
+  filter(map(attachments,
+           map(file.explode(.),
+               distinct(map(filter(.scan.url.urls,
+                                   .domain.domain not in~ (
+                                     "schemas.openxmlformats.org",
+                                     "schemas.microsoft.com",
+                                     "purl.org",
+                                     "www.w3.org",
+                                     "purl.oclc.org",
+                                     "schemas.apple.com"
+                                   )
+                                   or .domain.root_domain not in~ ("wps.cn")
+                            ),
+                            .url
+                        ),
+                        .
+               )
+           )
+       ),
+       length(.) > 0
   )
 severity: "informational"

--- a/insights/attachments/links_domains.yml
+++ b/insights/attachments/links_domains.yml
@@ -4,7 +4,7 @@ source: |
   filter(map(attachments,
            map(file.explode(.),
                distinct(map(filter(.scan.url.urls,
-                                   and .domain.root_domain not in $org_domains
+                                   .domain.root_domain not in $org_domains
                                    and .domain.root_domain not in (
                                      "sublimesecurity.com",
                                      "wps.cn"

--- a/insights/attachments/links_domains.yml
+++ b/insights/attachments/links_domains.yml
@@ -4,7 +4,13 @@ source: |
   filter(map(attachments,
            map(file.explode(.),
                distinct(map(filter(.scan.url.urls,
-                                   .domain.domain not in~ (
+                                   .domain.root_domain not in $tranco_1m
+                                   and .domain.root_domain not in $org_domains
+                                   and .domain.root_domain not in (
+                                     "sublimesecurity.com",
+                                     "wps.cn"
+                                   )
+                                   and .domain.domain not in~ (
                                      "schemas.openxmlformats.org",
                                      "schemas.microsoft.com",
                                      "purl.org",
@@ -12,7 +18,6 @@ source: |
                                      "purl.oclc.org",
                                      "schemas.apple.com"
                                    )
-                                   or .domain.root_domain not in~ ("wps.cn")
                             ),
                             .url
                         ),


### PR DESCRIPTION
# Description

This PR is related to #3151 and #3158. It is removing schema URls/domains from these insights to reduce cognitive overload.

Removing the following root_domains:
* "wps.cn"

Removing the following domains:

* "schemas.openxmlformats.org"
* "schemas.microsoft.com"
* "purl.org"
* "www.w3.org"
* "purl.oclc.org"
* "schemas.apple.com"


# Screenshot (insights)

<img width="1434" height="884" alt="484685984-b6537035-6b27-450e-9f18-369bd41b8ff1" src="https://github.com/user-attachments/assets/935f5eb3-97c8-4f5f-aefa-ad07e3a516eb" />
<img width="1441" height="861" alt="484685988-14ec4f5e-4f95-482b-9dd4-83b5ea3e35a4" src="https://github.com/user-attachments/assets/3d9f6184-f0b6-4099-aa48-fbda86a926d9" />
<img width="1444" height="854" alt="484685989-2cf97a81-c90a-4650-8f3e-21f233ca57e2" src="https://github.com/user-attachments/assets/43988717-bf74-459c-a9e3-db48cb683aea" />



