### PR TITLE
Update attachment_eml_cred_theft_language.yml

### DIFF
--- a/detection-rules/attachment_eml_cred_theft_language.yml
+++ b/detection-rules/attachment_eml_cred_theft_language.yml
@@ -71,7 +71,10 @@ source: |
       and not profile.by_sender_email().any_messages_benign
     )
     // sender address listed as a recipient 
-    or sender.email.email in map(recipients.to, .email.email)
+    or (
+      length(recipients.to) == 1
+      and sender.email.email in map(recipients.to, .email.email)
+    )
   )
   and not profile.by_sender_email().any_messages_benign
 attack_types:

--- a/detection-rules/attachment_eml_cred_theft_language.yml
+++ b/detection-rules/attachment_eml_cred_theft_language.yml
@@ -70,6 +70,8 @@ source: |
       profile.by_sender_email().any_messages_malicious_or_spam
       and not profile.by_sender_email().any_messages_benign
     )
+    // sender address listed as a recipient 
+    or sender.email.email in map(recipients.to, .email.email)
   )
   and not profile.by_sender_email().any_messages_benign
 attack_types:


### PR DESCRIPTION
# Description

adding condition to override sender profile if the sender email is listed as a recipient

# Associated samples
- https://platform.sublime.security/messages/4f7562e37ec5a561cbc5e3adee32f3f9a1ca5ef3e11cf2db4c447580385151a9

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=0199349f-3f8b-7799-9da5-924f03302a52