### PR TITLE
Create attachment_ics_file_new_link_domain.yml

### DIFF
--- a/detection-rules/attachment_ics_file_new_link_domain.yml
+++ b/detection-rules/attachment_ics_file_new_link_domain.yml
@@ -1,0 +1,30 @@
+name: "Attachment: ICS file with links to newly registered domains"
+description: "Detects calendar invite attachments (ICS files) containing links to domains registered within the last 30 days, which may indicate malicious calendar invitations designed to redirect users to suspicious websites."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(attachments,
+          (
+            .file_extension in~ ('ics')
+            or .content_type in ("application/ics", "text/calendar")
+          )
+          //
+          // This rule makes use of a beta feature and is subject to change without notice
+          // using the beta feature in custom rules is not suggested until it has been formally released
+          //
+          and any(beta.file.parse_ics(.).events,
+                  any(.links, network.whois(.href_url.domain).days_old < 30)
+          )
+  )
+
+
+attack_types:
+  - "Credential Phishing"
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "File analysis"
+  - "URL analysis"
+  - "Whois"

--- a/detection-rules/attachment_ics_file_new_link_domain.yml
+++ b/detection-rules/attachment_ics_file_new_link_domain.yml
@@ -25,7 +25,6 @@ tags:
  - "Attack surface reduction"
 attack_types:
   - "Credential Phishing"
-  - "Malware/Ransomware"
 tactics_and_techniques:
   - "Social engineering"
 detection_methods:

--- a/detection-rules/attachment_ics_file_new_link_domain.yml
+++ b/detection-rules/attachment_ics_file_new_link_domain.yml
@@ -6,8 +6,11 @@ source: |
   type.inbound
   and any(attachments,
           (
-            .file_extension in~ ('ics')
-            or .content_type in ("application/ics", "text/calendar")
+            .file_type == "ics"
+            or (
+              .file_extension == "ics"
+              or .content_type in ("application/ics", "text/calendar")
+            )
           )
           //
           // This rule makes use of a beta feature and is subject to change without notice
@@ -18,7 +21,8 @@ source: |
           )
   )
 
-
+tags:
+ - "Attack surface reduction"
 attack_types:
   - "Credential Phishing"
   - "Malware/Ransomware"

--- a/detection-rules/attachment_ics_file_new_link_domain.yml
+++ b/detection-rules/attachment_ics_file_new_link_domain.yml
@@ -28,3 +28,4 @@ detection_methods:
   - "File analysis"
   - "URL analysis"
   - "Whois"
+id: "9d8ea98f-4a4b-5e35-9c3f-d3a3ac11bdc4"


### PR DESCRIPTION
# Description
Detects calendar invite attachments (ICS files) containing links to domains registered within the last 30 days, which may indicate malicious calendar invitations designed to redirect users to suspicious websites.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

[- Sample 1](https://platform.sublime.security/messages/504f56ad86ba2a7c9f8f83a4d815861095966cf606f452828776cff9d1a0a275)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019dab28-2bc5-766d-9d15-446cced95c4c)


