### PR TITLE
Create attachment_pdf_object_hash_partial_match.yml

### DIFF
--- a/detection-rules/attachment_pdf_object_hash_partial_match.yml
+++ b/detection-rules/attachment_pdf_object_hash_partial_match.yml
@@ -7,7 +7,7 @@ source: |
   and any(filter(attachments, .file_type == "pdf"),
           any(file.explode(.),
               strings.contains(.scan.pdf_obj_hash.hash_string,
-                               "Catalog|Pages|Page|Filter|Font/TrueType|FontDescriptor|ExtGState|ExtGState|Font/Type0|None|Font/CIDFontType2|Ordering|FontDescriptor|Font/TrueType|FontDescriptor|Subtype|Subtype|Font/Type0|None|Font/CIDFontType2|Ordering|FontDescriptor|"
+                               "Catalog|Pages|Page|Filter|Font/TrueType|FontDescriptor|ExtGState|ExtGState|Font/Type0|None|Font/CIDFontType2|Ordering|FontDescriptor|Font/TrueType|FontDescriptor|Subtype|Subtype|Font/Type0|None|Font/CIDFontType2|Ordering|FontDescriptor|Subtype|XObject/Image|Subtype|XObject/Image|"
               )
           )
   )

--- a/detection-rules/attachment_pdf_object_hash_partial_match.yml
+++ b/detection-rules/attachment_pdf_object_hash_partial_match.yml
@@ -4,12 +4,13 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and any(filter(attachments, .file_type == "pdf"), 
-      any(file.explode(.),
-          strings.contains(.scan.pdf_obj_hash.hash_string, "Catalog|Pages|Page|Filter|Font/TrueType|FontDescriptor|ExtGState|ExtGState|Font/Type0|None|Font/CIDFontType2|Ordering|FontDescriptor|Font/TrueType|FontDescriptor|Subtype|Subtype|Font/Type0|None|Font/CIDFontType2|Ordering|FontDescriptor|")
-      )   
+  and any(filter(attachments, .file_type == "pdf"),
+          any(file.explode(.),
+              strings.contains(.scan.pdf_obj_hash.hash_string,
+                               "Catalog|Pages|Page|Filter|Font/TrueType|FontDescriptor|ExtGState|ExtGState|Font/Type0|None|Font/CIDFontType2|Ordering|FontDescriptor|Font/TrueType|FontDescriptor|Subtype|Subtype|Font/Type0|None|Font/CIDFontType2|Ordering|FontDescriptor|"
+              )
+          )
   )
-
 attack_types:
   - "Malware/Ransomware"
 tactics_and_techniques:
@@ -17,3 +18,4 @@ tactics_and_techniques:
   - "PDF"
 detection_methods:
   - "File analysis"
+id: "39a99174-f2f3-5106-9e99-0684bc7b738c"

--- a/detection-rules/attachment_pdf_object_hash_partial_match.yml
+++ b/detection-rules/attachment_pdf_object_hash_partial_match.yml
@@ -1,0 +1,19 @@
+name: "Attachment: PDF with specific object hash pattern"
+description: "Detects PDF attachments containing a specific object hash string pattern. This may indicate similar build characteristics or templated features."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(filter(attachments, .file_type == "pdf"), 
+      any(file.explode(.),
+          strings.contains(.scan.pdf_obj_hash.hash_string, "Catalog|Pages|Page|Filter|Font/TrueType|FontDescriptor|ExtGState|ExtGState|Font/Type0|None|Font/CIDFontType2|Ordering|FontDescriptor|Font/TrueType|FontDescriptor|Subtype|Subtype|Font/Type0|None|Font/CIDFontType2|Ordering|FontDescriptor|")
+      )   
+  )
+
+attack_types:
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Evasion"
+  - "PDF"
+detection_methods:
+  - "File analysis"


### PR DESCRIPTION
# Description
Detects PDF attachments containing a specific object hash string pattern. This may indicate similar build characteristics or templated features.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/50064524b2054b1e46878b63d29d973e2781d7d832d1010b89c67eb5d1a553c5?preview_id=019c1f43-05f2-7c16-a9f9-13696201494f)
- [Sample 2](https://platform.sublime.security/messages/500841d48508bdaeb0cc11bb391dbc0f67b4f6a7465fa9fb077fea633f4b464e?preview_id=019c2e37-06cd-752c-8aa6-ebf95696cf3b)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019c4412-94c3-7500-9fa4-aa391a84d6fd)
