### PR TITLE
[senderprofile] Removing Bulk Set 29

### DIFF
--- a/detection-rules/attachment_encrypted_pdf_cred_theft.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft.yml
@@ -51,14 +51,6 @@ source: |
   )
   and (
     (
-      profile.by_sender_email().prevalence in ("new", "outlier")
-      and not profile.by_sender_email().solicited
-    )
-    or (
-      profile.by_sender_email().any_messages_malicious_or_spam
-      and not profile.by_sender_email().any_messages_benign
-    )
-    or (
       length(recipients.to) == 0
       or all(recipients.to,
              strings.ilike(.display_name, "undisclosed?recipients")

--- a/detection-rules/attachment_extortion.yml
+++ b/detection-rules/attachment_extortion.yml
@@ -162,13 +162,7 @@ source: |
           )
   )
   and (
-    not profile.by_sender().solicited
-    or (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_messages_benign
-    )
-    or any(headers.hops, any(.fields, .name == "X-Google-Group-Id"))
-  
+    any(headers.hops, any(.fields, .name == "X-Google-Group-Id"))
     // many extortion emails spoof sender domains and fail sender authentication
     or any(headers.hops,
            .authentication_results.dmarc == "fail"

--- a/detection-rules/attachment_fake_gmail_attachment.yml
+++ b/detection-rules/attachment_fake_gmail_attachment.yml
@@ -29,14 +29,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-  // if the sender has been marked as malicious, but has FPs, don't alert
-  and (
-    (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_messages_benign
-    )
-    or not profile.by_sender().any_messages_malicious_or_spam
-  )
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/attachment_fake_scan_to_email.yml
+++ b/detection-rules/attachment_fake_scan_to_email.yml
@@ -91,14 +91,6 @@ source: |
     or length(filter(attachments, .file_type in ("doc", "docx"))) == 1
   )
   and sender.email.domain.domain not in~ $org_domains
-  and (
-    not profile.by_sender().solicited
-    or (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_messages_benign
-    )
-  )
-  and not profile.by_sender().any_messages_benign
 
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/attachment_file_scheme_link_to_executable_filetype.yml
+++ b/detection-rules/attachment_file_scheme_link_to_executable_filetype.yml
@@ -28,11 +28,6 @@ source: |
                   )
           )
   )
-  and (
-    not profile.by_sender().any_messages_benign
-    or profile.by_sender().any_messages_malicious_or_spam
-  )
-
 tags:
   - "Attack surface reduction"
   - "Malfam: Pikabot"

--- a/detection-rules/attachment_html_attachment_login_page.yml
+++ b/detection-rules/attachment_html_attachment_login_page.yml
@@ -98,16 +98,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-  and (
-    (
-      not profile.by_sender().solicited
-      and profile.by_sender().prevalence in ("new", "outlier")
-    )
-    or (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_messages_benign
-    )
-  )
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/attachment_html_emoji_map.yml
+++ b/detection-rules/attachment_html_emoji_map.yml
@@ -14,14 +14,6 @@ source: |
                            '[\x{1F300}-\x{1F5FF}\x{1F600}-\x{1F64F}\x{1F680}-\x{1F6FF}\x{1F700}-\x{1F77F}\x{1F780}-\x{1F7FF}\x{1F900}-\x{1F9FF}\x{2600}-\x{26FF}\x{2700}-\x{27BF}\x{2300}-\x{23FF}].{0,10},'
           ) > 10
   )
-  and (
-    (
-      profile.by_sender().prevalence in ("new", "outlier")
-      and not profile.by_sender().solicited
-    )
-    or profile.by_sender().any_messages_malicious_or_spam
-  )
-  and not profile.by_sender().any_messages_benign
   
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (

--- a/detection-rules/attachment_html_hidden_body.yml
+++ b/detection-rules/attachment_html_hidden_body.yml
@@ -4,7 +4,6 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and not profile.by_sender().solicited
   // not high trust sender domains
   and (
     (


### PR DESCRIPTION
# Description

These have been moved from https://github.com/sublime-security/sublime-rules/pull/3976 to this PR by breaking them out into individual commits. See testing results in the other PR.

## Rules & Notes

| Should Merge | Rule Name | Notes |
|---------------|------------|-------|
| Yes | Attachment: Encrypted PDF with credential theft body | Gained malicious. |
| Yes | Extortion / sextortion in attachment from untrusted sender | No gained. | 
| Yes | Impersonation: Fake Gmail attachment | No gained. |
| Yes | Attachment: Fake scan-to-email | No gain. |
| Yes | Attachment: HTML attachment with login portal indicators | There are many LBs but several are definitely malicious so we should move forward with this one. |
| Yes | Attachment: HTML with emoji-to-character map | Really zero results we have access to. |
| Yes | Attachment: HTML with hidden body | No gained. |
| Yes | Attachment: OLE external relationship containing file scheme link to executable filetype | No gain. |


### Rules Evaluated & Reverted

- [ ] 
