### PR TITLE
Create detection rule for invoice/inquiry current thread

### DIFF
--- a/detection-rules/link_previous_thread_invoice.yml
+++ b/detection-rules/link_previous_thread_invoice.yml
@@ -1,0 +1,61 @@
+name: "Link: Invoice-related BEC with newly registered domain < 60 days "
+description: "Detects Business Email Compromise attacks using fake reply/forward threads containing links to newly registered domains (less than 60 days old) with invoice-related language and engaging action words. The message includes financial or payment terminology and prompts the recipient to take action through suspicious links."
+type: "rule"
+severity: "medium"
+source: |
+    type.inbound
+    and (subject.is_reply or subject.is_forward)
+    and (
+      any(body.current_thread.links, network.whois(.href_url.domain).days_old < 60)
+      and any(body.links,
+              regex.icontains(.display_text,
+                              '[VIEW|REVIEW|CLICK|DOWNLOAD|CHECK|VALIDATE]'
+              )
+      )
+      and any([body.current_thread.text],
+              regex.icontains(.,
+                              'wire transfer',
+                              'payment',
+                              'invoice',
+                              'ACH',
+                              'kindly download',
+                              'document',
+                              'kindly',
+                              'urgently',
+                              'confirm'
+              )
+      )
+      and (
+        // language attempting to engage
+        (
+          any(ml.nlu_classifier(body.current_thread.text).entities,
+              .name in ("request", "financial")
+          )
+        )
+        // invoicing language
+        and any(ml.nlu_classifier(body.current_thread.text).tags,
+                .name == "invoice"
+        )
+      )
+    )
+    // prevent benign emails
+    and any(ml.nlu_classifier(body.current_thread.text).intents, .name != "benign")
+    // negate highly trusted sender domains unless they fail DMARC authentication
+    and (
+      (
+        sender.email.domain.root_domain in $high_trust_sender_root_domains
+        and not headers.auth_summary.dmarc.pass
+      )
+      or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+    )
+
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Evasion"
+  - "Spoofing"
+detection_methods:
+  - "Header analysis"
+  - "Sender analysis"
+  - "URL analysis"

--- a/detection-rules/link_previous_thread_invoice.yml
+++ b/detection-rules/link_previous_thread_invoice.yml
@@ -23,7 +23,6 @@ source: |
                               'ACH',
                               'kindly download',
                               'document',
-                              'kindly',
                               'urgently',
                               'confirm'
               )
@@ -32,13 +31,11 @@ source: |
         any(ml.nlu_classifier(body.current_thread.text).intents,
             .name == "bec" and .confidence != "low"
         )
-        or (
-          any(ml.nlu_classifier(body.current_thread.text).entities,
-              .name in ("urgency", "request")
-          )
-        )
         or any(ml.nlu_classifier(body.current_thread.text).tags,
                .name in ("invoice", "payment")
+        )
+        or any(ml.nlu_classifier(body.current_thread.text).entities,
+               .name == "request" and .text == "kindly download to view"
         )
       )
     )
@@ -46,16 +43,6 @@ source: |
     and not any(ml.nlu_classifier(body.current_thread.text).intents,
                 .name == "benign"
     )
