### PR TITLE
Use checkout for sublime-security/sublime-rules for scripts

### DIFF
--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -116,6 +116,9 @@ jobs:
         run: |
           pip install -r sublime-rules-main/scripts/generate-rule-ids/requirements.txt
           python sublime-rules-main/scripts/generate-rule-ids/main.py
+          
+          # Delete path to prevent interference with later steps (such as git add and commit)
+          rm -r sublime-rules-main
 
       - name: Validate Rules
         if: github.event_name != 'issue_comment'

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -103,12 +103,19 @@ jobs:
         with:
           python-version: '3.10'
 
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          repository: sublime-security/sublime-rules
+          ref: main
+          path: sublime-rules-main
+
       - name: Add Rule IDs as Needed & Check for Duplicates
         if: github.event_name != 'issue_comment'
         # Run before testing, just in case this could invalidate the rule itself
         run: |
-          pip install -r scripts/generate-rule-ids/requirements.txt
-          python scripts/generate-rule-ids/main.py
+          pip install -r sublime-rules-main/scripts/generate-rule-ids/requirements.txt
+          python sublime-rules-main/scripts/generate-rule-ids/main.py
 
       - name: Validate Rules
         if: github.event_name != 'issue_comment'

--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Checkout
+      - name: Checkout script from Sublime fork main
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: sublime-security/sublime-rules


### PR DESCRIPTION
# Description

Ensure that we cannot run a 3rd parties script in our own context. Tested in https://github.com/sublime-security/sublime-rules/pull/3392