### PR TITLE
Add detection rule for BAT file attachments

### DIFF
--- a/detection-rules/attachment_bat_file.yml
+++ b/detection-rules/attachment_bat_file.yml
@@ -1,0 +1,23 @@
+name: "Attachment: BAT file"
+description: "Detects inbound messages containing batch (.bat) files either as direct attachments or within compressed archives. Batch files can be used to execute malicious commands on Windows systems and are commonly used in malware distribution."
+type: "rule"
+severity: "high"
+source: |
+    type.inbound
+    and length(attachments) > 0
+    and any(attachments,
+            .file_extension =~ "bat"
+            or (
+              .file_extension in~ $file_extensions_common_archives
+              and any(file.explode(.), .file_extension =~ "bat")
+            )
+    )
+
+attack_types:
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Scripting"
+  - "Evasion"
+detection_methods:
+  - "Archive analysis"
+  - "File analysis"

--- a/detection-rules/attachment_bat_file.yml
+++ b/detection-rules/attachment_bat_file.yml
@@ -21,3 +21,4 @@ tactics_and_techniques:
 detection_methods:
   - "Archive analysis"
   - "File analysis"
+id: "0fb8a010-1d12-579a-9ca0-186ee8782510"


### PR DESCRIPTION
# Description

This rule detects inbound messages with batch files as attachments or within compressed archives.

# Associated samples
- https://platform.sublime.security/messages/4ff835e44f7d1e0ead380a0d9212ec6c85a18d7f66f617f873c2a95a7424ce05?preview_id=019bd899-1d45-7c29-98ca-23339ebcc513&organization_id=dd9bdcae-c771-4263-9d48-71ea47cd49c2

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=019c0640-7cd4-7283-ab73-69e48b2b98ec