### PR TITLE
Create attachment_link_sharepoint_netorgft.yml

### DIFF
--- a/detection-rules/attachment_link_sharepoint_netorgft.yml
+++ b/detection-rules/attachment_link_sharepoint_netorgft.yml
@@ -1,0 +1,26 @@
+name: "Attachment: EML with SharePoint files shared from GoDaddy federated tenants"
+description: "Detects EML attachments containing SharePoint links with 'netorg' subdomain patterns, which may indicate suspicious redirection tactics or domain abuse."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and length(filter(attachments,
+                    .file_extension == "eml" or .content_type == "message/rfc822"
+             )
+  ) == 1
+  and any(attachments,
+          any(file.parse_eml(.).body.links,
+              strings.starts_with(.href_url.domain.subdomain, 'netorg')
+              and .href_url.domain.root_domain == "sharepoint.com"
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "File analysis"
+  - "URL analysis"
+  - "Content analysis"


### PR DESCRIPTION
# Description
Detects EML attachments containing SharePoint links with 'netorg' subdomain patterns, which may indicate suspicious redirection tactics or domain abuse.
# Associated samples

- [Sample 1](https://platform.sublime.security/messages/4f77ebe70bb12dc88697c970946dc543c9e1012900ee41fa12064a847026572d?preview_id=01994cd5-b9e1-792c-b821-2468770f4d52)
- [Sample 2](https://platform.sublime.security/messages/4f77d4bd1c244f5ce40dab5bbacb9d5cfbd4acda00255393ed72341bd373c228)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019963d1-29c6-7628-bb23-698e467fed28)
