### PR TITLE
New rule: Google Drive embedded image

### DIFF
--- a/detection-rules/attachment_google_drive_embedded_image.yml
+++ b/detection-rules/attachment_google_drive_embedded_image.yml
@@ -1,0 +1,39 @@
+name: "Attachment: Fake Google Drive embedded attachment"
+description: "Detects messages with small image attachments that contain PDF-related text but are embedded images combined with attachment related language."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // link as image
+  and (
+    all(attachments, .file_type in $file_types_images)
+    and regex.icontains(body.html.raw, 'src="cid')
+    // mentions attachments but there are none or just images with no pdfs
+    and regex.icontains(body.current_thread.text, 'please (?:see|find) attached')
+    and any(body.links, .display_url.url is null)
+  )
+  // filter suspicious image by file size, char count, image size & keywords
+  and any(filter(attachments, .file_extension in $file_types_images),
+          length(beta.ocr(.).text) < 40
+          and regex.icontains(beta.ocr(.).text, '\bpdf|pof\b')
+          and beta.parse_exif(.).image_height < 130
+          and beta.parse_exif(.).image_width < 190
+  )
+  and any(ml.nlu_classifier(body.current_thread.text).intents, .name != "benign")
+
+attack_types:
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Evasion"
+  - "Image as content"
+  - "Social engineering"
+detection_methods:
+  - "Computer Vision"
+  - "Content analysis"
+  - "Exif analysis"
+  - "File analysis"
+  - "HTML analysis"
+  - "Natural Language Understanding"
+  - "Optical Character Recognition"
+  - "URL analysis"

--- a/detection-rules/attachment_google_drive_embedded_image.yml
+++ b/detection-rules/attachment_google_drive_embedded_image.yml
@@ -37,3 +37,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Optical Character Recognition"
   - "URL analysis"
+id: "92ecb9d3-9621-56ea-9b08-1e30ff409a05"

--- a/detection-rules/attachment_google_drive_embedded_image.yml
+++ b/detection-rules/attachment_google_drive_embedded_image.yml
@@ -4,21 +4,17 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  // link as image
-  and (
-    all(attachments, .file_type in $file_types_images)
-    and regex.icontains(body.html.raw, 'src="cid')
-    // mentions attachments but there are none or just images with no pdfs
-    and regex.icontains(body.current_thread.text, 'please (?:see|find) attached')
-    and any(body.links, .display_url.url is null)
-  )
-  // filter suspicious image by file size, char count, image size & keywords
+  // link as image filtered char count, image size & keywords
   and any(filter(attachments, .file_extension in $file_types_images),
-          length(beta.ocr(.).text) < 40
+          4 < length(beta.ocr(.).text) < 40
           and regex.icontains(beta.ocr(.).text, '\bpdf|pof\b')
           and beta.parse_exif(.).image_height < 130
           and beta.parse_exif(.).image_width < 190
+          and strings.icontains(body.html.raw,
+                                strings.concat("cid:", .content_id)
+          )
   )
+  and regex.icontains(body.current_thread.text, '(?:see|find) attached')
   and any(ml.nlu_classifier(body.current_thread.text).intents, .name != "benign")
 
 attack_types:

--- a/dlp-discovery-rules/dlp_argentina_dni.yml
+++ b/dlp-discovery-rules/dlp_argentina_dni.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "bcd91739-4e68-5af3-8c99-97fed0525753"

--- a/dlp-discovery-rules/dlp_australia_bank_account.yml
+++ b/dlp-discovery-rules/dlp_australia_bank_account.yml
@@ -15,3 +15,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "702cb14e-fc14-5171-93db-001310bcfe63"

--- a/dlp-discovery-rules/dlp_australia_credit_card.yml
+++ b/dlp-discovery-rules/dlp_australia_credit_card.yml
@@ -18,3 +18,4 @@ source: |
 detection_methods:
   - "File analysis"
   - "Optical Character Recognition"
+id: "3fcd700c-b076-5e48-9550-cf5db48a58eb"

--- a/dlp-discovery-rules/dlp_australia_drivers_license.yml
+++ b/dlp-discovery-rules/dlp_australia_drivers_license.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "c46ff6a4-2a51-5067-99a7-f55e8f384a03"

