### PR TITLE
Update credential_phishing_esign_document_notification.yml

### DIFF
--- a/detection-rules/credential_phishing_esign_document_notification.yml
+++ b/detection-rules/credential_phishing_esign_document_notification.yml
@@ -89,6 +89,7 @@ source: |
     ) > 50
     // lookalike docusign
     or regex.icontains(body.html.raw, '>Docus[1l]gn<')
+    or strings.icontains(body.current_thread.text, 'completed by all parties')
     or (
       regex.icontains(body.html.inner_text, 'Document')
       and length(body.html.inner_text) < 500


### PR DESCRIPTION
# Description
additional keywords in the DocuSign lookalike section to cover missed sample

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/4f736d6825fb7d44215002fd5774d86f1ce267e7e4e3e6800c0e8f0f43894e2f?preview_id=01992b6e-c9df-7dd9-807b-2464c83fe48b)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/hunts/019971cf-e81e-7351-a477-688282a3ffa5) - exclusive hunt showing just this string addition 
