### PR TITLE
Update impersonation_microsoft_teams.yml

### DIFF
--- a/detection-rules/impersonation_microsoft_teams.yml
+++ b/detection-rules/impersonation_microsoft_teams.yml
@@ -9,19 +9,31 @@ source: |
                     .file_type in $file_types_images or .file_type == "pdf"
              )
   ) < 10
-  and any(attachments,
-          (.file_type in $file_types_images or .file_type == "pdf")
-          and any(file.explode(.),
-                  regex.icontains(.scan.ocr.raw,
-                                  "trying to reach you.*microsoft teams"
-                  )
-          )
+  and (
+    regex.icontains(body.current_thread.text,
+                    'trying to reach you.*microsoft teams',
+                    'new message in teams'
+    )
+    or any(attachments,
+           (.file_type in $file_types_images or .file_type == "pdf")
+           and any(file.explode(.),
+                   regex.icontains(.scan.ocr.raw,
+                                   "trying to reach you.*microsoft teams"
+                   )
+           )
+    )
   )
-  and sender.email.domain.root_domain not in (
-    "microsoft.com",
-    "microsoftsupport.com",
-    "office.com"
+  // not sent via legitimate Microsoft infra
+  and not strings.ends_with(headers.message_id, '@odspnotify>')
+  and not (
+    sender.email.domain.root_domain in (
+      "microsoft.com",
+      "microsoftsupport.com",
+      "office.com"
+    )
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
+
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/impersonation_microsoft_teams.yml
+++ b/detection-rules/impersonation_microsoft_teams.yml
@@ -29,7 +29,10 @@ source: |
     sender.email.domain.root_domain in (
       "microsoft.com",
       "microsoftsupport.com",
-      "office.com"
+      "office.com",
+      "mail.microsoft",
+      "service-now.com",
+      "atlassian.net"
     )
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )


### PR DESCRIPTION
# Description
expanding scope of this rule to look for impersonation techniques in body current thread, while adding a new negation for sending through legitimate Microsoft infrastructure to negate FPs 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50542ed1b85f555371b798fa9754294405b092823031a65c0fa0d08e8dd1f5a5?preview_id=019db02f-73d7-70a5-9af8-982b465b7402)


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019db050-31cd-7829-9126-e8ab9f6574bc) - net new results
