### PR TITLE
Create attachment_pdf_cred_theft_invalid_reply_to.yml

### DIFF
--- a/detection-rules/attachment_pdf_cred_theft_invalid_reply_to.yml
+++ b/detection-rules/attachment_pdf_cred_theft_invalid_reply_to.yml
@@ -18,7 +18,11 @@ source: |
                   )
           )
   )
-
+  // negate highly trusted sender domains unless they fail DMARC authentication or DMARC is missing
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/attachment_pdf_cred_theft_invalid_reply_to.yml
+++ b/detection-rules/attachment_pdf_cred_theft_invalid_reply_to.yml
@@ -6,7 +6,7 @@ source: |
   type.inbound
   and length(recipients.to) == 1
   and recipients.to[0].email.domain.valid
-  and any(headers.reply_to, not .email.domain.valid)
+  and any(headers.reply_to, .email.email == "")
   and any(attachments,
           .file_type == 'pdf'
           and any(file.explode(.),

--- a/detection-rules/attachment_pdf_cred_theft_invalid_reply_to.yml
+++ b/detection-rules/attachment_pdf_cred_theft_invalid_reply_to.yml
@@ -1,0 +1,30 @@
+name: "Attachment: PDF with credential theft language and invalid reply-to domain"
+description: "Detects PDF attachments containing high-confidence credential theft language that references the recipient's email address, combined with an invalid reply-to domain header."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(headers.reply_to, not .email.domain.valid)
+  and any(attachments,
+          .file_type == 'pdf'
+          and any(file.explode(.),
+                  any(ml.nlu_classifier(.scan.strings.raw).intents,
+                      .name == 'cred_theft' and .confidence == 'high'
+                  )
+                  and strings.icontains(.scan.strings.raw,
+                                        recipients.to[0].email.email
+                  )
+          )
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "PDF"
+  - "Social engineering"
+  - "Spoofing"
+detection_methods:
+  - "File analysis"
+  - "Header analysis"
+  - "Natural Language Understanding"
+  - "Content analysis"

--- a/detection-rules/attachment_pdf_cred_theft_invalid_reply_to.yml
+++ b/detection-rules/attachment_pdf_cred_theft_invalid_reply_to.yml
@@ -28,3 +28,4 @@ detection_methods:
   - "Header analysis"
   - "Natural Language Understanding"
   - "Content analysis"
+id: "52e54b5d-940f-5b54-b175-0a55f2a44fa2"

--- a/detection-rules/attachment_pdf_cred_theft_invalid_reply_to.yml
+++ b/detection-rules/attachment_pdf_cred_theft_invalid_reply_to.yml
@@ -4,6 +4,8 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
+  and length(recipients.to) == 1
+  and recipients.to[0].email.domain.valid
   and any(headers.reply_to, not .email.domain.valid)
   and any(attachments,
           .file_type == 'pdf'


### PR DESCRIPTION
# Description
Detects PDF attachments containing high-confidence credential theft language that references the recipient's email address, combined with an invalid reply-to domain header.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50415e34e08e2fa871c072ec6b009ed950462ba3b2d146b58d1073bd4a9f1677)
## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019d6db1-1025-72e4-b5a3-b6f586a477d1)