### PR TITLE
Update attachment_office_sharing_sus_ocr.yml

### DIFF
--- a/detection-rules/attachment_office_sharing_sus_ocr.yml
+++ b/detection-rules/attachment_office_sharing_sus_ocr.yml
@@ -28,7 +28,7 @@ source: |
               )
               or (
                 length(.scan.ocr.raw) < 500
-                strings.ends_with(.scan.ocr.raw, 'REVIEW DOCUMENTS')
+                and strings.ends_with(.scan.ocr.raw, 'REVIEW DOCUMENTS')
               )
           )
           // copy/paste stuff or disclaimer text in the OCR output


### PR DESCRIPTION
# Description
Add condition to match when the "sent you" phrasing doesn't get picked up by OCR, but the CTA button does
# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/4f76713a8d004e80717a1a1a4c4e676469f10c5b228255e7e72b83d0d7d3d65f?preview_id=01995022-02a0-7281-8afe-e39c45bab184)
- Sample 2

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Exclusive matches introduced by the new logic](https://platform.sublime.security/messages/hunt?huntId=01995055-26d0-728a-a072-f942728fa60f)
