### PR TITLE
Negate tracking pixels as images in fake VM rule

### DIFF
--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -72,7 +72,7 @@ source: |
     or (
       length(attachments) > 0
       and (
-        all(attachments, .file_type in $file_types_images)
+        all(attachments, .file_type in $file_types_images and beta.parse_exif(.).image_height != 1)
         or (
           // there is a mix of fake audio attachments and images
           length(filter(filter(attachments,
@@ -86,7 +86,7 @@ source: |
                  )
           // the total # of fake audio attachments + the total # of image attachments = the total # of attachments
           // meaning, all attachments that are NOT fake audio attachments MUST be images
-          ) + length(filter(attachments, .file_type in $file_types_images)) == length(attachments
+          ) + length(filter(attachments, .file_type in $file_types_images and beta.parse_exif(.).image_height != 1)) == length(attachments
           )
         )
       )


### PR DESCRIPTION
# Description

Negating tiny images.

# Associated samples
- https://platform.sublime.security/messages/a255b9edfed4d359b3ab9af47dc9f1a3f51ce5fc7763eb3a6d58a33363ba3e5f?preview_id=0197e5e6-7abd-71ba-894c-7aaf9e2dd41c