### PR TITLE
Insight: Ignoring root domain dublincore.org

### DIFF
--- a/insights/attachments/links.yml
+++ b/insights/attachments/links.yml
@@ -12,7 +12,7 @@ source: |
                                      "purl.oclc.org",
                                      "schemas.apple.com"
                                    )
-                                   and .domain.root_domain not in~ ("wps.cn")
+                                   and .domain.root_domain not in~ ("wps.cn", "dublincore.org")
                             ),
                             .url
                         ),

--- a/insights/attachments/links_domains.yml
+++ b/insights/attachments/links_domains.yml
@@ -7,7 +7,8 @@ source: |
                                    .domain.root_domain not in $org_domains
                                    and .domain.root_domain not in (
                                      "sublimesecurity.com",
-                                     "wps.cn"
+                                     "wps.cn",
+                                     "dublincore.org"
                                    )
                                    and .domain.domain not in~ (
                                      "schemas.openxmlformats.org",

--- a/insights/attachments/links_low_reputation.yml
+++ b/insights/attachments/links_low_reputation.yml
@@ -8,7 +8,8 @@ source: |
                                    and .domain.root_domain not in $org_domains
                                    and .domain.root_domain not in (
                                      "sublimesecurity.com",
-                                     "wps.cn"
+                                     "wps.cn",
+                                     "dublincore.org"
                                    )
                                    and .domain.domain not in~ (
                                      "schemas.openxmlformats.org",


### PR DESCRIPTION
# Description

This PR updates 3 insights to ignore the root_domain `dublincore.org` for hosting schema files used by docs/files.


# Screenshot (insights)

Before insight changes

<img width="1454" height="888" alt="Screenshot 2025-09-04 at 8 50 16 AM" src="https://github.com/user-attachments/assets/932e233a-6c9a-463c-9fec-756ebb3cb288" />
<img width="1449" height="899" alt="Screenshot 2025-09-04 at 8 50 27 AM" src="https://github.com/user-attachments/assets/2bf7ae7b-c2c6-462b-8292-6bab2a85db0b" />

After changes to insight
<img width="1442" height="880" alt="Screenshot 2025-09-04 at 8 53 35 AM" src="https://github.com/user-attachments/assets/26954666-5105-45a5-8ade-90136b324d24" />
<img width="1454" height="888" alt="Screenshot 2025-09-04 at 8 53 50 AM" src="https://github.com/user-attachments/assets/1f676ae5-c8fb-4802-968d-0e50a1020a54" />
