### PR TITLE
Update abuse_google_classroom.yml

### DIFF
--- a/detection-rules/abuse_google_classroom.yml
+++ b/detection-rules/abuse_google_classroom.yml
@@ -1,10 +1,19 @@
-name: "Google Classroom Spoofing With WhatsApp Contact Information"
+name: "Service abuse: Google classroom solicitation"
 description: "Detects messages impersonating Google Classroom notifications that contain WhatsApp contact information, likely attempting to redirect victims to out-of-band communication channels for social engineering attacks."
 type: "rule"
 severity: "medium"
 source: |
   type.inbound
+  // 
+  //  Warning: This rule contains sexually explicit keywords
+  // 
   and sender.email.email == "no-reply@classroom.google.com"
+  and any(regex.iextract(body.html.display_text,
+                       '(?P<sender_email>(?P<sender_name>[a-zA-Z0-9._%+-]+)@(?P<sender_domain>[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}))'
+        ),
+        .named_groups["sender_email"] not in $sender_emails
+        and .named_groups["sender_email"] not in $recipient_emails
+    )
   and (
     // check for a WhatsApp invitation in the currend_thread
     (
@@ -13,10 +22,18 @@ source: |
         strings.icontains(body.current_thread.text, "WhatsApp")
         and strings.icontains(body.current_thread.text, "invited")
       )
+      // look for an emoji in the subject
+      or (
+          regex.icontains(subject.subject,
+          '[\x{1F300}-\x{1F5FF}\x{1F600}-\x{1F64F}\x{1F680}-\x{1F6FF}\x{1F700}-\x{1F77F}\x{1F780}-\x{1F7FF}\x{1F900}-\x{1F9FF}\x{2600}-\x{26FF}\x{2700}-\x{27BF}\x{2300}-\x{23FF}]')
+      )
+      // look for sexually explicit subject titles
+      or regex.icontains(subject.subject, 
+          '(?:give me|your satisfaction|sex|horny|cock|fuck|\bass\b|pussy|dick|tits|cum|girlfriend|boyfriend|naked|porn|video|webcam|masturbate|orgasm|breasts|penis|vagina|strip|suck|blowjob|hardcore|xxx|nudes?|sexting|cheating|affair|erotic|\blust\b|desire|intimate|explicit|fetish|kinky|seduce|adult community|cam shows|local (?:girls?|women|single)|hook.?up|bed partner)')
     )
     // check for WhatsApp invitation within the OCR of an attachment. 
     or (
-      any(file.explode(beta.message_screenshot()),
+      any(file.explode(file.message_screenshot()),
           regex.icontains(.scan.ocr.raw,
                           // International format with OCR-friendly character classes
                           '\+?[ilo0-9]{1,3}[\s\.\-⋅]?\(?[ilo0-9]{3}\)?[\s\.\-⋅]{0,3}[ilo0-9]{3}[\s\.\-⋅]{0,3}[ilo0-9]{3,4}',


### PR DESCRIPTION
# Description

Casting a wider net with the Classroom Abuse rule to catch explicit or otherwise engaging subject titles.

# Associated samples
- Sample 1
- Sample 2

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01997300-7de8-702a-a2f6-ae3230d79898)
- [Hunt Excluding Explicit Language - This shows the viability of having just the emoji check](https://platform.sublime.security/messages/hunt?huntId=01997300-7de8-702a-a2f6-ae3230d79898)