### PR TITLE
Create brand_impersonation_robert_half.yml

### DIFF
--- a/detection-rules/brand_impersonation_robert_half.yml
+++ b/detection-rules/brand_impersonation_robert_half.yml
@@ -26,6 +26,7 @@ source: |
     or (
       sender.email.domain.root_domain in (
         "roberthalf.com",
+        "roberthalf.be",
         "service-now.com",
         "protiviti.com",
         "atlassian.net",


### PR DESCRIPTION
# Description
Detects messages impersonating Robert Half, a staffing and recruiting company, by analyzing sender display names, logo detection in message screenshots, and specific company address references in the message body. The rule flags messages from senders not authenticated from legitimate Robert Half domains.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/4f7451d97d4cd6014150e1b8ef84bf6e400b562943a39bd4d3317e8ca7c8f697)
- [Sample 2](https://platform.sublime.security/messages/4f6f702c61add1f69f7f6bdd6f14b4864ca87bd002508d68540af414a5c16541?preview_id=01991498-aceb-7824-8599-2f9ee54de8ce)

## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01994df7-2c18-7e74-bd45-1557506e9178)

