### PR TITLE
Create attachment_pdf_obj_hash_generic_invoice.yml

### DIFF
--- a/detection-rules/attachment_pdf_obj_hash_generic_invoice.yml
+++ b/detection-rules/attachment_pdf_obj_hash_generic_invoice.yml
@@ -1,0 +1,23 @@
+name: "Attachment: PDF object hash - generic invoice theme"
+description: "Detects PDF attachments containing objects with specific hash values known for generic invoices, typically with the file name 'Payment-#'. The rule identifies PDF files by analyzing their internal object structures and matching against known, harmful object hashes."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(filter(attachments, .file_type == "pdf"),
+          any(file.explode(.),
+              .scan.pdf_obj_hash.object_hash in (
+                "092325d8f3eb11f3642a9da5c430a0fc",
+                "335f56339b6ac9c308a2cc45d0644352"
+              )
+          )
+  )
+
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "PDF"
+  - "Evasion"
+detection_methods:
+  - "File analysis"
+  - "Threat intelligence"

--- a/detection-rules/attachment_pdf_obj_hash_generic_invoice.yml
+++ b/detection-rules/attachment_pdf_obj_hash_generic_invoice.yml
@@ -21,3 +21,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "Threat intelligence"
+id: "d162b2cb-1eab-59d4-9304-65db8426bd5d"


### PR DESCRIPTION
# Description

Creating a rule based on PDF object hash pulls and research. Object hashes come from an exif data workflow that pulls PDFs from the API, analyzes EXIF data while running against PDF object hash library, then stores results in a database. These object hash values have been directly associated with malicious messages, follow a generic invoice theme, and have been grouped based on image based hashing.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50034d0c75a3f8992fc8fc6ba2a6e53017623e09e76a3740c4452b5f19f19b0d?preview_id=019c248c-2d30-7217-b88a-169666c7c208)
- [Sample 2](https://platform.sublime.security/messages/500d722b98a19f5ef8097cedfefdbbe9bcd02536797659ad75b28dc54b9f84f3?preview_id=019c4358-7543-7dd5-ab33-000e97daa1fa)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019c76d2-0a31-721c-a6d0-9f3dbcfd9e7f)
