### PR TITLE
Update fake_thread_suspicious_indicators.yml

### DIFF
--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -148,6 +148,16 @@ source: |
     // body contains recipient SLD
     any(recipients.to,
         strings.icontains(body.current_thread.text, .email.domain.sld)
+    ),
+    // mailto mismatch from freemailer
+    (
+      any(body.links,
+          strings.istarts_with(.href_url.url, "mailto:")
+          and .display_text is not null
+          and strings.icontains(.display_text, "@")
+          and not strings.icontains(.href_url.url, .display_text)
+      )
+      and sender.email.domain.root_domain in $free_email_providers
     )
   )
   

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -152,7 +152,7 @@ source: |
     // mailto mismatch from freemailer
     (
       any(body.links,
-          strings.istarts_with(.href_url.url, "mailto:")
+          .href_url.scheme == 'mailto'
           and .display_text is not null
           and strings.icontains(.display_text, "@")
           and not strings.icontains(.href_url.url, .display_text)

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -149,15 +149,18 @@ source: |
     any(recipients.to,
         strings.icontains(body.current_thread.text, .email.domain.sld)
     ),
-
+  
     // mailto display text shows email from different root domain than href target
     (
       any(filter(body.links, .href_url.scheme == 'mailto'),
           .display_text is not null
-          and regex.icontains(.display_text, '[a-zA-Z0-9._+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}')
-          and not strings.icontains(
-            .href_url.url,
-            regex.extract(.display_text, '[a-zA-Z0-9._+-]+@(?:[a-zA-Z0-9-]+\.)*(?P<root>[a-zA-Z0-9-]+\.[a-zA-Z]{2,})')[0].named_groups["root"]
+          and regex.icontains(.display_text,
+                              '[a-zA-Z0-9._+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'
+          )
+          and not strings.icontains(.href_url.url,
+                                    regex.extract(.display_text,
+                                                  '[a-zA-Z0-9._+-]+@(?:[a-zA-Z0-9-]+\.)*(?P<root>[a-zA-Z0-9-]+\.[a-zA-Z]{2,})'
+                                    )[0].named_groups["root"]
           )
       )
       and sender.email.domain.root_domain in $free_email_providers
@@ -166,13 +169,13 @@ source: |
         or all(headers.references, strings.icontains(., ".ref@"))
       )
     ),
-
+  
     // freemail sender using bulk or marketing mailer
     (
       sender.email.domain.root_domain in $free_email_providers
       and headers.mailer is not null
       and regex.icontains(headers.mailer,
-          '(marketing|campaign|mass|bulk|mailer|newsletter|sendinblue|mailchimp|sendgrid|mailgun|postmark|constant.contact|hubspot|pardot|marketo|brevo|klaviyo|drip)'
+                          '(marketing|campaign|mass|bulk|mailer|newsletter|sendinblue|mailchimp|sendgrid|mailgun|postmark|constant.contact|hubspot|pardot|marketo|brevo|klaviyo|drip)'
       )
     )
   )

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -149,15 +149,31 @@ source: |
     any(recipients.to,
         strings.icontains(body.current_thread.text, .email.domain.sld)
     ),
-    // mailto mismatch from freemailer
+
+    // mailto display text shows email from different root domain than href target
     (
-      any(body.links,
-          .href_url.scheme == 'mailto'
-          and .display_text is not null
-          and strings.icontains(.display_text, "@")
-          and not strings.icontains(.href_url.url, .display_text)
+      any(filter(body.links, .href_url.scheme == 'mailto'),
+          .display_text is not null
+          and regex.icontains(.display_text, '[a-zA-Z0-9._+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}')
+          and not strings.icontains(
+            .href_url.url,
+            regex.extract(.display_text, '[a-zA-Z0-9._+-]+@(?:[a-zA-Z0-9-]+\.)*(?P<root>[a-zA-Z0-9-]+\.[a-zA-Z]{2,})')[0].named_groups["root"]
+          )
       )
       and sender.email.domain.root_domain in $free_email_providers
+      and (
+        length(headers.references) == 0
+        or all(headers.references, strings.icontains(., ".ref@"))
+      )
+    ),
+
+    // freemail sender using bulk or marketing mailer
+    (
+      sender.email.domain.root_domain in $free_email_providers
+      and headers.mailer is not null
+      and regex.icontains(headers.mailer,
+          '(marketing|campaign|mass|bulk|mailer|newsletter|sendinblue|mailchimp|sendgrid|mailgun|postmark|constant.contact|hubspot|pardot|marketo|brevo|klaviyo|drip)'
+      )
     )
   )
   

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -74,9 +74,9 @@ source: |
     // urgency request
     any(ml.nlu_classifier(body.current_thread.text).entities, .name == "urgency"),
   
-    // cred_theft detection
+    // cred_theft or bec detection
     any(ml.nlu_classifier(body.current_thread.text).intents,
-        .name == "cred_theft" and .confidence in~ ("medium", "high")
+        .name in ("cred_theft", 'bec') and .confidence in~ ("medium", "high")
     ),
   
     // commonly abused sender TLD
@@ -160,6 +160,7 @@ source: |
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
   and not profile.by_sender().any_messages_benign
+
 tags:
   - "Attack surface reduction"
 attack_types:

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -149,9 +149,8 @@ source: |
     any(recipients.to,
         strings.icontains(body.current_thread.text, .email.domain.sld)
     ),
-  
     (
-      // bec 
+      // bec
       any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == "bec" and .confidence != "low"
       )
@@ -172,7 +171,6 @@ source: |
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
   and not profile.by_sender().any_messages_benign
-
 tags:
   - "Attack surface reduction"
 attack_types:

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -173,7 +173,6 @@ source: |
   )
   and not profile.by_sender().any_messages_benign
 
