### PR TITLE
Update generic_pdf.yar

### DIFF
--- a/yara/generic_pdf.yar
+++ b/yara/generic_pdf.yar
@@ -156,106 +156,97 @@ rule SAI_Global_ISO9001_Logo_PDF_Fuzzy
         )
 }
 
-rule Phishing_PDF_Split_QR_Code_Pair_330
-  {
-      meta:                                                                                                                                                                  
-          author = "brandon murphy"
-          date = "2026-04-09"                                                                                                                                                
-          updated = "2026-04-10"                                                                                                                                           
-          description = "PDF containing two 165x330 JPEG images — a vertically split QR code pair"                                                                           
+rule Phishing_PDF_Split_QR_Code_Pair_330                                                                                                                                 
+{                                                                                                                                                                          
+  meta:                                                                                                                                                                  
+      author = "brandon murphy"                                                                                                                                          
+      date = "2026-04-09"                                                                                                                                                
+      updated = "2026-04-10"                                                                                                                                             
+      description = "PDF containing two 165x330 JPEG images — a vertically split QR code pair"                                                                           
+                                                                                                                                                                         
+  strings:                                                                                                                                                               
+      $header = {25 50 44 46 2d 31 2e}                                                                                                                                   
+                                                                                                                                                                         
+      // --- PDF object layer ---                                                                                                                                        
+      // Image XObject definitions for the QR halves.                                                                                                                    
+      // Both objects declare the same dimensions + JPEG filter.                                                                                                         
+      $w = "/Width 165"                                                                                                                                                  
+      $h = "/Height 330"                                                                                                                                                 
+      $jpeg_filter = "/Filter /DCTDecode"                                                                                                                                
+      $xobj_image = "/Subtype /Image"                                                                                                                                    
+                                                                                                                                                                         
+      // --- JPEG layer ---                                                                                                                                              
+      // SOF0 (baseline) marker encoding exactly 165x330:                                                                                                                
+      //   ff c0       = SOF0 marker                                                                                                                                     
+      //   00 11       = segment length (17 bytes)                                                                                                                       
+      //   08          = 8-bit precision                                                                                                                                 
+      //   01 4a       = height 330                                                                                                                                      
+      //   00 a5       = width 165                                                                                                                                       
+      //   03          = 3 components (YCbCr)                                                                                                                            
+      //   01 22 00    = component 1: Y, 2x2 sampling, QT 0                                                                                                              
+      //   02 11 01    = component 2: Cb, 1x1 sampling, QT 1                                                                                                             
+      //   03 11 01    = component 3: Cr, 1x1 sampling, QT 1                                                                                                             
+      $sof0 = {ff c0 00 11 08 01 4a 00 a5 03 01 22 00 02 11 01 03 11 01}                                                                                                 
+                                                                                                                                                                         
+  condition:                                                                                                                                                             
+      $header at 0 and                                                                                                                                                   
+                                                                                                                                                                         
+      // Both are JPEG XObject images                                                                                                                                    
+      $jpeg_filter and                                                                                                                                                   
+      $xobj_image and                                                                                                                                                    
+                                                                                                                                                                         
+      // Exactly two QR-half image objects in the PDF                                                                                                                    
+      #sof0 == 2 and                                                                                                                                                     
+      #w == 2 and                                                                                                                                                        
+      #h == 2 and                                                                                                                                                        
+                                                                                                                                                                         
+      // The two JPEG SOF0 markers appear within 100KB of each other                                                                                                     
+      @sof0[2] - @sof0[1] < 102400                                                                                                                                       
+}                                                                                                                                                                          
                                                                                                                                                                              
-      strings:                                                                                                                                                               
-          $header = {25 50 44 46 2d 31 2e}                                                                                                                                   
-                                                                                                                                                                             
-          // --- PDF object layer ---                                                                                                                                      
-          // Image XObject definitions for the QR halves.                                                                                                                    
-          // Both objects declare the same dimensions + JPEG filter.                                                                                                       
-          $w = "/Width 165"
-          $h = "/Height 330"
-          $jpeg_filter = "/Filter /DCTDecode"                                                                                                                                
-          $xobj_image = "/Subtype /Image"
-                                                                                                                                                                             
-          // --- JPEG layer ---                                                                                                                                              
-          // SOF0 (baseline) marker encoding exactly 165x330:
-          //   ff c0       = SOF0 marker                                                                                                                                     
-          //   00 11       = segment length (17 bytes)                                                                                                                       
-          //   08          = 8-bit precision                                                                                                                                 
-          //   01 4a       = height 330                                                                                                                                      
-          //   00 a5       = width 165                                                                                                                                       
-          //   03          = 3 components (YCbCr)                                                                                                                            
-          //   01 22 00    = component 1: Y, 2x2 sampling, QT 0                                                                                                              
-          //   02 11 01    = component 2: Cb, 1x1 sampling, QT 1                                                                                                             
-          //   03 11 01    = component 3: Cr, 1x1 sampling, QT 1                                                                                                             
-          $sof0 = {ff c0 00 11 08 01 4a 00 a5 03 01 22 00 02 11 01 03 11 01}                                                                                                 
-                                                                                                                                                                             
-      condition:                                                                                                                                                             
-          $header at 0 and                                                                                                                                                   
-                                                                                                                                                                             
-          // Both are JPEG XObject images                                                                                                                                    
-          $jpeg_filter and                                                                                                                                                   
-          $xobj_image and                                                                                                                                                    
-                                                                                                                                                                             
-          // Exactly two QR-half image objects in the PDF                                                                                                                    
-          #sof0 == 2 and                                                                                                                                                     
-          #w == 2 and                                                                                                                                                        
-          #h == 2 and                                                                                                                                                        
-                                                                                                                                                                             
-          // The two JPEG SOF0 markers appear within 100KB of each other                                                                                                     
-          for any i in (1..#sof0) : (                                                                                                                                        
-              for any j in (i+1..#sof0) : (                                                                                                                                  
-                  @sof0[j] - @sof0[i] < 102400                                                                                                                               
-              )                                                                                                                                                              
-          )                                                                                                                                                                  
-  }                                                                                                                                                                          
-                                                                                                                                                                             
-  rule Phishing_PDF_Split_QR_Code_Pair_290                                                                                                                                   
-  {
-      meta:                                                                                                                                                                  
-          author = "brandon murphy"                                                                                                                                          
-          date = "2026-04-10"                                                                                                                                                
-          description = "PDF containing two 145x290 JPEG images — a vertically split QR code pair"                                                                           
-                                                                                                                                                                             
-      strings:                                                                                                                                                               
-          $header = {25 50 44 46 2d 31 2e}                                                                                                                                   
-                                                                                                                                                                             
-          // --- PDF object layer ---                                                                                                                                        
-          // Image XObject definitions for the QR halves.                                                                                                                    
-          // Both objects declare the same dimensions + JPEG filter.                                                                                                         
-          $w = "/Width 145"                                                                                                                                                  
-          $h = "/Height 290"                                                                                                                                                 
-          $jpeg_filter = "/Filter /DCTDecode"                                                                                                                                
-          $xobj_image = "/Subtype /Image"                                                                                                                                    
-                                                                                                                                                                             
-          // --- JPEG layer ---                                                                                                                                              
-          // SOF0 (baseline) marker encoding exactly 145x290:                                                                                                                
-          //   ff c0       = SOF0 marker                                                                                                                                     
-          //   00 11       = segment length (17 bytes)                                                                                                                       
-          //   08          = 8-bit precision                                                                                                                                 
-          //   01 22       = height 290                                                                                                                                      
-          //   00 91       = width 145                                                                                                                                       
-          //   03          = 3 components (YCbCr)                                                                                                                            
-          //   01 22 00    = component 1: Y, 2x2 sampling, QT 0                                                                                                              
-          //   02 11 01    = component 2: Cb, 1x1 sampling, QT 1                                                                                                             
-          //   03 11 01    = component 3: Cr, 1x1 sampling, QT 1                                                                                                             
-          $sof0 = {ff c0 00 11 08 01 22 00 91 03 01 22 00 02 11 01 03 11 01}                                                                                                 
-                                                                                                                                                                             
-      condition:                                                                                                                                                             
-          $header at 0 and                                                                                                                                                   
-                                                                                                                                                                             
-          // Both are JPEG XObject images                                                                                                                                    
-          $jpeg_filter and                                                                                                                                                   
-          $xobj_image and                                                                                                                                                    
-                                                                                                                                                                             
-          // Exactly two QR-half image objects in the PDF                                                                                                                    
-          #sof0 == 2 and                                                                                                                                                     
-          #w == 2 and                                                                                                                                                        
-          #h == 2 and                                                                                                                                                        
-                                                                                                                                                                             
-          // The two JPEG SOF0 markers appear within 100KB of each other                                                                                                     
-          for any i in (1..#sof0) : (                                                                                                                                      
-              for any j in (i+1..#sof0) : (                                                                                                                                  
-                  @sof0[j] - @sof0[i] < 102400                                                                                                                               
-              )                                                                                                                                                              
-          )                                                                                                                                                                  
-  }                                                                                                                                                                          
-            
+rule Phishing_PDF_Split_QR_Code_Pair_290                                                                                                                                   
+{                                                                                                                                                                          
+  meta:                                                                                                                                                                  
+      author = "brandon murphy"                                                                                                                                          
+      date = "2026-04-10"                                                                                                                                                
+      description = "PDF containing two 145x290 JPEG images — a vertically split QR code pair"                                                                           
+                                                                                                                                                                         
+  strings:                                                                                                                                                               
+      $header = {25 50 44 46 2d 31 2e}                                                                                                                                   
+                                                                                                                                                                         
+      // --- PDF object layer ---                                                                                                                                        
+      // Image XObject definitions for the QR halves.                                                                                                                    
+      // Both objects declare the same dimensions + JPEG filter.                                                                                                         
+      $w = "/Width 145"                                                                                                                                                  
+      $h = "/Height 290"                                                                                                                                                 
+      $jpeg_filter = "/Filter /DCTDecode"                                                                                                                                
+      $xobj_image = "/Subtype /Image"                                                                                                                                    
+                                                                                                                                                                         
+      // --- JPEG layer ---                                                                                                                                              
+      // SOF0 (baseline) marker encoding exactly 145x290:                                                                                                                
+      //   ff c0       = SOF0 marker                                                                                                                                     
+      //   00 11       = segment length (17 bytes)                                                                                                                       
+      //   08          = 8-bit precision                                                                                                                                 
+      //   01 22       = height 290                                                                                                                                      
+      //   00 91       = width 145                                                                                                                                       
+      //   03          = 3 components (YCbCr)                                                                                                                            
+      //   01 22 00    = component 1: Y, 2x2 sampling, QT 0                                                                                                              
+      //   02 11 01    = component 2: Cb, 1x1 sampling, QT 1                                                                                                             
+      //   03 11 01    = component 3: Cr, 1x1 sampling, QT 1                                                                                                             
+      $sof0 = {ff c0 00 11 08 01 22 00 91 03 01 22 00 02 11 01 03 11 01}                                                                                                 
+                                                                                                                                                                         
+  condition:                                                                                                                                                             
+      $header at 0 and                                                                                                                                                   
+                                                                                                                                                                         
+      // Both are JPEG XObject images                                                                                                                                    
+      $jpeg_filter and                                                                                                                                                   
+      $xobj_image and                                                                                                                                                    
+                                                                                                                                                                         
+      // Exactly two QR-half image objects in the PDF                                                                                                                    
+      #sof0 == 2 and                                                                                                                                                     
+      #w == 2 and                                                                                                                                                        
+      #h == 2 and                                                                                                                                                        
+                                                                                                                                                                         
+      // The two JPEG SOF0 markers appear within 100KB of each other                                                                                                     
+      @sof0[2] - @sof0[1] < 102400                                                                                                                                       
+}                                                                                               

