### PR TITLE
Add ASR rule for newly registered domains spoofing Tranco brands

### DIFF
--- a/detection-rules/asr_new_domain_tranco_brand_lookalike.yml
+++ b/detection-rules/asr_new_domain_tranco_brand_lookalike.yml
@@ -10,7 +10,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(body.links) > 0
+  and 0 < length(body.links) < 10
   and (
     (
       network.whois(sender.email.domain).days_old <= 30

--- a/detection-rules/asr_new_domain_tranco_brand_lookalike.yml
+++ b/detection-rules/asr_new_domain_tranco_brand_lookalike.yml
@@ -41,7 +41,8 @@ source: |
                 "Political Mail",
                 "Events and Webinars",
                 "B2B Cold Outreach",
-                "Advertising and Promotions"
+                "Advertising and Promotions",
+                "Software and App Updates"
               )
   )
 tags:

--- a/detection-rules/asr_new_domain_tranco_brand_lookalike.yml
+++ b/detection-rules/asr_new_domain_tranco_brand_lookalike.yml
@@ -16,8 +16,35 @@ source: |
       network.whois(sender.email.domain).days_old <= 30
       and not sender.email.domain.root_domain in $high_trust_sender_root_domains
       and any($tranco_10k,
-              any(regex.extract(., '^(?P<sld>[a-z0-9-]{7,})\.'),
+              any(regex.extract(., '^(?P<sld>[a-z0-9-]{4,})\.'),
                   strings.icontains(sender.email.domain.sld, .named_groups["sld"])
+                  and length(.named_groups["sld"]) * 5 >= length(sender.email.domain.sld
+                  ) * 2
+                  // common short word negations
+                  and not .named_groups["sld"] in (
+                    "intel",
+                    "homes",
+                    "home",
+                    "real",
+                    "realestate",
+                    "realtor",
+                    "house",
+                    "news",
+                    "link",
+                    "mail",
+                    "work",
+                    "free",
+                    "live",
+                    "next",
+                    "site",
+                    "apps",
+                    "core",
+                    "sync",
+                    "shop",
+                    "nova",
+                    "meta",
+                    "mega"
+                  )
               )
       )
     )
@@ -27,8 +54,35 @@ source: |
                  and not .href_url.domain.root_domain in $high_trust_sender_root_domains
           ),
           any($tranco_10k,
-              any(regex.extract(., '^(?P<sld>[a-z0-9-]{7,})\.'),
+              any(regex.extract(., '^(?P<sld>[a-z0-9-]{4,})\.'),
                   strings.icontains(...href_url.domain.sld, .named_groups["sld"])
+                  and length(.named_groups["sld"]) * 5 >= length(...href_url.domain.sld
+                  ) * 2
+                  // common short word negations
+                  and not .named_groups["sld"] in (
+                    "intel",
+                    "homes",
+                    "home",
+                    "real",
+                    "realestate",
+                    "realtor",
+                    "house",
+                    "news",
+                    "link",
+                    "mail",
+                    "work",
+                    "free",
+                    "live",
+                    "next",
+                    "site",
+                    "apps",
+                    "core",
+                    "sync",
+                    "shop",
+                    "nova",
+                    "meta",
+                    "mega"
+                  )
               )
           )
       )

--- a/detection-rules/asr_new_domain_tranco_brand_lookalike.yml
+++ b/detection-rules/asr_new_domain_tranco_brand_lookalike.yml
@@ -56,3 +56,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "URL analysis"
   - "Whois"
+id: "236703c1-17ba-50e6-9633-4110370775c1"

--- a/detection-rules/asr_new_domain_tranco_brand_lookalike.yml
+++ b/detection-rules/asr_new_domain_tranco_brand_lookalike.yml
@@ -57,3 +57,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "URL analysis"
   - "Whois"
+id: "236703c1-17ba-50e6-9633-4110370775c1"

--- a/detection-rules/asr_new_domain_tranco_brand_lookalike.yml
+++ b/detection-rules/asr_new_domain_tranco_brand_lookalike.yml
@@ -1,0 +1,59 @@
+name: "Newly registered domain spoofing established brand name (Tranco lookalike)"
+description: |
+  Detects messages where either the sender domain or a linked domain was registered within the
+  last 30 days and contains the name of an established brand from the Tranco 10k list within
+  its SLD. This is a common pattern in credential phishing and BEC attacks where threat actors
+  register lookalike domains (e.g., robinhoodinstruction.com, fidelitytimeout.com) to impersonate
+  trusted brands. Benign email categories such as newsletters, political mail, and B2B outreach
+  are excluded via NLU classification.
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and length(body.links) > 0
+  and (
+    (
+      network.whois(sender.email.domain).days_old <= 30
+      and not sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and any($tranco_10k,
+              any(regex.extract(., '^(?P<sld>[a-z0-9-]{7,})\.'),
+                  strings.icontains(sender.email.domain.sld, .named_groups["sld"])
+              )
+      )
+    )
+    or (
+      any(filter(body.links,
+                 network.whois(.href_url.domain).days_old <= 30
+                 and not .href_url.domain.root_domain in $high_trust_sender_root_domains
+          ),
+          any($tranco_10k,
+              any(regex.extract(., '^(?P<sld>[a-z0-9-]{7,})\.'),
+                  strings.icontains(...href_url.domain.sld, .named_groups["sld"])
+              )
+          )
+      )
+    )
+  )
+  and not any(ml.nlu_classifier(body.current_thread.text).topics,
+              .name in (
+                "Bounce Back and Delivery Failure Notifications",
+                "Newsletters and Digests",
+                "Political Mail",
+                "Events and Webinars",
+                "B2B Cold Outreach",
+                "Advertising and Promotions"
+              )
+  )
+tags:
+  - "Attack surface reduction"
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Domain squatting"
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Natural Language Understanding"
+  - "URL analysis"
+  - "Whois"

--- a/detection-rules/asr_new_domain_tranco_brand_lookalike.yml
+++ b/detection-rules/asr_new_domain_tranco_brand_lookalike.yml
@@ -50,11 +50,9 @@ attack_types:
   - "BEC/Fraud"
   - "Credential Phishing"
 tactics_and_techniques:
-  - "Domain squatting"
+  - "Lookalike domain"
   - "Impersonation: Brand"
-  - "Social engineering"
 detection_methods:
   - "Natural Language Understanding"
   - "URL analysis"
   - "Whois"
-id: "236703c1-17ba-50e6-9633-4110370775c1"


### PR DESCRIPTION


# Description

ASR - Detects sender or link domains registered within 30 days whose SLD contains an established brand name from the Tranco 10k list, using NLU classification to suppress benign categories like newsletters, political mail, and B2B outreach.


## Associated hunts


- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019cd40b-275a-785a-ac09-dc9c69612d46)

