### PR TITLE
Update bec_urgent_suspicious_patterns.yml

### DIFF
--- a/detection-rules/bec_urgent_suspicious_patterns.yml
+++ b/detection-rules/bec_urgent_suspicious_patterns.yml
@@ -25,7 +25,7 @@ source: |
     strings.ilike(subject.subject, '*quick question*'),
   
     // brand name
-    regex.icontains(body.current_thread.text, 'a\s?m\s?a\s?z\s?o\s?n'), // Catches "Amaz on", "Amazon", etc.
+    regex.icontains(body.current_thread.text, 'a\s?m\s?a\s?z\s?[o0]\s?n'), // Catches "Amaz on", "Amazon", etc.
     regex.icontains(body.current_thread.text, 'p\s?a\s?y\s?p\s?a\s?l'),
     regex.icontains(body.current_thread.text, 'a\s?p\s?p\s?l\s?e'),
   
@@ -40,7 +40,7 @@ source: |
   
     // suspicious recipient pattern
     any(recipients.to, strings.ilike(.display_name, 'undisclosed?recipients')),
-    length(recipients.to) == 1, // Single recipient
+    length(recipients.to) <= 1, // Single or 0 recipients
   
     // header checks
     strings.starts_with(headers.mailer, 'Open-Xchange Mailer'),


### PR DESCRIPTION
# Description

Updated `length(recipients.to)` logic to allow either 1 or 0 recipients, also updated 'Amazon' regex logic to look for `Amaz 0n` in `body.current_thread.text`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/504c2faf413e665108928c4a86f4fdf10cb35c0a89bc922d7da9c0ac4dacd1b5?preview_id=019d865a-7275-789a-b4ce-ed490421056c)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019d9823-a833-7e52-9926-de29f00f229c)
- [L30D 50 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/f8507550-7072-404c-88c6-b2c02da03a59)