### PR TITLE
Add "ICS Phishing" TTP to calendar/ICS rules

### DIFF
--- a/detection-rules/attachment_html_smuggling_atob_ics.yml
+++ b/detection-rules/attachment_html_smuggling_atob_ics.yml
@@ -61,6 +61,7 @@ source: |
   )
 attack_types:
   - "Credential Phishing"
+  - "ICS Phishing"
   - "Malware/Ransomware"
 tactics_and_techniques:
   - "Evasion"

--- a/detection-rules/attachment_html_smuggling_atob_ics.yml
+++ b/detection-rules/attachment_html_smuggling_atob_ics.yml
@@ -61,11 +61,11 @@ source: |
   )
 attack_types:
   - "Credential Phishing"
-  - "ICS Phishing"
   - "Malware/Ransomware"
 tactics_and_techniques:
   - "Evasion"
   - "HTML smuggling"
+  - "ICS Phishing"
   - "Scripting"
 detection_methods:
   - "File analysis"

--- a/detection-rules/attachment_html_smuggling_eval_atob_calendar.yml
+++ b/detection-rules/attachment_html_smuggling_eval_atob_calendar.yml
@@ -11,6 +11,7 @@ source: |
   )
 attack_types:
   - "Credential Phishing"
+  - "ICS Phishing"
   - "Malware/Ransomware"
 tactics_and_techniques:
   - "Evasion"

--- a/detection-rules/attachment_html_smuggling_eval_atob_calendar.yml
+++ b/detection-rules/attachment_html_smuggling_eval_atob_calendar.yml
@@ -11,11 +11,11 @@ source: |
   )
 attack_types:
   - "Credential Phishing"
-  - "ICS Phishing"
   - "Malware/Ransomware"
 tactics_and_techniques:
   - "Evasion"
   - "HTML smuggling"
+  - "ICS Phishing"
   - "Scripting"
 detection_methods:
   - "File analysis"

--- a/detection-rules/attachment_ics_aws_lambda_url.yml
+++ b/detection-rules/attachment_ics_aws_lambda_url.yml
@@ -15,11 +15,11 @@ source: |
 
 attack_types:
   - "Credential Phishing"
-  - "ICS Phishing"
   - "Malware/Ransomware"
 tactics_and_techniques:
   - "Evasion"
   - "Free file host"
+  - "ICS Phishing"
 detection_methods:
   - "Content analysis"
   - "File analysis"

--- a/detection-rules/attachment_ics_aws_lambda_url.yml
+++ b/detection-rules/attachment_ics_aws_lambda_url.yml
@@ -15,6 +15,7 @@ source: |
 
 attack_types:
   - "Credential Phishing"
+  - "ICS Phishing"
   - "Malware/Ransomware"
 tactics_and_techniques:
   - "Evasion"

--- a/detection-rules/attachment_ics_embedded_document.yml
+++ b/detection-rules/attachment_ics_embedded_document.yml
@@ -23,6 +23,7 @@ source: |
   )
 
 attack_types:
+  - "ICS Phishing"
   - "Malware/Ransomware"
 tactics_and_techniques:
   - "Evasion"

--- a/detection-rules/attachment_ics_embedded_document.yml
+++ b/detection-rules/attachment_ics_embedded_document.yml
@@ -23,10 +23,10 @@ source: |
   )
 
 attack_types:
-  - "ICS Phishing"
   - "Malware/Ransomware"
 tactics_and_techniques:
   - "Evasion"
+  - "ICS Phishing"
 detection_methods:
   - "File analysis"
 id: "8f9957d9-a06a-5c5a-83af-2dc5c25bed86"

--- a/detection-rules/attachment_ics_employee_policy.yml
+++ b/detection-rules/attachment_ics_employee_policy.yml
@@ -22,6 +22,7 @@ source: |
 attack_types:
   - "Credential Phishing"
   - "BEC/Fraud"
