### PR TITLE
Update attachment_pdf_recip_email_in_link.yml

### DIFF
--- a/detection-rules/attachment_pdf_recip_email_in_link.yml
+++ b/detection-rules/attachment_pdf_recip_email_in_link.yml
@@ -6,6 +6,7 @@ source: |
   type.inbound
   // one or more PDF documents
   and length(filter(attachments, .file_type == "pdf")) >= 1
+  and length(attachments) <= 4
   // a single recipient (this is in the link so there can be only one)
   and length(recipients.to) == 1
   and all(recipients.to, .email.domain.valid)
@@ -48,6 +49,8 @@ source: |
                                                                .domain.domain
                                          )
                                        )
+                                       // common observed invoice system that exhibits this behavior
+                                       and not .domain.root_domain == "univarsolutions.com"
                                 ),
                                 .url
                        )


### PR DESCRIPTION
# Description

Move QR code matching to be independent of the links in the PDF
expand logic of url filtering to better account for URL observed in PDFs
allow for multiple PDFs 

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Multiple PDFS](https://platform.sublime.security/messages/hunt?huntId=019972e7-6882-7ba0-b53d-ec8fa15f9a92)
- [New matches](https://platform.sublime.security/messages/hunt?huntId=019972eb-8bb7-7852-99c6-eb660b871df4)
