### PR TITLE
Add detection rule for Zendesk callback phishing

### DIFF
--- a/detection-rules/callback_phishing_zendesk.yml
+++ b/detection-rules/callback_phishing_zendesk.yml
@@ -1,0 +1,21 @@
+name: "Service abuse: Callback phishing via Zendesk support ticket"
+description: "Detects messages sent via Zendesk with subject lines containing callback scam indicators."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and headers.mailer == "Zendesk Mailer"
+  and (
+    any(ml.nlu_classifier(subject.subject).intents,
+        .name in ("callback_scam") and .confidence in ("medium", "high")
+    )
+  )
+
+attack_types:
+  - "Callback Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Out of band pivot"
+detection_methods:
+  - "Header analysis"
+  - "Natural Language Understanding"

--- a/detection-rules/callback_phishing_zendesk.yml
+++ b/detection-rules/callback_phishing_zendesk.yml
@@ -19,3 +19,4 @@ tactics_and_techniques:
 detection_methods:
   - "Header analysis"
   - "Natural Language Understanding"
+id: "a0342325-6692-5ad8-8514-9743dd96a816"


### PR DESCRIPTION
# Description

This rule detects callback phishing attempts via Zendesk support tickets by analyzing subject lines for scam indicators.

https://www.bleepingcomputer.com/news/security/zendesk-ticket-systems-hijacked-in-massive-global-spam-wave/1%3E

https://www.techradar.com/pro/security/zendesk-tickets-hijacked-in-massive-spam-campaign2%3E

# Associated samples
- https://platform.sublime.security/messages/5003969ec881ad2f336eda9f5780044038a6a8171b3ba4b81cdc2fdc1ea306b4?preview_id=019c0fc2-98d6-7f20-bca6-c3908d532a94
- https://platform.sublime.security/messages/4fad04b3e8792abc531a0df79366e360e8dcedccc60196134e1a99b595febb60?preview_id=019a54c6-2f9b-75d5-8342-036374d970ac
- https://platform.sublime.security/messages/4fed46a83a769db21417cb8b8a1b24c9ee3ba4a3a5692921f1aaec193dbb680e?preview_id=019b9e21-6529-7c10-9bfa-5e65e790d327

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=019c1300-cf4d-79c7-8e68-6e449739dfa0