### PR TITLE
Create attachment_pdf_base64_javascript_eval.yml

### DIFF
--- a/detection-rules/abused_payoneer_callback.yml
+++ b/detection-rules/abused_payoneer_callback.yml
@@ -17,20 +17,20 @@ source: |
                            '.*\+[ilo0-9]{1,3}[ilo0-9]{10}.*\n'
         )
         or // +12028001238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
         )
         or // 202-800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
         or // (202) 800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
         )
         or // (202)-800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
         or ( // 8123456789
           regex.icontains(strings.replace_confusables(body.current_thread.text),

--- a/detection-rules/attachment_pdf_base64_javascript_eval.yml
+++ b/detection-rules/attachment_pdf_base64_javascript_eval.yml
@@ -8,14 +8,10 @@ source: |
           any(file.explode(.),
               .depth == 0
               and any(.scan.yara.matches,
-                      .name in (
-                        "pdf_b64_js_var_eval",
-                        "pdf_acro_js_functions",
-                      )
+                      .name in ("pdf_b64_js_var_eval", "pdf_acro_js_functions", )
               )
           )
   )
-
 attack_types:
   - "Malware/Ransomware"
 tactics_and_techniques:
@@ -25,3 +21,4 @@ detection_methods:
   - "File analysis"
   - "Javascript analysis"
   - "YARA"
+id: "1b1b9c12-5473-546e-ae4e-038e372a02a8"

--- a/detection-rules/attachment_pdf_base64_javascript_eval.yml
+++ b/detection-rules/attachment_pdf_base64_javascript_eval.yml
@@ -1,0 +1,27 @@
+name: "Attachment: PDF with base64 JavaScript and eval functions"
+description: "PDF attachment contains base64-encoded JavaScript variables with eval functions, indicating potential code obfuscation and execution techniques commonly used in malicious documents."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(filter(attachments, .file_type == "pdf"),
+          any(file.explode(.),
+              .depth == 0
+              and any(.scan.yara.matches,
+                      .name in (
+                        "pdf_b64_js_var_eval",
+                        "pdf_acro_js_functions",
+                      )
+              )
+          )
+  )
+
+attack_types:
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Evasion"
+  - "PDF"
+detection_methods:
+  - "File analysis"
+  - "Javascript analysis"
+  - "YARA"

--- a/detection-rules/attachment_pdf_base64_javascript_eval.yml
+++ b/detection-rules/attachment_pdf_base64_javascript_eval.yml
@@ -7,9 +7,7 @@ source: |
   and any(filter(attachments, .file_type == "pdf"),
           any(file.explode(.),
               .depth == 0
-              and any(.scan.yara.matches,
-                      .name in ("pdf_b64_js_var_eval", )
-              )
+              and any(.scan.yara.matches, .name in ("pdf_b64_js_var_eval", ))
           )
   )
 attack_types:

--- a/detection-rules/attachment_pdf_base64_javascript_eval.yml
+++ b/detection-rules/attachment_pdf_base64_javascript_eval.yml
@@ -8,7 +8,7 @@ source: |
           any(file.explode(.),
               .depth == 0
               and any(.scan.yara.matches,
-                      .name in ("pdf_b64_js_var_eval", "pdf_acro_js_functions", )
+                      .name in ("pdf_b64_js_var_eval", )
               )
           )
   )

--- a/detection-rules/bec_student_loan_callback_scam.yml
+++ b/detection-rules/bec_student_loan_callback_scam.yml
@@ -7,7 +7,7 @@ source: |
   // there is no HTML body
   and body.html.raw is null
   
-  // but the current thread contains what's most likely an html tag 
+  // but the current thread contains what's most likely an html tag
   // (eg. <>'s' followed by a closing </> )
   and regex.contains(body.current_thread.text, '<[^>]+>.*?</[^>]+>')
   
@@ -26,24 +26,24 @@ source: |
                       '\+\d{1,3}[ilo0-9]{10}'
     )
     or // +12028001238
