### PR TITLE
Scope ADÉ auto run automations to user reported messages

### DIFF
--- a/automations/ade_auto_run_graymail.yml
+++ b/automations/ade_auto_run_graymail.yml
@@ -13,3 +13,4 @@ source: |
     or triage.agents.asa.verdict =~ "graymail"
   )
   and length(triage.flagged_rules) == 0
+  and triage.user_reports.count > 0

--- a/automations/ade_auto_run_spam.yml
+++ b/automations/ade_auto_run_spam.yml
@@ -13,3 +13,4 @@ source: |
     or triage.agents.asa.verdict =~ "spam"
   )
   and length(triage.flagged_rules) == 0
+  and triage.user_reports.count > 0


### PR DESCRIPTION
# Description

Non-malicious verdicts for automations with the Send to ADÉ action should be scoped to user reported messages. Since these are triggered by classifications changes and ASA complete triggers, the user report count will be settled.

This is similar to the existing logic we already use for Close-the-loop automations
