### PR TITLE
Update link_fake_password_expiration.yml

### DIFF
--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -128,7 +128,14 @@ source: |
   
   // a body link does not match the sender domain
   and any(body.links,
-          .href_url.domain.root_domain != sender.email.domain.root_domain
+          (
+            .href_url.domain.root_domain != sender.email.domain.root_domain
+            // or link URL contains an IPv4 address
+            or (
+              .href_url.domain.root_domain is null
+              and regex.icontains(.href_url.url, '(\d{1,3}.){3}\d{1,3}')
+            )
+          )
           and .href_url.domain.root_domain not in $org_domains
   )
   


### PR DESCRIPTION
# Description

adding logic to account for URLs leading directly to a IPv4 address

# Associated samples
- https://platform.sublime.security/messages/4f8fa397728e7854c919318364979d7b9470bb4957fd1f9ac8ff3214a29e5af1
