### PR TITLE
Create self_sender_cred_theft_short_path_link.yml

### DIFF
--- a/detection-rules/self_sender_cred_theft_short_path_link.yml
+++ b/detection-rules/self_sender_cred_theft_short_path_link.yml
@@ -1,0 +1,32 @@
+name: "Link: Self-sent credential theft with single character path"
+description: "Detects messages sent to oneself containing links with single character paths and credential theft language, commonly used to bypass security filters and deliver malicious content."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // self sender
+  and length(recipients.to) == 1
+  and (
+    sender.email.email == recipients.to[0].email.email
+    or recipients.to[0].email.domain.valid == false
+  )
+  // path contains 1 character
+  and any(body.current_thread.links,
+          regex.imatch(.href_url.path, '\/[A-Za-z0-9]')
+          and .href_url.query_params is null
+          and .href_url.fragment is null
+          and .display_url.url is null
+  )
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "cred_theft" and .confidence != "low"
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "Natural Language Understanding"
+  - "URL analysis"
+  - "Sender analysis"
+  - "Header analysis"

--- a/detection-rules/self_sender_cred_theft_short_path_link.yml
+++ b/detection-rules/self_sender_cred_theft_short_path_link.yml
@@ -30,3 +30,4 @@ detection_methods:
   - "URL analysis"
   - "Sender analysis"
   - "Header analysis"
+id: "c97982e6-eaa2-53e3-ba8f-0dc4db55b936"

--- a/detection-rules/self_sender_cred_theft_short_path_link.yml
+++ b/detection-rules/self_sender_cred_theft_short_path_link.yml
@@ -1,10 +1,10 @@
-name: "Link: Single character path with credential theft body and self sender behavior"
-description: "Detects messages sent to oneself containing links with single character paths and credential theft language, commonly used to bypass security filters and deliver malicious content."
+name: "Link: Single character path with credential theft body and self sender behavior or invalid recipient"
+description: "Message where the sender and recipient are the same or the recipient domain is invalid, contains a link with a single character path and no query parameters or fragments, and includes credential theft language."
 type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  // self sender
+  // self sender or invaild recipent domain
   and length(recipients.to) == 1
   and (
     sender.email.email == recipients.to[0].email.email

--- a/detection-rules/self_sender_cred_theft_short_path_link.yml
+++ b/detection-rules/self_sender_cred_theft_short_path_link.yml
@@ -1,4 +1,4 @@
-name: "Link: Self-sent credential theft with single character path"
+name: "Link: Single character path with credential theft body and self sender behavior"
 description: "Detects messages sent to oneself containing links with single character paths and credential theft language, commonly used to bypass security filters and deliver malicious content."
 type: "rule"
 severity: "medium"


### PR DESCRIPTION
# Description
Detects self sender messages containing links with single character paths and credential theft language.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50502d81795fd0676b115d5383b0990d7e62bf2c66e8cd54bdfa2d8aae8f5d34)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019db20b-61d2-7af8-bc66-776ab6b80b4f)
- Multi hunts inside ESC-11425
- Mode results look good