+  - "ICS Phishing"
 tactics_and_techniques:
   - "Evasion"
   - "Social engineering"

--- a/detection-rules/attachment_ics_employee_policy.yml
+++ b/detection-rules/attachment_ics_employee_policy.yml
@@ -22,9 +22,9 @@ source: |
 attack_types:
   - "Credential Phishing"
   - "BEC/Fraud"
-  - "ICS Phishing"
 tactics_and_techniques:
   - "Evasion"
+  - "ICS Phishing"
   - "Social engineering"
 detection_methods:
   - "File analysis"

--- a/detection-rules/attachment_ics_exessive_custom_properties.yml
+++ b/detection-rules/attachment_ics_exessive_custom_properties.yml
@@ -14,6 +14,7 @@ source: |
   )
 
 attack_types:
+  - "ICS Phishing"
   - "Malware/Ransomware"
 tactics_and_techniques:
   - "Evasion"

--- a/detection-rules/attachment_ics_exessive_custom_properties.yml
+++ b/detection-rules/attachment_ics_exessive_custom_properties.yml
@@ -14,10 +14,10 @@ source: |
   )
 
 attack_types:
-  - "ICS Phishing"
   - "Malware/Ransomware"
 tactics_and_techniques:
   - "Evasion"
+  - "ICS Phishing"
 detection_methods:
   - "File analysis"
   - "Content analysis"

--- a/detection-rules/attachment_ics_file_non_rfc_compliant.yml
+++ b/detection-rules/attachment_ics_file_non_rfc_compliant.yml
@@ -28,6 +28,8 @@ source: |
           )
   )
   and not profile.by_sender_email().any_messages_benign
+attack_types:
+  - "ICS Phishing"
 tags:
  - "Attack surface reduction"
 tactics_and_techniques:

--- a/detection-rules/attachment_ics_file_non_rfc_compliant.yml
+++ b/detection-rules/attachment_ics_file_non_rfc_compliant.yml
@@ -28,12 +28,11 @@ source: |
           )
   )
   and not profile.by_sender_email().any_messages_benign
-attack_types:
-  - "ICS Phishing"
 tags:
  - "Attack surface reduction"
 tactics_and_techniques:
   - "Evasion"
+  - "ICS Phishing"
   - "Social engineering"
 detection_methods:
   - "Archive analysis"

--- a/detection-rules/attachment_ics_google_redirect_invoice.yml
+++ b/detection-rules/attachment_ics_google_redirect_invoice.yml
@@ -20,8 +20,8 @@ source: |
 attack_types:
   - "Credential Phishing"
   - "BEC/Fraud"
-  - "ICS Phishing"
 tactics_and_techniques:
+  - "ICS Phishing"
   - "Open redirect"
   - "Social engineering"
 detection_methods:

--- a/detection-rules/attachment_ics_google_redirect_invoice.yml
+++ b/detection-rules/attachment_ics_google_redirect_invoice.yml
@@ -20,6 +20,7 @@ source: |
 attack_types:
   - "Credential Phishing"
   - "BEC/Fraud"
+  - "ICS Phishing"
 tactics_and_techniques:
   - "Open redirect"
   - "Social engineering"

--- a/detection-rules/attachment_ics_meeting_invite.yml
+++ b/detection-rules/attachment_ics_meeting_invite.yml
@@ -14,8 +14,8 @@ source: |
 attack_types:
   - "BEC/Fraud"
   - "Credential Phishing"
-  - "ICS Phishing"
 tactics_and_techniques:
+  - "ICS Phishing"
   - "Social engineering"
 detection_methods:
   - "File analysis"

--- a/detection-rules/attachment_ics_meeting_invite.yml
+++ b/detection-rules/attachment_ics_meeting_invite.yml
@@ -14,6 +14,7 @@ source: |
 attack_types:
   - "BEC/Fraud"
   - "Credential Phishing"
+  - "ICS Phishing"
 tactics_and_techniques:
   - "Social engineering"
 detection_methods:

