### PR TITLE
Create headers_self_sender_empty_body.yml

### DIFF
--- a/detection-rules/headers_self_sender_empty_body.yml
+++ b/detection-rules/headers_self_sender_empty_body.yml
@@ -23,3 +23,4 @@ detection_methods:
   - "Header analysis"
   - "Sender analysis"
   - "Content analysis"
+id: "6fda670e-8378-5a85-98e6-39fef5d19821"

--- a/detection-rules/headers_self_sender_empty_body.yml
+++ b/detection-rules/headers_self_sender_empty_body.yml
@@ -1,0 +1,25 @@
+name: "Headers: Self-addressed message with empty body"
+description: "Detects messages where the sender address matches the recipient address or the recipient has an invalid domain, with an empty plain text body. This pattern is commonly used to bypass security filters or test mail routing configurations."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and length(recipients.to) == 1
+  and length(recipients.cc) == 0
+  and length(recipients.bcc) == 0
+  and (
+    sender.email.email == recipients.to[0].email.email
+    or recipients.to[0].email.domain.valid == false
+  )
+  and length(body.plain.raw) == 0
+
+attack_types:
+  - "BEC/Fraud"
+  - "Spam"
+tactics_and_techniques:
+  - "Evasion"
+  - "Spoofing"
+detection_methods:
+  - "Header analysis"
+  - "Sender analysis"
+  - "Content analysis"


### PR DESCRIPTION
# Description
Detects messages where the sender address matches the recipient address or the recipient has an invalid domain, with an empty plain text body. This pattern is commonly used to bypass security filters or test mail routing configurations.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/4fecc6f854f59a015a49de610a589def3687f64e475455e7223b7e874ca7eeeb?preview_id=019bb3d3-baf8-7dec-b215-78df649b6a28)


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019bfc95-58e4-78f5-89ab-f607a227f0b8)

