### PR TITLE
Update impersonation_social_security_admin.yml

### DIFF
--- a/detection-rules/impersonation_social_security_admin.yml
+++ b/detection-rules/impersonation_social_security_admin.yml
@@ -37,6 +37,8 @@ source: |
   and not any(ml.nlu_classifier(body.current_thread.text).topics,
               .name == "Newsletters and Digests" and .confidence == "high"
   )
+  // not a forward or reply
+  and (headers.in_reply_to is null or length(headers.references) == 0)
   and (
     not profile.by_sender().solicited
     or (

--- a/detection-rules/impersonation_social_security_admin.yml
+++ b/detection-rules/impersonation_social_security_admin.yml
@@ -9,13 +9,16 @@ source: |
   and (
     regex.contains(sender.display_name, '^SSA\b')
     or strings.icontains(sender.display_name, "Social Security Administration")
+    or any([sender.display_name, subject.subject],
+           regex.icontains(., 'Social (?:benefits|security)', )
+    )
   )
   
   // Contains a link
   and length(body.links) >= 1
   
   // Not from a .gov domain
-  and not sender.email.domain.tld == ".gov"
+  and not (sender.email.domain.tld == "gov" and headers.auth_summary.dmarc.pass)
   
   // Additional suspicious indicator
   and (
@@ -31,7 +34,9 @@ source: |
            )
     )
   )
-  
+  and not any(ml.nlu_classifier(body.current_thread.text).topics,
+              .name == "Newsletters and Digests" and .confidence == "high"
+  )
   and (
     not profile.by_sender().solicited
     or (
@@ -39,7 +44,6 @@ source: |
       and not profile.by_sender().any_messages_benign
     )
   )
-  
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)


### PR DESCRIPTION
# Description
Added additional keywords in the subject and display name check, added a negation for newsletters and digests and replies/forwards, and fixed the .gov negation to work properly with an auth check to cover missed samples below. 

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/4f4af1abb4f652dfa49d57e99fb77efa38a18815252bac3704a2f47ab05cbcac?preview_id=0198581f-86e5-7221-854f-c6e1195e1698)
- [Sample 2](https://platform.sublime.security/messages/4f6c8e657b9c935e15b91a2a363e3683f74cc2a99a46f407effb6f51219fd14d?preview_id=0199072b-10eb-7e40-a537-04812c6faaee)
- [Sample 3](https://platform.sublime.security/messages/4f760030205b11a8a02bb9b112d0162f437fc02ba2ecaaf776057720c5ddba92?preview_id=019938fa-52e6-7779-b73c-0aa9f2684bcf)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019952ca-eba4-7247-b79c-d27597dad08a) - hunt of updated rule
- [Hunt 2](https://platform.sublime.security/messages/hunt?huntId=019952ce-35b6-75de-b179-36cd9e444cde) - hunt of difference of changes between new logic and old logic