--- a/yara/generic_pdf.yar
+++ b/yara/generic_pdf.yar
@@ -176,17 +176,14 @@ rule Phishing_PDF_Split_QR_Code_Pair_330
       $xobj_image = "/Subtype /Image"                                                                                                                                    
                                                                                                                                                                          
       // --- JPEG layer ---                                                                                                                                              
-      // SOF0 (baseline) marker encoding exactly 165x330:                                                                                                                
-      //   ff c0       = SOF0 marker                                                                                                                                     
-      //   00 11       = segment length (17 bytes)                                                                                                                       
-      //   08          = 8-bit precision                                                                                                                                 
-      //   01 4a       = height 330                                                                                                                                      
-      //   00 a5       = width 165                                                                                                                                       
-      //   03          = 3 components (YCbCr)                                                                                                                            
-      //   01 22 00    = component 1: Y, 2x2 sampling, QT 0                                                                                                              
-      //   02 11 01    = component 2: Cb, 1x1 sampling, QT 1                                                                                                             
-      //   03 11 01    = component 3: Cr, 1x1 sampling, QT 1                                                                                                             
-      $sof0 = {ff c0 00 11 08 01 4a 00 a5 03 01 22 00 02 11 01 03 11 01}                                                                                                 
+      // SOF0 (baseline) marker encoding exactly 165x330:                                                                                                                        
+      //   ff c0       = SOF0 marker                                                                                                                                             
+      //   00 11       = segment length (17 bytes)                                                                                                                               
+      //   08          = 8-bit precision                                                                                                                                         
+      //   01 4a       = height 330                                                                                                                                              
+      //   00 a5       = width 165                                                                                                                                               
+      //   03          = 3 components (YCbCr)                                                                                                                                    
+      $sof0 = {ff c0 00 11 08 01 4a 00 a5 03}
                                                                                                                                                                          
   condition:                                                                                                                                                             
       $header at 0 and                                                                                                                                                   
