### PR TITLE
Update credential_theft_cloud_storage_impersonation.yml

### DIFF
--- a/detection-rules/credential_theft_cloud_storage_impersonation.yml
+++ b/detection-rules/credential_theft_cloud_storage_impersonation.yml
@@ -33,6 +33,7 @@ source: |
           or .href_url.domain.root_domain in $url_shorteners
           or network.whois(.href_url.domain).days_old < 365
           or .href_url.domain.root_domain == "beehiiv.com"
+          or regex.icontains(.href_url.path, '^\/[a-z0-9]{20,}$')
           or (
             strings.icontains(.href_url.path, '.html')
             and coalesce(.href_url.domain.root_domain, "null") != sender.email.domain.root_domain


### PR DESCRIPTION
# Description

Adding `body.current_thread.link` logic to match on links where the entire URL path is an alphanumeric string of 20 or more characters

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50539f9f818ef16d880e086f12e16999dee5b4a6b2405f17add4fbfc65173895?preview_id=019dab95-163e-7593-8804-9ae1d2c6a4aa)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019db69b-194f-738d-aa95-3a6007fc333b)
- [L30D 40 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/51a6f0c6-77be-4216-97fa-4e98181ec650)
