### PR TITLE
Update attachment_callback_phish_via_text_file.yml

### DIFF
--- a/detection-rules/attachment_callback_phish_via_text_file.yml
+++ b/detection-rules/attachment_callback_phish_via_text_file.yml
@@ -21,28 +21,45 @@ source: |
   and (body.current_thread.text is null or length(body.current_thread.text) < 50)
   and 0 < length(attachments) < 4
   and any(attachments,
-          (.content_type == "text/plain" or .file_type in ("doc", "docx"))
+          (
+            .content_type == "text/plain"
+            or .file_type in ("doc", "docx", "xls", "xlsx")
+          )
           and any(file.explode(.),
                   (.depth == 0 or .flavors.mime == "text/plain")
-                  and any(.scan.strings.strings,
-                          strings.ilike(.,
-                                        "*mcafee*",
-                                        "*norton*",
-                                        "*geek squad*",
-                                        "*paypal*",
-                                        "*ebay*",
-                                        "*symantec*",
-                                        "*best buy*",
-                                        "*lifelock*",
-                                        "*geek total*"
-                          )
-                          and any(..scan.strings.strings,
-                                  regex.icontains(.,
-                                                  '\b\+?(\d{1}.)?\(?\d{3}?\)?.~?.?\d{3}.?~?.\d{4}\b',
-                                                  '\+?([ilo0-9]{1}.)?\(?[ilo0-9]{3}?\)?.[ilo0-9]{3}.?[ilo0-9]{4}',
-                                                  '\+?([ilo0-9]{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}[ilo0-9]{3}[\s\.\-⋅]{0,5}[ilo0-9]{4}'
-                                  )
-                          )
+                  // 4 of the following strings are found        
+                  and 4 of (
+                    // this section is synced with attachment_callback_phish_with_pdf.yml and body_callback_phishing_no_attachment.yml
+                    strings.icontains(.scan.strings.raw, "purchase"),
+                    strings.icontains(.scan.strings.raw, "payment"),
+                    strings.icontains(.scan.strings.raw, "transaction"),
+                    strings.icontains(.scan.strings.raw, "subscription"),
+                    strings.icontains(.scan.strings.raw, "antivirus"),
+                    strings.icontains(.scan.strings.raw, "order"),
+                    strings.icontains(.scan.strings.raw, "support"),
+                    strings.icontains(.scan.strings.raw, "help line"),
+                    strings.icontains(.scan.strings.raw, "receipt"),
+                    strings.icontains(.scan.strings.raw, "invoice"),
+                    strings.icontains(.scan.strings.raw, "call"),
+                    strings.icontains(.scan.strings.raw, "helpdesk"),
+                    strings.icontains(.scan.strings.raw, "cancel"),
+                    strings.icontains(.scan.strings.raw, "renew"),
+                    strings.icontains(.scan.strings.raw, "refund"),
+                    regex.icontains(.scan.strings.raw, "(?:reach|contact) us at"),
+                    strings.icontains(.scan.strings.raw, "+1"),
+                    strings.icontains(.scan.strings.raw, "amount"),
+                    strings.icontains(.scan.strings.raw, "charged"),
+                    strings.icontains(.scan.strings.raw, "crypto"),
+                    strings.icontains(.scan.strings.raw, "wallet address"),
+                    regex.icontains(.scan.strings.raw, '\$\d{3}\.\d{2}\b'),
+                    regex.icontains(.scan.strings.raw,
+                                    '\+?([ilo0-9]{1}.)?\(?[ilo0-9]{3}?\)?.[ilo0-9]{3}.?[ilo0-9]{4}',
+                                    '\+?([ilo0-9]{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}[ilo0-9]{3}[\s\.\-⋅]{0,5}[ilo0-9]{4}'
+                    ),
+                  )
+                  // this section is synced with attachment_callback_phish_with_pdf.yml and body_callback_phishing_no_attachment.yml
+                  and regex.icontains(.scan.strings.raw,
+                                      '(p.{0,3}a.{0,3}y.{0,3}p.{0,3}a.{0,3}l|ma?c.?fee|n[o0]rt[o0]n|geek.{0,5}squad|ebay|symantec|best buy|lifel[o0]c|secure anywhere|starz|utilities premium|pc security|at&t)'
                   )
           )
   )


### PR DESCRIPTION
# Description

1. allow XLSX and XLS documents
2. sync up callback detection logic to [match other rules](https://github.com/search?q=repo%3Asublime-security%2Fsublime-rules%20strings.icontains(.scan.ocr.raw%2C+%22support%22)%2C&type=code)

# Associated samples
was provided confidently 

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

No new exclusive matches as a result of this change, but did match
-[ Hunt 1](https://platform.sublime.security/messages/hunt?huntId=0199130a-72b8-700c-95b0-46dac1d64f27)
