### PR TITLE
Updating scope of Microsoft form abuse links

### DIFF
--- a/detection-rules/link_multistage_microsoft_forms.yml
+++ b/detection-rules/link_multistage_microsoft_forms.yml
@@ -4,7 +4,7 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and any(filter(body.links, .href_url.domain.domain == "forms.office.com"),
+  and any(filter(body.current_thread.links, .href_url.domain.domain == "forms.office.com"),
           // avoid doing Link Analysis if the display-text has strong indications of phishing
           (
             // replace confusables - observed ITW


### PR DESCRIPTION
# Description

Noticed in a customers environment that there were false positives because of threads so setting scope to `current_thread` for link evaluations.

# Associated samples

- 4f77c89f0bc3f72b0eb35811422f63b805ae64e0b08b98b1e00fe62dab835e95

## Associated hunts

- Hunt 1

