### PR TITLE
Add detection rule for MSG files with VBA macros

### DIFF
--- a/detection-rules/attachment_msg_macros.yml
+++ b/detection-rules/attachment_msg_macros.yml
@@ -11,6 +11,8 @@ source: |
           and file.oletools(.).indicators.vba_macros.risk in ("medium", "high")
   )
 
+tags:
+  - "Attack surface reduction"
 attack_types:
   - "Malware/Ransomware"
 tactics_and_techniques:

--- a/detection-rules/attachment_msg_macros.yml
+++ b/detection-rules/attachment_msg_macros.yml
@@ -20,3 +20,4 @@ detection_methods:
   - "File analysis"
   - "Macro analysis"
   - "OLE analysis"
+id: "61aa2756-ad88-56ea-8d29-3cf657adbdc5"

--- a/detection-rules/attachment_msg_macros.yml
+++ b/detection-rules/attachment_msg_macros.yml
@@ -1,0 +1,22 @@
+name: "Attachment: MSG file with VBA macros"
+description: "Detects MSG file attachments containing VBA macros with medium to high risk indicators. MSG files with attachments containing embedded macros can be used to deliver malicious code while appearing as legitimate Outlook message files."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and length(attachments) > 0
+  and any(attachments,
+          .file_extension =~ "msg"
+          and file.oletools(.).indicators.vba_macros.exists
+          and file.oletools(.).indicators.vba_macros.risk in ("medium", "high")
+  )
+
+attack_types:
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Evasion"
+  - "Macros"
+detection_methods:
+  - "File analysis"
+  - "Macro analysis"
+  - "OLE analysis"


### PR DESCRIPTION
# Description

This rule detects MSG file attachments that contain VBA macros with medium to high risk indicators, which can be used to deliver malicious code.

# Associated samples
- https://platform.sublime.security/messages/4ff803d62e26e2b7f6360fed05001ecca53b57d40f1b042b1d1d6e9d56dc710a?preview_id=019be798-3153-757f-b348-e00b905483d4

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=019c093e-d5c2-70cb-b8af-38b68ce39d52