### PR TITLE
Update attachment_pdf_sus_string_single_url.yml

### DIFF
--- a/detection-rules/attachment_pdf_sus_string_single_url.yml
+++ b/detection-rules/attachment_pdf_sus_string_single_url.yml
@@ -14,7 +14,7 @@ source: |
                   any(.scan.strings.strings,
                       regex.icontains(.,
                                       // action!
-                                      '^\s*(?:view documents?|view pdf|view presentation|preview new docusign|Download Secure PDF|VIEW DOCUMENT HERE|ACCESS DOCUMENT|REVIEW NEW SECURE DOCUMENT|OPEN SECURE VIEWER|DOWNLOAD RFP DOCUMENT|View Dashboard here|ACCESS SECURE DOCUMENTS|VIEW PROPOSAL DOCUMENTS|ACCESS / VIEW PROPOSAL DOCUMENT|Review & Sign Document|Open PDF|Access Document\(s\)|REVIEW SHARED DOCUMENT|New Secured Document|ACCESS SECURE RFP PORTAL|Please Review and Sign|Review and Validate|SECURE DOCUMENT|Open Document|View Details|Q!_Compensation/Salary Amendments\.pptx|PREVIEW DOCUMENT HERE|Download Tax Details Below:|Review and Sign Document|Review Document|Open Encrypted|OPEN DOCUMENT HERE|Click to read message)\s*$',
+                                      '^\s*(?:view documents?|view pdf|view presentation|preview new docusign|Download Secure PDF|VIEW DOCUMENT HERE|ACCESS DOCUMENT|REVIEW NEW SECURE DOCUMENT|OPEN SECURE VIEWER|DOWNLOAD RFP DOCUMENT|View Dashboard here|ACCESS SECURE DOCUMENTS|VIEW PROPOSAL DOCUMENTS|ACCESS / VIEW PROPOSAL DOCUMENT|Review & Sign Document|Open PDF|Access Document\(s\)|(?:P?RE)?VIEW SHARED DOCUMENT|New Secured Document|ACCESS SECURE RFP PORTAL|Please Review and Sign|Review and Validate|SECURE DOCUMENT|Open Document|View Details|Q!_Compensation/Salary Amendments\.pptx|PREVIEW DOCUMENT HERE|Download Tax Details Below:|Review and Sign Document|Review Document|Open Encrypted|OPEN DOCUMENT HERE|Click to read message)\s*$',
                                       // "secure fax"
                                       'View Secure Fax',
                                       // more fake errors
@@ -29,7 +29,9 @@ source: |
                                       '.*sent you a \S+ to review(?:\s*(?:and|&)\s*sign)$',
                                       '^You received a \S+ to review and sign$',
                                       // docusign
-                                      '\s*DocuSign Contract Under Review\s*'
+                                      '\s*DocuSign Contract Under Review\s*',
+                                      'DOCUMENT PREVIEW',
+                                      'PREVIEW DOCUMENT'
                       )
                   )
                   // fake error messages


### PR DESCRIPTION
# Description

Updating `.scan.strings.strings` to include the keywords `DOCUMENT PREVIEW` and `PREVIEW DOCUMENT`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5048c0d4eca2b628e1b664895128e4626121bec239186780f75a1fa4d6856f1b?preview_id=019d72b4-7e44-772d-813b-bb679121c6fd)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019d78ca-8fa5-7909-8762-0003e655444b)

Multi-Hunt located in ESC