### PR TITLE
Create service_abuse_intuit_noreply.yml

### DIFF
--- a/detection-rules/service_abuse_intuit_noreply.yml
+++ b/detection-rules/service_abuse_intuit_noreply.yml
@@ -21,3 +21,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Sender analysis"
   - "URL analysis"
+id: "1ad5dc14-2360-59f6-bf42-872052be8499"

--- a/detection-rules/service_abuse_intuit_noreply.yml
+++ b/detection-rules/service_abuse_intuit_noreply.yml
@@ -1,0 +1,23 @@
+name: "Service abuse: Intuit no-reply with credential theft indicators"
+description: "Detects messages from Intuit's legitimate do_not_reply address that contain credential theft language or links to non-Intuit domains, indicating potential compromise of legitimate infrastructure."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and sender.email.email == 'do_not_reply@intuit.com'
+  and (
+    any(ml.nlu_classifier(body.current_thread.text).intents,
+        .name == "cred_theft" and .confidence != "low"
+    )
+    or (all(body.links, .href_url.domain.root_domain != "intuit.com"))
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Natural Language Understanding"
+  - "Sender analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description
Detects messages from Intuit's legitimate do_not_reply address that contain credential theft language or links to non-Intuit domains, indicating potential compromise of legitimate infrastructure.

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/4fe2652448adb5019cfb655f64b2da64a6ab5d9ee83a74520f3dfb39a598eb96?preview_id=019b6b2b-ecb9-7ddc-b7a9-ce83ebdccc1a)

## Associated hunts
- [Hunt 1](https://platform.sublime.security/hunts/019bb945-83b9-7657-8fb7-2808c6a74c14)


