### PR TITLE
Update self_sender_cred_theft_auth_failures.yml

### DIFF
--- a/detection-rules/self_sender_cred_theft_auth_failures.yml
+++ b/detection-rules/self_sender_cred_theft_auth_failures.yml
@@ -17,9 +17,7 @@ source: |
           .name == "cred_theft" and .confidence != "low"
   )
   // microsoft compauth pass, but spf and dmarc fail
-  and any(headers.hops,
-          any(.fields, strings.icontains(.value, 'compauth=pass'))
-  )
+  and any(headers.hops, any(.fields, strings.icontains(.value, 'compauth=pass')))
   and not headers.auth_summary.dmarc.pass
   and not headers.auth_summary.spf.pass
 tags:

--- a/detection-rules/self_sender_cred_theft_auth_failures.yml
+++ b/detection-rules/self_sender_cred_theft_auth_failures.yml
@@ -1,5 +1,5 @@
 name: "Headers: Self-sender using Microsoft CompAuth bypass with credential theft content"
-description: "Detects messages sent to self or invalid domains containing credential theft content that bypass Microsoft's CompAuth with reason 703 while failing both SPF and DMARC authentication checks."
+description: "Detects messages sent to self or invalid domains containing credential theft content that bypass Microsoft's CompAuth while failing both SPF and DMARC authentication checks."
 type: "rule"
 severity: "high"
 source: |
@@ -16,12 +16,12 @@ source: |
   and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == "cred_theft" and .confidence != "low"
   )
-  // microsoft compauth pass with a 703, but spf and dmarc fail
+  // microsoft compauth pass, but spf and dmarc fail
   and any(headers.hops,
-          any(.fields, strings.icontains(.value, 'compauth=pass reason=703'))
+          any(.fields, strings.icontains(.value, 'compauth=pass'))
   )
-  and not coalesce(headers.auth_summary.dmarc.pass, false)
-  and not coalesce(headers.auth_summary.spf.pass, false)
+  and not headers.auth_summary.dmarc.pass
+  and not headers.auth_summary.spf.pass
 tags:
   - "Attack surface reduction"
 attack_types:


### PR DESCRIPTION
# Description

We've observed some other compauth reasons with the same campaign. Loosening up to not require a reason check.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5053fe0edf9acdef7fd2dfc73410e5cd6b60a06307ff132b9f93455a8555ed75?preview_id=019db151-a7ea-7a91-9435-b6e66e0759c5)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt showing messages that will no longer match (removing coalesce)](https://hunt.limeseed.email/hunts/0b0d785f-0cdc-4a0c-ad36-3b923abbad61)
- [net new hunt](https://hunt.limeseed.email/hunts/74b91b79-42c8-49aa-b6cc-84fb933afae2)