### PR TITLE
Exclude CheckPoint encrypted messages from fake VM rule

### DIFF
--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -634,6 +634,14 @@ source: |
     )
     and any(attachments, .content_type == "message/rfc822")
   )
+  // negate CheckPoint encrypted messages
+  and not (
+      // CheckPoint banner
+      length(attachments) == 1
+      and any(body.links, .href_url.domain.root_domain == "checkpointcloudsec.com")
+      and strings.istarts_with(headers.message_id, "<encrypted")
+      and any(headers.domains, .root_domain == "checkpointcloudsec.com")
+  )
   // an impersonated high trust domain 
   and (
     (


### PR DESCRIPTION

# Description

Added a condition to exclude CheckPoint encrypted messages from detection rules.


# Associated samples
- https://platform.sublime.security/messages/583e62ac34dd5d942e8ebfea9e4f03645f4e57154b7a752e76c982e1ded4440d?preview_id=0197e5e5-bd27-7c77-9e0d-87b128be883e