### PR TITLE
Adding additional domains and logic

### DIFF
--- a/detection-rules/salesforce_infra_abuse.yml
+++ b/detection-rules/salesforce_infra_abuse.yml
@@ -15,7 +15,7 @@ source: |
                     and .href_url.domain.root_domain not in (
                       "salesforce.com",
                       "force.com",
-                      "site.com", // salesforce CRM 
+                      "site.com", // salesforce CRM
                       "agentforce.com"
                     )
              )

--- a/detection-rules/salesforce_infra_abuse.yml
+++ b/detection-rules/salesforce_infra_abuse.yml
@@ -9,19 +9,23 @@ source: |
   // we've seen, the From is a custom domain
   and headers.return_path.domain.root_domain == "salesforce.com"
   and length(attachments) == 0
-  // theare are external links (not org or SF domains)
+  // there are external links (not org or SF domains)
   and length(filter(body.links,
                     .href_url.domain.domain not in $org_domains
                     and .href_url.domain.root_domain not in (
                       "salesforce.com",
                       "force.com",
-                      "site.com" // salesforce CRM 
+                      "site.com", // salesforce CRM 
+                      "agentforce.com"
                     )
              )
   ) > 0
   and (
-    any(ml.nlu_classifier(body.current_thread.text).intents,
-        .name == "cred_theft" and .confidence == "high"
+    (
+      any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "cred_theft" and .confidence == "high"
+      )
+      and ml.nlu_classifier(body.current_thread.text).language == "english"
     )
     // subject match when cred_theft doesn't match
     // high confidence observed subject intros in the format of "Urgent Thing: ..."
@@ -29,17 +33,20 @@ source: |
                        '^(?:(?:Final|Last)?\s*Warning|(?:Final|Last|Legal|Critical|Content Violation)?\s*(?:Alert|Noti(?:ce|fication))|Appeal Required|Time.Sensitive|Critical.Alert|Important|Copyright Issue)\s*:\s*'
     )
     or any(ml.logo_detect(beta.message_screenshot()).brands,
-           .name in ("Facebook", "Meta", "Instagram", "Threads") and .confidence in ("medium", "high")
+           .name in ("Facebook", "Meta", "Instagram", "Threads")
+           and .confidence in ("medium", "high")
     )
     // any of the links are for newly registered domains
     or any(filter(body.links,
-                      .href_url.domain.domain not in $org_domains
-                      and .href_url.domain.root_domain not in (
-                        "salesforce.com",
-                        "force.com",
-                        "site.com" // salesforce CRM 
-                      )
-               ), network.whois(.href_url.domain).days_old < 30
+                  .href_url.domain.domain not in $org_domains
+                  and .href_url.domain.root_domain not in (
+                    "salesforce.com",
+                    "force.com",
+                    "site.com", // salesforce CRM
+                    "agentforce.com"
+                  )
+           ),
+           network.whois(.href_url.domain).days_old < 30
     )
   )
   and 1 of (
@@ -51,7 +58,8 @@ source: |
                 and .href_url.domain.root_domain not in (
                   "salesforce.com",
                   "force.com",
-                  "site.com"
+                  "site.com",
+                  "agentforce.com"
                 )
               )
               or .href_url.domain.root_domain is null
@@ -72,7 +80,7 @@ source: |
                 )
                 // cloudflare turnstile or phishing warning page
                 or strings.icontains(ml.link_analysis(., mode="aggressive").final_dom.display_text,
-                                "cloudflare"
+                                     "cloudflare"
                 )
         )
     ),
@@ -292,8 +300,21 @@ source: |
       and any(headers.hops,
               any(.fields,
                   .name == "X-SFDC-EmailCategory"
-                  and .value in ("apiMassMail", "networksNewUser", "Not Specified")
+                  and .value in (
+                    "apiMassMail",
+                    "networksNewUser",
+                    "Not Specified"
+                  )
               )
+      )
+      // negate "meta" emails from the mentioned org itself
+      // for example, subject: "a sandbox has been deleted for org ID, a1b2c3"
+      // the org ID will appear in the X-SFDC-LK header
+      and not any(headers.hops,
+                  any(.fields,
+                      .name == "X-SFDC-LK"
+                      and strings.ends_with(subject.subject, .value)
+                  )
       )
     )
     or (


### PR DESCRIPTION
# Description

This pull request updates the `salesforce_infra_abuse.yml` detection rule to improve its accuracy and coverage for identifying suspicious emails targeting Salesforce infrastructure. The main changes focus on expanding the detection logic to include additional domains, refining intent and language checks, and excluding false positives from internal Salesforce notifications.

**Detection logic improvements:**

* Added `agentforce.com` to the list of Salesforce-related domains to be excluded from external link and newly registered domain checks, reducing false positives for legitimate Salesforce links. [[1]](diffhunk://#diff-bc38b76bef59613a9984f865db78b90c8cee0dfaec8fe96af87fa81e6415dbf7L12-R49) [[2]](diffhunk://#diff-bc38b76bef59613a9984f865db78b90c8cee0dfaec8fe96af87fa81e6415dbf7L54-R62)
* Improved intent detection by explicitly checking that the message is in English, increasing precision for credential theft scenarios.

**False positive reduction:**

* Enhanced logic to exclude emails originating from Salesforce itself by checking the `X-SFDC-LK` header and ensuring the subject does not end with the org ID, which helps avoid flagging legitimate internal notifications.

# Associated samples
- https://platform.sublime.security/messages/4f69749d97464b40a48db14ee916138db4ab724e96d88818dfd9f84889ce1087?preview_id=01990c1c-0543-7333-ba38-d787aff7f485
- https://platform.sublime.security/messages/4f694a5e307d37ad7b3b497d3bdc17fc77de2f362393b8b8d5b60e351c60831a?preview_id=01990c1c-b272-76f1-8e0b-a43f98e57c7f
- https://platform.sublime.security/messages/4f64a5a10e8159409f721f2e81f7618ca83b8d2580c4cfa27764eda6eeb185e6?preview_id=01990c7f-5661-7c48-b1b6-517032a51d19
