### PR TITLE
Update zoom_events_abuse.yml

### DIFF
--- a/detection-rules/zoom_events_abuse.yml
+++ b/detection-rules/zoom_events_abuse.yml
@@ -13,6 +13,7 @@ source: |
   and any(html.xpath(body.html,
                      "//div[@class='eb-content css-1l7xmti']//td[@data-dynamic-style-background-color='email.bodyColor.color' and @style='border-radius: 8px; background-color: rgb(255, 255, 255);']"
           ).nodes,
+          // look at the content before the copyright footer in the template and pass it to NLU to see if it's cred theft 
           any(html.xpath(.,
                          "//td[@data-dynamic-style-background-color='email.bodyColor.color']/*[position() < last()]"
               ).nodes,

--- a/detection-rules/zoom_events_abuse.yml
+++ b/detection-rules/zoom_events_abuse.yml
@@ -8,25 +8,18 @@ source: |
   type.inbound
   and sender.email.email == "noreply-zoomevents@zoom.us"
   and headers.auth_summary.spf.pass
-  and headers.auth_summary.dmarc.pass
   
   // extract the actor controlled message from the email body
   and any(html.xpath(body.html,
                      "//div[@class='eb-content css-1l7xmti']//td[@data-dynamic-style-background-color='email.bodyColor.color' and @style='border-radius: 8px; background-color: rgb(255, 255, 255);']"
           ).nodes,
-          any(regex.extract(.display_text, '(?P<body_text>[\s\S]*?)Visit the'),
-              any(ml.nlu_classifier(.named_groups['body_text']).intents,
+          any(html.xpath(.,
+                         "//td[@data-dynamic-style-background-color='email.bodyColor.color']/*[position() < last()]"
+              ).nodes,
+              any(ml.nlu_classifier(..display_text).intents,
                   .name == "cred_theft" and .confidence != "low"
               )
           )
-  )
-  
-  and (
-    any(body.links,
-        .href_url.domain.root_domain in $free_file_hosts
-        or .href_url.domain.root_domain in $free_subdomain_hosts
-        or any(body.links, .href_url.domain.domain == "docs.zoom.us")
-    )
   )
 
 attack_types:

--- a/detection-rules/zoom_events_abuse.yml
+++ b/detection-rules/zoom_events_abuse.yml
@@ -7,7 +7,10 @@ references:
 source: |
   type.inbound
   and sender.email.email == "noreply-zoomevents@zoom.us"
-  and headers.auth_summary.spf.pass
+  and (
+    headers.auth_summary.spf.pass
+    or headers.auth_summary.dmarc.pass
+  )
   
   // extract the actor controlled message from the email body
   and any(html.xpath(body.html,


### PR DESCRIPTION
# Description
added an additional xpath to look at content before the copyright footer rather than just keyword, removed DMARC auth consideration so we can get it regardless if it passes auth or not, and removed body.links FP negation stanza as hunts across many environments show no new FPs without it. Covers sample below 

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/4f7b5e3df10db482e2addc184ce843c924fca9853dcb2ef023f1993b7e7642f1?preview_id=01995900-f407-75b9-867f-f00fdb911370)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=0199594d-c9d6-700f-b80f-9201371288b5)
- [Hunt 2](https://platform.sublime.security/messages/hunt?huntId=0199594e-2c1f-7078-b194-bd1576407a2e) hunt with body.links FP negation still in, shows only this sample being introduced and new no FPs. 

