### PR TITLE
Create attachment_pdf_object_hash_compensation_lure.yml

### DIFF
--- a/detection-rules/attachment_pdf_object_hash_compensation_lure.yml
+++ b/detection-rules/attachment_pdf_object_hash_compensation_lure.yml
@@ -1,12 +1,15 @@
 name: "Attachment: PDF Object Hash - Malicious PDF with compensation lure"
-description: "Detects PDF attachments containing a specific object hash (baf7a7496c205fd7d27267e0dce6e5ef) that has been identified as malicious. This hash-based detection targets known malicious PDF objects used in targeted attacks."
+description: "Detects PDF attachments containing a specific object hash that has been identified as malicious. This hash-based detection targets known malicious PDF objects used in targeted attacks."
 type: "rule"
 severity: "medium"
 source: |
   type.inbound
   and any(filter(attachments, .file_type == "pdf"),
           any(file.explode(.),
-              .scan.pdf_obj_hash.object_hash == "baf7a7496c205fd7d27267e0dce6e5ef"
+              .scan.pdf_obj_hash.object_hash in (
+                "baf7a7496c205fd7d27267e0dce6e5ef",
+                "c57d382b638960d183fd955be1063a3a"
+              )
           )
   )
 

--- a/detection-rules/attachment_pdf_object_hash_compensation_lure.yml
+++ b/detection-rules/attachment_pdf_object_hash_compensation_lure.yml
@@ -1,4 +1,4 @@
-name: "Attachment: PDF Object Hash - Malicious PDF with compenstation lure"
+name: "Attachment: PDF Object Hash - Malicious PDF with compensation lure"
 description: "Detects PDF attachments containing a specific object hash (baf7a7496c205fd7d27267e0dce6e5ef) that has been identified as malicious. This hash-based detection targets known malicious PDF objects used in targeted attacks."
 type: "rule"
 severity: "medium"

--- a/detection-rules/attachment_pdf_object_hash_compensation_lure.yml
+++ b/detection-rules/attachment_pdf_object_hash_compensation_lure.yml
@@ -18,3 +18,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "Threat intelligence"
+id: "fc2397ab-1951-567f-8f20-aa15be5f2889"

--- a/detection-rules/attachment_pdf_object_hash_compensation_lure.yml
+++ b/detection-rules/attachment_pdf_object_hash_compensation_lure.yml
@@ -3,12 +3,12 @@ description: "Detects PDF attachments containing a specific object hash (baf7a74
 type: "rule"
 severity: "medium"
 source: |
-    type.inbound
-    and any(filter(attachments, .file_type == "pdf"),
-            any(file.explode(.),
-                .scan.pdf_obj_hash.object_hash == "baf7a7496c205fd7d27267e0dce6e5ef"
-            )
-    )
+  type.inbound
+  and any(filter(attachments, .file_type == "pdf"),
+          any(file.explode(.),
+              .scan.pdf_obj_hash.object_hash == "baf7a7496c205fd7d27267e0dce6e5ef"
+          )
+  )
 
 attack_types:
   - "Malware/Ransomware"
@@ -18,4 +18,3 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "Threat intelligence"
-id: "dcae734a-2c38-5dd0-a0cc-c5b4235d64a9"

--- a/detection-rules/attachment_pdf_object_hash_compenstation_lure.yml
+++ b/detection-rules/attachment_pdf_object_hash_compenstation_lure.yml
@@ -18,3 +18,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "Threat intelligence"
+id: "dcae734a-2c38-5dd0-a0cc-c5b4235d64a9"

--- a/detection-rules/attachment_pdf_object_hash_compenstation_lure.yml
+++ b/detection-rules/attachment_pdf_object_hash_compenstation_lure.yml
@@ -1,0 +1,20 @@
+name: "Attachment: PDF Object Hash - Malicious PDF with compenstation lure"
+description: "Detects PDF attachments containing a specific object hash (baf7a7496c205fd7d27267e0dce6e5ef) that has been identified as malicious. This hash-based detection targets known malicious PDF objects used in targeted attacks."
+type: "rule"
+severity: "medium"
+source: |
+    type.inbound
+    and any(filter(attachments, .file_type == "pdf"),
+            any(file.explode(.),
+                .scan.pdf_obj_hash.object_hash == "baf7a7496c205fd7d27267e0dce6e5ef"
+            )
+    )
+
+attack_types:
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "PDF"
+  - "Evasion"
+detection_methods:
+  - "File analysis"
+  - "Threat intelligence"


### PR DESCRIPTION
# Description
Detects PDF attachments containing a specific object hash that has been identified as malicious. This hash-based detection targets known malicious PDF objects used in targeted attacks.

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019cd84c-9efd-7a5f-a068-3723376836c3)

