### PR TITLE
Enhance spam detection rule for dating profiles

### DIFF
--- a/detection-rules/spam_fake_dating_profile.yml
+++ b/detection-rules/spam_fake_dating_profile.yml
@@ -4,7 +4,17 @@ type: "rule"
 severity: "low"
 source: |
   type.inbound
-  and sender.email.domain.root_domain in $free_email_providers
+  and (
+    sender.email.domain.root_domain in $free_email_providers
+    or (
+      // Google Calendar invite
+      strings.starts_with(subject.base, "Invitation:")
+      and length(attachments) == 2
+      and all(attachments,
+              .content_type == "text/calendar" or .file_extension == "ics"
+      )
+    )
+  )
   // not a reply
   and length(headers.references) == 0
   and 0 < length(distinct(body.current_thread.links, .href_url.domain.root_domain)
@@ -13,13 +23,32 @@ source: |
           any(.href_url.query_params_decoded["email"],
               strings.parse_email(.).email in map(recipients.to, .email.email)
           )
+          or .href_url.domain.domain == "sites.google.com"
+          or strings.ilike(.href_url.path,
+                           "*Flirt*",
+                           "*Singles*",
+                           "*Dating*",
+                           "*Girls*",
+          )
   )
   and (
     any(ml.nlu_classifier(body.current_thread.text).entities,
         .name == "org"
-        and strings.ilike(.text, "*Date*", "*Dating*", "*Girls*", "*Love*")
+        and strings.ilike(.text,
+                          "*Flirt*",
+                          "*Singles*",
+                          "*Date*",
+                          "*Dating*",
+                          "*Girls*",
+                          "*Love*"
+        )
     )
     or any(ml.nlu_classifier(body.current_thread.text).topics, .name == "Romance")
+  )
+  // negate iCloud Private Message Relay
+  and not (
+    sender.email.domain.root_domain == "privaterelay.appleid.com"
+    or any(headers.hops, any(.fields, .name == "X-ICLOUD-HME"))
   )
 
 attack_types:


### PR DESCRIPTION
# Description

broadening scope of the rule to include messages sent via Google Calendar invites, with additional suspicious indicators such as a link to Google Sites. 

Also negating iCloud Private Relay

# Associated samples
- https://platform.sublime.security/messages/4f6c38ce372a294d3b883e2194631b791e0902b5f38ed692e357a6de5b367a45?preview_id=019bb206-cf6a-7804-809f-d8d950e65c34

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=019bba09-42d5-7c57-a7c0-441d23c86e80 - net new matches
