### PR TITLE
add capitalonetradecredit.com domain to impersonation_capitalone.yml

### DIFF
--- a/detection-rules/impersonation_capitalone.yml
+++ b/detection-rules/impersonation_capitalone.yml
@@ -39,7 +39,8 @@ source: |
       "capitalonearena.com", // the arena
       "monumentalsports.com", // the company that owns a bunch of teams that play at the arena?
       "ticketmaster.com", // sell and advertises tickets at Capital One Arena
-      "credible.com" // known loan marketplace
+      "credible.com", // known loan marketplace
+      "capitalonetradecredit.com" // domain associated with Capital One's trade credit platform
     )
     and headers.auth_summary.dmarc.pass
   )


### PR DESCRIPTION
# Description

Updating the rule `impersonation_capitalone.yml` to include exclusion for another Capital One owned & operated domain `capitalonetradecredit.com`, used for their trade credit service platform. 

# Associated samples
With this update we eliminate false positives such as:

- [Sample 1](https://platform.sublime.security/messages/4f8361e54064ce21ad753b5c999838d7259982c89294857329a69b60ebf6d35d)
- [Sample 2](https://platform.sublime.security/messages/4f6f0b80598049edcd667746f138f59f832943c62809cd413e9c6c9eb5fb5fc6)
