### PR TITLE
Update link_credential_phishing_secure_message.yml

### DIFF
--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -32,7 +32,7 @@ source: |
     )
     or any(body.current_thread.links,
            regex.icontains(ml.link_analysis(.).final_dom.display_text,
-                           'secured? (message|directory|document)'
+                           'secured? (message|directory|document) access'
            )
     )
   )

--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -30,6 +30,11 @@ source: |
            or strings.icontains(.text, "encrypted message")
            or strings.icontains(.text, "protected message")
     )
+    or any(body.current_thread.links,
+           regex.icontains(ml.link_analysis(.).final_dom.display_text,
+                           'secured? (message|directory|document)'
+           )
+    )
   )
   // todo: automated display name / human local part
   // todo: suspicious link (unfurl click trackers)


### PR DESCRIPTION
# Description
Adding an additional OR statement that uses LA to check the final DOM for similar wording around secure documents 

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/5049003a5e26203311e9e9877d5ea33287cc71c35ab263abc610a843840dc71d?preview_id=019d7959-971e-7932-b6fd-3d8451cab54e)

## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019d886e-bafb-7c0b-a107-c2415b9188ef)

