### PR TITLE
Create link_base64_encoded_email_in_url_parameters_self_sender.yml

### DIFF
--- a/detection-rules/link_base64_encoded_email_in_url_parameters_self_sender.yml
+++ b/detection-rules/link_base64_encoded_email_in_url_parameters_self_sender.yml
@@ -12,6 +12,9 @@ source: |
               any(., strings.decode_base64(.) == sender.email.email)
           )
   )
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+        .name == 'cred_theft' and .confidence == 'high'
+  )
   and not (sender.email.email is null or regex.imatch(sender.email.email, '\s*'))
   
 

--- a/detection-rules/link_base64_encoded_email_in_url_parameters_self_sender.yml
+++ b/detection-rules/link_base64_encoded_email_in_url_parameters_self_sender.yml
@@ -1,0 +1,27 @@
+name: "Link: Self-sender with base64 encoded email in URL parameters"
+description: "Detects messages where the sender emails themselves and includes their own email address encoded in base64 within URL query parameters. This technique is commonly used to bypass security filters and deliver malicious links while appearing to come from a trusted internal source."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // self sender
+  and length(recipients.to) == 1
+  and sender.email.email == recipients.to[0].email.email
+  and any(body.current_thread.links,
+          any(values(.href_url.query_params_decoded),
+              any(., strings.decode_base64(.) == sender.email.email)
+          )
+  )
+  and not (sender.email.email is null or regex.imatch(sender.email.email, '\s*'))
+  
+
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "Header analysis"
+  - "Sender analysis"
+  - "URL analysis"

--- a/detection-rules/link_base64_encoded_email_in_url_parameters_self_sender.yml
+++ b/detection-rules/link_base64_encoded_email_in_url_parameters_self_sender.yml
@@ -13,11 +13,9 @@ source: |
           )
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents,
-        .name == 'cred_theft' and .confidence == 'high'
+          .name == 'cred_theft' and .confidence == 'high'
   )
   and not (sender.email.email is null or regex.imatch(sender.email.email, '\s*'))
-  
-
 attack_types:
   - "BEC/Fraud"
   - "Credential Phishing"

--- a/detection-rules/link_base64_encoded_email_in_url_parameters_self_sender.yml
+++ b/detection-rules/link_base64_encoded_email_in_url_parameters_self_sender.yml
@@ -25,3 +25,4 @@ detection_methods:
   - "Header analysis"
   - "Sender analysis"
   - "URL analysis"
+id: "1469d5f9-37b2-56d6-8a38-cd37099abcd6"


### PR DESCRIPTION
# Description

Detects messages where the sender emails themselves and includes their own email address encoded in base64 within URL query parameters.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/501f86f5a91a0b0344a9cd901f4ebe657a675eeb4bb6571984290a0da9f5807b)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019d49ed-f862-74be-9e06-f164967b839f)
