### PR TITLE
LWescott create gophish_abuse_pixel_tracking rule

### DIFF
--- a/detection-rules/gophish_abuse_pixel_tracking.yml
+++ b/detection-rules/gophish_abuse_pixel_tracking.yml
@@ -1,0 +1,22 @@
+name: "Credential theft: Gophish abuse with hidden tracking image"
+description: "Detects messages containing hidden tracking images with display:none style and tracking parameters in the source URL, commonly used for user tracking and engagement monitoring."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and (
+    strings.icontains(body.html.raw,
+                      '<img alt='''' style=''display: none'' src='''
+    )
+    or strings.icontains(body.html.raw, 'img alt="" style="display: none" src="')
+  )
+  and strings.icontains(body.html.raw, '/track?rid=')
+
+attack_types:
+  - "Spam"
+tactics_and_techniques:
+  - "Evasion"
+  - "Image as content"
+detection_methods:
+  - "Content analysis"
+  - "HTML analysis"


### PR DESCRIPTION
# Description
Creating a rule to detect the use of gophish abuse with hidden pixel tracking images. Meant to look at instances where 

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/4f8b9be15f269a2c489c7ae6a46d103c68ed1b10f9adf41e6e4f0439a0cffcb2?preview_id=0199a6d2-d596-75b9-a6bc-492bf5205bfd)
- [Sample 2](https://platform.sublime.security/messages/1c702c1b287373d5b53fcf48bb2ac27f9b67ddedda8d1c987a7de95473685c12?preview_id=01944cb2-845d-7ab3-8bb5-033e4c3f847c) - older sample showing matches on phishing campaigns 

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=0199ab07-0d7f-7cb1-8aef-5ee41efe0aca)
