### PR TITLE
Create eml_attachment_unrelated_sharepoint_link.yml

### DIFF
--- a/detection-rules/eml_attachment_unrelated_sharepoint_link.yml
+++ b/detection-rules/eml_attachment_unrelated_sharepoint_link.yml
@@ -1,0 +1,109 @@
+name: "Attachment: EML with Sharepoint link likely unrelated to sender"
+description: "Detects EML attachments containing SharePoint links where the subdomain differs significantly from the sender's domain, potentially indicating SharePoint impersonation or domain spoofing tactics."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and length(filter(attachments,
+                    .file_extension == "eml" or .content_type == "message/rfc822"
+             )
+  ) == 1
+  and any(attachments,
+          any(filter(file.parse_eml(.).body.links,
+                     .href_url.domain.root_domain == 'sharepoint.com'
+              ),
+              // Normalize Levenshtein distance by string length (0 = identical, 0.7+ = different)
+              // Working with what we have in MQL, considering we dont have max() or any other forms of string distancing
+              (
+                (
+                  strings.iends_with(.href_url.domain.subdomain,
+                                     '-my'
+                  ) // common Sharepoint subdomain suffix
+                  and (
+                    (
+                      strings.ilevenshtein(.href_url.domain.subdomain,
+                                           sender.email.domain.sld
+                      ) - 3 // subtract aforementioned suffix for more accurate calculation
+                    ) / (
+                      (
+                        (length(.href_url.domain.subdomain) - 3) + length(sender.email.domain.sld
+                        )
+   + (
+                          (
+                            (length(.href_url.domain.subdomain) - 3) - length(sender.email.domain.sld
+                            )
+                          ) + (
+                            length(sender.email.domain.sld) - (
+                              length(.href_url.domain.subdomain) - 3
+                            )
+                          )
+                        )
+                      ) / 2.0 // to ensure we keep the result as a float
+                    )
+                  ) > 0.7 // customizable threshold
+                )
+                or (
+                  not strings.iends_with(.href_url.domain.subdomain,
+                                         '-my'
+                  ) // no suffix, continue with original calculation
+                  and (
+                    strings.ilevenshtein(.href_url.domain.subdomain,
+                                         sender.email.domain.sld
+                    ) / (
+                      (
+                        length(.href_url.domain.subdomain) + length(sender.email.domain.sld
+                        )
+   + (
+                          (
+                            length(.href_url.domain.subdomain) - length(sender.email.domain.sld
+                            )
+                          ) + (
+                            length(sender.email.domain.sld) - length(.href_url.domain.subdomain
+                            )
+                          )
+                        )
+                      ) / 2.0 // to ensure we keep the result as a float
+                    )
+                  ) > 0.7 // customizable threshold
+                )
+              )
+              and not strings.icontains(.href_url.path, sender.email.local_part)
+              and not any($org_slds,
+                          strings.icontains(..href_url.domain.subdomain, .)
+              )
+  
+              // it is either a OneNote or PDF file, or unknown
+              and regex.icontains(.href_url.path, '\/:[obu]:\/(?:p|g\/personal)')
+          )
+  
+          // a way to negate long threads
+          // the full thread must be less than 6 times the length of the current thread
+          and length(body.html.inner_text) < 6 * length(body.current_thread.text)
+          and sender.email.domain.root_domain not in (
+            "sharepoint.com",
+            "sharepointonline.com"
+          )
+  )
+  
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  
+
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+  - "Evasion"
+detection_methods:
+  - "File analysis"
+  - "URL analysis"
+  - "Header analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description
Detects EML attachments containing SharePoint links where the subdomain differs significantly from the sender's domain, potentially indicating SharePoint impersonation or domain spoofing tactics.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/4f77d4bd1c244f5ce40dab5bbacb9d5cfbd4acda00255393ed72341bd373c228)

## Associated hunts


- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019963dd-a4b3-7cf5-90a0-1c0656abfb06)