--- a/dlp-discovery-rules/dlp_australia_medical_account.yml
+++ b/dlp-discovery-rules/dlp_australia_medical_account.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "6b5477cf-256c-5f96-bd6a-28a6b0a8746f"

--- a/dlp-discovery-rules/dlp_australia_passport.yml
+++ b/dlp-discovery-rules/dlp_australia_passport.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "a34b102b-4640-5a77-b17a-18321040b3a2"

--- a/dlp-discovery-rules/dlp_australia_swift_code.yml
+++ b/dlp-discovery-rules/dlp_australia_swift_code.yml
@@ -13,3 +13,4 @@ source: |
 detection_methods:
   - "Content analysis"
   - "Computer Vision"
+id: "4da18a44-7112-58b2-a8a2-e85dc76e4a60"

--- a/dlp-discovery-rules/dlp_australia_tax_file_number.yml
+++ b/dlp-discovery-rules/dlp_australia_tax_file_number.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "6f995365-e040-5065-b866-df2b4e11b698"

--- a/dlp-discovery-rules/dlp_austria_identity_card.yml
+++ b/dlp-discovery-rules/dlp_austria_identity_card.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "5e0d9f33-420e-5640-9607-e0d36672b0f5"

--- a/dlp-discovery-rules/dlp_austria_social_security.yml
+++ b/dlp-discovery-rules/dlp_austria_social_security.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "a815a321-4e4b-5bfb-9ab6-23b57af3ed92"

--- a/dlp-discovery-rules/dlp_austria_tax_id.yml
+++ b/dlp-discovery-rules/dlp_austria_tax_id.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "1b03538f-90be-5ee2-8d63-756d6d7b9ea6"

--- a/dlp-discovery-rules/dlp_aws_credentials.yml
+++ b/dlp-discovery-rules/dlp_aws_credentials.yml
@@ -20,3 +20,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "2142c73a-22da-541b-85ff-320e6b20640f"

--- a/dlp-discovery-rules/dlp_azure_auth_token.yml
+++ b/dlp-discovery-rules/dlp_azure_auth_token.yml
@@ -17,3 +17,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "39f05b16-8795-5ed5-8f5b-a03d029fa611"

--- a/dlp-discovery-rules/dlp_basic_auth_header.yml
+++ b/dlp-discovery-rules/dlp_basic_auth_header.yml
@@ -11,3 +11,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "44fc91c8-53c7-5678-b166-dd2851fabe22"

--- a/dlp-discovery-rules/dlp_belgium_national_number.yml
+++ b/dlp-discovery-rules/dlp_belgium_national_number.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "962a3dfb-ef20-52bb-9fec-e85866e3c5ca"

--- a/dlp-discovery-rules/dlp_brazil_cpf.yml
+++ b/dlp-discovery-rules/dlp_brazil_cpf.yml
@@ -19,3 +19,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "a0f9bcb7-844a-5512-a013-683efa12261e"

--- a/dlp-discovery-rules/dlp_brazil_rg.yml
+++ b/dlp-discovery-rules/dlp_brazil_rg.yml
@@ -19,3 +19,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "869f94d6-8b08-5194-a6be-21662dd62372"

--- a/dlp-discovery-rules/dlp_bulgaria_uniform_civil_number.yml
+++ b/dlp-discovery-rules/dlp_bulgaria_uniform_civil_number.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "09141e4a-e91c-59c0-b4cc-e612d4c534f7"

--- a/dlp-discovery-rules/dlp_canada_bank_account.yml
+++ b/dlp-discovery-rules/dlp_canada_bank_account.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "6ce27d37-a2ae-50dd-a932-23d3dd58f1ac"

--- a/dlp-discovery-rules/dlp_canada_credit_card.yml
+++ b/dlp-discovery-rules/dlp_canada_credit_card.yml
@@ -21,3 +21,4 @@ source: |
 detection_methods:
   - "File analysis"
   - "Optical Character Recognition"
+id: "e508f0d1-bd70-5365-9e29-0c93e144a7fe"

--- a/dlp-discovery-rules/dlp_canada_drivers_license.yml
+++ b/dlp-discovery-rules/dlp_canada_drivers_license.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "ff9b87eb-837e-5594-acf7-4903502fe5fb"

--- a/dlp-discovery-rules/dlp_canada_health_service.yml
+++ b/dlp-discovery-rules/dlp_canada_health_service.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "4f45b372-92f2-5196-ac2c-e220ef63b741"

