### PR TITLE
Negate SharePoint file shares with Mimecast rewrites

### DIFF
--- a/detection-rules/impersonation_sharepoint_body_credential_theft.yml
+++ b/detection-rules/impersonation_sharepoint_body_credential_theft.yml
@@ -136,6 +136,25 @@ source: |
             )
     )
   )
+  // negate sharepoint file shares with mimecast rewrites
+  and not (
+    // rewritten message ID
+    strings.iends_with(headers.message_id, 'mimecast.lan>')
+    and all(filter(body.links,
+                   strings.icontains(subject.subject, .display_text)
+                   or .display_text == "Open"
+            ),
+            .href_url.domain.root_domain == "mimecastprotect.com"
+            and (
+              any(.href_url.query_params_decoded["domain"], . == "sharepoint.com")
+              or (
+                any(.href_url.query_params_decoded["domain"],
+                    strings.parse_domain(.).tld == "ms"
+                )
+              )
+            )
+    )
+  )
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/impersonation_sharepoint_body_credential_theft.yml
+++ b/detection-rules/impersonation_sharepoint_body_credential_theft.yml
@@ -144,14 +144,13 @@ source: |
                    strings.icontains(subject.subject, .display_text)
                    or .display_text == "Open"
             ),
-            .href_url.domain.root_domain == "mimecastprotect.com"
-            and (
-              any(.href_url.query_params_decoded["domain"], . == "sharepoint.com")
-              or (
-                any(.href_url.query_params_decoded["domain"],
+            .href_url.domain.root_domain in (
+              "mimecastprotect.com",
+              "mimecast.com"
+            )
+            and any(.href_url.query_params_decoded["domain"],
                     strings.parse_domain(.).tld == "ms"
-                )
-              )
+                    or strings.parse_domain(.).root_domain == "sharepoint.com"
             )
     )
   )


### PR DESCRIPTION
# Description

Added a condition to negate legitimate SharePoint file shares with Mimecast rewrites.

# Associated samples
- https://platform.sublime.security/messages/5039f8d6156b22dd7df920bfc925fdef3d40ceaca2a31062853b53b673c57567?preview_id=019d2f13-e1ec-76d0-8178-4786cb30e06b
- https://na-east-4.platform.sublime.security/messages/503bf3fe0ab56928b5fc5d351883bec465ba5644671034debad17af0b38b0659?preview_id=019d2f19-732a-7319-89dc-696571fce1aa