### PR TITLE
Create callback_scam_file_extensions.yml

### DIFF
--- a/detection-rules/callback_scam_file_extension.yml
+++ b/detection-rules/callback_scam_file_extension.yml
@@ -22,6 +22,11 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
+  and not (
+    any(ml.nlu_classifier(body.current_thread.text).intents,
+        .name == "benign" and .confidence == "high"
+    )
+  )
 attack_types:
   - "Callback Phishing"
 tactics_and_techniques:

--- a/detection-rules/callback_scam_file_extension.yml
+++ b/detection-rules/callback_scam_file_extension.yml
@@ -1,0 +1,25 @@
+name: "Attachment: Callback scam file extension"
+description: "Detects inbound messages with short or no text content containing an attachment that exhibit callback scam characteristics, sent from untrusted domains."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (body.current_thread.text is null or length(body.current_thread.text) < 500)
+  and any(attachments,
+          (.file_extension in~ ("ppt", "pptx"))
+          and (
+            any(file.explode(.),
+                any(ml.nlu_classifier(.scan.strings.raw).intents,
+                    .name == "callback_scam" and .confidence != "low"
+                )
+            )
+            )
+          )
+  and not sender.email.domain.root_domain in $high_trust_sender_root_domains
+attack_types:
+  - "Callback Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "File analysis"
+  - "Sender analysis"

--- a/detection-rules/callback_scam_file_extension.yml
+++ b/detection-rules/callback_scam_file_extension.yml
@@ -4,18 +4,24 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and (body.current_thread.text is null or length(body.current_thread.text) < 500)
+  and length(body.current_thread.text) < 2000
   and any(attachments,
-          (.file_extension in~ ("ppt", "pptx"))
-          and (
-            any(file.explode(.),
-                any(ml.nlu_classifier(.scan.strings.raw).intents,
-                    .name == "callback_scam" and .confidence != "low"
-                )
-            )
+          .file_extension in~ ("ppt", "pptx")
+          and any(file.explode(.),
+                  any(ml.nlu_classifier(.scan.strings.raw).intents,
+                      .name == "callback_scam" and .confidence != "low"
+                  )
           )
   )
-  and not sender.email.domain.root_domain in $high_trust_sender_root_domains
+  and sender.email.domain.root_domain in $free_email_providers
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    coalesce(sender.email.domain.root_domain in $high_trust_sender_root_domains
+             and not headers.auth_summary.dmarc.pass,
+             false
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
 attack_types:
   - "Callback Phishing"
 tactics_and_techniques:

--- a/detection-rules/callback_scam_file_extension.yml
+++ b/detection-rules/callback_scam_file_extension.yml
@@ -13,8 +13,8 @@ source: |
                     .name == "callback_scam" and .confidence != "low"
                 )
             )
-            )
           )
+  )
   and not sender.email.domain.root_domain in $high_trust_sender_root_domains
 attack_types:
   - "Callback Phishing"
@@ -23,3 +23,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "Sender analysis"
+id: "769b3333-4cde-544c-a081-ef9a75dddd24"


### PR DESCRIPTION
# Description
From a runner ping (ESC-9806) - creating new rule to expand on finding incoming emails that have file extensions -  callback scams

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/503ec2649facce842583a8d25515e253581cc9d760ded3259163c03943f60db6?preview_id=019d4010-1aa6-7bf4-8265-448d28c099e8)
- [Sample 2](https://platform.sublime.security/messages/5037d3f65460e2816f549a23751d36d0fed2acb0e61726bd7cd5a317273f7cac)

## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019dd651-562c-7232-a8c7-206a8610c916)
- [Multi-hunt90Days](https://platform.sublime.security/messages/hunt?huntId=019dd651-562c-7232-a8c7-206a8610c916)