--- a/detection-rules/attachment_ics_non-gregorian.yml
+++ b/detection-rules/attachment_ics_non-gregorian.yml
@@ -13,9 +13,9 @@ source: |
   )
 attack_types:
   - "Credential Phishing"
-  - "ICS Phishing"
 tactics_and_techniques:
   - "Evasion"
+  - "ICS Phishing"
 detection_methods:
   - "File analysis"
   - "Content analysis"

--- a/detection-rules/attachment_ics_non-gregorian.yml
+++ b/detection-rules/attachment_ics_non-gregorian.yml
@@ -13,6 +13,7 @@ source: |
   )
 attack_types:
   - "Credential Phishing"
+  - "ICS Phishing"
 tactics_and_techniques:
   - "Evasion"
 detection_methods:

--- a/detection-rules/attachment_ics_open_redirect.yml
+++ b/detection-rules/attachment_ics_open_redirect.yml
@@ -53,6 +53,7 @@ source: |
   and not profile.by_sender().any_messages_benign
 
 attack_types:
+  - "ICS Phishing"
   - "Spam"
 tactics_and_techniques:
   - "Free email provider"

--- a/detection-rules/attachment_ics_open_redirect.yml
+++ b/detection-rules/attachment_ics_open_redirect.yml
@@ -53,12 +53,12 @@ source: |
   and not profile.by_sender().any_messages_benign
 
 attack_types:
-  - "ICS Phishing"
   - "Spam"
 tactics_and_techniques:
   - "Free email provider"
   - "Free file host"
   - "Free subdomain host"
+  - "ICS Phishing"
   - "Open redirect"
 detection_methods:
   - "Content analysis"

--- a/detection-rules/attachment_ics_organizer_new_domain.yml
+++ b/detection-rules/attachment_ics_organizer_new_domain.yml
@@ -21,6 +21,7 @@ tags:
   - "Attack surface reduction"
 attack_types:
   - "Callback Phishing"
+  - "ICS Phishing"
 tactics_and_techniques:
   - "Evasion"
   - "Social engineering"

--- a/detection-rules/attachment_ics_organizer_new_domain.yml
+++ b/detection-rules/attachment_ics_organizer_new_domain.yml
@@ -21,9 +21,9 @@ tags:
   - "Attack surface reduction"
 attack_types:
   - "Callback Phishing"
-  - "ICS Phishing"
 tactics_and_techniques:
   - "Evasion"
+  - "ICS Phishing"
   - "Social engineering"
 detection_methods:
   - "File analysis"

--- a/detection-rules/attachment_ics_spoofed_with_attachment.yml
+++ b/detection-rules/attachment_ics_spoofed_with_attachment.yml
@@ -53,10 +53,10 @@ source: |
   )
 attack_types:
   - "Credential Phishing"
-  - "ICS Phishing"
 tactics_and_techniques:
   - "Spoofing"
   - "Evasion"
+  - "ICS Phishing"
 detection_methods:
   - "File analysis"
   - "Header analysis"

--- a/detection-rules/attachment_ics_spoofed_with_attachment.yml
+++ b/detection-rules/attachment_ics_spoofed_with_attachment.yml
@@ -53,6 +53,7 @@ source: |
   )
 attack_types:
   - "Credential Phishing"
+  - "ICS Phishing"
 tactics_and_techniques:
   - "Spoofing"
   - "Evasion"

--- a/detection-rules/attachment_ics_svg_js.yml
+++ b/detection-rules/attachment_ics_svg_js.yml
@@ -31,6 +31,7 @@ source: |
   )
 attack_types:
   - "Credential Phishing"
+  - "ICS Phishing"
   - "Malware/Ransomware"
 tactics_and_techniques:
   - "Scripting"

--- a/detection-rules/attachment_ics_svg_js.yml
+++ b/detection-rules/attachment_ics_svg_js.yml
@@ -31,11 +31,11 @@ source: |
   )
 attack_types:
   - "Credential Phishing"