--- a/dlp-discovery-rules/dlp_canada_passport.yml
+++ b/dlp-discovery-rules/dlp_canada_passport.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "ce780bd1-1760-59b6-8b0d-c086745a3180"

--- a/dlp-discovery-rules/dlp_canada_phin.yml
+++ b/dlp-discovery-rules/dlp_canada_phin.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "ac349280-46b6-5224-9e81-e996a86dc32c"

--- a/dlp-discovery-rules/dlp_canada_sin.yml
+++ b/dlp-discovery-rules/dlp_canada_sin.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "795285bd-5143-52ae-92af-b5d499b5f9d5"

--- a/dlp-discovery-rules/dlp_chile_cdi.yml
+++ b/dlp-discovery-rules/dlp_chile_cdi.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "22bc7cb6-fd39-5d23-9589-8e52c3f8bf42"

--- a/dlp-discovery-rules/dlp_china_resident_id.yml
+++ b/dlp-discovery-rules/dlp_china_resident_id.yml
@@ -15,3 +15,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "03c59035-48e2-5925-904a-10a1e089bc8d"

--- a/dlp-discovery-rules/dlp_colombia_cdc.yml
+++ b/dlp-discovery-rules/dlp_colombia_cdc.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "3fe1bd8c-a0c7-567f-a465-4848973938f6"

--- a/dlp-discovery-rules/dlp_croatia_oib.yml
+++ b/dlp-discovery-rules/dlp_croatia_oib.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "d9b89f12-cec5-52a6-880c-f77a3c9aac76"

--- a/dlp-discovery-rules/dlp_cyprus_identity_card.yml
+++ b/dlp-discovery-rules/dlp_cyprus_identity_card.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "0022129b-de93-539b-bae5-b0e2733844c6"

--- a/dlp-discovery-rules/dlp_czech_personal_id.yml
+++ b/dlp-discovery-rules/dlp_czech_personal_id.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "d85379d1-4dc9-5ce1-af6f-e64de1a6e140"

--- a/dlp-discovery-rules/dlp_denmark_personal_id.yml
+++ b/dlp-discovery-rules/dlp_denmark_personal_id.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "20487b51-9229-5ed3-8fae-9c4faa83a5ab"

--- a/dlp-discovery-rules/dlp_estonia_personal_code.yml
+++ b/dlp-discovery-rules/dlp_estonia_personal_code.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "9a0ff69a-fde6-52fb-be06-74f19b57df8f"

--- a/dlp-discovery-rules/dlp_eu_debit_card.yml
+++ b/dlp-discovery-rules/dlp_eu_debit_card.yml
@@ -49,3 +49,4 @@ source: |
 detection_methods:
   - "File analysis"
   - "Optical Character Recognition"
+id: "0f31c606-5ea3-530d-a711-a6c6b9c7cd38"

--- a/dlp-discovery-rules/dlp_finland_national_id.yml
+++ b/dlp-discovery-rules/dlp_finland_national_id.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "73b30e39-52ad-51ad-98a8-269497bba106"

--- a/dlp-discovery-rules/dlp_france_bank_account.yml
+++ b/dlp-discovery-rules/dlp_france_bank_account.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "e1083a78-9e9a-5ba5-9748-4c2d797e2e2b"

--- a/dlp-discovery-rules/dlp_france_cni.yml
+++ b/dlp-discovery-rules/dlp_france_cni.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "427419ff-b519-5551-ae50-5d032ae1df2a"

--- a/dlp-discovery-rules/dlp_france_credit_card.yml
+++ b/dlp-discovery-rules/dlp_france_credit_card.yml
@@ -21,3 +21,4 @@ source: |
 detection_methods:
   - "File analysis"
   - "Optical Character Recognition"
+id: "d569a299-e59d-5564-9591-8a98df0616b1"

--- a/dlp-discovery-rules/dlp_france_debit_card.yml
+++ b/dlp-discovery-rules/dlp_france_debit_card.yml
@@ -21,3 +21,4 @@ source: |
 detection_methods:
   - "File analysis"
   - "Optical Character Recognition"
+id: "4b9cf269-0a74-55de-88d5-39e9e1b04beb"

