### PR TITLE
Spam: Website errors solicitation rule to combat FNs

### DIFF
--- a/detection-rules/spam_website_errors_solicitation.yml
+++ b/detection-rules/spam_website_errors_solicitation.yml
@@ -1,0 +1,24 @@
+name: "Spam: Website errors solicitation"
+description: "This rule detects messages claiming to have identified errors on a website. The messages typically offer to send pricing or information upon request."
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and sender.email.email not in $recipient_emails
+  and strings.icontains(body.current_thread.text, "waiting for your reply")
+  and any(
+      body.previous_threads, strings.icontains(.text, "errors on your web")
+      or strings.icontains(.text, "errors report")
+      or (
+          strings.icontains(.text, "screenshot") and strings.icontains(.text, "errors")
+      )
+      or strings.icontains(.text, "OK-SEND")
+  )
+
+tags:
+  - "Attack surface reduction"
+attack_types:
+  - "Spam"
+detection_methods:
+  - "Content analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

As part of our new internal process to reduce FNs, we are creating this rule to reduce these Spam attempts of offering to fix errors on a website.

# Associated samples

- [Sample1](https://platform.sublime.security/messages/4f8a62a2dca3ee46c92cdb8f84f4cf40dc6c7415a3306a49618278481f3e020c?preview_id=0199a07c-7dd1-742b-827c-7b3ed48f8939)

## Associated hunts

- [All Messages Hunt 1](https://platform.sublime.security/messages/hunt?huntId=0199a6da-bfb9-7f32-9ca5-3e575b67e85d)
