### PR TITLE
Update callback_phishing_microsoft_comment.yml

### DIFF
--- a/detection-rules/callback_phishing_microsoft_comment.yml
+++ b/detection-rules/callback_phishing_microsoft_comment.yml
@@ -17,7 +17,7 @@ source: |
     // Callback Phishing
     and (
       any(ml.nlu_classifier(body.current_thread.text).intents,
-          .name in ("callback_scam")
+          .name in ("callback_scam", "cred_theft")
           and .confidence in ("medium", "high")
           and length(body.current_thread.text) < 1750
       )

--- a/detection-rules/callback_phishing_microsoft_comment.yml
+++ b/detection-rules/callback_phishing_microsoft_comment.yml
@@ -5,6 +5,7 @@ severity: "medium"
 source: |
   type.inbound
   and length(attachments) == 0
+  and length(body.current_thread.text) < 1750
   
   // Legitimate MicrosoftOnline sending infrastructure
   // or invites@microsoft.com abuse
@@ -19,22 +20,6 @@ source: |
       any(ml.nlu_classifier(body.current_thread.text).intents,
           .name in ("callback_scam", "cred_theft")
           and .confidence in ("medium", "high")
- and length(attachments) == 0
- and length(body.current_thread.text) < 1750
- 
- // Legitimate MicrosoftOnline sending infrastructure
- // or invites@microsoft.com abuse
- and (
-   (
-     sender.email.domain.root_domain in ('microsoftonline.com')
-     or sender.email.email == "invites@microsoft.com"
-   )
- 
-   // Callback Phishing
-   and (
-     any(ml.nlu_classifier(body.current_thread.text).intents,
-          .name in ("callback_scam", "cred_theft")
-         and .confidence in ("medium", "high")
       )
       or 3 of (
         strings.ilike(body.current_thread.text, '*purchase*'),

--- a/detection-rules/callback_phishing_microsoft_comment.yml
+++ b/detection-rules/callback_phishing_microsoft_comment.yml
@@ -19,7 +19,22 @@ source: |
       any(ml.nlu_classifier(body.current_thread.text).intents,
           .name in ("callback_scam", "cred_theft")
           and .confidence in ("medium", "high")
-          and length(body.current_thread.text) < 1750
+ and length(attachments) == 0
+ and length(body.current_thread.text) < 1750
+ 
+ // Legitimate MicrosoftOnline sending infrastructure
+ // or invites@microsoft.com abuse
+ and (
+   (
+     sender.email.domain.root_domain in ('microsoftonline.com')
+     or sender.email.email == "invites@microsoft.com"
+   )
+ 
+   // Callback Phishing
+   and (
+     any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name in ("callback_scam", "cred_theft")
+         and .confidence in ("medium", "high")
       )
       or 3 of (
         strings.ilike(body.current_thread.text, '*purchase*'),


### PR DESCRIPTION
# Description

Adding `cred_theft` as an nlu intent to capture additional FNs

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5045c779c130fb36d57c00dca9d1204008596e6a95acd20cb6a82cf502ee8b48?preview_id=019d6d53-ae44-73e9-bd37-4f1fd6eac6bc)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019d8795-a67a-7c35-9023-9568e82f1a37)

- [L7D 27 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/ea9b0289-757e-4d0f-b087-7d598bb9d62c)