### PR TITLE
Test NLU Embedding Function

### DIFF
--- a/detection-rules/test_nlu_embedding.yml
+++ b/detection-rules/test_nlu_embedding.yml
@@ -6,7 +6,7 @@ type: "rule"
 severity: "informational"
 source: |
   type.inbound
-  and length(internal.nlu_embedding(body.current_thread.text).vectors) = 1000000
+  and length(internal.nlu_embedding(body.current_thread.text).vectors) == 1000000
 tags:
   - "Test"
 detection_methods:

--- a/detection-rules/test_nlu_embedding.yml
+++ b/detection-rules/test_nlu_embedding.yml
@@ -1,0 +1,14 @@
+name: "Test: NLU Embedding"
+description: |
+  Exercises vector generation for the nlu embedding function.
+  Ensures that the rule will not flag any messages
+type: "rule"
+severity: "informational"
+source: |
+  type.inbound
+  and length(internal.nlu_embedding(body.current_thread.text).vectors) = 1000000
+tags:
+  - "Test"
+detection_methods:
+  - "Natural Language Understanding"
+id: "50c50b97-a590-4489-8ea8-33651b446e5c"


### PR DESCRIPTION
# Description
Creates a basic rule to exercise nlu_embedding at scale. This rule is guaranteed not to trigger (at most, we'll have four vectors), but will give us data on the embedding endpoint performance at scale before we begin relying on the function in attack score and stratum.
