### PR TITLE
Update impersonation_amazon.yml

### DIFF
--- a/detection-rules/impersonation_amazon.yml
+++ b/detection-rules/impersonation_amazon.yml
@@ -91,7 +91,9 @@ source: |
     'amazonworkspaces.com',
     'awsapps.com',
     'aws.com',
-    'awsevents.com'
+    'awsevents.com',
+    'amazon.se',
+    'amazon.ie'
   )
   
   // negate amazon.com.be explicitly, this cannot be part of the root_domain set above as it uses the PSL (Public suffix list) for parsing and com.be is owned by amazon directly.


### PR DESCRIPTION
# Description

Adding two legitimate amazon international domains as an FP negation.

[- Reference 1](https://www.whois.com/whois/amazon.se)
[- Reference 2](https://www.whois.com/whois/amazon.ie)
[- Reference 3](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/se.html)
[- Reference 4](https://www.aboutamazon.com/news/retail/amazon-ireland)

# Associated samples

[- Sample 1](https://platform.sublime.security/messages/4f810a76cd4c0ed36fb5a99cdd2be4101c6b9b3733795737d2fa644d61decb93?preview_id=01999554-a367-70b5-aa27-7174ad7aa61f)
[- Sample 2](https://platform.sublime.security/messages/4f844e688ce1f4d4fdf62745a9a5f10d9da5f844b5c757a522107fe6d2914195?preview_id=019995b0-01eb-793a-a630-f3b94b24d339)