### PR TITLE
Create credential_phishing_nifty.com_domain_abuse.yml

### DIFF
--- a/detection-rules/credential_phishing_nifty.com_domain_abuse.yml
+++ b/detection-rules/credential_phishing_nifty.com_domain_abuse.yml
@@ -1,0 +1,32 @@
+name: "Credential phishing: Nifty.com domain abuse"
+description: "Detects emails from nifty.com where the sender's local part matches a recipient's local part or organizational SLD, which has been observed in credential harvesting campaigns"
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and sender.email.domain.root_domain == "nifty.com"
+  and (
+    sender.email.local_part in map(recipients.to, .email.local_part)
+    or sender.email.local_part in $org_slds
+  )
+  
+  // negate replies
+  and (
+    length(headers.references) == 0
+    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+  )
+  
+  // and no false positives and not solicited
+  and (
+    (
+      not profile.by_sender_email().any_messages_benign
+      and not profile.by_sender_email().solicited
+    )
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Spoofing"
+detection_methods:
+  - "Sender analysis"


### PR DESCRIPTION
# Description

Detects emails from nifty.com where the sender's local part matches a recipient's local part or organizational SLD, which has been observed in credential harvesting campaigns

# Associated samples
- https://platform.sublime.security/messages/4f88a9b5e9588b7b4662fc585f4c33f29b9508b68171339ca3cd2302dd17ced4
- https://platform.sublime.security/messages/4f835e874be237b411e8de6857337cd3306e094d54617f2805e6238587ddcd2f
- https://platform.sublime.security/messages/4f831a7ab9a4d2d5696940ba8040c114c21540766e8db7d04059a586226f7d7a

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=0199bb76-058e-75df-b521-b022bdbdbb95