### PR TITLE
Update link_url_shortener_fragment_in_subject.yml

### DIFF
--- a/detection-rules/link_url_shortener_fragment_in_subject.yml
+++ b/detection-rules/link_url_shortener_fragment_in_subject.yml
@@ -7,6 +7,7 @@ source: |
   and any(body.current_thread.links,
           .href_url.domain.root_domain in $url_shorteners
           and .href_url.fragment is not null
+          and length(.href_url.fragment) > 5
           and strings.contains(subject.subject, .href_url.fragment)
   )
 


### PR DESCRIPTION
# Description
This update adds a fragment length check on  `Link: Shortened URL with fragment matching subject` to prevent FPs.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [TP Sample](https://platform.sublime.security/messages/503e09a8a5c489e225f75c8cd03db3f78e6f52ea0ef1f6d7cb51715f291a32ca?preview_id=019d69c9-47d3-72b7-8edb-b5c6337d2f9d)
- [FP Sample](https://platform.sublime.security/messages/503f805f432191e63d07eb6d8ec5cb8df2423de424ac48f52dcaae5405b3d854?preview_id=019d6446-8b63-7b96-b2b7-11f8141797b4)
- [FP Sample](https://platform.sublime.security/messages/5029cc1cd8c6fd6a70d2a0d359e8e179b0ae351c0f5c8eac445057e022ebc89e?preview_id=019d643a-3a6b-795c-b3ca-892ef296353c)
- [FP Sample](https://platform.sublime.security/messages/502bd307881f5078a41b0b2d378e5c22fb8317d797956b527e81b2fcec25897e?preview_id=019d6433-99f3-74b4-95c7-3b49123d798c)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Updated Rule](https://platform.sublime.security/messages/hunt?huntId=019d72d6-ee15-78b5-841a-438892e0e541)
- [FP Hunt](https://platform.sublime.security/messages/hunt?huntId=019d72d4-2bec-71c0-b45c-b0ec937db406)
- Mult-hunts in ESC-10578