@@ -223,17 +220,14 @@ rule Phishing_PDF_Split_QR_Code_Pair_290
       $xobj_image = "/Subtype /Image"                                                                                                                                    
                                                                                                                                                                          
       // --- JPEG layer ---                                                                                                                                              
-      // SOF0 (baseline) marker encoding exactly 145x290:                                                                                                                
-      //   ff c0       = SOF0 marker                                                                                                                                     
-      //   00 11       = segment length (17 bytes)                                                                                                                       
-      //   08          = 8-bit precision                                                                                                                                 
-      //   01 22       = height 290                                                                                                                                      
-      //   00 91       = width 145                                                                                                                                       
-      //   03          = 3 components (YCbCr)                                                                                                                            
-      //   01 22 00    = component 1: Y, 2x2 sampling, QT 0                                                                                                              
-      //   02 11 01    = component 2: Cb, 1x1 sampling, QT 1                                                                                                             
-      //   03 11 01    = component 3: Cr, 1x1 sampling, QT 1                                                                                                             
-      $sof0 = {ff c0 00 11 08 01 22 00 91 03 01 22 00 02 11 01 03 11 01}                                                                                                 
+      // SOF0 (baseline) marker encoding exactly 145x290:                                                                                                                        
+      //   ff c0       = SOF0 marker                                                                                                                                             
+      //   00 11       = segment length (17 bytes)                                                                                                                               
+      //   08          = 8-bit precision                                                                                                                                         
+      //   01 22       = height 290                                                                                                                                              
+      //   00 91       = width 145                                                                                                                                               
+      //   03          = 3 components (YCbCr)                                                                                                                                    
+      $sof0 = {ff c0 00 11 08 01 22 00 91 03}                                                                                                   
                                                                                                                                                                          
   condition:                                                                                                                                                             
       $header at 0 and                                                                                                                                                   

