### PR TITLE
Create link_credential_phishing_cloud_service.yml

### DIFF
--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -34,3 +34,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Sender analysis"
   - "URL analysis"
+id: "5f1395a6-e2ae-5175-ad29-5f35111219fd"

--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -1,0 +1,36 @@
+name: "Link: Cloud service with credential theft language"
+description: "Detects messages impersonating cloud services that contain high-confidence credential theft language and file sharing topics. The message starts with 'Cloud' or a cloud emoji, contains links to external domains not matching the sender's domain, and lacks recipient identification entities."
+type: "rule"
+severity: ""
+source: |
+  type.inbound
+  and (
+    strings.starts_with(body.current_thread.text, 'Cloud')
+    // cloud emoji
+    or regex.contains(body.current_thread.text, '^\x{2601}')
+  )
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == 'cred_theft' and .confidence == 'high'
+  )
+  and any(ml.nlu_classifier(body.current_thread.text).topics,
+          .name == 'File Sharing and Cloud Services' and .confidence == 'high'
+  )
+  // sender domain matches no body domains
+  and length(body.links) > 0
+  and all(body.links,
+          .href_url.domain.root_domain != sender.email.domain.root_domain
+  )
+  // No recipient in email
+  and not any(ml.nlu_classifier(body.current_thread.text).entities,
+              .name == 'recipient'
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"
+  - "URL analysis"

--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -20,10 +20,6 @@ source: |
   and all(body.links,
           .href_url.domain.root_domain != sender.email.domain.root_domain
   )
-  // No recipient in email
-  and not any(ml.nlu_classifier(body.current_thread.text).entities,
-              .name == 'recipient'
-  )
 
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -20,7 +20,12 @@ source: |
   and all(body.links,
           .href_url.domain.root_domain != sender.email.domain.root_domain
   )
-
+  // negate legit cloud companies
+  and not (
+    sender.email.domain.root_domain in ("cloud-cme.com", "cloudcounting.online")
+    // check for SPF or DMARC passed
+    and (headers.auth_summary.spf.pass or headers.auth_summary.dmarc.pass)
+  )
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -1,7 +1,7 @@
 name: "Link: Cloud service with credential theft language"
 description: "Detects messages impersonating cloud services that contain high-confidence credential theft language and file sharing topics. The message starts with 'Cloud' or a cloud emoji, contains links to external domains not matching the sender's domain, and lacks recipient identification entities."
 type: "rule"
-severity: ""
+severity: "medium"
 source: |
   type.inbound
   and (

--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -26,6 +26,11 @@ source: |
     // check for SPF or DMARC passed
     and (headers.auth_summary.spf.pass or headers.auth_summary.dmarc.pass)
   )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description
Detects messages impersonating cloud services that contain high-confidence credential theft language and file sharing topics. The message starts with 'Cloud' or a cloud emoji, and contains links to external domains not matching the sender's domain.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/504c0790e2a562d72a2e8676a35d65e0620b44d4c631c113b11f990b396d5b9b?preview_id=019d88c9-2992-7ef0-9ce7-3c3a6328277c)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019d9d01-737b-71c6-9336-3b2717d66fe3)
- Multi-hunts in ESC-10973
- Mode results look great 
