### PR TITLE
Refactor IRS impersonation rule

### DIFF
--- a/detection-rules/brand_impersonation_irs.yml
+++ b/detection-rules/brand_impersonation_irs.yml
@@ -10,23 +10,49 @@ source: |
       strings.ilike(strings.replace_confusables(sender.display_name),
                     '*internal revenue service*'
       )
-      or strings.ilike(strings.replace_confusables(sender.display_name),
-                    'IRS*'
-      )
+      or strings.ilike(strings.replace_confusables(sender.display_name), 'IRS*')
     )
     // levenshtein distance similar to IRS
     or strings.ilevenshtein(strings.replace_confusables(sender.display_name),
                             'internal revenue service'
     ) <= 1
+    or (
+      strings.ilike(strings.replace_confusables(subject.base), 'IRS*')
+      and any(ml.nlu_classifier(body.current_thread.text).topics,
+              .name == "Government Services" and .confidence != "low"
+      )
+    )
   )
   and (
-    any(beta.ml_topic(body.current_thread.text).topics,
-        .name in ("Security and Authentication", "Financial Communications")
-        and .confidence in ("high")
+    (
+      any(ml.nlu_classifier(body.current_thread.text).topics,
+          .name in ("Security and Authentication", "Financial Communications")
+          and .confidence == "high"
+      )
+      and not any(ml.nlu_classifier(body.current_thread.text).topics,
+                  .name in (
+                    "Advertising and Promotions",
+                    "Newsletters and Digests",
+                    "Political Mail",
+                    "Events and Webinars"
+                  )
+                  and .confidence != "low"
+      )
     )
-    or any(beta.ml_topic(beta.ocr(file.message_screenshot()).text).topics,
-           .name in ("Security and Authentication", "Financial Communications")
-           and .confidence in ("high")
+    or (
+      any(ml.nlu_classifier(beta.ocr(file.message_screenshot()).text).topics,
+          .name in ("Security and Authentication", "Financial Communications")
+          and .confidence == "high"
+      )
+      and not any(ml.nlu_classifier(beta.ocr(file.message_screenshot()).text).topics,
+                  .name in (
+                    "Advertising and Promotions",
+                    "Newsletters and Digests",
+                    "Political Mail",
+                    "Events and Webinars"
+                  )
+                  and .confidence != "low"
+      )
     )
     or any(ml.nlu_classifier(body.current_thread.text).intents,
            .name == "cred_theft" and .confidence == "high"


### PR DESCRIPTION
# Description

This pull request updates the detection logic in `detection-rules/brand_impersonation_irs.yml` to improve the accuracy of identifying IRS impersonation emails. The changes enhance the rule by expanding the checks for IRS-related terms in email subjects, refining the use of machine learning classifiers, and excluding certain topics to reduce false positives.

**Detection logic improvements:**

* Added a new check for IRS-related terms in the email subject, combined with a machine learning topic classifier to confirm relevance to "Government Services" with sufficient confidence.
* Updated topic classification logic to use `ml.nlu_classifier` instead of `beta.ml_topic` for both the email body and OCR-extracted text, and refined confidence checks to require `"high"` confidence.

**False positive reduction:**

* Added exclusions for messages classified under topics like "Advertising and Promotions", "Newsletters and Digests", "Political Mail", and "Events and Webinars" unless their confidence is `"low"`, helping to filter out irrelevant emails.

# Associated samples
- https://platform.sublime.security/messages/44e1eea5fe24a459d56061a48cab7be53dc7933d277f6689f6fff7c7dc721bf7?preview_id=0197cce2-e1f1-727a-b6e7-0797a07dd26e
