### PR TITLE
Create credential_phishing_fake_tax_form_document.yml

### DIFF
--- a/detection-rules/credential_phishing_fake_tax_form_document.yml
+++ b/detection-rules/credential_phishing_fake_tax_form_document.yml
@@ -27,6 +27,9 @@ source: |
           )
           and any(body.links, strings.icontains(.display_text, "PDF"))
   )
+  and not any(ml.nlu_classifier(body.current_thread.text).topics,
+            .name == "Events and Webinars"
+  )
   and not sender.email.domain.root_domain in (
     "intuit.com",
     "hrblock.com",

--- a/detection-rules/credential_phishing_fake_tax_form_document.yml
+++ b/detection-rules/credential_phishing_fake_tax_form_document.yml
@@ -28,7 +28,7 @@ source: |
           and any(body.links, strings.icontains(.display_text, "PDF"))
   )
   and not any(ml.nlu_classifier(body.current_thread.text).topics,
-            .name == "Events and Webinars"
+              .name in ("Events and Webinars", "Newsletters and Digests")
   )
   and not sender.email.domain.root_domain in (
     "intuit.com",

--- a/detection-rules/credential_phishing_fake_tax_form_document.yml
+++ b/detection-rules/credential_phishing_fake_tax_form_document.yml
@@ -8,8 +8,8 @@ source: |
           regex.icontains(.,
                           'schedule.c',
                           'tax.form',
-                          '1099',
-                          'w-?2',
+                          '1099\b',
+                          'w-?2\b',
                           'tax.return',
                           'tax.preparation'
           )

--- a/detection-rules/credential_phishing_fake_tax_form_document.yml
+++ b/detection-rules/credential_phishing_fake_tax_form_document.yml
@@ -6,10 +6,10 @@ source: |
   type.inbound
   and any([body.current_thread.text, subject.subject],
           regex.icontains(.,
-                          'schedule.c',
+                          'schedule.c\b',
                           'tax.form',
                           '1099\b',
-                          'w-?2\b',
+                          '\bw-?2\b',
                           'tax.return',
                           'tax.preparation'
           )

--- a/detection-rules/credential_phishing_fake_tax_form_document.yml
+++ b/detection-rules/credential_phishing_fake_tax_form_document.yml
@@ -1,4 +1,4 @@
-name: "Tax form impersonation with payment request"
+name: "Credential phishing: Tax form impersonation with payment request"
 description: "Detects messages impersonating tax-related communications that contain payment requests and PDF links, excluding legitimate tax service providers. The rule identifies tax terminology combined with payment solicitation language and PDF link references, which is a common pattern in tax season scams."
 type: "rule"
 severity: "medium"

--- a/detection-rules/credential_phishing_fake_tax_form_document.yml
+++ b/detection-rules/credential_phishing_fake_tax_form_document.yml
@@ -1,0 +1,61 @@
+name: "Tax form impersonation with payment request"
+description: "Detects messages impersonating tax-related communications that contain payment requests and PDF links, excluding legitimate tax service providers. The rule identifies tax terminology combined with payment solicitation language and PDF link references, which is a common pattern in tax season scams."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any([body.current_thread.text, subject.subject],
+          regex.icontains(.,
+                          'schedule.c',
+                          'tax.form',
+                          '1099',
+                          'w-?2',
+                          'tax.return',
+                          'tax.preparation'
+          )
+          and (
+            regex.icontains(body.current_thread.text,
+                            "reply.with.your.payment",
+                            "payment.details",
+                            "send.payment.information",
+                            "provide.payment",
+                            "payment.method",
+                            "billing.information",
+                            "processing.fee",
+                            "completion.fee"
+            )
+          )
+          and any(body.links, strings.icontains(.display_text, "PDF"))
+  )
+  and not sender.email.domain.root_domain in (
+    "intuit.com",
+    "hrblock.com",
+    "turbotax.com",
+    "taxact.com",
+    "freetaxusa.com",
+    "geico.com",
+    "email1.geico.com",
+    "exs.eventshq.com",
+    "square.com"
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+  - "PDF"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Sender analysis"
+  - "URL analysis"

--- a/detection-rules/credential_phishing_fake_tax_form_document.yml
+++ b/detection-rules/credential_phishing_fake_tax_form_document.yml
@@ -59,3 +59,4 @@ detection_methods:
   - "Header analysis"
   - "Sender analysis"
   - "URL analysis"
+id: "717695cf-caf0-5673-a8a8-223bb56ec8e1"


### PR DESCRIPTION
# Description
Detects messages impersonating tax-related communications that contain payment requests and PDF links, excluding legitimate tax service providers. The rule identifies tax terminology combined with payment solicitation language and PDF link references, which is a common pattern in tax season scams.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/4f66d6ed042d6fc5c42251c46aac2c359f5bade6dba5433449d3be2503d113be?preview_id=0198e769-d86c-79af-b8b2-91ad1c9fe72b)
- [Sample 2](https://platform.sublime.security/messages/4f666adb669d57d254f2aba4e0918ee91340d4319cc8db5ecb70bfe7011a40ff?preview_id=0198e769-d6f3-727c-a744-a90593d4caf8)
- [Sample 3](https://platform.sublime.security/messages/4f4c9716396997f0d1495a5d346d699aa63d2324a367dd4c30bce8201772d947?preview_id=01988645-c389-73e6-a548-5f7cf4ab8418)

## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01992ae6-3c38-716f-a281-84a9ac3af15a)

