### PR TITLE
Update impersonation_meta.yml

### DIFF
--- a/detection-rules/impersonation_meta.yml
+++ b/detection-rules/impersonation_meta.yml
@@ -20,7 +20,6 @@ source: |
                       'meta ?business',
                       'meta ?for ?business',
                       'meta ?policy',
-                      
                       'page ?ads ?support',
                       'Instagram ?Not',
                       'Instagram ?Policies',

--- a/detection-rules/impersonation_meta.yml
+++ b/detection-rules/impersonation_meta.yml
@@ -177,7 +177,8 @@ source: |
     'capterra.com', // they mention "Community Guidelines"
     'facebookblueprint.com',
     'metaenterprisemail.com',
-    'pigfacebookstore.com.au' // unrelated domain but hitting on facebook 
+    'pigfacebookstore.com.au', // unrelated domain but hitting on facebook 
+    'metacompliance.com'
   )
   // negate metaenterprise links
   and not any(headers.reply_to, .email.email == "noreply@facebookmail.com")

--- a/detection-rules/impersonation_meta.yml
+++ b/detection-rules/impersonation_meta.yml
@@ -20,6 +20,7 @@ source: |
                       'meta ?business',
                       'meta ?for ?business',
                       'meta ?policy',
+                      
                       'page ?ads ?support',
                       'Instagram ?Not',
                       'Instagram ?Policies',
@@ -29,7 +30,10 @@ source: |
                       'Ads ?Team',
                       'Meta & Coursera',
                       'Compliance & Security',
-                      'meta.*inc'
+                      'meta.*inc',
+                      'meta ?copyright',
+                      'meta ?compliance',
+                      'meta ?pro'
       )
       or strings.ilevenshtein(sender.display_name, 'facebook ads') <= 2
       or strings.ilevenshtein(sender.display_name, 'facebook business') <= 2

--- a/detection-rules/impersonation_meta.yml
+++ b/detection-rules/impersonation_meta.yml
@@ -178,7 +178,8 @@ source: |
     'facebookblueprint.com',
     'metaenterprisemail.com',
     'pigfacebookstore.com.au', // unrelated domain but hitting on facebook 
-    'metacompliance.com'
+    'metacompliance.com',
+    'metaprop.com' // unrelated domain but hitting on meta pro
   )
   // negate metaenterprise links
   and not any(headers.reply_to, .email.email == "noreply@facebookmail.com")


### PR DESCRIPTION
# Description
Added three additional keywords in the sender display name check to cover missed samples + negation for legitimate Meta domain.
# Associated samples

- [Sample 1](https://platform.sublime.security/messages/4f89ad3602ca47dd46a4c63ed4cf9073221348cdf0d0309e2f586c1344f683fd?preview_id=01999b00-0f02-738b-80ef-f2cb09ee3dbd)
- [Sample 2](https://platform.sublime.security/messages/4f8951029a0e08ffc6ab6d3d3343be369ab39c5d6a63754a34f93e68242d36bf?preview_id=01999a33-18c0-79b1-952e-0fa131e89949)
- [Sample 3 ](https://platform.sublime.security/messages/4f71133f0b1f4aa81128d7bf91f116009ddbfe7051a42a64ac4d2dcccc9a65bd?preview_id=01991f79-8758-781e-af66-348379ecfced)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=0199a5bf-0af4-78ea-9b5a-cfabdc925cd3) exclusive hunt showing just new additions from new logic

