### PR TITLE
Update spam_website_errors_solicitation.yml

### DIFF
--- a/detection-rules/spam_website_errors_solicitation.yml
+++ b/detection-rules/spam_website_errors_solicitation.yml
@@ -14,7 +14,7 @@ source: |
       regex.icontains(strings.replace_confusables(subject.subject),
                       '(?:proposal|cost|estimate|error|bug|audit|screenshot|strategy|rankings|issues|fix|website|design|review|price)'
       )
-      or regex.icontains(subject.subject,
+      or regex.icontains(subject.base,
                          '[^\x{2600}-\x{27BF}\x{1F300}-\x{1F9FF}][\x{2600}-\x{27BF}\x{1F300}-\x{1F9FF}]\x{FE0F}?$'
       )
       // report and follow up keywords

--- a/detection-rules/spam_website_errors_solicitation.yml
+++ b/detection-rules/spam_website_errors_solicitation.yml
@@ -12,7 +12,10 @@ source: |
     (
       // SEO or web development service keywords
       regex.icontains(strings.replace_confusables(subject.subject),
-                      "(?:proposal|cost|estimate|error|bug|audit|screenshot|strategy|rankings|issues|fix|website|design|review|price)"
+                      '(?:proposal|cost|estimate|error|bug|audit|screenshot|strategy|rankings|issues|fix|website|design|review|price)'
+      )
+      or regex.icontains(subject.subject,
+                         '[^\x{2600}-\x{27BF}\x{1F300}-\x{1F9FF}][\x{2600}-\x{27BF}\x{1F300}-\x{1F9FF}]\x{FE0F}?$'
       )
       // report and follow up keywords
       or (
@@ -59,9 +62,9 @@ source: |
                           "(?:site|website|page)"
       )
     )
-    // Single thread with only unsubscribe link
+    // Single thread with unsubscribe link or $org_domains link
     or (
-      length(body.links) == 1
+      length(body.links) <= 3
       and (
         // unsubscribe mailto link
         regex.icontains(body.html.raw, "mailto:*[++unsubscribe@]")


### PR DESCRIPTION
# Description

Broadening up `length(body.links)` and adding logic to look for a single emoji at the end of the subject 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50478c199fbf6be0010441f45e94be8f81775a8d0b3815a8ac817a8c98c554a0?preview_id=019d6cc8-ab01-71e7-99bb-a7a31ab888f7)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019d77d5-d0f8-782d-b6f6-3969610a2ec6)

Multi-Hunt located in ESC