### PR TITLE
Update brand_impersonation_google_careers.yml

### DIFF
--- a/detection-rules/brand_impersonation_google_careers.yml
+++ b/detection-rules/brand_impersonation_google_careers.yml
@@ -22,7 +22,7 @@ source: |
     // Turkish
     or strings.icontains(body.current_thread.text, 'Google Kariyer')
     or strings.icontains(body.current_thread.text, 'GoogleKariyer')
-    // The screenshot OCR captures google careers
+    // The screenshot OCR captures google careers or the google logo
     or (
       sender.email.domain.root_domain == "salesforce.com"
       and (

--- a/detection-rules/brand_impersonation_google_careers.yml
+++ b/detection-rules/brand_impersonation_google_careers.yml
@@ -22,6 +22,13 @@ source: |
     // Turkish
     or strings.icontains(body.current_thread.text, 'Google Kariyer')
     or strings.icontains(body.current_thread.text, 'GoogleKariyer')
+    // The screenshot OCR captures google careers
+    or (
+      sender.email.domain.root_domain == "salesforce.com"
+      and regex.icontains(beta.ocr(file.message_screenshot()).text,
+                          "google careers"
+      )
+    )
   )
   and not any(body.links, .href_url.domain.root_domain in ("google.com", "c.gle"))
   and not (

--- a/detection-rules/brand_impersonation_google_careers.yml
+++ b/detection-rules/brand_impersonation_google_careers.yml
@@ -25,8 +25,13 @@ source: |
     // The screenshot OCR captures google careers
     or (
       sender.email.domain.root_domain == "salesforce.com"
-      and regex.icontains(beta.ocr(file.message_screenshot()).text,
-                          "google careers"
+      and (
+        regex.icontains(beta.ocr(file.message_screenshot()).text,
+                        "google careers"
+        )
+        or any(ml.logo_detect(file.message_screenshot()).brands,
+               strings.starts_with(.name, "Google")
+        )
       )
     )
   )


### PR DESCRIPTION
# Description

Expanding the scope for instances where attackers might evade HTML detection. Suggesting an additional check for OCR of  screenshots detecting "Google Careers" 
Want to let this sit for a little bit to see how it performs in shares samples

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/a6ef3f41b8edf73cbb9b25cd219224ef5f65ac003106e9fa6f2ae9ebed4e4cc6?preview_id=01995d30-2156-7ddd-9d86-fc2452b7075b)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01995d44-3353-7800-af12-19af9525efce)
