### PR TITLE
Update brand_impersonation_vanguard.yml

### DIFF
--- a/detection-rules/brand_impersonation_vanguard.yml
+++ b/detection-rules/brand_impersonation_vanguard.yml
@@ -68,7 +68,8 @@ source: |
         "feedback-vanguard.com",
         "m-vanguard.com",
         "investordelivery.com",
-        "retsupport.com"
+        "retsupport.com",
+        "vanguardretirement.com"
       )
       and headers.auth_summary.dmarc.pass
     )


### PR DESCRIPTION
# Description
FP negation for legitimate Vanguard domain 

https://www.whois.com/whois/vanguardretirement.com

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/4f670a11d61129d8b48919bdc20d318828688faf120af6dad273e2532b50e0c6?preview_id=01991ad9-e045-74c2-8c72-c92400158f45)

