### PR TITLE
Create self_sender_cred_theft_auth_failures.yml

### DIFF
--- a/detection-rules/self_sender_cred_theft_auth_failures.yml
+++ b/detection-rules/self_sender_cred_theft_auth_failures.yml
@@ -28,3 +28,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Header analysis"
   - "Sender analysis"
+id: "549c4e66-ec29-50f5-aff7-4a85fa7318da"

--- a/detection-rules/self_sender_cred_theft_auth_failures.yml
+++ b/detection-rules/self_sender_cred_theft_auth_failures.yml
@@ -1,5 +1,5 @@
-name: "Self-sender credential theft with authentication failures"
-description: "Detects inbound messages where the sender appears to be emailing themselves, uses natural language understanding to identify credential theft intent with medium or high confidence, and fails both DMARC and SPF authentication checks. This pattern is commonly used to bypass basic security filters while delivering malicious content."
+name: "Headers: Self-sender using Microsoft CompAuth bypass with credential theft content"
+description: "Detects messages sent to self or invalid domains containing credential theft content that bypass Microsoft's CompAuth with reason 703 while failing both SPF and DMARC authentication checks."
 type: "rule"
 severity: "high"
 source: |

--- a/detection-rules/self_sender_cred_theft_auth_failures.yml
+++ b/detection-rules/self_sender_cred_theft_auth_failures.yml
@@ -12,8 +12,13 @@ source: |
     sender.email.email == recipients.to[0].email.email
     or recipients.to[0].email.domain.valid == false
   )
+  // cred theft
   and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == "cred_theft" and .confidence != "low"
+  )
+  // microsoft compauth pass with a 703, but spf and dmarc fail
+  and any(headers.hops,
+          any(.fields, strings.icontains(.value, 'compauth=pass reason=703'))
   )
   and not coalesce(headers.auth_summary.dmarc.pass, false)
   and not coalesce(headers.auth_summary.spf.pass, false)

--- a/detection-rules/self_sender_cred_theft_auth_failures.yml
+++ b/detection-rules/self_sender_cred_theft_auth_failures.yml
@@ -1,0 +1,30 @@
+name: "Self-sender credential theft with authentication failures"
+description: "Detects inbound messages where the sender appears to be emailing themselves, uses natural language understanding to identify credential theft intent with medium or high confidence, and fails both DMARC and SPF authentication checks. This pattern is commonly used to bypass basic security filters while delivering malicious content."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  // self sender
+  and length(recipients.to) == 1
+  and length(recipients.cc) == 0
+  and length(recipients.bcc) == 0
+  and (
+    sender.email.email == recipients.to[0].email.email
+    or recipients.to[0].email.domain.valid == false
+  )
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "cred_theft" and .confidence != "low"
+  )
+  and not coalesce(headers.auth_summary.dmarc.pass, false)
+  and not coalesce(headers.auth_summary.spf.pass, false)
+tags:
+  - "Attack surface reduction"
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Spoofing"
+  - "Evasion"
+detection_methods:
+  - "Natural Language Understanding"
+  - "Header analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

We're seeing a massive spike in this spoofed self-sender stuff. Wanted to make a wide-net rule to cast this but had to content with some FPs. Decided to go the ASR route with this and let ASV decide, it's done a really good job so far matching these.

<!-- 
Explain your change and why. For example, "negating legitimate replies," or "adding additional credential theft keywords."

If it's a new rule or insight, explain what the rule is designed to catch/what the insight should fire on.
-->

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5050eb49258c9587146a528071ae5e54224a851fa4ec9afbb0a7774f6bfe58d5?preview_id=019d9dc6-7e79-754f-8462-a1e4228f4331)
- [Sample 2](https://platform.sublime.security/messages/504daefff3f24dd3b43b8327e2d66d1feee21ea337fed2421d3d2aaa4c0b7c99?preview_id=019d9dc4-76e8-7934-b402-18eb81a6b0d8)
- [Sample 3](https://platform.sublime.security/messages/504d0a5a833e3e49df543c3ec3732869137fc7e11961137d1ecdedb7acf26139?preview_id=019dab48-b123-7813-9c13-a06f23ea8ae6)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019db01d-a392-702b-89e2-b5dfb77cda2e)
- [multihunt](https://hunt.limeseed.email/hunts/bd810c3b-2603-4969-8a5d-8211122ad147)
