### PR TITLE
Create scam_ghostwriting.yml

### DIFF
--- a/detection-rules/scam_ghostwriting.yml
+++ b/detection-rules/scam_ghostwriting.yml
@@ -1,0 +1,80 @@
+name: "Ghostwriting services scam with manipulative language"
+description: "Detects unsolicited messages promoting ghostwriting or book publishing services that use manipulative language patterns commonly seen in scams, such as offering complimentary samples, expressing fascination with the recipient's achievements, or requesting personal information under the guise of writing assistance."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+    // Ghostwriting and book-related terms in subject
+    (
+      strings.icontains(subject.subject, "book project")
+      or strings.icontains(subject.subject, "ghostwriting")
+      or strings.icontains(subject.subject, "becoming an author")
+      or strings.icontains(subject.subject, "your book")
+      or strings.icontains(subject.subject, "writing project")
+      or strings.icontains(subject.subject, "publish")
+      or strings.icontains(subject.subject, "author")
+    )
+    or 
+    // Body contains ghostwriting service offers
+    (
+      strings.icontains(body.current_thread.text, "ghostwriting")
+      or strings.icontains(body.current_thread.text, "ghostwriter")
+      or strings.icontains(body.current_thread.text, "writing firm")
+      or strings.icontains(body.current_thread.text, "book writing")
+      or strings.icontains(body.current_thread.text, "publishing")
+    )
+  )
+  // Common scam language patterns
+  and (
+    (
+      strings.icontains(body.current_thread.text, "complimentary")
+      and (
+        strings.icontains(body.current_thread.text, "sample")
+        or strings.icontains(body.current_thread.text, "chapter")
+        or strings.icontains(body.current_thread.text, "consultation")
+      )
+    )
+    or (
+      strings.icontains(body.current_thread.text, "fascinated")
+      and strings.icontains(body.current_thread.text, "what you have done")
+    )
+    or strings.icontains(body.current_thread.text, "inspiring stories")
+    or strings.icontains(body.current_thread.text, "gather some information")
+    or strings.icontains(body.current_thread.text, "few minutes of your time")
+    or strings.icontains(body.current_thread.text, "absolutely no obligation")
+    or strings.icontains(body.current_thread.text, "writing team")
+  )
+  and (
+    not any(ml.nlu_classifier(body.current_thread.text).topics,
+            .name in (
+              "Newsletters and Digests"
+            )
+            and .confidence == "high"
+    )
+    // Standard negations
+    and (
+      (
+        sender.email.domain.root_domain in $high_trust_sender_root_domains
+        and not headers.auth_summary.dmarc.pass
+      )
+      or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+    )
+    and (
+      not profile.by_sender().solicited
+      or (
+        profile.by_sender().any_messages_malicious_or_spam
+        and not profile.by_sender().any_messages_benign
+      )
+    )
+    and not profile.by_sender().any_messages_benign
+  )
+  
+
+attack_types:
+  - "Spam"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

This rule identifies scam like Ghostwriting activity which solicits responses from victims who are targeted by fake or scam like activities. 

This thread is identical: 

https://www.reddit.com/r/writing/comments/ydqjrv/just_a_warning_for_those_looking_for_a_editor/



# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/4f6d7c275d26526a379d8948d9e039abe5b3d98c8b6668e6171703c52ca37165?preview_id=01992ca8-f826-74b3-b70e-1bc86b6a37a5)
- [Sample 2](https://platform.sublime.security/messages/c8015d97188ea72209e32f079643dbe90f8247d54d79479bc37252f3b77c2849)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019934ac-6c0b-75fc-88b8-1df172adfc6c)

# Screenshot (insights)
<!-- 
**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
-->
