### PR TITLE
Create impersonate_hubspot_suspicious_content.yml

### DIFF
--- a/detection-rules/impersonate_hubspot_suspicious_content.yml
+++ b/detection-rules/impersonate_hubspot_suspicious_content.yml
@@ -60,3 +60,4 @@ detection_methods:
   - "Content analysis"
   - "QR code analysis"
   - "Header analysis"
+id: "5df09a5b-8a87-59be-9a73-bd8765dbcc20"

--- a/detection-rules/impersonate_hubspot_suspicious_content.yml
+++ b/detection-rules/impersonate_hubspot_suspicious_content.yml
@@ -11,19 +11,20 @@ source: |
     strings.icontains(body.current_thread.text, '25 first street'),
     strings.icontains(body.current_thread.text, 'MA 02141')
   )
-  and (
-    // contains a QR code
-    //
-    // This rule makes use of a beta feature and is subject to change without notice
-    // using the beta feature in custom rules is not suggested until it has been formally released
-    //
-    (
-      beta.scan_qr(file.message_screenshot()).found
-      and any(beta.scan_qr(file.message_screenshot()).items, .type == "url")
-    )
-    or strings.icontains(body.current_thread.text, "you can't unsubscribe")
-    or regex.icontains(body.current_thread.text,
-                       '(?:reconnect.{0,200}account|deactivat)'
+  and 2 of (
+    any(ml.nlu_classifier(body.current_thread.text).topics,
+        .name in (
+          "Security and Authentication",
+          "Software and App Updates",
+          "Customer Service and Support"
+        )
+        and .confidence != "low"
+    ),
+    any(ml.nlu_classifier(body.current_thread.text).intents,
+        .name == "cred_theft" and .confidence != "low"
+    ),
+    regex.icontains(body.current_thread.text,
+                    '(?:account|disactiv|deactiv|disabl|delet|profile)'
     )
   )
   // exclude legitimate HubSpot sends
@@ -43,11 +44,13 @@ source: |
       )
       and (
         any(headers.domains, strings.iends_with(.root_domain, 'hubspot.com'))
-        or any(headers.ips,
-               strings.icontains(headers.from.email.email, 'hubspot')
-        )
+        or strings.icontains(headers.from.email.email, 'hubspot')
       )
     )