--- a/dlp-discovery-rules/dlp_france_drivers_license.yml
+++ b/dlp-discovery-rules/dlp_france_drivers_license.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "a00d0405-c0b6-5df1-b21f-daa5d2dcc1fd"

--- a/dlp-discovery-rules/dlp_france_insee.yml
+++ b/dlp-discovery-rules/dlp_france_insee.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "533bb03b-ab3d-5aa3-a2e4-a1fd43ec2ead"

--- a/dlp-discovery-rules/dlp_france_passport.yml
+++ b/dlp-discovery-rules/dlp_france_passport.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "09b92ea2-e1d7-57de-b9e7-2addc4886cab"

--- a/dlp-discovery-rules/dlp_france_tax_id.yml
+++ b/dlp-discovery-rules/dlp_france_tax_id.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "80aba185-4d91-5ee7-82ec-eb1417caef5c"

--- a/dlp-discovery-rules/dlp_gcp_api_key.yml
+++ b/dlp-discovery-rules/dlp_gcp_api_key.yml
@@ -11,3 +11,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "05fbae4f-15a7-5e38-a49b-67c9f694db6a"

--- a/dlp-discovery-rules/dlp_germany_drivers_license.yml
+++ b/dlp-discovery-rules/dlp_germany_drivers_license.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "4bc3c392-19ea-5b38-a4bc-a4006d619250"

--- a/dlp-discovery-rules/dlp_germany_iban.yml
+++ b/dlp-discovery-rules/dlp_germany_iban.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "fe62c3a3-3989-5107-a3d9-234c97a63205"

--- a/dlp-discovery-rules/dlp_germany_identity_card.yml
+++ b/dlp-discovery-rules/dlp_germany_identity_card.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "3f7d0d95-e6a5-5036-945d-27a9e5434cac"

--- a/dlp-discovery-rules/dlp_germany_passport.yml
+++ b/dlp-discovery-rules/dlp_germany_passport.yml
@@ -19,3 +19,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "d3707f94-57a7-546f-af04-c70caa42cc09"

--- a/dlp-discovery-rules/dlp_germany_tax_id.yml
+++ b/dlp-discovery-rules/dlp_germany_tax_id.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "57d13b49-100c-54dd-8997-a676798e2270"

--- a/dlp-discovery-rules/dlp_github_token.yml
+++ b/dlp-discovery-rules/dlp_github_token.yml
@@ -11,3 +11,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "a88d0203-0684-5605-8f5d-bb25a93a8e83"

--- a/dlp-discovery-rules/dlp_greece_amka.yml
+++ b/dlp-discovery-rules/dlp_greece_amka.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "b2e09497-c178-5cff-b267-7f02d0bea67e"

--- a/dlp-discovery-rules/dlp_greece_national_id.yml
+++ b/dlp-discovery-rules/dlp_greece_national_id.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "0d9aa1e8-16cb-50bd-a09f-f5c4a868fbb4"

--- a/dlp-discovery-rules/dlp_greece_tax_id.yml
+++ b/dlp-discovery-rules/dlp_greece_tax_id.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "673c6cd1-e5d7-5468-b7c8-e60f26dfa2c4"

--- a/dlp-discovery-rules/dlp_hungary_personal_id.yml
+++ b/dlp-discovery-rules/dlp_hungary_personal_id.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "665808e5-7832-56b6-9a3a-d81fa32ce056"

--- a/dlp-discovery-rules/dlp_hungary_taj.yml
+++ b/dlp-discovery-rules/dlp_hungary_taj.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "d729eb83-4944-53d0-b01d-d58d48bd9c25"

--- a/dlp-discovery-rules/dlp_hungary_tax_id.yml
+++ b/dlp-discovery-rules/dlp_hungary_tax_id.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "52765fe0-64ad-57a5-9ac4-7838dbfd0142"

--- a/dlp-discovery-rules/dlp_imei.yml
+++ b/dlp-discovery-rules/dlp_imei.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "0faa7d25-0ea1-5921-b9fd-125d2d34b8d5"

--- a/dlp-discovery-rules/dlp_imsi.yml
+++ b/dlp-discovery-rules/dlp_imsi.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "c85b5b07-be6e-5ff4-821e-4490ad3d9f2d"

