### PR TITLE
Update callback_phishing_nlu_body_or_attachments.yml

### DIFF
--- a/detection-rules/callback_phishing_nlu_body_or_attachments.yml
+++ b/detection-rules/callback_phishing_nlu_body_or_attachments.yml
@@ -107,15 +107,6 @@ source: |
       and not profile.by_sender_email().any_messages_benign
     )
   )
-  
-  // negate highly trusted sender domains unless they fail DMARC authentication
-  and (
-    (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and not headers.auth_summary.dmarc.pass
-    )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
-  )
 attack_types:
   - "Callback Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description
looking at the possibility of removing the negation for high trust sender root domains from this rule. seeing plenty of these domains being abused with callback phishing and rather than creating new rules for each, going to see how FP prone it is to remove this stanza entirely. 

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019be77b-51d5-7021-a686-c3269839631d) - this hunt shows this rule matching only high trust sender root domains which provides many samples of domains from that list being abused


