### PR TITLE
[senderprofile] Update link_google_presentation_open_redirect.yml

### DIFF
--- a/detection-rules/link_google_presentation_open_redirect.yml
+++ b/detection-rules/link_google_presentation_open_redirect.yml
@@ -78,8 +78,6 @@ source: |
         'drive-shares-noreply@google.com',
         'calendar-notification@google.com'
       )
-      // ensure the sender prevalence is not common
-      and profile.by_sender().prevalence != "common"
     )
     // or the message is from google actual
     or (


### PR DESCRIPTION
# Description

Removing sender profile from top 10 rules.

This is related to task Exploration of removing FP gates from core feed rules when they have been overly suppressed

