### PR TITLE
Create link_apple_store_redirect.yml

### DIFF
--- a/detection-rules/link_apple_store_redirect.yml
+++ b/detection-rules/link_apple_store_redirect.yml
@@ -1,0 +1,21 @@
+name: "Link: Apple App Store business suite redirect"
+description: "Detects links to apps.apple.com with paths containing business suite, advertising, or campaign management related terms."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and 0 < length(body.current_thread.links) < 10
+  and any(body.current_thread.links,
+          .href_url.domain.domain in ('apps.apple.com')
+          and regex.icontains(.href_url.path,
+                              '(?:suite|business|advertising|ads|manager|campaigns)'
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "URL analysis"
+  - "Content analysis"

--- a/detection-rules/link_apple_store_redirect.yml
+++ b/detection-rules/link_apple_store_redirect.yml
@@ -19,3 +19,4 @@ tactics_and_techniques:
 detection_methods:
   - "URL analysis"
   - "Content analysis"
+id: "aacf7441-4d2d-54c7-b9ba-72fd96488193"

--- a/detection-rules/link_apple_store_redirect.yml
+++ b/detection-rules/link_apple_store_redirect.yml
@@ -4,13 +4,26 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and 0 < length(body.current_thread.links) < 10
+  and 0 < length(body.current_thread.links) < 12
   and any(body.current_thread.links,
           .href_url.domain.domain in ('apps.apple.com')
           and regex.icontains(.href_url.path,
                               '(?:suite|business|advertising|ads|manager|campaigns)'
           )
   )
+  and regex.icontains(body.current_thread.text,
+                      'openai|chatgpt|gemini|App store|IOS|ad*'
+  )
+  and any(ml.nlu_classifier(body.current_thread.text).topics,
+          .name in (
+            "Software and App Updates",
+            "Security and Authentication",
+            "Advertising and Promotions"
+          )
+  )
+  // Exclude legitimate Keeper Security domains as senders
+  and not sender.email.domain.root_domain == "keepersecurity.com"
+  and not (coalesce(headers.auth_summary.dmarc.pass, false))
 attack_types:
   - "Credential Phishing"
   - "BEC/Fraud"


### PR DESCRIPTION
# Description
Detects links to apps.apple.com with paths containing business suite, advertising, or campaign management related terms.

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/4fffb183f7984a2672ac6e6333f0a481fe767cc54837cd4402d0f48a07f78135?preview_id=019bfa2d-1050-7d11-9006-a116151217a2)

## Associated hunts



