### PR TITLE
Update credential_phishing_esign_document_notification.yml

### DIFF
--- a/detection-rules/credential_phishing_esign_document_notification.yml
+++ b/detection-rules/credential_phishing_esign_document_notification.yml
@@ -164,6 +164,10 @@ source: |
   
         // the display text is _exactly_
         or .display_text in~ ("Open")
+  
+        // URL fragment containing recipient's address
+        or .href_url.fragment in map(recipients.to, .email.email)
+
     )
     // one hyperlinked image that's not a tracking pixel
     or (


### PR DESCRIPTION
# Description

adding logic to flag links containing the recipient's email in a URL fragment

# Associated samples
- https://platform.sublime.security/messages/4f8f6960c212085092d29876dd7ce669490294072cccb1827eb4efe4a7587298

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=0199bb15-7138-7a2e-a844-de411f2e64c4