-   regex.contains(strings.replace_confusables(body.current_thread.text),
-                  '[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}'
+    regex.contains(strings.replace_confusables(body.current_thread.text),
+                   '[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}'
     )
     or // 202.800.1238
-   regex.contains(strings.replace_confusables(body.current_thread.text),
-                  '[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}'
+    regex.contains(strings.replace_confusables(body.current_thread.text),
+                   '[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}'
     )
     or // 202-800-1238
-   regex.contains(strings.replace_confusables(body.current_thread.text),
-                  '\([ilo0-9]{3}\)\s[ilo0-9]{3}-[ilo0-9]{4}'
+    regex.contains(strings.replace_confusables(body.current_thread.text),
+                   '\([ilo0-9]{3}\)\s[ilo0-9]{3}-[ilo0-9]{4}'
     )
     or // (202) 800-1238
-   regex.contains(strings.replace_confusables(body.current_thread.text),
-                  '\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}'
+    regex.contains(strings.replace_confusables(body.current_thread.text),
+                   '\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}'
     )
     or // (202)-800-1238
-   regex.contains(strings.replace_confusables(body.current_thread.text),
-                  '1 [ilo0-9]{3} [ilo0-9]{3} [ilo0-9]{4}'
+    regex.contains(strings.replace_confusables(body.current_thread.text),
+                   '1 [ilo0-9]{3} [ilo0-9]{3} [ilo0-9]{4}'
     ) // 8123456789
     or regex.contains(strings.replace_confusables(body.current_thread.text),
                       '8\d{9}'
@@ -57,8 +57,6 @@ source: |
   
   // sender is unsolicited
   and not profile.by_sender().solicited
-  
-
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:

--- a/detection-rules/brand_impersonation_sharepoint_pdf_cred_theft.yml
+++ b/detection-rules/brand_impersonation_sharepoint_pdf_cred_theft.yml
@@ -27,7 +27,7 @@ source: |
         and strings.ends_with(headers.message_id, '@odspnotify>')
       )
       or // negate legitimate access request to file
-   (
+      (
         strings.starts_with(headers.message_id, '<Sharing')
         and strings.ends_with(headers.message_id, '@odspnotify>')
       )
@@ -91,7 +91,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/callback_phishing_intuit.yml
+++ b/detection-rules/callback_phishing_intuit.yml
@@ -54,24 +54,24 @@ source: |
                          '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+\+\d{1,3}[ilo0-9]{10}.*\n'
       )
       or // +12028001238
-   regex.icontains(strings.replace_confusables(body.html.inner_text),
-                   '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
+      regex.icontains(strings.replace_confusables(body.html.inner_text),
+                      '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
       )
       or // 202-800-1238
-   regex.icontains(strings.replace_confusables(body.html.inner_text),
-                   '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+      regex.icontains(strings.replace_confusables(body.html.inner_text),
+                      '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
       )
       or // (202) 800-1238
-   regex.icontains(strings.replace_confusables(body.html.inner_text),
-                   '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
+      regex.icontains(strings.replace_confusables(body.html.inner_text),
+                      '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
       )
       or // (202)-800-1238
-   regex.icontains(strings.replace_confusables(body.html.inner_text),
-                   '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+      regex.icontains(strings.replace_confusables(body.html.inner_text),
+                      '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
       )
       or // 202 800 1238
-   regex.icontains(strings.replace_confusables(body.html.inner_text),
-                   '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+1\s?[ilo0-9]{3} [ilo0-9]{3} [ilo0-9]{4}.*\n'
+      regex.icontains(strings.replace_confusables(body.html.inner_text),
+                      '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+1\s?[ilo0-9]{3} [ilo0-9]{3} [ilo0-9]{4}.*\n'
       ) // 8123456789
       or (
         regex.icontains(strings.replace_confusables(body.html.inner_text),
@@ -93,7 +93,7 @@ source: |
                 and any(file.explode(.), .scan.exiftool.page_count < 3)
                 and any(file.explode(.), length(.scan.ocr.raw) > 60)
   
-                // 4 of the following strings are found        
+                // 4 of the following strings are found
                 and (
                   any(file.explode(.),
                       4 of (
@@ -124,7 +124,7 @@ source: |
                         )
                       )
   
-                      // 1 of the following strings is found, representing common Callback brands          
+                      // 1 of the following strings is found, representing common Callback brands
                       and (
                         1 of (
                           strings.icontains(.scan.ocr.raw, "geek squad"),
@@ -159,7 +159,7 @@ source: |
     )
   )
   
-  // 
+  //
   // This rule makes use of a beta feature and is subject to change without notice
   // using the beta feature in custom rules is not suggested until it has been formally released
   //

--- a/detection-rules/callback_phishing_sumup.yml
+++ b/detection-rules/callback_phishing_sumup.yml
@@ -21,20 +21,20 @@ source: |
                            '.*\+[ilo0-9]{1,3}[ilo0-9]{10}.*\n'
         )
         or // +12028001238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
         )
         or // 202-800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
         or // (202) 800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
         )
         or // (202)-800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
         or ( // 8123456789
           regex.icontains(strings.replace_confusables(body.current_thread.text),
@@ -108,8 +108,6 @@ source: |
       )
     )
   )
-  
-
 attack_types:
   - "BEC/Fraud"
   - "Callback Phishing"

--- a/detection-rules/callback_phishing_zelle.yml
+++ b/detection-rules/callback_phishing_zelle.yml
@@ -19,20 +19,20 @@ source: |
                          '.*\+[ilo0-9]{1,3}[ilo0-9]{10}.*'
       )
       or // +12028001238
-   regex.icontains(strings.replace_confusables(subject.subject),
-                   '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*'
+      regex.icontains(strings.replace_confusables(subject.subject),
+                      '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*'
       )
       or // 202-800-1238
-   regex.icontains(strings.replace_confusables(subject.subject),
-                   '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*'
+      regex.icontains(strings.replace_confusables(subject.subject),
+                      '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*'
       )
       or // (202) 800-1238
-   regex.icontains(strings.replace_confusables(subject.subject),
-                   '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*'
+      regex.icontains(strings.replace_confusables(subject.subject),
+                      '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*'
       )
       or // (202)-800-1238
-   regex.icontains(strings.replace_confusables(subject.subject),
-                   '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*'
+      regex.icontains(strings.replace_confusables(subject.subject),
+                      '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*'
       )
       or ( // 8123456789
         regex.icontains(strings.replace_confusables(subject.subject),
@@ -55,20 +55,20 @@ source: |
                            '\".*\+[ilo0-9]{1,3}[ilo0-9]{10}.*\"'
         )
         or // +12028001238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '\".*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\"'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '\".*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\"'
         )
         or // 202-800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '\".*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\"'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '\".*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\"'
         )
         or // (202) 800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '\".*\([ilo0-9]{3}\)\s[ilo0-9]{3}-[ilo0-9]{4}.*\"'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '\".*\([ilo0-9]{3}\)\s[ilo0-9]{3}-[ilo0-9]{4}.*\"'
         )
         or // (202)-800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '\".*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\"'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '\".*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\"'
         )
         or ( // 8123456789
           regex.icontains(strings.replace_confusables(body.current_thread.text),

--- a/detection-rules/canva_infra_abuse.yml
+++ b/detection-rules/canva_infra_abuse.yml
@@ -22,20 +22,20 @@ source: |
                            '.*\+[ilo0-9]{1,3}[ilo0-9]{10}.*\n'
         )
         or // +12028001238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
         )
         or // 202-800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
         or // (202) 800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
         )
         or // (202)-800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
         or ( // 8123456789
           regex.icontains(strings.replace_confusables(body.current_thread.text),
@@ -109,7 +109,6 @@ source: |
       )
     )
   )
-
 attack_types:
   - "BEC/Fraud"
   - "Callback Phishing"

--- a/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
+++ b/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
@@ -13,12 +13,12 @@ source: |
   
   // and contains html or url encoded strings, hex escaped strings, opening or closing html tags, or escaped non word characters
   and // subject contains common event handlers
-   regex.icontains(subject.subject,
-                   '(?:\b|%[a-f0-9]{2})(?:on(?:abort|blur|change|click|dblclick|error|focus|load|mouse(?:over|out|move|down|up)|key(?:down|up|press)|reset|select|submit|unload)|srcdoc|src\s*(?:=|%(?:25)?3d))',
-                   // subject contains javascript funcitons
-                   '(?:\b|%(?:25)?[a-f0-9]{2})(?:javascript|eval|settimeout|setinterval|document\.(?:cookie|write|location|createElement|body|appendChild)|fetch|constructor|__proto__|prototype|atob|getScript|script(?:\s|%(?:25)?20)src)(?:\b|%(?:25)?[a-f0-9]{2})',
-                   // url encoded forms of script src
-                   '(?:\b|%(?:25)?[a-f0-9]{2})script(?:\s|%(?:25)?20)src(?:\b|%(?:25)?[a-f0-9]{2})'
+  regex.icontains(subject.subject,
+                  '(?:\b|%[a-f0-9]{2})(?:on(?:abort|blur|change|click|dblclick|error|focus|load|mouse(?:over|out|move|down|up)|key(?:down|up|press)|reset|select|submit|unload)|srcdoc|src\s*(?:=|%(?:25)?3d))',
+                  // subject contains javascript funcitons
+                  '(?:\b|%(?:25)?[a-f0-9]{2})(?:javascript|eval|settimeout|setinterval|document\.(?:cookie|write|location|createElement|body|appendChild)|fetch|constructor|__proto__|prototype|atob|getScript|script(?:\s|%(?:25)?20)src)(?:\b|%(?:25)?[a-f0-9]{2})',
+                  // url encoded forms of script src
+                  '(?:\b|%(?:25)?[a-f0-9]{2})script(?:\s|%(?:25)?20)src(?:\b|%(?:25)?[a-f0-9]{2})'
   )
   and regex.icontains(subject.subject,
                       // Pattern 1: Quote followed by various special characters in encoded/literal forms:
@@ -49,7 +49,7 @@ source: |
                       '%[a-f0-9]{2}',
   
                       // Pattern 6: Unicode/hex escapes
-                      // e.g., \u003C for <, \x3C for 
+                      // e.g., \u003C for <, \x3C for
                       '\\[xXuU][a-f0-9]{4}',
                       // New patterns for this type of payload
                       '</[^>]+/[^>]+>', // Matches closing tags with slash delimiters

--- a/detection-rules/impersonation_capitalone.yml
+++ b/detection-rules/impersonation_capitalone.yml
@@ -55,7 +55,7 @@ source: |
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
   and // suspicious indicators here
-   (
+  (
     // // password theme
     (
       strings.icontains(body.current_thread.text, "new password")
@@ -72,7 +72,7 @@ source: |
       or strings.icontains(body.current_thread.text, "security breach")
       or (
         strings.icontains(body.current_thread.text, "security alert")
-        // some capital one notiifcaitons include directions to 
+        // some capital one notiifcaitons include directions to
         // change notificaiton preferences to only security alerts
         and (
           strings.icount(body.current_thread.text, "security alert") > strings.icount(body.current_thread.text,
@@ -127,7 +127,7 @@ source: |
                           '(?:ready|posted|review|available|online)\s*(?:\w+\s+){0,3}\s*document'
       )
     )
-    // // account/profile details 
+    // // account/profile details
     or (
       strings.icontains(body.current_thread.text, "about your account")
       or strings.icontains(body.current_thread.text, "action required")
@@ -183,7 +183,7 @@ source: |
   and not any(beta.ml_topic(body.html.display_text).topics,
               (
                 .name in (
-                  // lots of newsletters talk about capital one 
+                  // lots of newsletters talk about capital one
                   "Newsletters and Digests",
                   // lots of recruiting mention oppurtunties at capital one, often including the logo
                   "Professional and Career Development",

--- a/detection-rules/impersonation_sharepoint_body_credential_theft.yml
+++ b/detection-rules/impersonation_sharepoint_body_credential_theft.yml
@@ -100,7 +100,7 @@ source: |
         and strings.ends_with(headers.message_id, '@odspnotify>')
       )
       or // negate legitimate access request to file
-   (
+      (
         strings.starts_with(headers.message_id, '<Sharing')
         and strings.ends_with(headers.message_id, '@odspnotify>')
       )

--- a/detection-rules/impersonation_suspected_supplier_payment_request.yml
+++ b/detection-rules/impersonation_suspected_supplier_payment_request.yml
@@ -50,7 +50,7 @@ source: |
   and (
     not profile.by_sender_domain().solicited
     or // reply-to is not in $recipient_emails
-   any(headers.reply_to, .email.email not in $recipient_emails)
+    any(headers.reply_to, .email.email not in $recipient_emails)
   )
   and (
     2 of (
@@ -66,7 +66,7 @@ source: |
                 .name == "financial"
         )
       ),
-      // payment tag high confidence 
+      // payment tag high confidence
       any(ml.nlu_classifier(coalesce(body.plain.raw, body.current_thread.text)).tags,
           .name == "payment" and .confidence == "high"
       ),

--- a/detection-rules/paypal_invoice_abuse.yml
+++ b/detection-rules/paypal_invoice_abuse.yml
@@ -32,12 +32,12 @@ source: |
                                         '\+[ilo0-9]{1,3}[ilo0-9]{10}'
                      )
                      or // +12028001238
-   regex.icontains(strings.replace_confusables(.display_text),
-                   '[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}'
+                     regex.icontains(strings.replace_confusables(.display_text),
+                                     '[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}'
                      )
                      or // 202-800-1238
-   regex.icontains(strings.replace_confusables(.display_text),
-                   '[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}'
+                     regex.icontains(strings.replace_confusables(.display_text),
+                                     '[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}'
                      )
                      // (202) 800-1238
                      // (202) -800 -1238
@@ -47,8 +47,8 @@ source: |
                                         '\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}'
                      )
                      or // (202)-800-1238
-   regex.icontains(strings.replace_confusables(.display_text),
-                   '\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}'
+                     regex.icontains(strings.replace_confusables(.display_text),
+                                     '\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}'
                      )
                      or ( // 8123456789
                        regex.icontains(strings.replace_confusables(.display_text),

--- a/detection-rules/venmo_payment_abuse.yml
+++ b/detection-rules/venmo_payment_abuse.yml
@@ -18,20 +18,20 @@ source: |
                            '.*\+[ilo0-9]{1,3}[ilo0-9]{10}.*\n'
         )
         or // +12028001238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
         )
         or // 202-800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
         or // (202) 800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
         )
         or // (202)-800-1238
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+        regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
         or ( // 8123456789
           regex.icontains(strings.replace_confusables(body.current_thread.text),
@@ -94,7 +94,6 @@ source: |
       )
     )
   )
-
 attack_types:
   - "Callback Phishing"
   - "BEC/Fraud"


### PR DESCRIPTION
# Description
This is the MQL rule for the two yara rules related to js functions in PDFs, specifically the following:
- pdf_acro_js_functions -- this is looking for acrobat functions
- pdf_b64_js_var_eval -- this is looking for base64 encoded javascript staples like "eval".

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019d92d4-937d-76eb-8131-54d4f398370e)