--- a/dlp-discovery-rules/dlp_india_aadhaar.yml
+++ b/dlp-discovery-rules/dlp_india_aadhaar.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "00b9be99-2832-5cb3-a8a7-20fe2f8786e8"

--- a/dlp-discovery-rules/dlp_india_bank_account.yml
+++ b/dlp-discovery-rules/dlp_india_bank_account.yml
@@ -15,3 +15,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "1bf9a9d0-fcc7-5053-9167-25514ae26af2"

--- a/dlp-discovery-rules/dlp_india_pan.yml
+++ b/dlp-discovery-rules/dlp_india_pan.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "b7b62f6b-0e77-5020-ba9c-a2eaf35c749a"

--- a/dlp-discovery-rules/dlp_india_passport.yml
+++ b/dlp-discovery-rules/dlp_india_passport.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "4f8bdfce-d739-5212-a8a4-2a1a834da267"

--- a/dlp-discovery-rules/dlp_ip_address.yml
+++ b/dlp-discovery-rules/dlp_ip_address.yml
@@ -16,3 +16,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "d637bb74-67d5-58fb-87eb-5903a801876f"

--- a/dlp-discovery-rules/dlp_ireland_pps.yml
+++ b/dlp-discovery-rules/dlp_ireland_pps.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "dc58d847-a564-58b8-8c0e-b5608213884d"

--- a/dlp-discovery-rules/dlp_israel_bank_account.yml
+++ b/dlp-discovery-rules/dlp_israel_bank_account.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "1ca4fa07-523d-5e34-a59f-e64856cf7631"

--- a/dlp-discovery-rules/dlp_israel_credit_card.yml
+++ b/dlp-discovery-rules/dlp_israel_credit_card.yml
@@ -21,3 +21,4 @@ source: |
 detection_methods:
   - "File analysis"
   - "Optical Character Recognition"
+id: "0102f80f-a47f-5f52-a693-1fcf92b109c0"

--- a/dlp-discovery-rules/dlp_israel_national_id.yml
+++ b/dlp-discovery-rules/dlp_israel_national_id.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "ba2c1570-36d2-5b06-8939-0240c044ae73"

--- a/dlp-discovery-rules/dlp_israel_swift_code.yml
+++ b/dlp-discovery-rules/dlp_israel_swift_code.yml
@@ -13,3 +13,4 @@ source: |
 detection_methods:
   - "Content analysis"
   - "Computer Vision"
+id: "229ae7d5-7c40-5827-a357-189f8cbb9b0e"

--- a/dlp-discovery-rules/dlp_italy_fiscal_code.yml
+++ b/dlp-discovery-rules/dlp_italy_fiscal_code.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "9bc0116d-b518-50a1-95c4-15073e874c99"

--- a/dlp-discovery-rules/dlp_japan_bank_account.yml
+++ b/dlp-discovery-rules/dlp_japan_bank_account.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "25998e33-981c-5ad8-a27f-2f55ae8a2e44"

--- a/dlp-discovery-rules/dlp_japan_credit_card.yml
+++ b/dlp-discovery-rules/dlp_japan_credit_card.yml
@@ -21,3 +21,4 @@ source: |
 detection_methods:
   - "File analysis"
   - "Optical Character Recognition"
+id: "5182e877-7de5-573e-8cbe-ceb2a27e9de3"

--- a/dlp-discovery-rules/dlp_japan_drivers_license.yml
+++ b/dlp-discovery-rules/dlp_japan_drivers_license.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "9af8c166-2803-5447-8002-008ad40953cd"

--- a/dlp-discovery-rules/dlp_japan_mynumber.yml
+++ b/dlp-discovery-rules/dlp_japan_mynumber.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "500b0110-688d-54c9-8efd-0d4716250b00"

--- a/dlp-discovery-rules/dlp_japan_passport.yml
+++ b/dlp-discovery-rules/dlp_japan_passport.yml
@@ -19,3 +19,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "3d3f3405-784f-5c01-bebb-3a29c98208e0"

--- a/dlp-discovery-rules/dlp_japan_sin.yml
+++ b/dlp-discovery-rules/dlp_japan_sin.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "140a4fa1-a088-5f5a-8ce0-76e30af42b8d"

--- a/dlp-discovery-rules/dlp_json_web_token.yml
+++ b/dlp-discovery-rules/dlp_json_web_token.yml
@@ -11,3 +11,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "7591086a-9600-54a8-bc34-26d664b2c4bc"

