### PR TITLE
Add auto-tagging for external contributor PRs

### DIFF
--- a/.github/workflows/pr-auto-tag.yml
+++ b/.github/workflows/pr-auto-tag.yml
@@ -14,54 +14,26 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const username = context.payload.pull_request.user.login;
-            console.log(`Checking permissions for user: ${username}`);
+            const pr = context.payload.pull_request;
+            const username = pr.user.login;
+            const authorAssociation = pr.author_association;
             
-            let isInternal = false;
+            console.log(`PR author: ${username}`);
+            console.log(`Author association: ${authorAssociation}`);
             
-            // Check if user is a collaborator on the repository
-            try {
-              const { data: collab } = await github.rest.repos.getCollaboratorPermissionLevel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                username: username
-              });
-              
-              console.log(`Repository permission level: ${collab.permission}`);
-              
-              // Users with write, maintain, or admin permissions are considered internal
-              if (['write', 'maintain', 'admin'].includes(collab.permission)) {
-                isInternal = true;
-              }
-            } catch (error) {
-              console.log(`Error checking repository permissions: ${error.message}`);
-            }
-            
-            // Fallback: try organization membership (works for public memberships)
-            if (!isInternal) {
-              try {
-                const { data: org } = await github.rest.orgs.checkMembershipForUser({
-                  org: 'sublime-security',
-                  username: username
-                });
-                console.log(`Organization membership result:`, org);
-                if (org && org.state === 'active') {
-                  isInternal = true;
-                }
-              } catch (error) {
-                console.log(`Organization membership check: ${error.message} (expected for private memberships)`);
-              }
-            }
+            // MEMBER, OWNER, and COLLABORATOR are considered internal
+            const internalAssociations = ['MEMBER', 'OWNER', 'COLLABORATOR'];
+            const isInternal = internalAssociations.includes(authorAssociation);
             
             if (!isInternal) {
               console.log('User is external, adding review-needed label');
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
+                issue_number: pr.number,
                 labels: ['review-needed']
               });
               console.log('Added review-needed label to external PR');
             } else {
-              console.log('User is internal, no label added');
+              console.log(`User is internal (${authorAssociation}), no label added`);
             }


### PR DESCRIPTION
## Summary
This will add a workflow to automatically tag PRs from external contributors with `review-needed` to ensure that we pick up on these PRs in our internal alerting workflows.

## Test plan
- [x] Test with internal PR (should not add label)
	https://github.com/sublime-security/sublime-rules/actions/runs/17505667528/job/49728611401?pr=3193
- [x] Test with external PR (should add review-needed label)
	https://github.com/sublime-security/sublime-rules/actions/runs/17505717459/job/49728744439?pr=3194
- [x] Verify workflow permissions are correct

🤖 Generated with [Claude Code](https://claude.ai/code)