### PR TITLE
Create link_suspicious_email_contains_link_to_page_protected_by_captc…

### DIFF
--- a/detection-rules/link_suspicious_email_contains_link_to_page_protected_by_captcha_service.yml
+++ b/detection-rules/link_suspicious_email_contains_link_to_page_protected_by_captcha_service.yml
@@ -7,12 +7,9 @@ source: |
   and 0 < length(body.links) < 10
   and length(recipients.to) == 1
   and recipients.to[0].email.domain.valid
-  // email text likely classified as cred_theft
-  and any(ml.nlu_classifier(body.current_thread.text).intents,
-          .name == 'cred_theft' and .confidence == 'high'
-  )
   and any(body.links,
-          (
+          .parser == 'hyperlink'
+          and (
             (
               .href_url.domain.domain in $url_shorteners
               or .href_url.domain.root_domain in $url_shorteners
@@ -26,6 +23,11 @@ source: |
               or network.whois(.href_url.domain).days_old < 30
             )
             and not ml.link_analysis(.).effective_url.domain.root_domain in $tranco_10k
+            and not .href_url.domain.root_domain in (
+              'zendesk.com',
+              'cloudfront.net',
+              'onehub.com'
+            )
           )
           and regex.icontains(ml.link_analysis(.).final_dom.raw,
                               // page references hcaptcha
@@ -34,7 +36,6 @@ source: |
                               '(?:Cloudflare Ray ID|cloudflare\.com\/turnstile\/)',
                               // other captcha phrases
                               '\b(?:prove|verify) (?:that )?you are human\b',
-                              'Two[ -]?Factor Auth',
                               'enter (?:all of )?the characters you see',
                               'reached the limit for number of attempts',
                               'switch to the audio challenge',
@@ -50,14 +51,8 @@ source: |
   and not any(body.current_thread.links,
               regex.icontains(.href_url.url, '\.box\.com\/(?:signup|link)\/')
   )
-  
-  // negate emails
-  and not (
-    sender.email.email == 'quarantine@messaging.microsoft.com'
-    or sender.email.email == 'notifications@stripe.com'
-    or sender.email.email == 'no-reply@fellow.app'
-    or sender.email.email == 'clientstatement@africanbank.co.za'
-  )
+  // negating phish reports
+  and not any(recipients.to, .email.email in ('support@vimeo.com'))
 
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/link_suspicious_email_contains_link_to_page_protected_by_captcha_service.yml
+++ b/detection-rules/link_suspicious_email_contains_link_to_page_protected_by_captcha_service.yml
@@ -12,22 +12,51 @@ source: |
           .name == 'cred_theft' and .confidence == 'high'
   )
   and any(body.links,
-          regex.icontains(ml.link_analysis(.).final_dom.raw,
-                          // page references hcaptcha
-                          'hcaptcha\.com\/1\/api\.js',
-                          // page references cloudflare
-                          '(?:Cloudflare Ray ID|cloudflare\.com\/turnstile\/)',
-                          // recaptcha/generic captcha
-                          '\b(?:re)?captcha'
+          (
+            (
+              .href_url.domain.domain in $url_shorteners
+              or .href_url.domain.root_domain in $url_shorteners
+              or .href_url.domain.domain in $free_file_hosts
+              or .href_url.domain.root_domain in $free_file_hosts
+              or .href_url.domain.domain in $free_subdomain_hosts
+              or .href_url.domain.root_domain in $free_subdomain_hosts
+              or .href_url.domain.domain in $self_service_creation_platform_domains
+              or .href_url.domain.root_domain in $self_service_creation_platform_domains
+              or .href_url.domain.tld in $suspicious_tlds
+              or network.whois(.href_url.domain).days_old < 30
+            )
+            and not ml.link_analysis(.).effective_url.domain.root_domain in $tranco_10k
           )
-          and regex.icontains(ml.link_analysis(.).final_dom.inner_text,
-                              // generic captcha/lure strings
-                              '(?:(?:download|review).{0,25}document|verify.{0,25}(?:identity|human)|human (?:confirmation|verification|check(?:point)?)|verification (?:required|complete|failed)|checking your.{0,25}connection|enter the code below|(?:security|captcha) verification|access check|detected unusual traffic from your computer|security code|challenge solve|prove that you are human|not a robot|Enter displayed text)'
+          and regex.icontains(ml.link_analysis(.).final_dom.raw,
+                              // page references hcaptcha
+                              'hcaptcha\.com\/1\/api\.js',
+                              // page references cloudflare
+                              '(?:Cloudflare Ray ID|cloudflare\.com\/turnstile\/)',
+                              // other captcha phrases
+                              '\b(?:prove|verify) (?:that )?you are human\b',
+                              'Two[ -]?Factor Auth',
+                              'enter (?:all of )?the characters you see',
+                              'reached the limit for number of attempts',
+                              'switch to the audio challenge',
+                              'really you sending the requests',
+                              'enter text above',
+                              'type the code',
+                              'Solve the following tasks',
+                              "I'm not a robot",
+                              "ensure you're not a bot"
           )
   )
   // no box links
   and not any(body.current_thread.links,
               regex.icontains(.href_url.url, '\.box\.com\/(?:signup|link)\/')
+  )
+  
+  // negate emails
+  and not (
+    sender.email.email == 'quarantine@messaging.microsoft.com'
+    or sender.email.email == 'notifications@stripe.com'
+    or sender.email.email == 'no-reply@fellow.app'
+    or sender.email.email == 'clientstatement@africanbank.co.za'
   )
 
 attack_types:

--- a/detection-rules/link_suspicious_email_contains_link_to_page_protected_by_captcha_service.yml
+++ b/detection-rules/link_suspicious_email_contains_link_to_page_protected_by_captcha_service.yml
@@ -1,0 +1,42 @@
+name: "Link: Suspicious Email Contains Link to Page Protected by Captcha Service"
+description: "Detects messages containing links to credential theft pages that implement CAPTCHA or human verification challenges, including hCaptcha, Cloudflare Turnstile, or reCAPTCHA services. The linked pages contain verification prompts designed to appear legitimate while harvesting credentials."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and 0 < length(body.links) < 10
+  and length(recipients.to) == 1
+  and recipients.to[0].email.domain.valid
+  // email text likely classified as cred_theft
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == 'cred_theft' and .confidence == 'high'
+  )
+  and any(body.links,
+          regex.icontains(ml.link_analysis(.).final_dom.raw,
+                          // page references hcaptcha
+                          'hcaptcha\.com\/1\/api\.js',
+                          // page references cloudflare
+                          '(?:Cloudflare Ray ID|cloudflare\.com\/turnstile\/)',
+                          // recaptcha/generic captcha
+                          '\b(?:re)?captcha'
+          )
+          and regex.icontains(ml.link_analysis(.).final_dom.inner_text,
+                              // generic captcha/lure strings
+                              '(?:(?:download|review).{0,25}document|verify.{0,25}(?:identity|human)|human (?:confirmation|verification|check(?:point)?)|verification (?:required|complete|failed)|checking your.{0,25}connection|enter the code below|(?:security|captcha) verification|access check|detected unusual traffic from your computer|security code|challenge solve|prove that you are human|not a robot|Enter displayed text)'
+          )
+  )
+  // no box links
+  and not any(body.current_thread.links,
+              regex.icontains(.href_url.url, '\.box\.com\/(?:signup|link)\/')
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+  - "Impersonation: Brand"
+detection_methods:
+  - "Natural Language Understanding"
+  - "URL analysis"
+  - "Content analysis"

--- a/detection-rules/link_suspicious_email_contains_link_to_page_protected_by_captcha_service.yml
+++ b/detection-rules/link_suspicious_email_contains_link_to_page_protected_by_captcha_service.yml
@@ -40,3 +40,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "URL analysis"
   - "Content analysis"
+id: "c48be36f-a404-5a15-957b-4c92d03d0181"


### PR DESCRIPTION
…ha_service.yml

# Description

<!-- 
Explain your change and why. For example, "negating legitimate replies," or "adding additional credential theft keywords."

If it's a new rule or insight, explain what the rule is designed to catch/what the insight should fire on.
-->

Tying together an email with nlu cred theft and a link resulting in a captcha landing 

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019c970c-3ce9-79bf-9eb3-148e3fe14aea)