--- a/dlp-discovery-rules/dlp_korea_rrn.yml
+++ b/dlp-discovery-rules/dlp_korea_rrn.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "f8624d7d-b3eb-54f2-a0c7-efb708ab33d9"

--- a/dlp-discovery-rules/dlp_latvia_personal_code.yml
+++ b/dlp-discovery-rules/dlp_latvia_personal_code.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "cfc0c2e5-d685-59d6-a95e-81423a7f9deb"

--- a/dlp-discovery-rules/dlp_lithuania_personal_code.yml
+++ b/dlp-discovery-rules/dlp_lithuania_personal_code.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "7f6b533d-9ce2-5dfa-8826-6ec2635151e9"

--- a/dlp-discovery-rules/dlp_luxembourg_natural_id.yml
+++ b/dlp-discovery-rules/dlp_luxembourg_natural_id.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "8a20ea77-0543-55cf-a7c8-821309d0631a"

--- a/dlp-discovery-rules/dlp_luxembourg_nonnatural_id.yml
+++ b/dlp-discovery-rules/dlp_luxembourg_nonnatural_id.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "5f54f877-122e-5862-a961-5c8606ee1b31"

--- a/dlp-discovery-rules/dlp_mac_address.yml
+++ b/dlp-discovery-rules/dlp_mac_address.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "58524397-0945-5def-b67c-4ca92cc3e5fb"

--- a/dlp-discovery-rules/dlp_malta_identity_card.yml
+++ b/dlp-discovery-rules/dlp_malta_identity_card.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "83a8908a-8595-52e4-b946-636145107c10"

--- a/dlp-discovery-rules/dlp_malta_tax_id.yml
+++ b/dlp-discovery-rules/dlp_malta_tax_id.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "c7150d94-89d5-5e83-8f02-6b03eb73f3e0"

--- a/dlp-discovery-rules/dlp_mexico_curp.yml
+++ b/dlp-discovery-rules/dlp_mexico_curp.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "7ed7b32a-7cb1-5188-a1b5-8c087d018d52"

--- a/dlp-discovery-rules/dlp_mexico_passport.yml
+++ b/dlp-discovery-rules/dlp_mexico_passport.yml
@@ -19,3 +19,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "06e8a223-2e85-5674-be9a-774f839da233"

--- a/dlp-discovery-rules/dlp_netherlands_bsn.yml
+++ b/dlp-discovery-rules/dlp_netherlands_bsn.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "b8060844-9cb0-54d3-badb-e623cdb6be75"

--- a/dlp-discovery-rules/dlp_netherlands_tax_id.yml
+++ b/dlp-discovery-rules/dlp_netherlands_tax_id.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "fd0b508c-a369-5cf7-8233-d9d07c147ba0"

--- a/dlp-discovery-rules/dlp_oauth_client_secret.yml
+++ b/dlp-discovery-rules/dlp_oauth_client_secret.yml
@@ -15,3 +15,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "c5e1abfa-7ca5-5ab9-b4b1-a8a55d72917f"

--- a/dlp-discovery-rules/dlp_poland_identity_card.yml
+++ b/dlp-discovery-rules/dlp_poland_identity_card.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "d13fa901-201d-53c0-8ada-1ef52e30a8e2"

--- a/dlp-discovery-rules/dlp_poland_tax_id.yml
+++ b/dlp-discovery-rules/dlp_poland_tax_id.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "f3f37258-5c3a-5a70-89cc-5c21b7194cd2"

--- a/dlp-discovery-rules/dlp_portugal_citizen_card.yml
+++ b/dlp-discovery-rules/dlp_portugal_citizen_card.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "27a4c2c9-04aa-5719-a6ca-318be8e6cc7c"

--- a/dlp-discovery-rules/dlp_portugal_tax_id.yml
+++ b/dlp-discovery-rules/dlp_portugal_tax_id.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "728fe0ff-138d-5d89-8ec5-b2467359d532"

--- a/dlp-discovery-rules/dlp_private_key.yml
+++ b/dlp-discovery-rules/dlp_private_key.yml
@@ -13,3 +13,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "7d0dff01-be4d-5223-a78c-26b4954481da"

