### PR TITLE
Update link_credential_phishing_secure_message.yml

### DIFF
--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -171,7 +171,7 @@ source: |
       and not headers.auth_summary.dmarc.pass
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
-)
+  )
 
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -6,8 +6,22 @@ severity: "medium"
 source: |
   type.inbound
   and (
-    any(ml.nlu_classifier(body.current_thread.text).intents,
-        .name == "cred_theft" and .confidence == "high"
+    (
+      any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "cred_theft" and .confidence == "high"
+      )
+      // add fallback when NLU doesn't pick up cred theft to check for suspicious links
+      or any(body.current_thread.links,
+             regex.icontains(.display_text, '(?:read|view|open) the message')
+             and (
+               .href_url.domain.root_domain not in $tranco_1m
+               or .href_url.domain.domain in $free_file_hosts
+               or .href_url.domain.root_domain in $free_file_hosts
+               or .href_url.domain.root_domain in $free_subdomain_hosts
+               or .href_url.domain.domain in $url_shorteners
+               or .href_url.domain.domain in $social_landing_hosts
+             )
+      )
     )
     or any(ml.nlu_classifier(beta.ocr(file.message_screenshot()).text).intents,
            .name == "cred_theft" and .confidence in ("medium", "high")
@@ -157,7 +171,7 @@ source: |
       and not headers.auth_summary.dmarc.pass
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
-  )
+)
 
 attack_types:
   - "Credential Phishing"


### PR DESCRIPTION
# Description
adding an additional condition to look for suspicious links when NLU does not see it as cred theft

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/504139782b156d4e29315355681c296cc5d5f0f59c96d1890c6bd63c364daafa?preview_id=019d8856-29c5-7d61-9031-7d41da2ce903)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/hunts/019d8d1a-e2ef-7a60-bb6b-67f1baeeb735)
