### PR TITLE
Update headers_replyto_new_domain_nlu_request.yml

### DIFF
--- a/detection-rules/headers_replyto_new_domain_nlu_request.yml
+++ b/detection-rules/headers_replyto_new_domain_nlu_request.yml
@@ -7,11 +7,17 @@ severity: "medium"
 source: |
   type.inbound
   and length(body.current_thread.text) < 5000
-  and any(headers.reply_to,
-          // mismatched reply-to and sender domain
-          .email.domain.root_domain != sender.email.domain.root_domain
-          // newly registered reply-to domain
-          and network.whois(.email.domain).days_old <= 30
+  and (
+    any(headers.reply_to,
+        // mismatched reply-to and sender domain
+        .email.domain.root_domain != sender.email.domain.root_domain
+        // newly registered reply-to domain
+        and network.whois(.email.domain).days_old <= 30
+    )
+    or (
+      network.whois(sender.email.domain).days_old < 30
+      and sender.email.domain.tld in $suspicious_tlds
+    )
   )
   // request is being made
   and any(ml.nlu_classifier(body.current_thread.text).entities,


### PR DESCRIPTION
# Description

Identified as a good candidate rule change for a new pattern we've been observing for these newly registered domains that don't have reply_to's or they aren't mismatched. I enforced this change with a suspicious tld's check as it was a very common pattern I had observed. 

<!-- 
Explain your change and why. For example, "negating legitimate replies," or "adding additional credential theft keywords."

If it's a new rule or insight, explain what the rule is designed to catch/what the insight should fire on.
-->

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50470897cbc81547d583af99d5d09c31cf1766f22cda5dd446d8110766757403?preview_id=019d6d89-b45f-7944-b0f3-5296120e7564)
- [Sample 2](https://platform.sublime.security/messages/504933f4ea0da41a025d8e0467518f4ef83a93ee63466afd8ceee8508fe00dd4?preview_id=019d77d8-2a95-7e93-ba87-4d6ca24743f7)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/hunts/019d9c2e-e32a-7571-b04b-c94a605a30db) showing net-new results that came directly from results I grabbed from a multhunt while working on a net-new rule I was working on
- [Multihunt for the other rule that netted the results found in shared samples](https://hunt.limeseed.email/hunts/0176dc5d-2f28-4f57-ab24-530e96000473)
- [latest hunt (with shares from multihunt) L30D ](https://platform.sublime.security/messages/hunt?huntId=019df385-6093-7186-a35c-cf8dbc13a747)
- [multihunt L30D](https://hunt.limeseed.email/hunts/36c47a85-161a-48b5-8d43-ccf5dcf038a5)