### PR TITLE
Create attachment_pdf_with_jsfck_yara.yml

### DIFF
--- a/detection-rules/attachment_pdf_with_jsfck_yara.yml
+++ b/detection-rules/attachment_pdf_with_jsfck_yara.yml
@@ -8,7 +8,7 @@ source: |
           any(file.explode(.),
               .depth == 0
               and any(.scan.yara.matches,
-                      .name in ("pdf_jsfck_strings", "pdf_jsfck_ratio", )
+                      .name in ("pdf_jsfck_strings", "pdf_jsfck_ratio")
               )
           )
   )

--- a/detection-rules/attachment_pdf_with_jsfck_yara.yml
+++ b/detection-rules/attachment_pdf_with_jsfck_yara.yml
@@ -1,0 +1,26 @@
+name: "Attachment: PDF with JSFck obfuscation"
+description: "PDF attachment contains JavaScript obfuscated using JSFck encoding techniques. JSFck is a method of writing JavaScript code using only six characters: []()!+ which is often used to evade detection by security tools."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(filter(attachments, .file_type == "pdf"),
+          any(file.explode(.),
+              .depth == 0
+              and any(.scan.yara.matches,
+                      .name in (
+                        "pdf_jsfck_strings",
+                        "pdf_jsfck_ratio",
+                      )
+              )
+          )
+  )
+
+attack_types:
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Evasion"
+  - "PDF"
+detection_methods:
+  - "File analysis"
+  - "YARA"

--- a/detection-rules/attachment_pdf_with_jsfck_yara.yml
+++ b/detection-rules/attachment_pdf_with_jsfck_yara.yml
@@ -8,14 +8,10 @@ source: |
           any(file.explode(.),
               .depth == 0
               and any(.scan.yara.matches,
-                      .name in (
-                        "pdf_jsfck_strings",
-                        "pdf_jsfck_ratio",
-                      )
+                      .name in ("pdf_jsfck_strings", "pdf_jsfck_ratio", )
               )
           )
   )
-
 attack_types:
   - "Malware/Ransomware"
 tactics_and_techniques:
@@ -24,3 +20,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "YARA"
+id: "25af625c-2e3c-5bf9-ae33-8061df95f607"


### PR DESCRIPTION
# Description
This is the MQL rule to go along with the yara rules for PDFs containing jsfck obfuscated code. 

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019d926d-a66a-777a-b062-0fb6ab1d377b)