--- a/dlp-discovery-rules/dlp_romania_personal_code.yml
+++ b/dlp-discovery-rules/dlp_romania_personal_code.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "cef9fa6d-c206-5657-bc41-2f782a9f4fce"

--- a/dlp-discovery-rules/dlp_saudi_arabia_iban.yml
+++ b/dlp-discovery-rules/dlp_saudi_arabia_iban.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "02049a28-c93a-501b-9ae4-1e23d965e4bf"

--- a/dlp-discovery-rules/dlp_saudi_arabia_national_id.yml
+++ b/dlp-discovery-rules/dlp_saudi_arabia_national_id.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "72f47fe9-4fe5-5c19-93d8-5938c485e546"

--- a/dlp-discovery-rules/dlp_saudi_arabia_swift_code.yml
+++ b/dlp-discovery-rules/dlp_saudi_arabia_swift_code.yml
@@ -13,3 +13,4 @@ source: |
 detection_methods:
   - "Content analysis"
   - "Computer Vision"
+id: "8b5d1443-6d10-5d90-8a66-1fabb3b29d21"

--- a/dlp-discovery-rules/dlp_slack_token.yml
+++ b/dlp-discovery-rules/dlp_slack_token.yml
@@ -13,3 +13,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "99723c25-994d-59a5-ab4f-030415050c2e"

--- a/dlp-discovery-rules/dlp_slovakia_personal_number.yml
+++ b/dlp-discovery-rules/dlp_slovakia_personal_number.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "583d0628-bd2c-58cf-93e2-9551d73a3401"

--- a/dlp-discovery-rules/dlp_slovenia_emso.yml
+++ b/dlp-discovery-rules/dlp_slovenia_emso.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "9abda55d-9926-517d-84c4-42d494d27abc"

--- a/dlp-discovery-rules/dlp_slovenia_tax_id.yml
+++ b/dlp-discovery-rules/dlp_slovenia_tax_id.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "e6ff12e8-d28b-5d24-a475-b69f76aa9038"

--- a/dlp-discovery-rules/dlp_spain_bank_account.yml
+++ b/dlp-discovery-rules/dlp_spain_bank_account.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "b6342006-546b-5058-acc3-776726e9c9b7"

--- a/dlp-discovery-rules/dlp_spain_dni_nie.yml
+++ b/dlp-discovery-rules/dlp_spain_dni_nie.yml
@@ -15,3 +15,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "bfbf18fd-1fdd-5590-9b0f-d6ef0a6b3dcd"

--- a/dlp-discovery-rules/dlp_spain_passport.yml
+++ b/dlp-discovery-rules/dlp_spain_passport.yml
@@ -19,3 +19,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "d2f36e97-ee19-5155-a474-b215eda5e706"

--- a/dlp-discovery-rules/dlp_spain_ssn.yml
+++ b/dlp-discovery-rules/dlp_spain_ssn.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "04f9e1a3-2905-5df1-8b2b-318f75b23ea1"

--- a/dlp-discovery-rules/dlp_spain_tax_id.yml
+++ b/dlp-discovery-rules/dlp_spain_tax_id.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "33636552-bf9a-5074-8920-5a2d80e8eb19"

--- a/dlp-discovery-rules/dlp_ssl_certificate.yml
+++ b/dlp-discovery-rules/dlp_ssl_certificate.yml
@@ -13,3 +13,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "9432a3c1-a364-583d-a5bf-2253b9707e91"

--- a/dlp-discovery-rules/dlp_sweden_national_id.yml
+++ b/dlp-discovery-rules/dlp_sweden_national_id.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "4e5ed37b-00b6-530f-b9c8-d2efbe89431c"

--- a/dlp-discovery-rules/dlp_sweden_tax_id.yml
+++ b/dlp-discovery-rules/dlp_sweden_tax_id.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "534ab363-6d9b-53ef-91b9-d24326b26d8b"

--- a/dlp-discovery-rules/dlp_taiwan_id.yml
+++ b/dlp-discovery-rules/dlp_taiwan_id.yml
@@ -18,3 +18,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "65f678cb-64d8-5bc8-bb9c-56014c499371"

--- a/dlp-discovery-rules/dlp_turkey_id.yml
+++ b/dlp-discovery-rules/dlp_turkey_id.yml
@@ -19,3 +19,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "21c402c9-8a24-53df-b019-01f312d58c68"

