### PR TITLE
Create headers_system_account_spoof.yml

### DIFF
--- a/detection-rules/headers_system_account_spoof.yml
+++ b/detection-rules/headers_system_account_spoof.yml
@@ -16,6 +16,7 @@ source: |
           and .confidence == "high"
       )
       or regex.icontains(subject.subject, 'Undeliver(?:ed|able)')
+      or regex.icontains(subject.subject, 'Mensagem não entregue') // portuguese variant 
     )
   )
   

--- a/detection-rules/headers_system_account_spoof.yml
+++ b/detection-rules/headers_system_account_spoof.yml
@@ -16,7 +16,8 @@ source: |
           and .confidence == "high"
       )
       or regex.icontains(subject.subject, 'Undeliver(?:ed|able)')
-      or regex.icontains(subject.subject, 'Mensagem não entregue') // portuguese variant 
+      or regex.icontains(subject.subject, 'Mensagem não entregue') // portuguese bounce back variant 
+      or regex.icontains(subject.subject, '系统退信') // chinese bounce back variant 
     )
   )
   

--- a/detection-rules/headers_system_account_spoof.yml
+++ b/detection-rules/headers_system_account_spoof.yml
@@ -8,11 +8,15 @@ source: |
   and (
     strings.icontains(sender.display_name, "mailer-daemon")
     or strings.icontains(sender.display_name, "postmaster")
-    or strings.icontains(sender.display_name, "administrator")
   )
-  and not any(ml.nlu_classifier(body.current_thread.text).topics,
-              .name == "Bounce Back and Delivery Failure Notifications"
-              and .confidence == "high"
+  and not (
+    (
+      any(ml.nlu_classifier(body.current_thread.text).topics,
+          .name == "Bounce Back and Delivery Failure Notifications"
+          and .confidence == "high"
+      )
+      or regex.icontains(subject.subject, 'Undeliver(?:ed|able)')
+    )
   )
   
 attack_types:

--- a/detection-rules/headers_system_account_spoof.yml
+++ b/detection-rules/headers_system_account_spoof.yml
@@ -26,3 +26,4 @@ detection_methods:
   - "Header analysis"
   - "Sender analysis"
   - "Natural Language Understanding"
+id: "887f7953-9dbc-5582-a4b6-b5b79cce6744"

--- a/detection-rules/headers_system_account_spoof.yml
+++ b/detection-rules/headers_system_account_spoof.yml
@@ -1,0 +1,28 @@
+name: "Headers: System account impersonation with empty sender address"
+description: "Detects messages with an empty sender email address and a display name impersonating system accounts like mailer-daemon, postmaster, or administrator, but lacking legitimate bounce back content as determined by natural language processing."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and sender.email.email == ""
+  and (
+    strings.icontains(sender.display_name, "mailer-daemon")
+    or strings.icontains(sender.display_name, "postmaster")
+    or strings.icontains(sender.display_name, "administrator")
+  )
+  and not any(ml.nlu_classifier(body.current_thread.text).topics,
+              .name == "Bounce Back and Delivery Failure Notifications"
+              and .confidence == "high"
+  )
+  
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Employee"
+  - "Social engineering"
+  - "Spoofing"
+detection_methods:
+  - "Header analysis"
+  - "Sender analysis"
+  - "Natural Language Understanding"


### PR DESCRIPTION
# Description
Detects messages with an empty sender email address and a display name impersonating system accounts like mailer-daemon, postmaster, or administrator, but lacking legitimate bounce back content as determined by natural language processing.

## Associated samples
- [Sample 1](https://platform.sublime.security/messages/4f8997954c6b1e826bfcdfadcc2f76d24e07f1abdf63e6ff9ed111ae2db727a6?preview_id=01999ad4-6068-7121-9708-3a8c55205902)
- [Sample 2](https://platform.sublime.security/messages/4f8904a8e9e3d6631c146555da3ed92e6988276f90801df2bf36f4381f48d7b1?preview_id=01999ad4-68a5-705d-bc83-a0cf7ce92269)
- [Sample 3](https://platform.sublime.security/messages/4f88768fb3ab939b13f6eb1f8e5fe2b893995baaf0c704de585ffa5e13400703?preview_id=01999ad4-6f2e-7669-91a4-6efecc75e953)
## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01999aef-c4fd-7367-85ca-43685befb2ed)
