### PR TITLE
Update attachment_encrypted_pdf_cred_theft.yml

### DIFF
--- a/detection-rules/attachment_encrypted_pdf_cred_theft.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft.yml
@@ -51,14 +51,16 @@ source: |
       profile.by_sender_email().any_messages_malicious_or_spam
       and not profile.by_sender_email().any_messages_benign
     )
+    or profile.by_sender_email().days_since.last_contact > 120
     or (
-      profile.by_sender_email().days_since.last_contact > 120
-      and (
-        length(recipients.to) == 0
-        or all(recipients.to,
-               strings.ilike(.display_name, "undisclosed?recipients")
-        )
+      length(recipients.to) == 0
+      or all(recipients.to,
+             strings.ilike(.display_name, "undisclosed?recipients")
       )
+    )
+    or (
+      length(recipients.to) == 1
+      and any(recipients.to, .email.email == sender.email.email)
     )
   )
   // negate highly trusted sender domains unless they fail DMARC authentication

--- a/detection-rules/attachment_encrypted_pdf_cred_theft.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft.yml
@@ -44,7 +44,7 @@ source: |
   )
   // not forwards/replies
   and not (
-    length(headers.references) > 0
+    (length(headers.references) > 0 or headers.in_reply_to is not null)
     and (subject.is_forward or subject.is_reply)
     and length(body.previous_threads) >= 1
   )

--- a/detection-rules/attachment_encrypted_pdf_cred_theft.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft.yml
@@ -51,7 +51,6 @@ source: |
       profile.by_sender_email().any_messages_malicious_or_spam
       and not profile.by_sender_email().any_messages_benign
     )
-    or profile.by_sender_email().days_since.last_contact > 120
     or (
       length(recipients.to) == 0
       or all(recipients.to,

--- a/detection-rules/attachment_encrypted_pdf_cred_theft.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft.yml
@@ -20,7 +20,7 @@ source: |
     any(ml.nlu_classifier(body.current_thread.text).intents,
         .name == "cred_theft" and .confidence in ("medium", "high")
     )
-    or any(ml.nlu_classifier(beta.ocr(beta.message_screenshot()).text).intents,
+    or any(ml.nlu_classifier(beta.ocr(file.message_screenshot()).text).intents,
            .name == "cred_theft" and .confidence in ("medium", "high")
     )
     or (
@@ -41,6 +41,12 @@ source: |
         )
       )
     )
+  )
+  // not forwards/replies
+  and not (
+    length(headers.references) > 0
+    and (subject.is_forward or subject.is_reply)
+    and length(body.previous_threads) >= 1
   )
   and (
     (

--- a/detection-rules/attachment_encrypted_pdf_cred_theft.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft.yml
@@ -26,17 +26,16 @@ source: |
     or (
       (
         regex.icontains(body.current_thread.text,
-                        'PDF\s*(?:Access|Unlock|Decrypt)\s*(?:Pass)?code'
+                        'PDF\s*(?:Access|Preview|Unlock|Decrypt)\s*(?:Pass)?code'
         )
-        or ( 
+        or (
           (
             length(body.current_thread.text) <= 10
             or (body.current_thread.text is null)
           )
           and any(body.previous_threads,
                   regex.icontains(.text,
-                                  'PDF\s*(?:Access|Unlock|Decrypt)\s*(?:Pass)?code'
-
+                                  'PDF\s*(?:Access|Preview|Unlock|Decrypt)\s*(?:Pass)?code'
                   )
           )
         )
@@ -50,7 +49,16 @@ source: |
     )
     or (
       profile.by_sender_email().any_messages_malicious_or_spam
-      and not profile.by_sender_email().any_false_positives
+      and not profile.by_sender_email().any_messages_benign
+    )
+    or (
+      profile.by_sender_email().days_since.last_contact > 120
+      and (
+        length(recipients.to) == 0
+        or all(recipients.to,
+               strings.ilike(.display_name, "undisclosed?recipients")
+        )
+      )
     )
   )
   // negate highly trusted sender domains unless they fail DMARC authentication


### PR DESCRIPTION
# Description
Added sender profile override if the recipients field is empty or the sender and recipient are the same. Added an additional keyword as well for more coverage.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/4f7c338e17945c964a1cbf57b4afed1a592045455e236509d7008203aa4e920c?preview_id=01995961-efa2-7197-98ee-60609c26f456)
- [Sample 2](https://platform.sublime.security/messages/4f7cc068ee7de03b43852d35b76ed6839cb847fa38f0e882d012c7c03688d59a?preview_id=01995db3-da68-73a5-bc20-a7785ec7b9d3)
- [Sample 3](https://platform.sublime.security/messages/4f7ce0c5fde3cb5bda306f76017aafbf0aae9160feccdb83d712c85b7abd3590?preview_id=01995db5-0b7e-7b3f-8fa2-0dacc531e4a7)
- [Sample 4](https://platform.sublime.security/messages/4f75129fa68ac3f464069b825f8adf6be3a1d304412b3b65bf136418f7406efc?preview_id=01997c42-59d3-74ec-980e-ea505009cac7)

## Associated hunts

- sender profile related so hunts ran in multiple large envs, no new FPs introduced 

