### PR TITLE
Update impersonation_quickbooks.yml

### DIFF
--- a/detection-rules/impersonation_quickbooks.yml
+++ b/detection-rules/impersonation_quickbooks.yml
@@ -7,6 +7,7 @@ source: |
   and (
     (
       strings.ilike(sender.display_name, 'quickbook*')
+      or strings.ilike(sender.display_name, 'Intuit*')
       or strings.ilevenshtein(sender.display_name, 'quickbooks') <= 1
       or strings.ilike(sender.email.domain.domain, '*quickbook*')
     )

--- a/detection-rules/impersonation_quickbooks.yml
+++ b/detection-rules/impersonation_quickbooks.yml
@@ -7,7 +7,7 @@ source: |
   and (
     (
       strings.ilike(sender.display_name, 'quickbook*')
-      or strings.ilike(sender.display_name, 'Intuit*')
+      or strings.ilike(sender.display_name, 'intuit*')
       or strings.ilevenshtein(sender.display_name, 'quickbooks') <= 1
       or strings.ilike(sender.email.domain.domain, '*quickbook*')
     )


### PR DESCRIPTION
# Description
additional check for Intuit in the sender display name to cover missed samples below 

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/4f8143c26107f3cc47e2b595239f4607928c0c81a76bf5588a485171464e1fc9?preview_id=0199821e-5f02-756f-a990-d93b7e858ba3)
- [Sample 2](https://platform.sublime.security/messages/4f811613e030a89cdbb5549727c824286458b1f0931bf4985203099205f74b81?preview_id=01998260-f362-7953-978a-386d49ce5137)
- [Sample 3](https://platform.sublime.security/messages/4f810a43cdc92400e1698bd57c68b1fe4c97b1c290d9448cf4bd3e76d92dbefd?preview_id=01997228-6aea-7629-b8fc-6c6f2b3cff4f)

## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019995b2-16a3-7588-92b8-167d34941b2c) - hunt with just new addition, multiple samples here the current rule is missing

