### PR TITLE
Update link_credential_phishing_secure_message.yml

### DIFF
--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -49,6 +49,15 @@ source: |
                            'secured? (message|directory|document) access'
            )
     )
+    or (
+      length(filter(ml.nlu_classifier(body.current_thread.text).entities,
+                    .name == "urgency"
+             )
+      ) >= 2
+      and any(ml.nlu_classifier(body.current_thread.text).topics,
+              .name == "Secure Message" and .confidence != "low"
+      )
+    )
   )
   // todo: automated display name / human local part
   // todo: suspicious link (unfurl click trackers)


### PR DESCRIPTION
# Description
adding an additional OR statement that uses NLU to look for secure messages and multiple urgency entities

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/504cffff5b2ce97795980f590ac867d677b9a153f66938d127398a1ba324c6f1?from_canonical_id=504c68a94adefe4b476ebc7b091721acbb071fc1cd3cb82b5bbd7876c3c60102&preview_id=019d9779-46ed-70c1-b29f-c7976a86e31d)
- [Sample 2](https://platform.sublime.security/messages/504cc43882c220d870bfa4ff7febfe6b7441a1c7733e5acf442aee5f4d2ff477?preview_id=019d98b5-edf1-7d73-89ea-da8a0f516ec3)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019dac7b-4513-72ee-a76c-41225ec8d5d4)

