### PR TITLE
fix: Use PAT for ioc_management access

### DIFF
--- a/.github/workflows/update-ioc-rules.yml
+++ b/.github/workflows/update-ioc-rules.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Checkout IOC management repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          repository: sublime-security/ioc_management
-          ssh-key: ${{ secrets.IOC_MANAGEMENT_DEPLOY_KEY }}  # Read-only deploy key
+          repository: sublime-security/ioc-management
+          ssh-key: ${{ secrets.IOC_MANAGEMENT_DEPLOY_KEY }}  # Deploy key with write access
           path: ioc-repo
           fetch-depth: 0
 

--- a/.github/workflows/update-ioc-rules.yml
+++ b/.github/workflows/update-ioc-rules.yml
@@ -40,27 +40,10 @@ jobs:
           cd ioc-repo
           pip install -r requirements.txt
 
-      - name: Configure git for IOC repo metadata commits
-        run: |
-          cd ioc-repo
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-
       - name: Parse IOCs and generate rule files
         run: |
           cd ioc-repo
           python scripts/main.py --log-level INFO
-
-      - name: Commit CSV metadata back to ioc_management repo
-        run: |
-          cd ioc-repo
-          git add iocs/csv/
-          if ! git diff --cached --quiet; then
-            git commit -m "chore: Auto-populate IOC metadata (added_date, sha256)"
-            git push origin main
-          else
-            echo "No metadata changes to commit"
-          fi
 
       - name: Create or switch to automated-ioc-updates branch
         run: |

--- a/.github/workflows/update-ioc-rules.yml
+++ b/.github/workflows/update-ioc-rules.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: sublime-security/ioc_management
-          token: ${{ secrets.IOC_MANAGEMENT_TOKEN }}  # PAT with read access to ioc_management
+          ssh-key: ${{ secrets.IOC_MANAGEMENT_DEPLOY_KEY }}  # Read-only deploy key
           path: ioc-repo
           fetch-depth: 0
 

--- a/.github/workflows/update-ioc-rules.yml
+++ b/.github/workflows/update-ioc-rules.yml
@@ -40,10 +40,27 @@ jobs:
           cd ioc-repo
           pip install -r requirements.txt
 
+      - name: Configure git for IOC repo metadata commits
+        run: |
+          cd ioc-repo
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
       - name: Parse IOCs and generate rule files
         run: |
           cd ioc-repo
           python scripts/main.py --log-level INFO
+
+      - name: Commit CSV metadata back to ioc-management repo
+        run: |
+          cd ioc-repo
+          git add iocs/csv/
+          if ! git diff --cached --quiet; then
+            git commit -m "chore: Auto-populate IOC metadata (added_date, sha256)"
+            git push origin main
+          else
+            echo "No metadata changes to commit"
+          fi
 
       - name: Create or switch to automated-ioc-updates branch
         run: |

--- a/.github/workflows/update-ioc-rules.yml
+++ b/.github/workflows/update-ioc-rules.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: sublime-security/ioc_management
-          token: ${{ github.token }}  # Works because ioc_management is internal
+          token: ${{ secrets.IOC_MANAGEMENT_TOKEN }}  # PAT with read access to ioc_management
           path: ioc-repo
           fetch-depth: 0
 
@@ -117,7 +117,7 @@ jobs:
       - name: Create or update PR
         if: steps.commit.outputs.changed == 'true'
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Built-in token (shows as bot)
           TARGET_REPOSITORY: ${{ github.repository }}  # sublime-security/sublime-rules
         run: |
           cd ioc-repo


### PR DESCRIPTION
## Summary
Fixes the IOC workflow to properly access the internal ioc_management repo.

## Changes
- Use `IOC_MANAGEMENT_TOKEN` secret (PAT) for checking out ioc_management
- Use built-in `GITHUB_TOKEN` for PR creation (shows as `app/github-actions` bot)

## Why
The built-in `github.token` cannot access other repos, even Internal ones. This matches the pattern from `update-umbrella.yml` which uses a PAT for external data access but built-in token for PR creation.

## Requirements
- ✅ `IOC_MANAGEMENT_TOKEN` secret added to sublime-rules (read-only access to ioc_management)
- ⏳ PAT is pending org admin approval

## Testing
Ready to test once PAT is approved.