### PR TITLE
Create attachment_ics_uid_rcpt_email.yml

### DIFF
--- a/detection-rules/attachment_ics_uid_rcpt_email.yml
+++ b/detection-rules/attachment_ics_uid_rcpt_email.yml
@@ -30,3 +30,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "Content analysis"
+id: "507d814e-1db5-56ce-929f-13c4c78b345f"

--- a/detection-rules/attachment_ics_uid_rcpt_email.yml
+++ b/detection-rules/attachment_ics_uid_rcpt_email.yml
@@ -1,0 +1,32 @@
+name: "Attachment: ICS calendar file with recipient address in UID field"
+description: "Detects inbound messages containing ICS calendar attachments where the UID property matches the recipient's email address, indicating potential calendar-based social engineering."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(attachments,
+          (
+            .file_type == "ics"
+            or (
+              .file_extension == "ics"
+              or .content_type in ("application/ics", "text/calendar")
+            )
+          )
+          //
+          // This rule makes use of a beta feature and is subject to change without notice
+          // using the beta feature in custom rules is not suggested until it has been formally released
+          //
+          and any(beta.file.parse_ics(.).events,
+                  any(.raw_properties,
+                      .key == "UID" and .value == recipients.to[0].email.email
+                  )
+          )
+  )
+  
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "File analysis"
+  - "Content analysis"


### PR DESCRIPTION
# Description
detect when the UID field of the ICS file is the recipient's email address. RFC 5545 defines the UID field as a globally unique identifier for calendar events, so the deviation from spec is a strong malicious indicator 

## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019d9ce1-1d6a-7b93-b9f0-a289dc77eaa8)
- [Multi-hunt](https://hunt.limeseed.email/hunts/9c4ddfdd-f325-443f-b950-c88b578ffccf)