### PR TITLE
Update credential_phishing_suspicious_subject_nlu_financial_urgent.yml

### DIFF
--- a/detection-rules/credential_phishing_suspicious_subject_nlu_financial_urgent.yml
+++ b/detection-rules/credential_phishing_suspicious_subject_nlu_financial_urgent.yml
@@ -270,7 +270,12 @@ source: |
     not profile.by_sender_email().solicited
     or (
       profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_messages_benign
+      and (
+        not profile.by_sender().any_messages_benign
+        or (
+          not headers.auth_summary.dmarc.pass or not headers.auth_summary.spf.pass
+        )
+      )
     )
   )
   

--- a/detection-rules/credential_phishing_suspicious_subject_nlu_financial_urgent.yml
+++ b/detection-rules/credential_phishing_suspicious_subject_nlu_financial_urgent.yml
@@ -270,12 +270,12 @@ source: |
     not profile.by_sender_email().solicited
     or (
       profile.by_sender().any_messages_malicious_or_spam
-      and (
-        not profile.by_sender().any_messages_benign
-        or (
-          not headers.auth_summary.dmarc.pass or not headers.auth_summary.spf.pass
-        )
-      )
+      and not profile.by_sender().any_messages_benign
+    )
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and profile.by_sender().any_messages_benign
+      and (not headers.auth_summary.dmarc.pass or not headers.auth_summary.spf.pass)
     )
   )
   

--- a/detection-rules/credential_phishing_suspicious_subject_nlu_financial_urgent.yml
+++ b/detection-rules/credential_phishing_suspicious_subject_nlu_financial_urgent.yml
@@ -267,10 +267,12 @@ source: |
   
   // the message is unsolicited and no false positives
   and (
-    not profile.by_sender().solicited
-    or profile.by_sender().any_messages_malicious_or_spam
+    not profile.by_sender_email().solicited
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and not profile.by_sender().any_messages_benign
+    )
   )
-  and not profile.by_sender().any_messages_benign
   
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (


### PR DESCRIPTION
# Description

From a runner... testing just removing this second check for benign messages. Want to see if it explodes with FPs again after the fact. Will keep an eye on this early into the week. 

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/4f7a4264dda8eb0efe2b7944eca8061a0f8addfe50b0c27293897b7f8cbff8e5?preview_id=01994f34-b8d7-7ce8-8fb9-2420e0cea811) - doesn't match in customer env because they marked sender as benign... pls dm me for more context