### PR TITLE
Create service_abuse_cisco_secure_email.yml

### DIFF
--- a/detection-rules/service_abuse_cisco_secure_email.yml
+++ b/detection-rules/service_abuse_cisco_secure_email.yml
@@ -29,3 +29,4 @@ detection_methods:
   - "Header analysis"
   - "Natural Language Understanding"
   - "Sender analysis"
+id: "43a6daa8-e401-5b49-a6a2-ee9ed7e379fd"

--- a/detection-rules/service_abuse_cisco_secure_email.yml
+++ b/detection-rules/service_abuse_cisco_secure_email.yml
@@ -1,0 +1,31 @@
+name: "Service abuse: Cisco secure email service with financial request"
+description: "Detects messages impersonating Cisco (res.cisco.com) that contain financial topics or invoice requests, with mismatched reply-to domains and undisclosed recipients."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and sender.email.domain.domain == 'res.cisco.com'
+  and any(headers.reply_to, .email.domain.domain != 'res.cisco.com')
+  and (
+    length(recipients.to) == 0
+    or all(recipients.to, .display_name == "Undisclosed recipients")
+  )
+  and (
+    any(ml.nlu_classifier(body.current_thread.text).topics,
+        .name in ("Financial Communications", "Request to View Invoice")
+    )
+    or any(ml.nlu_classifier(subject.base).entities, .name == "financial")
+  )
+  
+
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+  - "Evasion"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"

--- a/detection-rules/service_abuse_cisco_secure_email.yml
+++ b/detection-rules/service_abuse_cisco_secure_email.yml
@@ -1,5 +1,5 @@
 name: "Service abuse: Cisco secure email service with financial request"
-description: "Detects messages impersonating Cisco (res.cisco.com) that contain financial topics or invoice requests, with mismatched reply-to domains and undisclosed recipients."
+description: "Detects messages abusing Cisco's secure email service (res.cisco.com) that contain financial topics or invoice requests, with mismatched reply-to domains and undisclosed recipients."
 type: "rule"
 severity: "high"
 source: |


### PR DESCRIPTION
# Description
Detects messages abusing Cisco's secure email service (res.cisco.com) that contain financial topics or invoice requests, with mismatched reply-to domains and undisclosed recipients.

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=0199a077-4f47-7015-99f1-4b4e88fccfd4)