--- a/yara/generic_pdf.yar
+++ b/yara/generic_pdf.yar
@@ -111,3 +111,96 @@ rule rmm_pdf_lure {
         $header at 0 and
         $link1
 }
+
+rule SAI_Global_ISO9001_Logo_PDF_Fuzzy                                                                                                                                    
+{                                                                                                                                                                       
+   meta:
+       author = "brandon murphy"
+       date = "2026-04-09"
+       description = "fuzzy detection of SAI Global ISO 9001 logo variants in PDFs (re-encoded, resized)"
+
+  strings:
+        // PDF markers
+        $pdf_header   = "%PDF"
+        $is_image     = "/Subtype /Image"
+        $is_jpeg      = "/Filter /DCTDecode"
+
+        // JPEG quantization table — shorter anchor (16 bytes from luma QT)
+        // This specific sequence of QT values is rare and survives minor edits
+        $qt_anchor = {
+            14 14 14 14 15 14 17 19
+            19 17 1F 22 1E 22 1F 2E
+        }
+
+        // SOF progressive marker with 1024x768
+        $sof_1024x768 = { FF C2 00 11 08 03 00 04 00 }
+
+        // Alternate: SOF baseline with 1024x768
+        $sof_baseline = { FF C0 00 11 08 03 00 04 00 }
+
+        // Unique scan-data byte patterns (mid-stream anchors)
+        // From ~25% into the JPEG scan data
+        $scan_mid1 = { 14 20 31 41 51 53 60 71 15 40 52 72 22 33 34 35 }
+        // From ~50% into the JPEG scan data
+        $scan_mid2 = { E6 0F 4A FA F9 6D 97 45 75 C8 69 DD 9D 8B 31 CC }
+
+    condition:
+        $pdf_header at 0 and
+        $is_image and $is_jpeg and
+        (
+            // High confidence: QT match + dimensions
+            ($qt_anchor and ($sof_1024x768 or $sof_baseline))
+            or
+            // Medium confidence: QT match + scan data anchor
+            ($qt_anchor and ($scan_mid1 or $scan_mid2))
+        )
+}
+
+rule Phishing_PDF_Split_QR_Code_Pair
+{
+   meta:
+       author = "brandon murphy"
+       date = "2026-04-09"
+       description = "PDF containing two 165x330 JPEG images — a vertically split QR code pair"
+
+    strings:
+        $pdf = "%PDF"
+
+        // --- PDF object layer ---
+        // Image XObject definitions for the QR halves.
+        // Both objects declare the same dimensions + JPEG filter.
+        $qr_width    = "/Width 165"
+        $qr_height   = "/Height 330"
+        $jpeg_filter = "/Filter /DCTDecode"
+        $xobj_image  = "/Subtype /Image"
+
+        // --- JPEG layer ---
+        // SOF0 (baseline) marker encoding exactly 165x330:
+        //   FF C0       = SOF0 marker
+        //   00 11       = segment length (17 bytes)
+        //   08          = 8-bit precision
+        //   01 4A       = height 330
+        //   00 A5       = width 165
+        //   03          = 3 components (YCbCr)
+        //   01 22 00    = component 1: Y, 2x2 sampling, QT 0
+        //   02 11 01    = component 2: Cb, 1x1 sampling, QT 1
+        //   03 11 01    = component 3: Cr, 1x1 sampling, QT 1
+        $sof0_165x330 = {
+            FF C0 00 11 08 01 4A 00 A5 03 01 22 00 02 11 01 03 11 01
+        }
+
+    condition:
+        $pdf at 0 and
+
+        // Two QR-half image objects in the PDF
+        #qr_width  >= 2 and
+        #qr_height >= 2 and
+
+        // Both are JPEG XObject images
+        $jpeg_filter and
+        $xobj_image and
+
+        // The actual JPEG SOF0 marker with 165x330 appears twice
+        #sof0_165x330 >= 2
+}
+

