### PR TITLE
Update impersonation_employee_urgent_request.yml

### DIFF
--- a/detection-rules/impersonation_employee_urgent_request.yml
+++ b/detection-rules/impersonation_employee_urgent_request.yml
@@ -42,6 +42,22 @@ source: |
         and not strings.istarts_with(subject.subject, "fwd:")
       )
     )
+    or (
+      any(ml.nlu_classifier(body.current_thread.text).entities,
+          .name == "request"
+      )
+      and sender.email.domain.root_domain in $free_email_providers
+      and any(headers.hops,
+              any(.fields,
+                  .name == "X-Forefront-Antispam-Report"
+                  and (
+                    strings.icontains(.value, "CAT:PHISH")
+                    or strings.icontains(.value, "CAT:SPOOF")
+                    or strings.icontains(.value, "CAT:HSPM")
+                  )
+              )
+      )
+    )
   )
   and (
     (
@@ -50,7 +66,7 @@ source: |
     )
     or (
       profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_false_positives
+      and not profile.by_sender().any_messages_benign
     )
     or not headers.auth_summary.dmarc.pass
   )
@@ -72,7 +88,7 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-  and not profile.by_sender().any_false_positives
+  and not profile.by_sender().any_messages_benign
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:


### PR DESCRIPTION
# Description

For a runner ping, updated logic to look for the `request` entities, freemail sender, and `PHISH`, `SPOOF`, or `HSPM` category header values 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/504dd8d2d959905661f2b99c18e6ca6b4ec3443dac8468a5841d8713725a0ee9?preview_id=019d9156-ebb2-7332-8815-6a9b778ab0c7)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L7D 50 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/199c19fa-6f51-4bd4-9c6a-eb26bb8de045)