### PR TITLE
Create attachment_embedded_pdf_icon.yml

### DIFF
--- a/detection-rules/attachment_embedded_pdf_icon.yml
+++ b/detection-rules/attachment_embedded_pdf_icon.yml
@@ -4,9 +4,10 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
+  and length(html.xpath(body.html, '//img').nodes) == 1
   and any(html.xpath(body.html, '//img[@alt="PDF"]').nodes,
-          regex.contains(.raw, 'src="cid:image[0-9]{3}\.png@')
-  )
+      regex.contains(.raw, 'src="cid:image[0-9]{3}\.png@')
+  ) 
 attack_types:
   - "Credential Phishing"
   - "BEC/Fraud"

--- a/detection-rules/attachment_embedded_pdf_icon.yml
+++ b/detection-rules/attachment_embedded_pdf_icon.yml
@@ -5,9 +5,8 @@ severity: "medium"
 source: |
   type.inbound
   and any(html.xpath(body.html, '//img[@alt="PDF"]').nodes,
-      regex.contains(.raw, 'src="cid:image[0-9]{3}\.png@')
+          regex.contains(.raw, 'src="cid:image[0-9]{3}\.png@')
   )
-
 attack_types:
   - "Credential Phishing"
   - "BEC/Fraud"
@@ -17,3 +16,4 @@ tactics_and_techniques:
 detection_methods:
   - "HTML analysis"
   - "Content analysis"
+id: "118751f2-9ce2-5a04-9c7d-d42c32d504fb"

--- a/detection-rules/attachment_embedded_pdf_icon.yml
+++ b/detection-rules/attachment_embedded_pdf_icon.yml
@@ -1,0 +1,19 @@
+name: "Attachment: Embedded PDF icon with inline image reference"
+description: "Detects messages containing HTML with PDF icons that reference inline images using Content-ID (CID) patterns, commonly used to create misleading PDF attachment appearances without actual PDF files."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(html.xpath(body.html, '//img[@alt="PDF"]').nodes,
+      regex.contains(.raw, 'src="cid:image[0-9]{3}\.png@')
+  )
+
+attack_types:
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Evasion"
+  - "Image as content"
+detection_methods:
+  - "HTML analysis"
+  - "Content analysis"

--- a/detection-rules/attachment_embedded_pdf_icon.yml
+++ b/detection-rules/attachment_embedded_pdf_icon.yml
@@ -6,8 +6,8 @@ source: |
   type.inbound
   and length(html.xpath(body.html, '//img').nodes) == 1
   and any(html.xpath(body.html, '//img[@alt="PDF"]').nodes,
-      regex.contains(.raw, 'src="cid:image[0-9]{3}\.png@')
-  ) 
+          regex.contains(.raw, 'src="cid:image[0-9]{3}\.png@')
+  )
 attack_types:
   - "Credential Phishing"
   - "BEC/Fraud"


### PR DESCRIPTION
# Description
Detects messages containing HTML with PDF icons that reference inline images using Content-ID (CID) patterns, commonly used to create misleading PDF attachment appearances without actual PDF files.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/50000bb9ce5f439bbb87d5c1fd9f3a127bda118ba4bb853edd95047bf697c248?preview_id=019c00f4-c108-79b2-9824-1e6eec3e6cfa)
- [Sample 2](https://platform.sublime.security/messages/500818cbc46e2ace10452ea03924c7896b579200c1b82b56f63b6605e5c623ee?preview_id=019c29fb-e325-786a-bb4b-3df334a72510)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019c47ec-8a51-75a8-8bda-9712aeb7a62e)
