### PR TITLE
Create html_comic_sans_usage.yml

### DIFF
--- a/detection-rules/html_comic_sans_usage.yml
+++ b/detection-rules/html_comic_sans_usage.yml
@@ -36,3 +36,4 @@ detection_methods:
   - "Header analysis"
   - "HTML analysis"
   - "Sender analysis"
+id: "f4a83da8-a99a-5247-83e8-8d487f1feab1"


### PR DESCRIPTION
# Description

This rule is used to detect the presence of comic sans in html, often used as an attempt to appear informal and in testing has led to the detection of malicious phishing samples.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/4f73f2cce1446f852c38c4770ec61bd06e7fe4bcee9b0d7e3db3ddcf04c37561?preview_id=0199271c-ab52-7e7e-bacc-2cf1afc2543b)
- [Sample 2](https://platform.sublime.security/messages/4f74e5db60fd80ff31a404fbc537bc80cefd3d13a0a3ef2d8001951f7c37d7f9?preview_id=01992f27-93fc-7225-a03e-90635b309355)
- [Sample 3](https://platform.sublime.security/messages/4f73cfdc62a0af74abef2f5b0a8131cb037a7a45e8884e69c332fe1efc172ed2?preview_id=01992da5-6181-7286-a079-1ca7cd274c74)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01992f2a-5abb-7886-8853-b0d56b1c876a)

# Screenshot (insights)
<!-- 
**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
-->
