### PR TITLE
Update attachment_eml_suspicious_indicators.yml

### DIFF
--- a/detection-rules/attachment_eml_suspicious_indicators.yml
+++ b/detection-rules/attachment_eml_suspicious_indicators.yml
@@ -74,6 +74,7 @@ source: |
       profile.by_sender().any_messages_malicious_or_spam
       and not profile.by_sender().any_messages_benign
     )
+    or length(recipients.to) > 10
   )
   
   // negate highly trusted sender domains unless they fail DMARC authentication


### PR DESCRIPTION
# Description
Adding sender profile override when recipients is more than 10 to cover samples below.

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/4f77d4bd1c244f5ce40dab5bbacb9d5cfbd4acda00255393ed72341bd373c228?preview_id=01994cd3-2290-789f-8348-5d6567a6ceb8)
- [Sample 2](https://platform.sublime.security/messages/4f77ebe70bb12dc88697c970946dc543c9e1012900ee41fa12064a847026572d?preview_id=01994cd5-b9e1-792c-b821-2468770f4d52)

## Associated hunts
- sender profile related so hunts being ran in customer envs
