### PR TITLE
Update fake thread detection rules for references

### DIFF
--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -29,7 +29,7 @@ source: |
       )
     )
   )
-
+  
   // negating bouncebacks
   and not any(attachments,
               .content_type in ("message/delivery-status", "message/rfc822")
@@ -49,7 +49,7 @@ source: |
     and headers.hops[0].received.server.raw == "relay.mimecast.com"
     and strings.icontains(headers.hops[0].received.source.raw, 'mimecast.lan')
   )
-
+  
   // and not solicited
   and not profile.by_sender().solicited
   and 4 of (
@@ -62,7 +62,7 @@ source: |
               .name == "financial"
       )
     ),
-
+  
     // invoicing language
     (
       any(ml.nlu_classifier(body.current_thread.text).tags, .name == "invoice")
@@ -70,32 +70,30 @@ source: |
              .text == "invoice"
       )
     ),
-
+  
     // urgency request
-    any(ml.nlu_classifier(body.current_thread.text).entities,
-        .name == "urgency"
-    ),
-
+    any(ml.nlu_classifier(body.current_thread.text).entities, .name == "urgency"),
+  
     // cred_theft detection
     any(ml.nlu_classifier(body.current_thread.text).intents,
         .name == "cred_theft" and .confidence in~ ("medium", "high")
     ),
-
+  
     // commonly abused sender TLD
     strings.ilike(sender.email.domain.tld, "*.jp"),
-
+  
     // headers traverse abused TLD
     any(headers.domains, strings.ilike(.tld, "*.jp")),
-
+  
     // known suspicious pattern in the URL path
     any(body.links, regex.match(.href_url.path, '\/[a-z]{3}\d[a-z]')),
-
+  
     // link display text is in all caps
     any(body.links, regex.match(.display_text, '[A-Z ]+')),
-
+  
     // link display text contains invisible characters (U+200F)
     any(body.links, strings.contains(.display_text, "\u{200F}")),
-
+  
     // Low reputation link with display text ending in a document extension
     any(body.links,
         .href_url.domain.root_domain not in $tranco_1m
@@ -107,33 +105,33 @@ source: |
           or strings.ends_with(.display_text, 'pdf')
         )
     ),
-
+  
     // display name contains an email
     regex.contains(sender.display_name, '[a-z0-9]+@[a-z]+'),
-
+  
     // Sender domain is empty
     sender.email.domain.domain == "",
-
+  
     // sender domain matches no body domains
     all(body.links,
         .href_url.domain.root_domain != sender.email.domain.root_domain
     ),
-
+  
     // body contains name of VIP
     (
       any($org_vips, strings.icontains(body.html.inner_text, .display_name))
       or any($org_vips, strings.icontains(body.plain.raw, .display_name))
     ),
-
+  
     // new body domain
     any(body.links, network.whois(.href_url.domain).days_old < 30),
-
+  
     // new sender domain
     network.whois(sender.email.domain).days_old < 30,
-
+  
     // new sender
     profile.by_sender().days_known < 7,
-
+  
     // excessive whitespace
     (
       regex.icontains(body.html.raw, '((<br\s*/?>\s*){20,}|\n{20,})')
@@ -146,7 +144,7 @@ source: |
       or regex.icontains(body.html.raw, '(<p[^>]*>\s*&nbsp;<br>\s*</p>\s*){5,}')
       or regex.icontains(body.html.raw, '(<p[^>]*>&nbsp;</p>\s*){7,}')
     ),
-
+  
     // body contains recipient SLD
     any(recipients.to,
         strings.icontains(body.current_thread.text, .email.domain.sld)
@@ -157,7 +155,7 @@ source: |
               .name != "benign" and .confidence == "high"
           )
   )
-
+  
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -5,7 +5,7 @@ severity: "medium"
 source: |
   type.inbound
   // fake thread check
-  and (length(headers.references) == 0 or headers.in_reply_to is null)
+  and (length(headers.references) >= 0 or headers.in_reply_to is null)
   and (
     subject.is_reply
     or subject.is_forward
@@ -148,8 +148,20 @@ source: |
     // body contains recipient SLD
     any(recipients.to,
         strings.icontains(body.current_thread.text, .email.domain.sld)
+    ),
+    // mailto mismatch from freemailer
+    (
+      any(body.links,
+          .href_url.scheme == 'mailto'
+          and .display_text is not null
+          and strings.icontains(.display_text, "@")
+          and not strings.icontains(.href_url.url, .display_text)
+      )
+      and sender.email.domain.root_domain in $free_email_providers
     )
   )
+  
+  and any(body.previous_threads, any(ml.nlu_classifier(.text).intents, .name != "benign" and .confidence == "high"))
   
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -29,7 +29,7 @@ source: |
       )
     )
   )
