### PR TITLE
Add detection rule for suspicious Google Meet invitations

### DIFF
--- a/detection-rules/abuse_google_meet.yml
+++ b/detection-rules/abuse_google_meet.yml
@@ -45,3 +45,4 @@ detection_methods:
   - "Content analysis"
   - "HTML analysis"
   - "URL analysis"
+id: "92fa8397-4c0a-56e1-9990-37b15feeb95f"

--- a/detection-rules/abuse_google_meet.yml
+++ b/detection-rules/abuse_google_meet.yml
@@ -1,0 +1,47 @@
+name: "Service abuse: Suspicious Google Meet invitation"
+description: "Detects calendar invitations containing Google Meet links that include suspicious product offers, pricing details, partnership language, or links to messaging platforms like Telegram or WhatsApp. These invitations may be used to lure recipients into fraudulent business discussions or social engineering attacks through trusted calendar services."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and strings.starts_with(subject.base, "Invitation:")
+  and length(attachments) == 2
+  and all(attachments,
+          .content_type == "text/calendar" or .file_extension == "ics"
+  )
+  // Google Meet indicators
+  and (
+    any(body.links,
+        .display_text == "Join with Google Meet"
+        and .href_url.domain.domain == "meet.google.com"
+    )
+  )
+  and (
+    any(html.xpath(body.html,
+                   "//div[@class='primary-text' and @role='presentation'][1]/span"
+        ).nodes,
+        strings.icontains(.display_text, "product offer")
+        or strings.icontains(.display_text, "pricing detail")
+        or (
+          length(.display_text) < 500
+          and regex.icontains(.display_text,
+                              '(?:potential|long([[:punct:]]|\s)term) partner'
+          )
+        )
+        or any(.links,
+               .href_url.domain.domain in $url_shorteners
+               or .href_url.domain.domain in ("t.me", "wa.me")
+        )
+    )
+  )
+  
+
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Out of band pivot"
+detection_methods:
+  - "Content analysis"
+  - "HTML analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description

This rule detects suspicious Google Meet invitations that may be used for fraudulent activities, analyzing calendar invitations for specific indicators and content.

# Associated samples
- https://platform.sublime.security/messages/4fafbd98d85e045ce1651dc1d8d045f5c4071c9f3d9305e493dae5a926a88856
- https://platform.sublime.security/messages/8a2e4c908e9b8a9dcadf5e7c32516be8636a105ddf2f1ff2812b49723c549132