-
 tags:
   - "Attack surface reduction"
 attack_types:

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -76,7 +76,7 @@ source: |
   
     // cred_theft or bec detection
     any(ml.nlu_classifier(body.current_thread.text).intents,
-        .name in ("cred_theft", 'bec') and .confidence in~ ("medium", "high")
+        .name in ("cred_theft") and .confidence in~ ("medium", "high")
     ),
   
     // commonly abused sender TLD
@@ -148,6 +148,18 @@ source: |
     // body contains recipient SLD
     any(recipients.to,
         strings.icontains(body.current_thread.text, .email.domain.sld)
+    ),
+  
+    (
+      // bec 
+      any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "bec" and .confidence != "low"
+      )
+      // previous thread contains matching domain but mismatch local part in current thread
+      and any(body.previous_threads,
+              .sender.email.domain.root_domain == recipients.to[0].email.domain.root_domain
+              and .sender.email.email != recipients.to[0].email.email
+      )
     )
   )
   
@@ -160,6 +172,7 @@ source: |
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
   and not profile.by_sender().any_messages_benign
+
 
 tags:
   - "Attack surface reduction"

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -76,7 +76,7 @@ source: |
   
     // cred_theft detection
     any(ml.nlu_classifier(body.current_thread.text).intents,
-        .name in ("cred_theft") and .confidence in~ ("medium", "high")
+        .name == "cred_theft" and .confidence in~ ("medium", "high")
     ),
   
     // commonly abused sender TLD

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -74,7 +74,7 @@ source: |
     // urgency request
     any(ml.nlu_classifier(body.current_thread.text).entities, .name == "urgency"),
   
-    // cred_theft or bec detection
+    // cred_theft detection
     any(ml.nlu_classifier(body.current_thread.text).intents,
         .name in ("cred_theft") and .confidence in~ ("medium", "high")
     ),


### PR DESCRIPTION
# Description

<!-- 
Explain your change and why. For example, "negating legitimate replies," or "adding additional credential theft keywords."

If it's a new rule or insight, explain what the rule is designed to catch/what the insight should fire on.
-->

Resolving an FN that came through with a fake thread. Updating to check for BEC as well as the recipients domain being in a previous thread but not the current thread local part. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/503bcf8e342cc84696677c31baab916998a198bc6c7484bbb9cc166451456da7?preview_id=019d44a0-6a26-7c41-b0d2-de5d236def56)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [multihunt](https://hunt.limeseed.email/hunts/0a762871-aea8-4209-9a7d-039e5dab15aa) - some FPs but since ASR I'm tolerant of leaning on ASA for these. 