-  
+
   // negating bouncebacks
   and not any(attachments,
               .content_type in ("message/delivery-status", "message/rfc822")
@@ -49,7 +49,7 @@ source: |
     and headers.hops[0].received.server.raw == "relay.mimecast.com"
     and strings.icontains(headers.hops[0].received.source.raw, 'mimecast.lan')
   )
-  
+
   // and not solicited
   and not profile.by_sender().solicited
   and 4 of (
@@ -62,7 +62,7 @@ source: |
               .name == "financial"
       )
     ),
-  
+
     // invoicing language
     (
       any(ml.nlu_classifier(body.current_thread.text).tags, .name == "invoice")
@@ -70,30 +70,32 @@ source: |
              .text == "invoice"
       )
     ),
-  
+
     // urgency request
-    any(ml.nlu_classifier(body.current_thread.text).entities, .name == "urgency"),
-  
+    any(ml.nlu_classifier(body.current_thread.text).entities,
+        .name == "urgency"
+    ),
+
     // cred_theft detection
     any(ml.nlu_classifier(body.current_thread.text).intents,
         .name == "cred_theft" and .confidence in~ ("medium", "high")
     ),
-  
+
     // commonly abused sender TLD
     strings.ilike(sender.email.domain.tld, "*.jp"),
-  
+
     // headers traverse abused TLD
     any(headers.domains, strings.ilike(.tld, "*.jp")),
-  
+
     // known suspicious pattern in the URL path
     any(body.links, regex.match(.href_url.path, '\/[a-z]{3}\d[a-z]')),
-  
+
     // link display text is in all caps
     any(body.links, regex.match(.display_text, '[A-Z ]+')),
-  
+
     // link display text contains invisible characters (U+200F)
     any(body.links, strings.contains(.display_text, "\u{200F}")),
-  
+
     // Low reputation link with display text ending in a document extension
     any(body.links,
         .href_url.domain.root_domain not in $tranco_1m
@@ -105,33 +107,33 @@ source: |
           or strings.ends_with(.display_text, 'pdf')
         )
     ),
-  
+
     // display name contains an email
     regex.contains(sender.display_name, '[a-z0-9]+@[a-z]+'),
-  
+
     // Sender domain is empty
     sender.email.domain.domain == "",
-  
+
     // sender domain matches no body domains
     all(body.links,
         .href_url.domain.root_domain != sender.email.domain.root_domain
     ),
-  
+
     // body contains name of VIP
     (
       any($org_vips, strings.icontains(body.html.inner_text, .display_name))
       or any($org_vips, strings.icontains(body.plain.raw, .display_name))
     ),
-  
+
     // new body domain
     any(body.links, network.whois(.href_url.domain).days_old < 30),
-  
+
     // new sender domain
     network.whois(sender.email.domain).days_old < 30,
-  
+
     // new sender
     profile.by_sender().days_known < 7,
-  
+
     // excessive whitespace
     (
       regex.icontains(body.html.raw, '((<br\s*/?>\s*){20,}|\n{20,})')
@@ -144,20 +146,10 @@ source: |
       or regex.icontains(body.html.raw, '(<p[^>]*>\s*&nbsp;<br>\s*</p>\s*){5,}')
       or regex.icontains(body.html.raw, '(<p[^>]*>&nbsp;</p>\s*){7,}')
     ),
-  
+
     // body contains recipient SLD
     any(recipients.to,
         strings.icontains(body.current_thread.text, .email.domain.sld)
-    ),
-    // mailto mismatch from freemailer
-    (
-      any(body.links,
-          .href_url.scheme == 'mailto'
-          and .display_text is not null
-          and strings.icontains(.display_text, "@")
-          and not strings.icontains(.href_url.url, .display_text)
-      )
-      and sender.email.domain.root_domain in $free_email_providers
     )
   )
   and any(body.previous_threads,
@@ -165,7 +157,7 @@ source: |
               .name != "benign" and .confidence == "high"
           )
   )
-  
+
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -160,8 +160,11 @@ source: |
       and sender.email.domain.root_domain in $free_email_providers
     )
   )
-  
-  and any(body.previous_threads, any(ml.nlu_classifier(.text).intents, .name != "benign" and .confidence == "high"))
+  and any(body.previous_threads,
+          any(ml.nlu_classifier(.text).intents,
+              .name != "benign" and .confidence == "high"
+          )
+  )
   
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (


### PR DESCRIPTION
# Description
Adding an update for the fake thread  - headers, replacing coverage for runner ping

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/504edb21a8bb354d9f50d649cf9ab059fda1313f26f9958400d9fcb9e55792c1?preview_id=019d91d7-4a35-718d-ac13-a010447b4b86)

## Associated hunts
- [NetNewCoverage30Days](https://platform.sublime.security/messages/hunt?huntId=019da88a-b1a2-7bfc-a227-a8f233d7c6e5)