### PR TITLE
Update impersonation_norton_lifelock.yml

### DIFF
--- a/detection-rules/impersonation_norton_lifelock.yml
+++ b/detection-rules/impersonation_norton_lifelock.yml
@@ -12,7 +12,7 @@ source: |
   type.inbound
   and (
     any([sender.display_name, subject.base],
-      regex.icontains(., 'norton.{0,5}(?:lifelock|subscription|billing)')
+        regex.icontains(., 'norton.{0,5}(?:lifelock|subscription|billing)')
     )
     or any(attachments,
            (.file_type in $file_types_images or .file_type == "pdf")

--- a/detection-rules/impersonation_norton_lifelock.yml
+++ b/detection-rules/impersonation_norton_lifelock.yml
@@ -11,9 +11,8 @@ severity: "low"
 source: |
   type.inbound
   and (
-    strings.icontains(sender.display_name, "norton")
-    or regex.icontains(subject.base,
-                       "norton.{0,5}(?:lifelock|subscription|renewal)"
+    any([sender.display_name, subject.base],
+      regex.icontains(., 'norton.{0,5}(?:lifelock|subscription|billing)')
     )
     or any(attachments,
            (.file_type in $file_types_images or .file_type == "pdf")

--- a/detection-rules/impersonation_norton_lifelock.yml
+++ b/detection-rules/impersonation_norton_lifelock.yml
@@ -10,58 +10,35 @@ type: "rule"
 severity: "low"
 source: |
   type.inbound
-  and sender.email.domain.domain != "norton.com"
-  and any(attachments,
-          (.file_type in $file_types_images or .file_type == "pdf")
-          and (
-            (
-              strings.ilike(.file_name, "*norton*")
-              and not (
-                any(recipients.to, strings.iends_with(.display_name, "Norton"))
-              )
-            )
-            or any(file.explode(.),
-                   regex.icontains(.scan.ocr.raw,
-                                   ".*norton.?60.*",
-                                   ".*lifelock.*",
-                                   ".*norton.?security.*",
-                                   ".*norton.?anti.?virus.*",
-                                   ".*Norton.{2,3}subscription.*"
-                   )
-            )
-          )
-  )
   and (
-    (
-      // if freemail, flag if it's a first-time sender
-      sender.email.domain.root_domain in $free_email_providers
-      and sender.email.email not in $sender_emails
+    strings.icontains(sender.display_name, "norton")
+    or regex.icontains(subject.base,
+                       "norton.{0,5}(?:lifelock|subscription|renewal)"
     )
-    or (
-      // if custom domain, we want to avoid flagging
-      // on the real Norton invoices
-      // so we flag if it's not a first-time sender
-      // and if it's not in the tranco 1M w/ a reply-to mismatch
-      // for example we've observed:
-      // Sender: Norton <quickbooks@notification.intuit.com>
-      // Reply-to: foo@outlook.com
-      sender.email.domain.root_domain not in $free_email_providers
-      and sender.email.domain.domain not in $sender_domains
-      and (
-        sender.email.domain.root_domain not in $tranco_1m
-        or any(headers.reply_to,
-               .email.domain.domain != sender.email.domain.domain
-        )
-      )
+    or any(attachments,
+           (.file_type in $file_types_images or .file_type == "pdf")
+           and (
+             (
+               strings.ilike(.file_name, "*norton*")
+               and not (
+                 any(recipients.to, strings.iends_with(.display_name, "Norton"))
+               )
+             )
+             or any(file.explode(.),
+                    regex.icontains(.scan.ocr.raw,
+                                    ".*norton.?60.*",
+                                    ".*lifelock.*",
+                                    ".*norton.?security.*",
+                                    ".*norton.?anti.?virus.*",
+                                    ".*norton.{2,3}subscription.*"
+                    )
+             )
+           )
     )
-    or (
-      (
-        length(recipients.to) == 0
-        or all(recipients.to, .display_name == "Undisclosed recipients")
-      )
-      and length(recipients.cc) == 0
-      and length(recipients.bcc) == 0
-    )
+  )
+  and not (
+    sender.email.domain.root_domain in~ ("norton.com")
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
 attack_types:
   - "Credential Phishing"


### PR DESCRIPTION
# Description
broadening the scope of this rule massively to find more Norton impersonation, looking at both the subject and sender display name while keeping the attachment logic looking at PDFs. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/4fe7f850d139ab948bd467ca0694d6fed6fc7d4a815ce3d9b8bae96f1cc10b45?preview_id=019bf172-ac2e-7891-9d27-4d54487d5bf3)
- [Sample 2](https://platform.sublime.security/messages/5007b9a48bf66681876e9bb53cf2e4ad5feeff232eb2d533eab6c61a844587a9?preview_id=019c23c0-3310-711f-b609-eda110121e86)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019c2471-fb91-70a2-aeb8-79cb77380e72) - net new results of proposed logic, plenty more samples here not being covered by current rule