-  - "ICS Phishing"
   - "Malware/Ransomware"
 tactics_and_techniques:
   - "Scripting"
   - "Evasion"
+  - "ICS Phishing"
 detection_methods:
   - "File analysis"
   - "Javascript analysis"

--- a/detection-rules/attachment_ics_with_invisible_unicode_characters.yml
+++ b/detection-rules/attachment_ics_with_invisible_unicode_characters.yml
@@ -24,6 +24,7 @@ source: |
 attack_types:
   - "BEC/Fraud"
   - "Credential Phishing"
+  - "ICS Phishing"
   - "Malware/Ransomware"
 tactics_and_techniques:
   - "Evasion"

--- a/detection-rules/attachment_ics_with_invisible_unicode_characters.yml
+++ b/detection-rules/attachment_ics_with_invisible_unicode_characters.yml
@@ -24,10 +24,10 @@ source: |
 attack_types:
   - "BEC/Fraud"
   - "Credential Phishing"
-  - "ICS Phishing"
   - "Malware/Ransomware"
 tactics_and_techniques:
   - "Evasion"
+  - "ICS Phishing"
 detection_methods:
   - "File analysis"
   - "Content analysis"

--- a/detection-rules/callback_phishing_calendar_invite.yml
+++ b/detection-rules/callback_phishing_calendar_invite.yml
@@ -33,10 +33,10 @@ source: |
   )
 attack_types:
   - "Callback Phishing"
-  - "ICS Phishing"
 tactics_and_techniques:
   - "Social engineering"
   - "Evasion"
+  - "ICS Phishing"
 detection_methods:
   - "File analysis"
   - "Header analysis"

--- a/detection-rules/callback_phishing_calendar_invite.yml
+++ b/detection-rules/callback_phishing_calendar_invite.yml
@@ -33,6 +33,7 @@ source: |
   )
 attack_types:
   - "Callback Phishing"
+  - "ICS Phishing"
 tactics_and_techniques:
   - "Social engineering"
   - "Evasion"

--- a/detection-rules/link_gcal_invite_open_redirect.yml
+++ b/detection-rules/link_gcal_invite_open_redirect.yml
@@ -39,6 +39,7 @@ source: |
   )
 
 attack_types:
+  - "ICS Phishing"
   - "Spam"
 tactics_and_techniques:
   - "Free email provider"

--- a/detection-rules/link_gcal_invite_open_redirect.yml
+++ b/detection-rules/link_gcal_invite_open_redirect.yml
@@ -39,11 +39,11 @@ source: |
   )
 
 attack_types:
-  - "ICS Phishing"
   - "Spam"
 tactics_and_techniques:
   - "Free email provider"
   - "Free file host"
+  - "ICS Phishing"
   - "Open redirect"
   - "Social engineering"
 detection_methods:

--- a/detection-rules/service_abuse_google_calendar_notification.yml
+++ b/detection-rules/service_abuse_google_calendar_notification.yml
@@ -11,6 +11,7 @@ source: |
 
 attack_types:
   - "Callback Phishing"
+  - "ICS Phishing"
 tactics_and_techniques:
   - "Out of band pivot"
   - "Social engineering"

--- a/detection-rules/service_abuse_google_calendar_notification.yml
+++ b/detection-rules/service_abuse_google_calendar_notification.yml
@@ -11,8 +11,8 @@ source: |
 
 attack_types:
   - "Callback Phishing"
-  - "ICS Phishing"
 tactics_and_techniques:
+  - "ICS Phishing"
   - "Out of band pivot"
   - "Social engineering"
 detection_methods:


### PR DESCRIPTION
## Summary
- Adds `"ICS Phishing"` as a value to `tactics_and_techniques` across 18 calendar invite / ICS phishing-related detection rules
- Covers `attachment_ics_*` rules, HTML smuggling rules delivering ICS files, Google Calendar abuse, and calendar invite callback phishing rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)