-    // and (
-    //   (
-    //     profile.by_sender().prevalence != "common"
-    //     and not profile.by_sender().solicited
-    //   )
-    //   or (
-    //     profile.by_sender().any_messages_malicious_or_spam
-    //     and not profile.by_sender().any_messages_benign
-    //   )
-    // )
     // negate highly trusted sender domains unless they fail DMARC authentication
     and (
       (

--- a/detection-rules/link_previous_thread_invoice.yml
+++ b/detection-rules/link_previous_thread_invoice.yml
@@ -8,11 +8,11 @@ source: |
     and (
       any(body.current_thread.links, network.whois(.href_url.domain).days_old < 60)
       and regex.icontains(subject.subject,
-                          '\b(fyi|attention|proposal|purchase|invoice|payment|wire|agreement|contract|settlement)\b'
+                          '\b(proposal|purchase|invoice|payment|wire|agreement|contract|settlement)\b'
       )
       and any(body.links,
               regex.icontains(.display_text,
-                              '[VIEW|REVIEW|CLICK|DOWNLOAD|CHECK|VALIDATE]'
+                              '(?:VIEW|REVIEW|CLICK|DOWNLOAD|CHECK|VALIDATE)'
               )
       )
       and any([body.current_thread.text],
@@ -29,16 +29,33 @@ source: |
               )
       )
       and (
-        // language attempting to engage
-        (
+        any(ml.nlu_classifier(body.current_thread.text).intents,
+            .name == "bec" and .confidence != "low"
+        )
+        or (
           any(ml.nlu_classifier(body.current_thread.text).entities,
-              .name in ("request", "financial")
+              .name in ("urgency", "request")
           )
+        )
+        or any(ml.nlu_classifier(body.current_thread.text).tags,
+               .name in ("invoice", "payment")
         )
       )
     )
     // prevent benign emails
-    and any(ml.nlu_classifier(body.current_thread.text).intents, .name != "benign")
+    and not any(ml.nlu_classifier(body.current_thread.text).intents,
+                .name == "benign"
+    )
+    // and (
+    //   (
+    //     profile.by_sender().prevalence != "common"
+    //     and not profile.by_sender().solicited
+    //   )
+    //   or (
+    //     profile.by_sender().any_messages_malicious_or_spam
+    //     and not profile.by_sender().any_messages_benign
+    //   )
+    // )
     // negate highly trusted sender domains unless they fail DMARC authentication
     and (
       (
@@ -47,6 +64,7 @@ source: |
       )
       or sender.email.domain.root_domain not in $high_trust_sender_root_domains
     )
+    and not profile.by_sender().any_messages_benign
 
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/link_previous_thread_invoice.yml
+++ b/detection-rules/link_previous_thread_invoice.yml
@@ -59,3 +59,4 @@ detection_methods:
   - "Header analysis"
   - "Sender analysis"
   - "URL analysis"
+id: "fee020b6-4a01-5ed3-a924-b5aa4415d3e9"

--- a/detection-rules/link_previous_thread_invoice.yml
+++ b/detection-rules/link_previous_thread_invoice.yml
@@ -7,6 +7,9 @@ source: |
     and (subject.is_reply or subject.is_forward)
     and (
       any(body.current_thread.links, network.whois(.href_url.domain).days_old < 60)
+      and regex.icontains(subject.subject,
+                          '\b(fyi|attention|proposal|purchase|invoice|payment|wire|agreement|contract|settlement)\b'
+      )
       and any(body.links,
               regex.icontains(.display_text,
                               '[VIEW|REVIEW|CLICK|DOWNLOAD|CHECK|VALIDATE]'
@@ -32,10 +35,6 @@ source: |
               .name in ("request", "financial")
           )
         )
-        // invoicing language
-        and any(ml.nlu_classifier(body.current_thread.text).tags,
-                .name == "invoice"
-        )
       )
     )
     // prevent benign emails
@@ -44,7 +43,7 @@ source: |
     and (
       (
         sender.email.domain.root_domain in $high_trust_sender_root_domains
-        and not headers.auth_summary.dmarc.pass
+        and not coalesce(headers.auth_summary.dmarc.pass, false)
       )
       or sender.email.domain.root_domain not in $high_trust_sender_root_domains
     )

--- a/detection-rules/link_previous_thread_invoice.yml
+++ b/detection-rules/link_previous_thread_invoice.yml
@@ -4,39 +4,32 @@ type: "rule"
 severity: "medium"
 source: |
     type.inbound
-    and (subject.is_reply or subject.is_forward)
+    and 0 < length(body.current_thread.links) < 15
+    and any(body.current_thread.links,
+            network.whois(.href_url.domain).days_old < 60
+            and regex.icontains(.display_text,
+                                '(?:VIEW|REVIEW|CLICK|DOWNLOAD|CHECK|VALIDATE)'
+            )
+    )
+    and regex.icontains(subject.base,
+                        '\b(proposal|purchase|invoice|payment|wire|agreement|contract|settlement)\b'
+    )
+    and regex.icontains(body.current_thread.text,
+                        'wire transfer',
+                        'payment',
+                        'invoice',
+                        'ACH',
+                        'kindly download',
+                        'document',
+                        'urgently',
+                        'confirm'
+    )
     and (
-      any(body.current_thread.links, network.whois(.href_url.domain).days_old < 60)
-      and regex.icontains(subject.subject,
-                          '\b(proposal|purchase|invoice|payment|wire|agreement|contract|settlement)\b'
+      any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name in ("cred_theft", "bec") and .confidence != "low"
       )
-      and any(body.links,
-              regex.icontains(.display_text,
-                              '(?:VIEW|REVIEW|CLICK|DOWNLOAD|CHECK|VALIDATE)'
-              )
-      )
-      and any([body.current_thread.text],
-              regex.icontains(.,
-                              'wire transfer',
-                              'payment',
-                              'invoice',
-                              'ACH',
-                              'kindly download',
-                              'document',
-                              'urgently',
-                              'confirm'
-              )
-      )
-      and (
-        any(ml.nlu_classifier(body.current_thread.text).intents,
-            .name == "bec" and .confidence != "low"
-        )
-        or any(ml.nlu_classifier(body.current_thread.text).tags,
-               .name in ("invoice", "payment")
-        )
-        or any(ml.nlu_classifier(body.current_thread.text).entities,
-               .name == "request" and .text == "kindly download to view"
-        )
+      or any(ml.nlu_classifier(body.current_thread.text).tags,
+             .name in ("invoice", "payment")
       )
     )
     // prevent benign emails
@@ -51,7 +44,6 @@ source: |
       )
       or sender.email.domain.root_domain not in $high_trust_sender_root_domains
     )
