### PR TITLE
Create abuse_todo_list.yml

### DIFF
--- a/detection-rules/abuse_todo_list.yml
+++ b/detection-rules/abuse_todo_list.yml
@@ -18,10 +18,7 @@ source: |
     )
   )
   // utilizing sendgrid infra
-  and (
-    strings.icontains(headers.return_path.domain.root_domain, "sendgrid")
-    or any(headers.domains, strings.icontains(.root_domain, "sendgrid"))
-  )
+  and headers.return_path.domain.domain == "sendgrid.net"
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (

--- a/detection-rules/abuse_todo_list.yml
+++ b/detection-rules/abuse_todo_list.yml
@@ -4,32 +4,57 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  //subject contains "todo list"
+  // subject contains "todo list"
   and (
-    regex.icontains(subject.subject, "T[0o] D[o0] L[I1l]ST")
+    regex.icontains(subject.subject, "T[0o][-\\s]*D[o0][-\\s]*L[I1l]ST")
     or (
       strings.icontains(subject.subject, "todo")
+      and strings.icontains(subject.subject, "list")
+    )
+    or (
+      strings.icontains(subject.subject, "to-do")
       and strings.icontains(subject.subject, "list")
     )
     or (
       strings.icontains(subject.subject, "reminder")
       and strings.icontains(subject.subject, "list")
     )
-  )
-  // utilizing sendgrid infra
-  and strings.icontains(headers.return_path.domain.root_domain, "sendgrid")
-  and (
-    // and sender claims to be task/productivity related but domain doesn't match
-    (
-      regex.icontains(headers.from.display_name, "(task|todo|gtask|reminder)")
-      or regex.icontains(body.current_thread.text,
-                         "(waiting for review|new task.*added|[0-9]+ of [0-9]+ tasks? completed)"
+    // or we can check for todo list content with high cred_theft intent
+    or (
+      regex.icontains(body.current_thread.text,
+                      "T[0o][-\\s]*D[o0][-\\s]*L[I1l]ST"
+      )
+      and strings.icontains(body.current_thread.text, "list")
+      and any(ml.nlu_classifier(body.current_thread.text).intents,
+              .name == "cred_theft" and .confidence == "high"
       )
     )
-    // not from legitimate or internal domains (unless DMARC fails)
-    and not (
-      sender.email.domain.root_domain in $org_domains
-      and headers.auth_summary.dmarc.pass
+    or (
+      strings.icontains(body.current_thread.text, "to-do")
+      and strings.icontains(body.current_thread.text, "list")
+      and any(ml.nlu_classifier(body.current_thread.text).intents,
+              .name == "cred_theft" and .confidence == "high"
+      )
+    )
+  )
+  // utilizing sendgrid infra
+  and (
+    strings.icontains(headers.return_path.domain.root_domain, "sendgrid")
+    or any(headers.domains, strings.icontains(.root_domain, "sendgrid"))
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  and (
+    not profile.by_sender().solicited
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and not profile.by_sender().any_messages_benign
     )
   )
 

--- a/detection-rules/abuse_todo_list.yml
+++ b/detection-rules/abuse_todo_list.yml
@@ -1,4 +1,4 @@
-name: "Task management impersonation: Utilizing SendGrid infrastructure"
+name: "Service abuse: Task management message sent via SendGrid"
 description: "Detects messages impersonating task or productivity applications by using 'todo list' or 'reminder list' in the subject line while utilizing SendGrid infrastructure. The sender claims to be task-related through display name or body content but originates from non-legitimate domains without proper DMARC authentication."
 type: "rule"
 severity: "high"

--- a/detection-rules/abuse_todo_list.yml
+++ b/detection-rules/abuse_todo_list.yml
@@ -1,5 +1,5 @@
 name: "Service abuse: Task management message sent via SendGrid"
-description: "Detects messages impersonating task or productivity applications by using 'todo list' or 'reminder list' in the subject line while utilizing SendGrid infrastructure. The sender claims to be task-related through display name or body content but originates from non-legitimate domains without proper DMARC authentication."
+description: "Detects messages impersonating task or productivity applications by using 'todo list' in the subject line or body while utilizing SendGrid infrastructure. The sender claims to be task-related through display name or body content but originates from non-legitimate domains without proper DMARC authentication."
 type: "rule"
 severity: "high"
 source: |

--- a/detection-rules/abuse_todo_list.yml
+++ b/detection-rules/abuse_todo_list.yml
@@ -1,7 +1,7 @@
 name: "Service abuse: Task management message sent via SendGrid"
 description: "Detects messages impersonating task or productivity applications by using 'todo list' in the subject line or body while utilizing SendGrid infrastructure. The sender claims to be task-related through display name or body content but originates from non-legitimate domains without proper DMARC authentication."
 type: "rule"
-severity: "high"
+severity: "medium"
 source: |
   type.inbound
   // subject contains "todo list"

--- a/detection-rules/abuse_todo_list.yml
+++ b/detection-rules/abuse_todo_list.yml
@@ -1,0 +1,18 @@
+name: "Abuse To do list: subject with SendGrid routing"
+description: "Message with 'TO DO LIST' subject line variations routed through SendGrid infrastructure, potentially indicating task-based social engineering tactics."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and regex.icontains(subject.subject, "T[0o] D[o0] L[I1l]ST")
+  and strings.icontains(headers.return_path.domain.root_domain, "sendgrid")
+
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Evasion"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"

--- a/detection-rules/abuse_todo_list.yml
+++ b/detection-rules/abuse_todo_list.yml
@@ -7,31 +7,11 @@ source: |
   // subject contains "todo list"
   and (
     regex.icontains(subject.subject, "T[0o][-\\s]*D[o0][-\\s]*L[I1l]ST")
-    or (
-      strings.icontains(subject.subject, "todo")
-      and strings.icontains(subject.subject, "list")
-    )
-    or (
-      strings.icontains(subject.subject, "to-do")
-      and strings.icontains(subject.subject, "list")
-    )
-    or (
-      strings.icontains(subject.subject, "reminder")
-      and strings.icontains(subject.subject, "list")
-    )
-    // or we can check for todo list content with high cred_theft intent
+    // or we can check the body for todo list content with high cred_theft intent
     or (
       regex.icontains(body.current_thread.text,
                       "T[0o][-\\s]*D[o0][-\\s]*L[I1l]ST"
       )
-      and strings.icontains(body.current_thread.text, "list")
-      and any(ml.nlu_classifier(body.current_thread.text).intents,
-              .name == "cred_theft" and .confidence == "high"
-      )
-    )
-    or (
-      strings.icontains(body.current_thread.text, "to-do")
-      and strings.icontains(body.current_thread.text, "list")
       and any(ml.nlu_classifier(body.current_thread.text).intents,
               .name == "cred_theft" and .confidence == "high"
       )

--- a/detection-rules/abuse_todo_list.yml
+++ b/detection-rules/abuse_todo_list.yml
@@ -1,19 +1,45 @@
-name: "Abuse To do list: subject with SendGrid routing"
-description: "Message with 'TO DO LIST' subject line variations routed through SendGrid infrastructure, potentially indicating task-based social engineering tactics."
+name: "Task management impersonation: Utilizing SendGrid infrastructure"
+description: "Detects messages impersonating task or productivity applications by using 'todo list' or 'reminder list' in the subject line while utilizing SendGrid infrastructure. The sender claims to be task-related through display name or body content but originates from non-legitimate domains without proper DMARC authentication."
 type: "rule"
-severity: "medium"
+severity: "high"
 source: |
   type.inbound
-  and regex.icontains(subject.subject, "T[0o] D[o0] L[I1l]ST")
+  //subject contains "todo list"
+  and (
+    regex.icontains(subject.subject, "T[0o] D[o0] L[I1l]ST")
+    or (
+      strings.icontains(subject.subject, "todo")
+      and strings.icontains(subject.subject, "list")
+    )
+    or (
+      strings.icontains(subject.subject, "reminder")
+      and strings.icontains(subject.subject, "list")
+    )
+  )
+  // utilizing sendgrid infra
   and strings.icontains(headers.return_path.domain.root_domain, "sendgrid")
+  and (
+    // and sender claims to be task/productivity related but domain doesn't match
+    (
+      regex.icontains(headers.from.display_name, "(task|todo|gtask|reminder)")
+      or regex.icontains(body.current_thread.text,
+                         "(waiting for review|new task.*added|[0-9]+ of [0-9]+ tasks? completed)"
+      )
+    )
+    // not from legitimate or internal domains (unless DMARC fails)
+    and not (
+      sender.email.domain.root_domain in $org_domains
+      and headers.auth_summary.dmarc.pass
+    )
+  )
 
 attack_types:
-  - "BEC/Fraud"
   - "Credential Phishing"
 tactics_and_techniques:
+  - "Impersonation: Brand"
   - "Social engineering"
   - "Evasion"
 detection_methods:
   - "Content analysis"
   - "Header analysis"
-id: "568a63f5-dbd2-5f9a-a84a-b4d8aa49c59b"
+  - "Sender analysis"

--- a/detection-rules/abuse_todo_list.yml
+++ b/detection-rules/abuse_todo_list.yml
@@ -16,3 +16,4 @@ tactics_and_techniques:
 detection_methods:
   - "Content analysis"
   - "Header analysis"
+id: "568a63f5-dbd2-5f9a-a84a-b4d8aa49c59b"

--- a/detection-rules/abuse_todo_list.yml
+++ b/detection-rules/abuse_todo_list.yml
@@ -43,3 +43,4 @@ detection_methods:
   - "Content analysis"
   - "Header analysis"
   - "Sender analysis"
+id: "568a63f5-dbd2-5f9a-a84a-b4d8aa49c59b"


### PR DESCRIPTION
# Description
From a runner, testing coverage expansion for malicious todo list. My goal here is to just let this sit in test rules for a few days to see how it performs and iterate on the rule. 

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/4f7370d6dfd77d43d7c967fbebe938d69492cd448958655fe1aeb4b12449289c?preview_id=01992948-4a24-7877-8471-4f305c4f8cf7)

Edit one: expanding coverage preemptively to capture stuff like the following
- [Sample 2](https://platform.sublime.security/messages/4f80910eaab296f2085131d27cdd1aa69fd0b9365d241378a565503c1445b57a?preview_id=019971ed-027f-7b32-b3b9-bd24a8869fd8)

## Associated hunts
- [Hunt 1
](https://platform.sublime.security/messages/hunt?huntId=01995454-34ad-76db-ba6a-e60de047e53a)
- [Hunt 2 - goldmine](https://platform.sublime.security/messages/hunt?huntId=01997860-2f6b-795f-8c6e-951713b4b9fd)
