### PR TITLE
Update brand_impersonation_robert_half.yml

### DIFF
--- a/detection-rules/brand_impersonation_robert_half.yml
+++ b/detection-rules/brand_impersonation_robert_half.yml
@@ -23,7 +23,8 @@ source: |
   and not any(ml.nlu_classifier(body.current_thread.text).topics,
               .name in (
                 "Newsletters and Digests",
-                "Voicemail Call and Missed Call Notifications"
+                "Voicemail Call and Missed Call Notifications",
+                "Advertising and Promotions"
               )
               and .confidence != "low"
   )


### PR DESCRIPTION
# Description
FP negation for NLU advertising and promotions. This company has the same address as Robert Half and is already negated as a domain, but these are third party promotions for it.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/4f8a49720f804411a9b23bae91c1f09a76af7a1a061205726a6bf94391c58631?preview_id=0199a0aa-0810-7aac-8cec-dc1b3ab1a2ba)