--- a/yara/generic_pdf.yar
+++ b/yara/generic_pdf.yar
@@ -156,51 +156,106 @@ rule SAI_Global_ISO9001_Logo_PDF_Fuzzy
         )
 }
 
-rule Phishing_PDF_Split_QR_Code_Pair
-{
-   meta:
-       author = "brandon murphy"
-       date = "2026-04-09"
-       description = "PDF containing two 165x330 JPEG images — a vertically split QR code pair"
-
-    strings:
-        $pdf = "%PDF"
-
-        // --- PDF object layer ---
-        // Image XObject definitions for the QR halves.
-        // Both objects declare the same dimensions + JPEG filter.
-        $qr_width    = "/Width 165"
-        $qr_height   = "/Height 330"
-        $jpeg_filter = "/Filter /DCTDecode"
-        $xobj_image  = "/Subtype /Image"
-
-        // --- JPEG layer ---
-        // SOF0 (baseline) marker encoding exactly 165x330:
-        //   FF C0       = SOF0 marker
-        //   00 11       = segment length (17 bytes)
-        //   08          = 8-bit precision
-        //   01 4A       = height 330
-        //   00 A5       = width 165
-        //   03          = 3 components (YCbCr)
-        //   01 22 00    = component 1: Y, 2x2 sampling, QT 0
-        //   02 11 01    = component 2: Cb, 1x1 sampling, QT 1
-        //   03 11 01    = component 3: Cr, 1x1 sampling, QT 1
-        $sof0_165x330 = {
-            FF C0 00 11 08 01 4A 00 A5 03 01 22 00 02 11 01 03 11 01
-        }
-
-    condition:
-        $pdf at 0 and
-
-        // Two QR-half image objects in the PDF
-        #qr_width  >= 2 and
-        #qr_height >= 2 and
-
-        // Both are JPEG XObject images
-        $jpeg_filter and
-        $xobj_image and
-
-        // The actual JPEG SOF0 marker with 165x330 appears twice
-        #sof0_165x330 >= 2
-}
-
+rule Phishing_PDF_Split_QR_Code_Pair_330
+  {
+      meta:                                                                                                                                                                  
+          author = "brandon murphy"
+          date = "2026-04-09"                                                                                                                                                
+          updated = "2026-04-10"                                                                                                                                           
+          description = "PDF containing two 165x330 JPEG images — a vertically split QR code pair"                                                                           
+                                                                                                                                                                             
+      strings:                                                                                                                                                               
+          $header = {25 50 44 46 2d 31 2e}                                                                                                                                   
+                                                                                                                                                                             
+          // --- PDF object layer ---                                                                                                                                      
+          // Image XObject definitions for the QR halves.                                                                                                                    
+          // Both objects declare the same dimensions + JPEG filter.                                                                                                       
+          $w = "/Width 165"
+          $h = "/Height 330"
+          $jpeg_filter = "/Filter /DCTDecode"                                                                                                                                
+          $xobj_image = "/Subtype /Image"
+                                                                                                                                                                             
+          // --- JPEG layer ---                                                                                                                                              
+          // SOF0 (baseline) marker encoding exactly 165x330:
+          //   ff c0       = SOF0 marker                                                                                                                                     
+          //   00 11       = segment length (17 bytes)                                                                                                                       
+          //   08          = 8-bit precision                                                                                                                                 
+          //   01 4a       = height 330                                                                                                                                      
+          //   00 a5       = width 165                                                                                                                                       
+          //   03          = 3 components (YCbCr)                                                                                                                            
+          //   01 22 00    = component 1: Y, 2x2 sampling, QT 0                                                                                                              
+          //   02 11 01    = component 2: Cb, 1x1 sampling, QT 1                                                                                                             
+          //   03 11 01    = component 3: Cr, 1x1 sampling, QT 1                                                                                                             
+          $sof0 = {ff c0 00 11 08 01 4a 00 a5 03 01 22 00 02 11 01 03 11 01}                                                                                                 
+                                                                                                                                                                             
+      condition:                                                                                                                                                             
+          $header at 0 and                                                                                                                                                   
+                                                                                                                                                                             
+          // Both are JPEG XObject images                                                                                                                                    
+          $jpeg_filter and                                                                                                                                                   
+          $xobj_image and                                                                                                                                                    
+                                                                                                                                                                             
+          // Exactly two QR-half image objects in the PDF                                                                                                                    
+          #sof0 == 2 and                                                                                                                                                     
+          #w == 2 and                                                                                                                                                        
+          #h == 2 and                                                                                                                                                        
+                                                                                                                                                                             
+          // The two JPEG SOF0 markers appear within 100KB of each other                                                                                                     
+          for any i in (1..#sof0) : (                                                                                                                                        
+              for any j in (i+1..#sof0) : (                                                                                                                                  
+                  @sof0[j] - @sof0[i] < 102400                                                                                                                               
+              )                                                                                                                                                              
+          )                                                                                                                                                                  
+  }                                                                                                                                                                          
+                                                                                                                                                                             
+  rule Phishing_PDF_Split_QR_Code_Pair_290                                                                                                                                   
+  {
+      meta:                                                                                                                                                                  
+          author = "brandon murphy"                                                                                                                                          
+          date = "2026-04-10"                                                                                                                                                
+          description = "PDF containing two 145x290 JPEG images — a vertically split QR code pair"                                                                           
+                                                                                                                                                                             
+      strings:                                                                                                                                                               
+          $header = {25 50 44 46 2d 31 2e}                                                                                                                                   
+                                                                                                                                                                             
+          // --- PDF object layer ---                                                                                                                                        
+          // Image XObject definitions for the QR halves.                                                                                                                    
+          // Both objects declare the same dimensions + JPEG filter.                                                                                                         
+          $w = "/Width 145"                                                                                                                                                  
+          $h = "/Height 290"                                                                                                                                                 
+          $jpeg_filter = "/Filter /DCTDecode"                                                                                                                                
+          $xobj_image = "/Subtype /Image"                                                                                                                                    
+                                                                                                                                                                             
+          // --- JPEG layer ---                                                                                                                                              
+          // SOF0 (baseline) marker encoding exactly 145x290:                                                                                                                
+          //   ff c0       = SOF0 marker                                                                                                                                     
+          //   00 11       = segment length (17 bytes)                                                                                                                       
+          //   08          = 8-bit precision                                                                                                                                 
+          //   01 22       = height 290                                                                                                                                      
+          //   00 91       = width 145                                                                                                                                       
+          //   03          = 3 components (YCbCr)                                                                                                                            
+          //   01 22 00    = component 1: Y, 2x2 sampling, QT 0                                                                                                              
+          //   02 11 01    = component 2: Cb, 1x1 sampling, QT 1                                                                                                             
+          //   03 11 01    = component 3: Cr, 1x1 sampling, QT 1                                                                                                             
+          $sof0 = {ff c0 00 11 08 01 22 00 91 03 01 22 00 02 11 01 03 11 01}                                                                                                 
+                                                                                                                                                                             
+      condition:                                                                                                                                                             
+          $header at 0 and                                                                                                                                                   
+                                                                                                                                                                             
+          // Both are JPEG XObject images                                                                                                                                    
+          $jpeg_filter and                                                                                                                                                   
+          $xobj_image and                                                                                                                                                    
+                                                                                                                                                                             
+          // Exactly two QR-half image objects in the PDF                                                                                                                    
+          #sof0 == 2 and                                                                                                                                                     
+          #w == 2 and                                                                                                                                                        
+          #h == 2 and                                                                                                                                                        
+                                                                                                                                                                             
+          // The two JPEG SOF0 markers appear within 100KB of each other                                                                                                     
+          for any i in (1..#sof0) : (                                                                                                                                      
+              for any j in (i+1..#sof0) : (                                                                                                                                  
+                  @sof0[j] - @sof0[i] < 102400                                                                                                                               
+              )                                                                                                                                                              
+          )                                                                                                                                                                  
+  }                                                                                                                                                                          
+            


### PR DESCRIPTION
# Description

Add two yara rules
- Phishing_PDF_Split_QR_Code_Pair_290
- Phishing_PDF_Split_QR_Code_Pair_330
This rule detects the use of a "split" QR Code pair of images placed next to eachother to form a complete QR code

- SAI_Global_ISO9001_Logo_PDF_Fuzzy
this rule focuses on the use of the SAI Global logo in the PDF, which was observed in the upper right corner of the PDF, reduced in size (though the embedded image is full size)

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/503b26fd09676b637784f45b68faa6c339ed2b635c8c5f5bd05d5b229ed86534?preview_id=019d3076-bf19-7a68-95f7-a90b5cbf2407)
