### PR TITLE
Update unrelated_sharepoint_link.yml

### DIFF
--- a/detection-rules/unrelated_sharepoint_link.yml
+++ b/detection-rules/unrelated_sharepoint_link.yml
@@ -69,12 +69,7 @@ source: |
           and not any($org_slds, strings.icontains(..href_url.domain.subdomain, .))
   
           // it is either a OneNote or PDF file, or unknown
-          and (
-            strings.icontains(.href_url.path, '/:o:/p')
-            or strings.icontains(.href_url.path, '/:b:/p')
-            or strings.icontains(.href_url.path, '/:u:/p')
-          )
-  
+          and regex.icontains(.href_url.path, '\/:[obu]:\/(?:p|g\/personal)')
   )
   
   // a way to negate long threads


### PR DESCRIPTION
# Description

Added additional SharePoint URL tokens and consolidated/converted the strings.icontains to regex.icontains. This change enables the rule to catch SharePoint URLs that have global access permissions.


# Associated samples

Note: Linked Sample (1) would not trigger on this rule, but the attached EML within the shared sample would. 

1) https://platform.sublime.security/messages/4f77d4bd1c244f5ce40dab5bbacb9d5cfbd4acda00255393ed72341bd373c228
2) https://platform.sublime.security/messages/4f75bc1099fcdeadbaf92cb3200b8f85f9d231a6ea8bac64abdbd5a5a3b348fb

## Associated hunts

Hunt: SharePoint Link Likely Unrelated to Sender Rule Change Check

https://platform.sublime.security/messages/hunt?huntId=01994e9e-86ec-7b2b-b3e4-1de06ac565c6

