### PR TITLE
Add detection rule for suspicious AWS S3 links

### DIFF
--- a/detection-rules/link_aws_s3_service_abuse.yml
+++ b/detection-rules/link_aws_s3_service_abuse.yml
@@ -4,11 +4,43 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
+  and length(distinct(filter(body.links,
+                                 .href_url.domain.root_domain != "amazonaws.com"
+                          ),
+                          .href_url.domain.root_domain
+                 ),
+  ) <= 3
   and any(body.links,
           // Check root domain first
           .href_url.domain.root_domain in ("amazonaws.com")
           // Check for the specific s3.amazonaws.com subdomain pattern
           and strings.icontains(.href_url.domain.domain, "s3")
+          // Additional suspicious indicator
+          and (
+            // linking directly to the root folder
+            (
+              .href_url.path == "/" or .href_url.path is null
+            )
+            or (
+              strings.ilike(.href_url.path, "/index.html")
+              and .href_url.query_params is null
+            )
+            // target file doesn't have an extension (could also lead to a folder)
+            or not regex.imatch(.href_url.path, '\.\w{2,4}$')
+            // suspicious keywords in bucket name or URL path
+            or (
+              any([.href_url.path, .href_url.domain.domain],
+                  strings.ilike(., "*facebook*", "*sharepoint*", "*broker*")
+              )
+            )
+            // recipient email in URL fragment
+            or (
+              .href_url.fragment is not null
+              and any(recipients.to,
+                      strings.icontains(.email.email, ..href_url.fragment)
+              )
+            )
+          )
   )
   // negate emails with unsubscribe links
   and not any(body.links,
@@ -72,6 +104,7 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
+  and profile.by_sender().prevalence in ("new", "outlier")
   and (
     not profile.by_sender().solicited
     or (

--- a/detection-rules/link_aws_s3_service_abuse.yml
+++ b/detection-rules/link_aws_s3_service_abuse.yml
@@ -5,10 +5,10 @@ severity: "medium"
 source: |
   type.inbound
   and length(distinct(filter(body.links,
-                                 .href_url.domain.root_domain != "amazonaws.com"
-                          ),
-                          .href_url.domain.root_domain
-                 ),
+                             .href_url.domain.root_domain != "amazonaws.com"
+                      ),
+                      .href_url.domain.root_domain
+             ),
   ) <= 3
   and any(body.links,
           // Check root domain first
@@ -113,7 +113,6 @@ source: |
     )
   )
   and not profile.by_sender().any_messages_benign
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/link_aws_s3_service_abuse.yml
+++ b/detection-rules/link_aws_s3_service_abuse.yml
@@ -1,0 +1,93 @@
+name: "Suspicious link to Amazon S3"
+description: "Detects messages containing AWS S3 links from senders not associated with legitimate AWS or organizational domains, excluding newsletters and bulk mailers."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(body.links,
+          // Check root domain first
+          .href_url.domain.root_domain in ("amazonaws.com")
+          // Check for the specific s3.amazonaws.com subdomain pattern
+          and strings.icontains(.href_url.domain.domain, "s3")
+  )
+  // negate emails with unsubscribe links
+  and not any(body.links,
+              strings.icontains(.href_url.url, "unsubscribe")
+              or strings.icontains(.display_text, "unsubscribe")
+  )
+  // negate bulk mailer domains
+  and not any(body.links,
+              .href_url.domain.root_domain in $bulk_mailer_url_root_domains
+  )
+  // negate replies and forwards
+  and not (
+    (subject.is_reply or subject.is_forward) and length(headers.references) > 0
+  )
+  and not (
+    any(ml.nlu_classifier(body.current_thread.text).topics,
+        .name in (
+          "Newsletters and Digests",
+          "Advertising and Promotions",
+          "Educational and Research",
+          "B2B Cold Outreach",
+          "Health and Wellness",
+          "Professional and Career Development",
+          "Romance",
+          "Sexually Explicit Messages",
+          "Software and App Updates",
+          "Acts of Violence",
+          "Voicemail Call and Missed Call Notifications"
+        )
+        and .confidence == "high"
+    )
+  )
+  // Not from legitimate AWS domains
+  // there was a DMARC check here, but a lot of users send AWS notifications to groups/mailing lists that breaks DMARC
+  and not (
+    sender.email.domain.root_domain in $org_domains
+    or sender.email.domain.root_domain in (
+      "amazon.com",
+      "amazonaws.com",
+      "amazonses.com",
+      "awsevents.com",
+      "aws-experience.com",
+      "marketplace.aws",
+      "aws.com",
+      "amazonaws.cn",
+      "repost.aws",
+      "awscustomercouncil.com",
+      "airtableemail.com", // used for re:Invent
+      "nmls.org", // "state examination system", realtor software
+      "mktgcampaigns.com", // Elastic + AWS co-marketing emails
+      "awseducate.com",
+      "awsacademy.com"
+    )
+    or sender.email.domain.tld == "local"
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+  and (
+    not profile.by_sender().solicited
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and not profile.by_sender().any_messages_benign
+    )
+  )
+  and not profile.by_sender().any_messages_benign
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Free subdomain host"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"
+  - "URL analysis"

--- a/detection-rules/link_aws_s3_service_abuse.yml
+++ b/detection-rules/link_aws_s3_service_abuse.yml
@@ -91,3 +91,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Sender analysis"
   - "URL analysis"
+id: "e9a779c8-42eb-5373-a278-6bc14b1e9ec5"


### PR DESCRIPTION
# Description

This rule detects suspicious links to Amazon S3 from untrusted senders, excluding legitimate domains and certain types of emails.

# Associated samples
- https://platform.sublime.security/messages/50005108289cb484158b70f4c17aa423d76c689b91f2ae57466f2da14d0d02d0
- https://platform.sublime.security/messages/4ffff8d9e344b8684867d767dd37906bca1eeeeb42759c75e66cdae56e30f72b
- https://platform.sublime.security/messages/4ffd41750e173be99daed88864f994c3eae10a7ec0805ac44ce43c086c2f135a

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=019bfd5a-483f-7576-8f25-d39732b78083
