### PR TITLE
rename beta.expand_archives to file.expand_archives

### DIFF
--- a/detection-rules/attachment_base64_encoded_bash_command_in_filename.yml
+++ b/detection-rules/attachment_base64_encoded_bash_command_in_filename.yml
@@ -12,7 +12,7 @@ source: |
             .file_type in $file_extensions_common_archives
             or strings.contains(.file_name, "{")
           )
-          and any(beta.expand_archives(.).files,
+          and any(file.expand_archives(.).files,
                   strings.contains(.file_name, "{")
                   and (
                     strings.icontains(.file_name, 'echo,')


### PR DESCRIPTION
# Description

Renaming use of `beta.expand_archives` to `file.expand_archives` for GA.  There is no functional difference
