### PR TITLE
Fix ignoring testing_sha only test-rule updates

### DIFF
--- a/.github/workflows/update-test-rules.yml
+++ b/.github/workflows/update-test-rules.yml
@@ -153,24 +153,17 @@ jobs:
           GIT_STATUS=$(git status --porcelain "$FILE" | cut -c1-2 | tr -d ' ')
           if [[ "$GIT_STATUS" == "A" ]]; then
             ADDED_COUNT=$((ADDED_COUNT+1))
+            STATUS="added"
           elif [[ "$GIT_STATUS" == "M" ]]; then
             MODIFIED_COUNT=$((MODIFIED_COUNT+1))
+            STATUS="modified"
           else
             MODIFIED_COUNT=$((MODIFIED_COUNT+1))
+            STATUS="changed"
           fi
           
           # Extract rule name and commit
           RULE_NAME=$(grep -m 1 "name:" "$FILE" | sed 's/name: //' | sed 's/^"//' | sed 's/"$//' | sed "s/^'//" | sed "s/'$//")
-          
-          # Determine status directly from git
-          GIT_STATUS=$(git status --porcelain "$FILE" | cut -c1-2 | tr -d ' ')
-          if [[ "$GIT_STATUS" == "A" ]]; then
-            STATUS="added"
-          elif [[ "$GIT_STATUS" == "M" ]]; then
-            STATUS="modified" 
-          else
-            STATUS="changed"
-          fi
           
           # Build commit message
           COMMIT_MSG="[PR #${PR_NUMBER}] ${STATUS} rule: ${RULE_NAME}"


### PR DESCRIPTION
# Description

This reintroduces changes made in #3279 which were reverted in #3292.

I refactored and cleaned up changes which originally started in #3189. The approach there was not great and it was confusing. [Here](https://github.com/sublime-security/sublime-rules/compare/df81636e218c4ca98e218e7beaa4feb8090eafce...cd.fix-testing-sha-only-changes#diff-46da79a1bb80815448d4b83787836733bedb89d169329dd3bf05b98474d1128d) you can see the diff between this change and the version of the workflow before I started messing with it (I can't link the file, and I've only changed the `Commit changes` step of `update-test-rules.yml`) -- basically these changes are simpler than what was originally done.

## Testing
Rather than local testing, I spun up a fork and got its `test-rule` syncing working and then debugged through all the cases I knew to care about:

1. New rule
2. Modifications to an existing rule
3. Closing a PR
4. Updating a branch w/o changing the rest of the rule

This seems to at last work. I've also left some debug printing which should be helpful to understand what all is going on in case of future issues.