### PR TITLE
Update impersonation_netflix.yml

### DIFF
--- a/detection-rules/impersonation_netflix.yml
+++ b/detection-rules/impersonation_netflix.yml
@@ -50,7 +50,8 @@ source: |
     'netflixevents.com', // owned by netflix
     'netelixir.com', // unrelated marketing
     'netflixhouse.com', // owned by netflix
-    "instagram.com"
+    'instagram.com',
+    'netflix.net'
   )
   and sender.email.domain.domain not in (
     'netflix.zendesk.com' // netflix actual support


### PR DESCRIPTION
# Description
Negation for legitimate Netflix domain
https://www.whois.com/whois/netflix.net

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/4f76bd43486b6ba65abd5527353f1a9735eabf09ae798979b421b5ae1ebdb8b4?preview_id=01993ea2-43df-7aa8-97d3-d489361cb641)
