### PR TITLE
FP reduction: HTML with obfuscation and recipient's email in JavaScript strings

### DIFF
--- a/detection-rules/attachment_html_recipient_in_javascript_identifiers.yml
+++ b/detection-rules/attachment_html_recipient_in_javascript_identifiers.yml
@@ -50,6 +50,15 @@ source: |
                           or strings.contains(., "https://res.cisco.com:443")
                       )
           )
+          // Negating SolarWinds Kiwi Syslog server email reports
+          and not any(file.explode(.),
+                      length(.scan.url.urls) > 0
+                      and all(.scan.url.urls,
+                              strings.contains(.domain.root_domain,
+                                               "kiwisyslog.com"
+                              )
+                      )
+          )
   )
 
 attack_types:


### PR DESCRIPTION
# Description

This pull request adds an exclusion to the detection logic in `attachment_html_recipient_in_javascript_identifiers.yml` to prevent false positives from SolarWinds Kiwi Syslog server email reports.

Detection logic improvements:

* Updated the detection rule to exclude files containing URLs with the root domain `kiwisyslog.com`, which are associated with SolarWinds Kiwi Syslog server email reports, reducing false positives.

# Associated samples
- https://platform.sublime.security/messages/f153e38755a01c6aa4b895ef60ac8a2e58ec5438b46fe3141186f58df511f932?preview_id=0196d0cd-f41b-7226-8736-ea56fe02f672
