### PR TITLE
Spam: Meta Social Media Marketing

### DIFF
--- a/detection-rules/spam_meta_social_marketing.yml
+++ b/detection-rules/spam_meta_social_marketing.yml
@@ -15,3 +15,4 @@ attack_types:
   - "Spam"
 detection_methods:
   - "Content analysis"
+id: "a0a1b464-8374-599b-b47a-4af867da28b0"


### PR DESCRIPTION
# Description

We've seen a influx of spam related to offering a certification in social media marketing training. This rule is to detect these as spam.

# Associated samples

- [Sample](https://platform.sublime.security/messages/4f8cfac67f74ba6e2f268151e6708a5b9ddb6aa7a2cda4aede23fa7eebb8e664?preview_id=0199ab24-2c56-76de-ba29-fbe24026c049)

## Associated hunts

- [Hunt](https://platform.sublime.security/messages/hunt?huntId=0199ab38-5b00-78ad-a7c8-0ebdc3150920)

