### PR TITLE
Enhance impersonation detection for Chase emails

### DIFF
--- a/detection-rules/impersonation_chase.yml
+++ b/detection-rules/impersonation_chase.yml
@@ -47,7 +47,10 @@ source: |
                        '(Chase|J\.?\s?P\.?\sMorgan)\s(Privacy|Treasury)\sOperations|(Privacy|Treasury)\sOperations\s(Chase|J\.?\s?P\.?\sMorgan)'
     )
     or (
-      strings.icontains(sender.email.local_part, "chase")
+      (
+        strings.ilike(sender.email.local_part, "chase")
+        or regex.icontains(sender.email.local_part, '[^pur]chase')
+      )
       and (
         any([subject.base, sender.display_name],
             regex.icontains(., 'online ((banking|business|system)|.*alert)')

--- a/detection-rules/impersonation_chase.yml
+++ b/detection-rules/impersonation_chase.yml
@@ -46,6 +46,19 @@ source: |
     or regex.icontains(body.current_thread.text,
                        '(Chase|J\.?\s?P\.?\sMorgan)\s(Privacy|Treasury)\sOperations|(Privacy|Treasury)\sOperations\s(Chase|J\.?\s?P\.?\sMorgan)'
     )
+    or (
+      strings.icontains(sender.email.local_part, "chase")
+      and (
+        any([subject.base, sender.display_name],
+            regex.icontains(., 'online ((banking|business|system)|.*alert)')
+        )
+        or strings.ilike(body.current_thread.text,
+                         "*secure message*",
+                         "*secure login*",
+                         "*wire transfer*"
+        )
+      )
+    )
   )
   and not (
     sender.display_name is not null and sender.display_name in~ ("chaser", "case")
@@ -63,6 +76,8 @@ source: |
       profile.by_sender().any_messages_malicious_or_spam
       and not profile.by_sender().any_messages_benign
     )
+    // bypass sender profile checks if the message was sent via Mailgun
+    or any(headers.hops, any(.fields, strings.starts_with(.name, "X-Mailgun")))
   )
   
   // negate highly trusted sender domains unless they fail DMARC authentication


### PR DESCRIPTION
# Description

Broadening scope of the rule to include local_parts with an additional sus indicator

Also bypassing sender profile checks if the message was sent via Mailgun

# Associated samples
- https://platform.sublime.security/messages/4ff10c23c7e4dc991257aa93284952743ddb1d5889de687cd0c3eeb580b2b400
- https://platform.sublime.security/messages/4ff20704f5f6af23b893f713d3dc0cdcb98cbccb154129c3b18a29675e39590b
- https://platform.sublime.security/messages/4fe6557746eb40792a4e16ac83e8dfaaf78e000f927cb11f87dd9137679b6f13?preview_id=019b7bd6-87a0-7aa0-8e34-90084ea1b4d8

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=019bc935-c905-7bed-a50a-27446512d9c5 - hunt for net new matches
- https://platform.sublime.security/messages/hunt?huntId=019bc926-7ff7-7584-ae42-6a71492f9773 - hunt for messages explicitly sent via mailgun