--- a/dlp-discovery-rules/dlp_uk_nhs_number.yml
+++ b/dlp-discovery-rules/dlp_uk_nhs_number.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "dfddbcfe-16c0-56e9-8aa9-7cf75079c7df"

--- a/dlp-discovery-rules/dlp_uk_nino.yml
+++ b/dlp-discovery-rules/dlp_uk_nino.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "7d5e9b4c-51b2-516f-b0c3-46564c821e60"

--- a/dlp-discovery-rules/dlp_uk_passport.yml
+++ b/dlp-discovery-rules/dlp_uk_passport.yml
@@ -20,3 +20,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "f503ca57-f729-59d8-a55b-02d6f096185e"

--- a/dlp-discovery-rules/dlp_uk_swift_code.yml
+++ b/dlp-discovery-rules/dlp_uk_swift_code.yml
@@ -13,3 +13,4 @@ source: |
 detection_methods:
   - "Content analysis"
   - "Computer Vision"
+id: "130b64f4-d38d-54eb-970b-4e8edf958868"

--- a/dlp-discovery-rules/dlp_us_bank_account.yml
+++ b/dlp-discovery-rules/dlp_us_bank_account.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "b81d1c09-2caa-51d1-82ce-72cf504a2c9f"

--- a/dlp-discovery-rules/dlp_us_drivers_license.yml
+++ b/dlp-discovery-rules/dlp_us_drivers_license.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "bffdbcef-5ea5-5c8d-a2aa-64833faa073c"

--- a/dlp-discovery-rules/dlp_us_icd10.yml
+++ b/dlp-discovery-rules/dlp_us_icd10.yml
@@ -15,3 +15,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "436234d9-0095-5223-b6e4-f9830e186de0"

--- a/dlp-discovery-rules/dlp_us_icd9.yml
+++ b/dlp-discovery-rules/dlp_us_icd9.yml
@@ -15,3 +15,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "e6e2af96-e87c-5228-938d-64a29466dc7a"

--- a/dlp-discovery-rules/dlp_us_insurance_claim.yml
+++ b/dlp-discovery-rules/dlp_us_insurance_claim.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "63f12df8-006f-5ade-9bd5-cdb9259b6a13"

--- a/dlp-discovery-rules/dlp_us_itin.yml
+++ b/dlp-discovery-rules/dlp_us_itin.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "259d44e5-b0ac-5846-9153-25d08d05ac38"

--- a/dlp-discovery-rules/dlp_us_passport.yml
+++ b/dlp-discovery-rules/dlp_us_passport.yml
@@ -19,3 +19,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "df291668-d22b-5402-8705-45d39119d425"

--- a/dlp-discovery-rules/dlp_us_ssn.yml
+++ b/dlp-discovery-rules/dlp_us_ssn.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "5ed9e765-1827-5bec-9e04-77bad97ba4ba"

--- a/dlp-discovery-rules/dlp_vehicle_vin.yml
+++ b/dlp-discovery-rules/dlp_vehicle_vin.yml
@@ -14,3 +14,4 @@ source: |
 
 detection_methods:
   - "Content analysis"
+id: "18b68205-e1f8-5f09-a78b-1ac3e1ca3ad3"


### PR DESCRIPTION
# Description

<!-- 
Misses on "missing invoice" rule due to multiple reasons, the main reason being a common negation. Attempted LogoDetect but DS is saying the image is too small to use. Using beta.ocr because scan.ocr.raw does not parse the PDF function. POF is included as it can't fully detect PDF in the small image. Only one hit present. May be local rule, wanting RWF.
-->

This rule detects messages with small image attachments that contain PDF-related text but are actually embedded images. It includes various detection methods and attack types related to phishing and fraud.

# Associated samples

[- Sample 1](https://platform.sublime.security/messages/502b6fa408e821ca3985edc710c614bcb73b417cae59d515a32ba4c798c2850e?from_canonical_id=502b6fa408e821ca3985edc710c614bcb73b417cae59d515a32ba4c798c2850e%3Fpreview_id%3D019cdaad-9264-7def-8c59-f58c4242ee75&preview_id=019ce2b1-2a38-79ed-8715-bf60fee15e05)

## Associated hunts

[- Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019d1c38-2fd1-774a-a4aa-3d30c5e5fe7c)