### PR TITLE
Add detection rule for manipulated Outlook messages

### DIFF
--- a/detection-rules/body_outlook_message_manipulation.yml
+++ b/detection-rules/body_outlook_message_manipulation.yml
@@ -11,21 +11,18 @@ source: |
   )
   and (
     // conflicting template widths
-    (
-      length(html.xpath(body.html, "//table[contains(@style,'width: 600px')]").nodes
-      ) > 0
-      and length(html.xpath(body.html,
-                            "//table[contains(@style,'width: 640px') or contains(@style,'width: 673px')]"
-                 ).nodes
-      ) > 0
-    )
-    or 
-    // two different ESP template ID formats in the same doc
-    (
-      length(html.xpath(body.html, "//*[contains(@id,'x_x_x_x')]").nodes) > 0
-      and length(html.xpath(body.html, "//*[starts-with(@id,'x_section-')]").nodes
-      ) > 0
-    )
+    length(html.xpath(body.html, "//table[contains(@style,'width: 600px')]").nodes
+    ) > 0
+    and length(html.xpath(body.html,
+                          "//table[contains(@style,'width: 640px') or contains(@style,'width: 673px')]"
+               ).nodes
+    ) > 0
+  )
+  and (
+    // thread hijacking indicators
+    length(html.xpath(body.html, "//*[contains(@id,'x_x_x_x')]").nodes) > 0
+    or length(html.xpath(body.html, "//*[starts-with(@id,'x_section-')]").nodes) > 0
+    or strings.icontains(body.current_thread.text, 'unsubscribe')
   )
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/body_outlook_message_manipulation.yml
+++ b/detection-rules/body_outlook_message_manipulation.yml
@@ -22,7 +22,6 @@ source: |
     // thread hijacking indicators
     length(html.xpath(body.html, "//*[contains(@id,'x_x_x_x')]").nodes) > 0
     or length(html.xpath(body.html, "//*[starts-with(@id,'x_section-')]").nodes) > 0
-    or strings.icontains(body.current_thread.text, 'unsubscribe')
   )
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/body_outlook_message_manipulation.yml
+++ b/detection-rules/body_outlook_message_manipulation.yml
@@ -6,19 +6,25 @@ source: |
   type.inbound
   and (
     // embedded foreign message body
-    length(html.xpath(body.html, "//*[@data-olk-copy-source='MessageBody']").nodes) > 0
+    length(html.xpath(body.html, "//*[@data-olk-copy-source='MessageBody']").nodes
+    ) > 0
   )
   and (
     // conflicting template widths
     (
-      length(html.xpath(body.html, "//table[contains(@style,'width: 600px')]").nodes) > 0
-      and length(html.xpath(body.html, "//table[contains(@style,'width: 640px') or contains(@style,'width: 673px')]").nodes) > 0
+      length(html.xpath(body.html, "//table[contains(@style,'width: 600px')]").nodes
+      ) > 0
+      and length(html.xpath(body.html,
+                            "//table[contains(@style,'width: 640px') or contains(@style,'width: 673px')]"
+                 ).nodes
+      ) > 0
     )
-    or
+    or 
     // two different ESP template ID formats in the same doc
     (
       length(html.xpath(body.html, "//*[contains(@id,'x_x_x_x')]").nodes) > 0
-      and length(html.xpath(body.html, "//*[starts-with(@id,'x_section-')]").nodes) > 0
+      and length(html.xpath(body.html, "//*[starts-with(@id,'x_section-')]").nodes
+      ) > 0
     )
   )
 attack_types:
@@ -28,3 +34,4 @@ tactics_and_techniques:
   - "Social engineering"
 detection_methods:
   - "HTML analysis"
+id: "a51be50f-cb9c-5c37-b6bb-e4e9268e5914"

--- a/detection-rules/body_outlook_message_manipulation.yml
+++ b/detection-rules/body_outlook_message_manipulation.yml
@@ -1,0 +1,30 @@
+name: "Outlook embedded email with multiple manipulated messages in body"
+description: "Detects inbound messages containing an embedded fake message body (indicated by Outlook's data-olk-copy-source attribute) combined with conflicting template characteristics such as mismatched table widths or different ESP template ID formats, suggesting potential message manipulation or forwarding abuse."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and (
+    // embedded foreign message body
+    length(html.xpath(body.html, "//*[@data-olk-copy-source='MessageBody']").nodes) > 0
+  )
+  and (
+    // conflicting template widths
+    (
+      length(html.xpath(body.html, "//table[contains(@style,'width: 600px')]").nodes) > 0
+      and length(html.xpath(body.html, "//table[contains(@style,'width: 640px') or contains(@style,'width: 673px')]").nodes) > 0
+    )
+    or
+    // two different ESP template ID formats in the same doc
+    (
+      length(html.xpath(body.html, "//*[contains(@id,'x_x_x_x')]").nodes) > 0
+      and length(html.xpath(body.html, "//*[starts-with(@id,'x_section-')]").nodes) > 0
+    )
+  )
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "HTML analysis"


### PR DESCRIPTION
# Description

<!-- 
Explain your change and why. For example, "negating legitimate replies," or "adding additional credential theft keywords."

If it's a new rule or insight, explain what the rule is designed to catch/what the insight should fire on.
-->

Detects manipulated messages in Outlook emails with conflicting template characteristics.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/501ffcea2660c79097e0c0b4090a073feede41332781e4eca056939ed0e446c0?preview_id=019cb4f0-0777-7679-ab14-d8f2b4de0e7b)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019cb968-5953-70e5-9f29-824e4c1599ad)