-    and not profile.by_sender().any_messages_benign
 
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/link_previous_thread_invoice.yml
+++ b/detection-rules/link_previous_thread_invoice.yml
@@ -1,5 +1,5 @@
 name: "Link: BEC with newly registered domains and financial keywords"
-description: "Detects business email compromise attempts containing links to newly registered domains (less than 60 days old) with action-oriented display text, combined with financial subject lines and body content indicating payment, invoice, or wire transfer requests. Uses natural language processing to identify credential theft or BEC intent while filtering out benign communications."
+description: "Detects Business Email Compromise attacks containing links to newly registered domains (less than 60 days old) with invoice-related language and engaging action words. The message includes financial or payment terminology and prompts the recipient to take action through suspicious links. Uses natural language processing to identify credential theft or BEC intent while filtering out benign communications."
 type: "rule"
 severity: "medium"
 source: |

--- a/detection-rules/link_previous_thread_invoice.yml
+++ b/detection-rules/link_previous_thread_invoice.yml
@@ -1,5 +1,5 @@
-name: "Link: Invoice-related BEC with newly registered domain < 60 days "
-description: "Detects Business Email Compromise attacks using fake reply/forward threads containing links to newly registered domains (less than 60 days old) with invoice-related language and engaging action words. The message includes financial or payment terminology and prompts the recipient to take action through suspicious links."
+name: "Link: BEC with newly registered domains and financial keywords"
+description: "Detects business email compromise attempts containing links to newly registered domains (less than 60 days old) with action-oriented display text, combined with financial subject lines and body content indicating payment, invoice, or wire transfer requests. Uses natural language processing to identify credential theft or BEC intent while filtering out benign communications."
 type: "rule"
 severity: "medium"
 source: |
@@ -8,20 +8,20 @@ source: |
     and any(body.current_thread.links,
             network.whois(.href_url.domain).days_old < 60
             and regex.icontains(.display_text,
-                                '(?:VIEW|REVIEW|CLICK|DOWNLOAD|CHECK|VALIDATE)'
+                                '(?:view|click|download|check|validate)'
             )
     )
     and regex.icontains(subject.base,
-                        '\b(proposal|purchase|invoice|payment|wire|agreement|contract|settlement)\b'
+                        '\b(?:proposal|purchase|invoice|payment|wire|agreement|contract|settlement)\b'
     )
     and regex.icontains(body.current_thread.text,
-                        'wire transfer',
+                        '\bwire\b',
                         'payment',
                         'invoice',
-                        'ACH',
-                        'kindly download',
+                        '\bACH\b',
+                        'kindly',
                         'document',
-                        'urgently',
+                        'urgent',
                         'confirm'
     )
     and (
@@ -37,12 +37,9 @@ source: |
                 .name == "benign"
     )
     // negate highly trusted sender domains unless they fail DMARC authentication
-    and (
-      (
-        sender.email.domain.root_domain in $high_trust_sender_root_domains
-        and not coalesce(headers.auth_summary.dmarc.pass, false)
-      )
-      or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+    and not (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and coalesce(headers.auth_summary.dmarc.pass, false)
     )
 
 attack_types:


### PR DESCRIPTION
# Description
Running ping [ESC-11142] - coverage for common invoice/inquiry current threads that contains newly registered domains. 

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/504edb21a8bb354d9f50d649cf9ab059fda1313f26f9958400d9fcb9e55792c1?preview_id=019d91d7-4a35-718d-ac13-a010447b4b86)

# Associated hunts
- [Hunt](https://platform.sublime.security/messages/hunt?huntId=019de05b-39a1-7c42-bcc5-c08351cae405)
- [Net New](https://platform.sublime.security/messages/hunt?huntId=019de03e-cb51-72df-8734-4df5576a1217)
- [Multi-hunt](https://hunt.limeseed.email/hunts/1a92034e-374b-4d87-9cc5-70c80c6dac65)