### PR TITLE
Update qr_code_suspicious_indicators.yml

### DIFF
--- a/detection-rules/qr_code_suspicious_indicators.yml
+++ b/detection-rules/qr_code_suspicious_indicators.yml
@@ -388,13 +388,11 @@ source: |
   )
   and not profile.by_sender_email().any_messages_benign
   // negate highly trusted sender domains unless they fail DMARC authentication
-  and (
-    (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and not headers.auth_summary.dmarc.pass
-    )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
+
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description
Adjusted the high trust sender negation to account for DMARC being null to resolve missed sample.

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/4f6edd13bff95a3e864e7ae8b0441641f21c84703d3df195e85140713c5764cb?preview_id=0199114e-325d-7b70-900f-d85bbf87d731)

