### PR TITLE
New rule - Brand impersonation: Square

### DIFF
--- a/detection-rules/brand_impersonation_square.yml
+++ b/detection-rules/brand_impersonation_square.yml
@@ -5,13 +5,13 @@ severity: "medium"
 source: |
   type.inbound
   and (
-    // display name contains Square
-    strings.ilike(strings.replace_confusables(sender.display_name), '*square*')
-  
     // levenshtein distance similar to Square
-    or strings.ilevenshtein(strings.replace_confusables(sender.display_name),
-                            'square'
-    ) <= 1
+    (
+      strings.ilevenshtein(strings.replace_confusables(sender.display_name),
+                           'square'
+      ) <= 1
+      and sender.display_name not in ("SquareX")
+    )
     or any(ml.logo_detect(file.message_screenshot()).brands,
            .name == "Square" and .confidence == "high"
     )


### PR DESCRIPTION
# Description

This rule detects impersonation attempts of Square through various indicators, including sender display name and message content analysis.

# Associated samples
- https://platform.sublime.security/messages/4f3c8c96c5b1d2021562fe2a978e52f01fecf7e7fd6f31c973aa5a1ee104d298?preview_id=01983f98-c421-711e-b349-85e9f1a16f50
- https://platform.sublime.security/messages/hunt?huntId=019977ca-1a15-7277-a544-412a42da5ec5