+  )
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/impersonate_hubspot_suspicious_content.yml
+++ b/detection-rules/impersonate_hubspot_suspicious_content.yml
@@ -1,0 +1,62 @@
+name: "Brand impersonation: HubSpot with QR code or suspicious content"
+description: "Detects messages impersonating HubSpot by using the company name in the sender display name and including HubSpot-related content or addresses, while containing suspicious elements like QR codes, unsubscribe manipulation language, or account reconnection requests. Legitimate HubSpot communications are excluded through domain and authentication verification."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and strings.icontains(sender.display_name, 'hubspot')
+  and 2 of (
+    regex.contains(body.current_thread.text, '(?:HubSpot, Inc.|HubSpot)'),
+    strings.icontains(body.current_thread.text, '2 Canal Park Cambridge'),
+    strings.icontains(body.current_thread.text, '25 first street'),
+    strings.icontains(body.current_thread.text, 'MA 02141')
+  )
+  and (
+    // contains a QR code
+    //
+    // This rule makes use of a beta feature and is subject to change without notice
+    // using the beta feature in custom rules is not suggested until it has been formally released
+    //
+    (
+      beta.scan_qr(file.message_screenshot()).found
+      and any(beta.scan_qr(file.message_screenshot()).items, .type == "url")
+    )
+    or strings.icontains(body.current_thread.text, "you can't unsubscribe")
+    or regex.icontains(body.current_thread.text,
+                       '(?:reconnect.{0,200}account|deactivat)'
+    )
+  )
+  // exclude legitimate HubSpot sends
+  and not (
+    (
+      (
+        strings.iends_with(sender.email.domain.root_domain, 'hubspot.com')
+        or strings.iends_with(sender.email.domain.root_domain, 'hubspotqa.com')
+      )
+      and coalesce(headers.auth_summary.dmarc.pass, false)
+    )
+    or (
+      (
+        strings.iends_with(headers.return_path.domain.root_domain, 'hubspot.com')
+        or strings.icontains(headers.message_id, '@notifybf')
+        or strings.icontains(headers.message_id, '.hubspot.com')
+      )
+      and (
+        any(headers.domains, strings.iends_with(.root_domain, 'hubspot.com'))
+        or any(headers.ips,
+               strings.icontains(headers.from.email.email, 'hubspot')
+        )
+      )
+    )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "QR code"
+  - "Social engineering"
+detection_methods:
+  - "Sender analysis"
+  - "Content analysis"
+  - "QR code analysis"
+  - "Header analysis"

--- a/detection-rules/impersonate_hubspot_suspicious_content.yml
+++ b/detection-rules/impersonate_hubspot_suspicious_content.yml
@@ -1,5 +1,5 @@
-name: "Brand impersonation: HubSpot with QR code or suspicious content"
-description: "Detects messages impersonating HubSpot by using the company name in the sender display name and including HubSpot-related content or addresses, while containing suspicious elements like QR codes, unsubscribe manipulation language, or account reconnection requests. Legitimate HubSpot communications are excluded through domain and authentication verification."
+name: "Brand impersonation: HubSpot credential theft"
+description: "Detects fraudulent messages impersonating HubSpot that contain legitimate HubSpot branding elements and address information, combined with security-related topics and credential theft indicators, while excluding authenticated legitimate HubSpot communications."
 type: "rule"
 severity: "medium"
 source: |

--- a/detection-rules/impersonate_hubspot_suspicious_content.yml
+++ b/detection-rules/impersonate_hubspot_suspicious_content.yml
@@ -5,29 +5,31 @@ severity: "medium"
 source: |
   type.inbound
   and strings.icontains(sender.display_name, 'hubspot')
-  and 2 of (
-    regex.contains(body.current_thread.text, '(?:HubSpot, Inc.|HubSpot)'),
-    strings.icontains(body.current_thread.text, '2 Canal Park Cambridge'),
-    strings.icontains(body.current_thread.text, '25 first street'),
-    strings.icontains(body.current_thread.text, 'MA 02141')
-  )
-  and 2 of (
-    any(ml.nlu_classifier(body.current_thread.text).topics,
-        .name in (
-          "Security and Authentication",
-          "Software and App Updates",
-          "Customer Service and Support"
-        )
-        and .confidence != "low"
-    ),
-    any(ml.nlu_classifier(body.current_thread.text).intents,
-        .name == "cred_theft" and .confidence != "low"
-    ),
-    regex.icontains(body.current_thread.text,
-                    '(?:account|disactiv|deactiv|disabl|delet|profile)'
+  and (
+    // branding elements: copying HubSpot's footer
+    2 of (
+      regex.contains(body.current_thread.text, '(?:HubSpot, Inc\.|HubSpot)'),
+      strings.icontains(body.current_thread.text, '2 Canal Park'),
+      strings.icontains(body.current_thread.text, '25 first street'),
+      strings.icontains(body.current_thread.text, 'MA 02141')
+    )
+    // or typosquatting/confusable "hubspot" in sender domain
+    or (
+      not strings.icontains(strings.replace_confusables(sender.email.domain.domain
+                            ),
+                            'hubspot'
+      )
+      and strings.icontains(sender.email.domain.domain, 'hubsp')
     )
   )
-  and not strings.icontains(sender.email.email, 'hubspot')
+  and not (
+    strings.icontains(sender.email.local_part, 'hubspot')
+    or regex.icontains(sender.email.domain.domain, '^hubspot\.')
+  )
+  // negate if links go to HubSpot's click-tracking domain
+  and not any(body.current_thread.links,
+              .href_url.domain.root_domain == "hubspotlinks.com"
+  )
   // exclude legitimate HubSpot sends
   and not (
     (
@@ -53,6 +55,7 @@ source: |
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
+
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/impersonate_hubspot_suspicious_content.yml
+++ b/detection-rules/impersonate_hubspot_suspicious_content.yml
@@ -27,6 +27,7 @@ source: |
                     '(?:account|disactiv|deactiv|disabl|delet|profile)'
     )
   )
+  and not strings.icontains(sender.email.email, 'hubspot')
   // exclude legitimate HubSpot sends
   and not (
     (

--- a/detection-rules/impersonate_hubspot_suspicious_content.yml
+++ b/detection-rules/impersonate_hubspot_suspicious_content.yml
@@ -5,44 +5,56 @@ severity: "medium"
 source: |
   type.inbound
   and strings.icontains(sender.display_name, 'hubspot')
-  
-  // domain typosquats "hubspot" via character substitution/confusables
-  and (
-    not strings.icontains(strings.replace_confusables(sender.email.domain.domain),
-                          'hubspot'
-    )
-    and strings.icontains(sender.email.domain.domain, 'hubsp')
+  // body reproduces HubSpot's real corporate footer
+  and 2 of (
+    regex.icontains(body.current_thread.text, 'hubspot,?\s+inc'),
+    strings.icontains(body.current_thread.text, '2 canal park'),
+    strings.icontains(body.current_thread.text, '25 first street'),
+    regex.icontains(body.current_thread.text, 'cambridge,?\s+ma\s+0214[0-9]')
   )
-  and not (
-    strings.icontains(sender.email.local_part, 'hubspot')
-    or regex.icontains(sender.email.domain.domain, '^hubspot\.')
+  // HubSpot orange
+  and strings.icontains(body.html.raw, '#ff7a59')
+  // filter on visible action links off HubSpot's real infrastructure
+  and any(filter(body.links,
+                 .href_url.scheme in ('http', 'https')
+                 and coalesce(.visible, false)
+          ),
+          .href_url.domain.root_domain not in (
+            'hubspot.com',
+            'hubspotlinks.com',
+            'hs-sites.com',
+            'hsforms.com',
+            'hubspotemail.net',
+            'hubspotusercontent.com',
+            'hubapi.com'
+          )
   )
-  
-  // negate if links go to HubSpot's click-tracking domain
-  and not any(body.current_thread.links,
-              .href_url.domain.root_domain == "hubspotlinks.com"
-  )
-  
-  // exclude legitimate HubSpot sends
-  and not (
-    (
-      (
-        strings.iends_with(sender.email.domain.root_domain, 'hubspot.com')
-        or strings.iends_with(sender.email.domain.root_domain, 'hubspotqa.com')
-      )
-      and coalesce(headers.auth_summary.dmarc.pass, false)
-    )
-    or (
-      (
-        strings.iends_with(headers.return_path.domain.root_domain, 'hubspot.com')
-        or strings.icontains(headers.message_id, '@notifybf')
-        or strings.icontains(headers.message_id, '.hubspot.com')
-      )
-      and (
-        any(headers.domains, strings.iends_with(.root_domain, 'hubspot.com'))
-        or strings.icontains(headers.from.email.email, 'hubspot')
-      )
-    )
+  and not coalesce((
+                     sender.email.domain.root_domain in (
+                       'hubspot.com',
+                       'hubspotqa.com'
+                     )
+                     and (
+                       coalesce(headers.auth_summary.dmarc.pass, false)
+                       or coalesce(headers.auth_summary.spf.pass, false)
+                     )
+                   )
+                   or (
+                     (
+                       headers.return_path.domain.root_domain == 'hubspot.com'
+                       or strings.icontains(headers.message_id, '@notifybf')
+                       or strings.iends_with(headers.message_id, '.hubspot.com>')
+                     )
+                     and (
+                       strings.icontains(headers.from.email.email, 'hubspot')
+                       or any(headers.reply_to,
+                              strings.iends_with(.email.domain.root_domain,
+                                                 'hubspot.com'
+                              )
+                       )
+                     )
+                   ),
+                   false
   )
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains

--- a/detection-rules/impersonate_hubspot_suspicious_content.yml
+++ b/detection-rules/impersonate_hubspot_suspicious_content.yml
@@ -6,11 +6,16 @@ source: |
   type.inbound
   and strings.icontains(sender.display_name, 'hubspot')
   // body reproduces HubSpot's real corporate footer
-  and 2 of (
-    regex.icontains(body.current_thread.text, 'hubspot,?\s+inc'),
-    strings.icontains(body.current_thread.text, '2 canal park'),
-    strings.icontains(body.current_thread.text, '25 first street'),
-    regex.icontains(body.current_thread.text, 'cambridge,?\s+ma\s+0214[0-9]')
+  and (
+    2 of (
+      regex.icontains(body.current_thread.text, 'hubspot,?\s+inc'),
+      strings.icontains(body.current_thread.text, '2 canal park'),
+      strings.icontains(body.current_thread.text, '25 first street'),
+      regex.icontains(body.current_thread.text, 'cambridge,?\s+ma\s+0214[0-9]')
+    )
+    or sender.email.domain.root_domain != strings.replace_confusables(sender.email.domain.root_domain
+    )
+    or sender.email.domain.root_domain == 'hubsp0t.com'
   )
   // HubSpot orange
   and strings.icontains(body.html.raw, '#ff7a59')
@@ -29,32 +34,25 @@ source: |
             'hubapi.com'
           )
   )
-  and not coalesce((
-                     sender.email.domain.root_domain in (
-                       'hubspot.com',
-                       'hubspotqa.com'
-                     )
-                     and (
-                       coalesce(headers.auth_summary.dmarc.pass, false)
-                       or coalesce(headers.auth_summary.spf.pass, false)
-                     )
-                   )
-                   or (
-                     (
-                       headers.return_path.domain.root_domain == 'hubspot.com'
-                       or strings.icontains(headers.message_id, '@notifybf')
-                       or strings.iends_with(headers.message_id, '.hubspot.com>')
-                     )
-                     and (
-                       strings.icontains(headers.from.email.email, 'hubspot')
-                       or any(headers.reply_to,
-                              strings.iends_with(.email.domain.root_domain,
-                                                 'hubspot.com'
-                              )
-                       )
-                     )
-                   ),
-                   false
+  and not (
+    (
+      sender.email.domain.root_domain in ('hubspot.com', 'hubspotqa.com')
+      and (coalesce(headers.auth_summary.dmarc.pass, false))
+    )
+    or (
+      (
+        headers.return_path.domain.root_domain == 'hubspot.com'
+        or strings.icontains(headers.message_id, '@notifybf')
+        or strings.iends_with(headers.message_id, '.hubspot.com>')
+      )
+      and (
+        strings.icontains(headers.from.email.email, 'hubspot')
+        or any(headers.reply_to,
+               strings.iends_with(.email.domain.root_domain, 'hubspot.com')
+        )
+      )
+      and (coalesce(headers.auth_summary.dmarc.pass, false))
+    )
   )
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains

--- a/detection-rules/impersonate_hubspot_suspicious_content.yml
+++ b/detection-rules/impersonate_hubspot_suspicious_content.yml
@@ -5,7 +5,7 @@ severity: "medium"
 source: |
   type.inbound
   and strings.icontains(sender.display_name, 'hubspot')
-
+  
   // domain typosquats "hubspot" via character substitution/confusables
   and (
     not strings.icontains(strings.replace_confusables(sender.email.domain.domain),
@@ -13,17 +13,16 @@ source: |
     )
     and strings.icontains(sender.email.domain.domain, 'hubsp')
   )
-
   and not (
     strings.icontains(sender.email.local_part, 'hubspot')
     or regex.icontains(sender.email.domain.domain, '^hubspot\.')
   )
-
+  
   // negate if links go to HubSpot's click-tracking domain
   and not any(body.current_thread.links,
               .href_url.domain.root_domain == "hubspotlinks.com"
   )
-
+  
   // exclude legitimate HubSpot sends
   and not (
     (
@@ -49,7 +48,6 @@ source: |
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/impersonate_hubspot_suspicious_content.yml
+++ b/detection-rules/impersonate_hubspot_suspicious_content.yml
@@ -5,31 +5,25 @@ severity: "medium"
 source: |
   type.inbound
   and strings.icontains(sender.display_name, 'hubspot')
+
+  // domain typosquats "hubspot" via character substitution/confusables
   and (
-    // branding elements: copying HubSpot's footer
-    2 of (
-      regex.contains(body.current_thread.text, '(?:HubSpot, Inc\.|HubSpot)'),
-      strings.icontains(body.current_thread.text, '2 Canal Park'),
-      strings.icontains(body.current_thread.text, '25 first street'),
-      strings.icontains(body.current_thread.text, 'MA 02141')
+    not strings.icontains(strings.replace_confusables(sender.email.domain.domain),
+                          'hubspot'
     )
-    // or typosquatting/confusable "hubspot" in sender domain
-    or (
-      not strings.icontains(strings.replace_confusables(sender.email.domain.domain
-                            ),
-                            'hubspot'
-      )
-      and strings.icontains(sender.email.domain.domain, 'hubsp')
-    )
+    and strings.icontains(sender.email.domain.domain, 'hubsp')
   )
+
   and not (
     strings.icontains(sender.email.local_part, 'hubspot')
     or regex.icontains(sender.email.domain.domain, '^hubspot\.')
   )
+
   // negate if links go to HubSpot's click-tracking domain
   and not any(body.current_thread.links,
               .href_url.domain.root_domain == "hubspotlinks.com"
   )
+
   // exclude legitimate HubSpot sends
   and not (
     (


### PR DESCRIPTION
# Description

Detects credential phishing attacks impersonating HubSpot by matching messages with "HubSpot" in the sender display name, HubSpot-specific content indicators (company name, addresses), and suspicious elements including QR codes, unsubscribe manipulation, or account reconnection/deactivation language.

<!-- 
Explain your change and why. For example, "negating legitimate replies," or "adding additional credential theft keywords."

If it's a new rule or insight, explain what the rule is designed to catch/what the insight should fire on.
-->

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5031198a6f7e7439a1a0b5a768559ce80287a27f07706bd5e5b0fcc88871024d?preview_id=019d0134-b208-76c1-a897-1ed65647d2a0)
- [Sample 2](https://platform.sublime.security/messages/5030be929f28b8b0de8c29ffb6d91963a5acbdce39e194bf33633165b4b8d7cf?preview_id=019d0134-9749-7e87-8006-01bbd7220dab)
- [Sample 3](https://platform.sublime.security/messages/502cef7f3938fbca365f8285a55f34ac76db9dfebf0ac223558ad2e3b6777eed?preview_id=019ce3f7-01ac-7987-b841-401c81612622)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Latest multihunt](https://hunt.limeseed.email/hunts/884cb093-6ffd-46d2-9c7d-91cf7137975f)
- [Latest hunt (post multihunt shared) in shared samples](https://platform.sublime.security/messages/hunt?huntId=019f0516-90f8-7ea6-9dc6-ebed492248a8)

# Screenshot (insights)
<!-- 
**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
-->
