### PR TITLE
Update spam detection rule for website spam errors

### DIFF
--- a/detection-rules/spam_website_errors_solicitation.yml
+++ b/detection-rules/spam_website_errors_solicitation.yml
@@ -4,126 +4,122 @@ type: "rule"
 severity: "low"
 source: |
  type.inbound
-  and not profile.by_sender().solicited
-  // no attachments
-  and length(attachments) == 0
-  // subject must contain SEO or web dev spam keywords or be short
-  and (
-    (
-      // SEO or web development service keywords
-      regex.icontains(strings.replace_confusables(subject.subject),
-                      '(?:proposal|cost|estimate|error|bug|audit|screenshot|strategy|rankings|issues|fix|website|design|review|price)'
-      )
-      or regex.icontains(subject.base,
-                         '[^\x{2600}-\x{27BF}\x{1F300}-\x{1F9FF}][\x{2600}-\x{27BF}\x{1F300}-\x{1F9FF}]\x{FE0F}?$'
-      )
-      // report and follow up keywords
-      or (
-        strings.icontains(strings.replace_confusables(subject.subject),
-                          "report"
-        )
-        and regex.icontains(strings.replace_confusables(body.current_thread.text
-                            ),
-                            "(?:free|send you|can i send|may i send|let me know|interested|get back to me|reply back|just reply)"
-        )
-      )
-      // short subject
-      or length(subject.base) < 5
-    )
-    // or a reply or forward in a thread that mentions website or screenshots
-    or (
-      (length(subject.base) < 5 or subject.is_reply or subject.is_forward)
-      and any(body.previous_threads,
-              regex.icontains(strings.replace_confusables(.text),
-                              "(?:screenshot|website)"
-              )
-      )
-    )
-  )
-  // body structure and content patterns
-  and (
-    // Single thread with no links
-    (
-      length(body.links) == 0
-      and length(body.previous_threads) == 0
-      // short message between 20 and 500 chars
-      and 20 < length(body.current_thread.text) < 500
-      // service offering keywords
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          "(?:available|screenshot|error list|plan|quote|rank|professional|price|mistake|visibility|improvement|review|emailed.{0,10}more details)"
-      )
-      // generic greeting
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          'h(?:i|ello|ey)\b'
-      )
-      // problem or urgency keywords
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          '(?:error|report|issues|website|repair|redesign|upgrade|Google\s+.{0,15}find it|glitch)'
-      )
-      // website or page mention
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          "(?:site|website|page)"
-      )
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          '(mail\.|mx|\.u)?\.?@?(aol|yahoo|hotmail|google|gmail|googlemail)\.com'
-      )
-    )
-    or any(body.links, regex.icontains(.display_text, '\.?@?(hotmail)\.com'))
-  )
-
-  // Single thread with unsubscribe link or $org_domains link
-  or (
-    length(body.links) <= 3
-    and (
-      // unsubscribe mailto link
-      regex.icontains(body.html.raw, "mailto:*[++unsubscribe@]")
-      // or link to found in org_domains
-      or any(body.links, .href_url.domain.root_domain in~ $org_domains)
-    )
-    and length(body.previous_threads) == 0
-    // short message between 20 and 500 chars
-    and 20 < length(body.current_thread.text) < 500
-    // service offering keywords
-    and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                        "(?:screenshot|error list|plan|quote|rank|professional|price|mistake)"
-    )
-    // generic greeting
-    and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                        '(?:h(?:i|ello|ey)|morning)\b'
-    )
-    // problem or urgency keywords
-    and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                        '(?:error|report|issues|website|repair|redesign|upgrade|Google\s+.{0,15}find it)'
-    )
-    // website or page mention
-    and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                        "(?:site|website|page)"
-    )
-  )
-  // Multiple thread messages
-  or (
-    length(body.links) == 0
-    // small thread with less than 5 messages
-    and length(body.previous_threads) < 5
-    // check previous messages for spam characteristics
-    and any(body.previous_threads,
-            // short previous messages less than 400 chars
-            length(.text) < 400
-            and (
-              // generic greeting
-              regex.icontains(strings.replace_confusables(.text),
-                              '(?:h(?:i|ello|ey)|morning)\b'
-              )
-              // service offering keywords
-              and regex.icontains(strings.replace_confusables(.text),
-                                  '(?:\berror(?:\s+list)?\b|screenshot|report|plan)'
-              )
-              // previous threads written in English
-              and ml.nlu_classifier(.text).language == "english"
-            )
-    )
-  )
-
+ and not profile.by_sender().solicited
+ // no attachments
+ and length(attachments) == 0
+ // subject must contain SEO or web dev spam keywords or be short
+ and (
+   (
+     // SEO or web development service keywords
+     regex.icontains(strings.replace_confusables(subject.subject),
+                     '(?:proposal|cost|estimate|error|bug|audit|screenshot|strategy|rankings|issues|fix|website|design|review|price)'
+     )
+     or regex.icontains(subject.base,
+                        '[^\x{2600}-\x{27BF}\x{1F300}-\x{1F9FF}][\x{2600}-\x{27BF}\x{1F300}-\x{1F9FF}]\x{FE0F}?$'
+     )
+     // report and follow up keywords
+     or (
+       strings.icontains(strings.replace_confusables(subject.subject), "report")
+       and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           "(?:free|send you|can i send|may i send|let me know|interested|get back to me|reply back|just reply)"
+       )
+     )
+     // short subject
+     or length(subject.base) < 5
+   )
+   // or a reply or forward in a thread that mentions website or screenshots
+   or (
+     (length(subject.base) < 5 or subject.is_reply or subject.is_forward)
+     and any(body.previous_threads,
+             regex.icontains(strings.replace_confusables(.text),
+                             "(?:screenshot|website)"
+             )
+     )
+   )
+ )
+ // body structure and content patterns
+ and (
+   // Single thread with no links
+   (
+     length(body.links) == 0
+     and length(body.previous_threads) == 0
+     // short message between 20 and 500 chars
+     and 20 < length(body.current_thread.text) < 500
+     // service offering keywords
+     and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                         "(?:available|screenshot|error list|plan|quote|rank|professional|price|mistake|visibility|improvement|review|emailed.{0,10}more details)"
+     )
+     // generic greeting
+     and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                         'h(?:i|ello|ey)\b'
+     )
+     // problem or urgency keywords
+     and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                         '(?:error|report|issues|website|repair|redesign|upgrade|Google\s+.{0,15}find it|glitch)'
+     )
+     // website or page mention
+     and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                         "(?:site|website|page)"
+     )
+     and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                         '(mail\.|mx|\.u)?\.?@?(aol|yahoo|hotmail|google|gmail|googlemail)\.com'
+     )
+   )
+   or any(body.links, regex.icontains(.display_text, '\.?@?(hotmail)\.com'))
+ )
+ 
+ // Single thread with unsubscribe link or $org_domains link
+ or (
+   length(body.links) <= 3
+   and (
+     // unsubscribe mailto link
+     regex.icontains(body.html.raw, "mailto:*[++unsubscribe@]")
+     // or link to found in org_domains
+     or any(body.links, .href_url.domain.root_domain in~ $org_domains)
+   )
+   and length(body.previous_threads) == 0
+   // short message between 20 and 500 chars
+   and 20 < length(body.current_thread.text) < 500
+   // service offering keywords
+   and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                       "(?:screenshot|error list|plan|quote|rank|professional|price|mistake)"
+   )
+   // generic greeting
+   and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                       '(?:h(?:i|ello|ey)|morning)\b'
+   )
+   // problem or urgency keywords
+   and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                       '(?:error|report|issues|website|repair|redesign|upgrade|Google\s+.{0,15}find it)'
+   )
+   // website or page mention
+   and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                       "(?:site|website|page)"
+   )
+ )
+ // Multiple thread messages
+ or (
+   length(body.links) == 0
+   // small thread with less than 5 messages
+   and length(body.previous_threads) < 5
+   // check previous messages for spam characteristics
+   and any(body.previous_threads,
+           // short previous messages less than 400 chars
+           length(.text) < 400
+           and (
+             // generic greeting
+             regex.icontains(strings.replace_confusables(.text),
+                             '(?:h(?:i|ello|ey)|morning)\b'
+             )
+             // service offering keywords
+             and regex.icontains(strings.replace_confusables(.text),
+                                 '(?:\berror(?:\s+list)?\b|screenshot|report|plan)'
+             )
+             // previous threads written in English
+             and ml.nlu_classifier(.text).language == "english"
+           )
+   )
+ )
 tags:
   - "Attack surface reduction"
 attack_types:

--- a/detection-rules/spam_website_errors_solicitation.yml
+++ b/detection-rules/spam_website_errors_solicitation.yml
@@ -4,121 +4,121 @@ type: "rule"
 severity: "low"
 source: |
  type.inbound
-  and not profile.by_sender().solicited
-  // no attachments
-  and length(attachments) == 0
-  // subject must contain SEO or web dev spam keywords or be short
-  and (
-    (
-      // SEO or web development service keywords
-      regex.icontains(strings.replace_confusables(subject.subject),
-                      '(?:proposal|cost|estimate|error|bug|audit|screenshot|strategy|rankings|issues|fix|website|design|review|price)'
-      )
-      or regex.icontains(subject.base,
-                         '[^\x{2600}-\x{27BF}\x{1F300}-\x{1F9FF}][\x{2600}-\x{27BF}\x{1F300}-\x{1F9FF}]\x{FE0F}?$'
-      )
-      // report and follow up keywords
-      or (
-        strings.icontains(strings.replace_confusables(subject.subject), "report")
-        and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                            "(?:free|send you|can i send|may i send|let me know|interested|get back to me|reply back|just reply)"
-        )
-      )
-      // short subject
-      or length(subject.base) < 5
-    )
-    // or a reply or forward in a thread that mentions website or screenshots
-    or (
-      (length(subject.base) < 5 or subject.is_reply or subject.is_forward)
-      and any(body.previous_threads,
-              regex.icontains(strings.replace_confusables(.text),
-                              "(?:screenshot|website)"
-              )
-      )
-    )
-  )
-  // body structure and content patterns
-  and (
-    // Single thread with no links
-    (
-      length(body.links) == 0
-      and length(body.previous_threads) == 0
-      // short message between 20 and 500 chars
-      and 20 < length(body.current_thread.text) < 500
-      // service offering keywords
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          "(?:available|screenshot|error list|plan|quote|rank|professional|price|mistake|visibility|improvement|review|emailed.{0,10}more details)"
-      )
-      // generic greeting
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          'h(?:i|ello|ey)\b'
-      )
-      // problem or urgency keywords
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          '(?:error|report|issues|website|repair|redesign|upgrade|Google\s+.{0,15}find it|glitch)'
-      )
-      // website or page mention
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          "(?:site|website|page)"
-      )
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          '(mail\.|mx|\.u)?\.?@?(aol|yahoo|hotmail|google|gmail|googlemail)\.com'
-      )
-    )
-    or any(body.links, regex.icontains(.display_text, '\.?@?(hotmail)\.com'))
-    )
-    // Single thread with unsubscribe link or $org_domains link
-    or (
-      length(body.links) <= 3
-      and (
-        // unsubscribe mailto link
-        regex.icontains(body.html.raw, "mailto:*[++unsubscribe@]")
-        // or link to found in org_domains
-        or any(body.links, .href_url.domain.root_domain in~ $org_domains)
-      )
-      and length(body.previous_threads) == 0
-      // short message between 20 and 500 chars
-      and 20 < length(body.current_thread.text) < 500
-      // service offering keywords
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          "(?:screenshot|error list|plan|quote|rank|professional|price|mistake)"
-      )
-      // generic greeting
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          '(?:h(?:i|ello|ey)|morning)\b'
-      )
-      // problem or urgency keywords
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          '(?:error|report|issues|website|repair|redesign|upgrade|Google\s+.{0,15}find it)'
-      )
-      // website or page mention
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          "(?:site|website|page)"
-      )
-    // Multiple thread messages
-    or (
-      length(body.links) == 0
-      // small thread with less than 5 messages
-      and length(body.previous_threads) < 5
-      // check previous messages for spam characteristics
-      and any(body.previous_threads,
-              // short previous messages less than 400 chars
-              length(.text) < 400
-              and (
-                // generic greeting
-                regex.icontains(strings.replace_confusables(.text),
-                                '(?:h(?:i|ello|ey)|morning)\b'
-                )
-                // service offering keywords
-                and regex.icontains(strings.replace_confusables(.text),
-                                    '(?:\berror(?:\s+list)?\b|screenshot|report|plan)'
-                )
-                // previous threads written in English
-                and ml.nlu_classifier(.text).language == "english"
-              )
-      )
-    )
-  )
+ and not profile.by_sender().solicited
+ // no attachments
+ and length(attachments) == 0
+ // subject must contain SEO or web dev spam keywords or be short
+ and (
+   (
+     // SEO or web development service keywords
+     regex.icontains(strings.replace_confusables(subject.subject),
+                     '(?:proposal|cost|estimate|error|bug|audit|screenshot|strategy|rankings|issues|fix|website|design|review|price)'
+     )
+     or regex.icontains(subject.base,
+                        '[^\x{2600}-\x{27BF}\x{1F300}-\x{1F9FF}][\x{2600}-\x{27BF}\x{1F300}-\x{1F9FF}]\x{FE0F}?$'
+     )
+     // report and follow up keywords
+     or (
+       strings.icontains(strings.replace_confusables(subject.subject), "report")
+       and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           "(?:free|send you|can i send|may i send|let me know|interested|get back to me|reply back|just reply)"
+       )
+     )
+     // short subject
+     or length(subject.base) < 5
+   )
+   // or a reply or forward in a thread that mentions website or screenshots
+   or (
+     (length(subject.base) < 5 or subject.is_reply or subject.is_forward)
+     and any(body.previous_threads,
+             regex.icontains(strings.replace_confusables(.text),
+                             "(?:screenshot|website)"
+             )
+     )
+   )
+ )
+ // body structure and content patterns
+ and (
+   // Single thread with no links
+   (
+     length(body.links) == 0
+     and length(body.previous_threads) == 0
+     // short message between 20 and 500 chars
+     and 20 < length(body.current_thread.text) < 500
+     // service offering keywords
+     and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                         "(?:available|screenshot|error list|plan|quote|rank|professional|price|mistake|visibility|improvement|review|emailed.{0,10}more details)"
+     )
+     // generic greeting
+     and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                         'h(?:i|ello|ey)\b'
+     )
+     // problem or urgency keywords
+     and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                         '(?:error|report|issues|website|repair|redesign|upgrade|Google\s+.{0,15}find it|glitch)'
+     )
+     // website or page mention
+     and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                         "(?:site|website|page)"
+     )
+     and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                         '(mail\.|mx|\.u)?\.?@?(aol|yahoo|hotmail|google|gmail|googlemail)\.com'
+     )
+   )
+   or any(body.links, regex.icontains(.display_text, '\.?@?(hotmail)\.com'))
+ )
+ // Single thread with unsubscribe link or $org_domains link
+ or (
+   length(body.links) <= 3
+   and (
+     // unsubscribe mailto link
+     regex.icontains(body.html.raw, "mailto:*[++unsubscribe@]")
+     // or link to found in org_domains
+     or any(body.links, .href_url.domain.root_domain in~ $org_domains)
+   )
+   and length(body.previous_threads) == 0
+   // short message between 20 and 500 chars
+   and 20 < length(body.current_thread.text) < 500
+   // service offering keywords
+   and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                       "(?:screenshot|error list|plan|quote|rank|professional|price|mistake)"
+   )
+   // generic greeting
+   and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                       '(?:h(?:i|ello|ey)|morning)\b'
+   )
+   // problem or urgency keywords
+   and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                       '(?:error|report|issues|website|repair|redesign|upgrade|Google\s+.{0,15}find it)'
+   )
+   // website or page mention
+   and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                       "(?:site|website|page)"
+   )
+   // Multiple thread messages
+   or (
+     length(body.links) == 0
+     // small thread with less than 5 messages
+     and length(body.previous_threads) < 5
+     // check previous messages for spam characteristics
+     and any(body.previous_threads,
+             // short previous messages less than 400 chars
+             length(.text) < 400
+             and (
+               // generic greeting
+               regex.icontains(strings.replace_confusables(.text),
+                               '(?:h(?:i|ello|ey)|morning)\b'
+               )
+               // service offering keywords
+               and regex.icontains(strings.replace_confusables(.text),
+                                   '(?:\berror(?:\s+list)?\b|screenshot|report|plan)'
+               )
+               // previous threads written in English
+               and ml.nlu_classifier(.text).language == "english"
+             )
+     )
+   )
+ )
 tags:
   - "Attack surface reduction"
 attack_types:

--- a/detection-rules/spam_website_errors_solicitation.yml
+++ b/detection-rules/spam_website_errors_solicitation.yml
@@ -3,7 +3,7 @@ description: "This rule detects messages claiming to have identified errors on a
 type: "rule"
 severity: "low"
 source: |
-  type.inbound
+ type.inbound
   and not profile.by_sender().solicited
   // no attachments
   and length(attachments) == 0
@@ -19,8 +19,11 @@ source: |
       )
       // report and follow up keywords
       or (
-        strings.icontains(strings.replace_confusables(subject.subject), "report")
-        and regex.icontains(strings.replace_confusables(body.current_thread.text),
+        strings.icontains(strings.replace_confusables(subject.subject),
+                          "report"
+        )
+        and regex.icontains(strings.replace_confusables(body.current_thread.text
+                            ),
                             "(?:free|send you|can i send|may i send|let me know|interested|get back to me|reply back|just reply)"
         )
       )
@@ -47,7 +50,7 @@ source: |
       and 20 < length(body.current_thread.text) < 500
       // service offering keywords
       and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          "(?:screenshot|error list|plan|quote|rank|professional|price|mistake|visibility|improvement|review|emailed.{0,10}more details)"
+                          "(?:available|screenshot|error list|plan|quote|rank|professional|price|mistake|visibility|improvement|review|emailed.{0,10}more details)"
       )
       // generic greeting
       and regex.icontains(strings.replace_confusables(body.current_thread.text),
@@ -61,58 +64,63 @@ source: |
       and regex.icontains(strings.replace_confusables(body.current_thread.text),
                           "(?:site|website|page)"
       )
-    )
-    // Single thread with unsubscribe link or $org_domains link
-    or (
-      length(body.links) <= 3
-      and (
-        // unsubscribe mailto link
-        regex.icontains(body.html.raw, "mailto:*[++unsubscribe@]")
-        // or link to found in org_domains
-        or any(body.links, .href_url.domain.root_domain in~ $org_domains)
-      )
-      and length(body.previous_threads) == 0
-      // short message between 20 and 500 chars
-      and 20 < length(body.current_thread.text) < 500
-      // service offering keywords
       and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          "(?:screenshot|error list|plan|quote|rank|professional|price|mistake)"
-      )
-      // generic greeting
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          '(?:h(?:i|ello|ey)|morning)\b'
-      )
-      // problem or urgency keywords
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          '(?:error|report|issues|website|repair|redesign|upgrade|Google\s+.{0,15}find it)'
-      )
-      // website or page mention
-      and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          "(?:site|website|page)"
+                          '(mail\.|mx|\.u)?\.?@?(aol|yahoo|hotmail|google|gmail|googlemail)\.com'
       )
     )
-    // Multiple thread messages
-    or (
-      length(body.links) == 0
-      // small thread with less than 5 messages
-      and length(body.previous_threads) < 5
-      // check previous messages for spam characteristics
-      and any(body.previous_threads,
-              // short previous messages less than 400 chars
-              length(.text) < 400
-              and (
-                // generic greeting
-                regex.icontains(strings.replace_confusables(.text),
-                                '(?:h(?:i|ello|ey)|morning)\b'
-                )
-                // service offering keywords
-                and regex.icontains(strings.replace_confusables(.text),
-                                    '(?:\berror(?:\s+list)?\b|screenshot|report|plan)'
-                )
-                // previous threads written in English
-                and ml.nlu_classifier(.text).language == "english"
+    or any(body.links, regex.icontains(.display_text, '\.?@?(hotmail)\.com'))
+  )
+
+  // Single thread with unsubscribe link or $org_domains link
+  or (
+    length(body.links) <= 3
+    and (
+      // unsubscribe mailto link
+      regex.icontains(body.html.raw, "mailto:*[++unsubscribe@]")
+      // or link to found in org_domains
+      or any(body.links, .href_url.domain.root_domain in~ $org_domains)
+    )
+    and length(body.previous_threads) == 0
+    // short message between 20 and 500 chars
+    and 20 < length(body.current_thread.text) < 500
+    // service offering keywords
+    and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        "(?:screenshot|error list|plan|quote|rank|professional|price|mistake)"
+    )
+    // generic greeting
+    and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '(?:h(?:i|ello|ey)|morning)\b'
+    )
+    // problem or urgency keywords
+    and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        '(?:error|report|issues|website|repair|redesign|upgrade|Google\s+.{0,15}find it)'
+    )
+    // website or page mention
+    and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                        "(?:site|website|page)"
+    )
+  )
+  // Multiple thread messages
+  or (
+    length(body.links) == 0
+    // small thread with less than 5 messages
+    and length(body.previous_threads) < 5
+    // check previous messages for spam characteristics
+    and any(body.previous_threads,
+            // short previous messages less than 400 chars
+            length(.text) < 400
+            and (
+              // generic greeting
+              regex.icontains(strings.replace_confusables(.text),
+                              '(?:h(?:i|ello|ey)|morning)\b'
               )
-      )
+              // service offering keywords
+              and regex.icontains(strings.replace_confusables(.text),
+                                  '(?:\berror(?:\s+list)?\b|screenshot|report|plan)'
+              )
+              // previous threads written in English
+              and ml.nlu_classifier(.text).language == "english"
+            )
     )
   )
 

--- a/detection-rules/spam_website_errors_solicitation.yml
+++ b/detection-rules/spam_website_errors_solicitation.yml
@@ -4,122 +4,121 @@ type: "rule"
 severity: "low"
 source: |
  type.inbound
- and not profile.by_sender().solicited
- // no attachments
- and length(attachments) == 0
- // subject must contain SEO or web dev spam keywords or be short
- and (
-   (
-     // SEO or web development service keywords
-     regex.icontains(strings.replace_confusables(subject.subject),
-                     '(?:proposal|cost|estimate|error|bug|audit|screenshot|strategy|rankings|issues|fix|website|design|review|price)'
-     )
-     or regex.icontains(subject.base,
-                        '[^\x{2600}-\x{27BF}\x{1F300}-\x{1F9FF}][\x{2600}-\x{27BF}\x{1F300}-\x{1F9FF}]\x{FE0F}?$'
-     )
-     // report and follow up keywords
-     or (
-       strings.icontains(strings.replace_confusables(subject.subject), "report")
-       and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                           "(?:free|send you|can i send|may i send|let me know|interested|get back to me|reply back|just reply)"
-       )
-     )
-     // short subject
-     or length(subject.base) < 5
-   )
-   // or a reply or forward in a thread that mentions website or screenshots
-   or (
-     (length(subject.base) < 5 or subject.is_reply or subject.is_forward)
-     and any(body.previous_threads,
-             regex.icontains(strings.replace_confusables(.text),
-                             "(?:screenshot|website)"
-             )
-     )
-   )
- )
- // body structure and content patterns
- and (
-   // Single thread with no links
-   (
-     length(body.links) == 0
-     and length(body.previous_threads) == 0
-     // short message between 20 and 500 chars
-     and 20 < length(body.current_thread.text) < 500
-     // service offering keywords
-     and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                         "(?:available|screenshot|error list|plan|quote|rank|professional|price|mistake|visibility|improvement|review|emailed.{0,10}more details)"
-     )
-     // generic greeting
-     and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                         'h(?:i|ello|ey)\b'
-     )
-     // problem or urgency keywords
-     and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                         '(?:error|report|issues|website|repair|redesign|upgrade|Google\s+.{0,15}find it|glitch)'
-     )
-     // website or page mention
-     and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                         "(?:site|website|page)"
-     )
-     and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                         '(mail\.|mx|\.u)?\.?@?(aol|yahoo|hotmail|google|gmail|googlemail)\.com'
-     )
-   )
-   or any(body.links, regex.icontains(.display_text, '\.?@?(hotmail)\.com'))
- )
- 
- // Single thread with unsubscribe link or $org_domains link
- or (
-   length(body.links) <= 3
-   and (
-     // unsubscribe mailto link
-     regex.icontains(body.html.raw, "mailto:*[++unsubscribe@]")
-     // or link to found in org_domains
-     or any(body.links, .href_url.domain.root_domain in~ $org_domains)
-   )
-   and length(body.previous_threads) == 0
-   // short message between 20 and 500 chars
-   and 20 < length(body.current_thread.text) < 500
-   // service offering keywords
-   and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                       "(?:screenshot|error list|plan|quote|rank|professional|price|mistake)"
-   )
-   // generic greeting
-   and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                       '(?:h(?:i|ello|ey)|morning)\b'
-   )
-   // problem or urgency keywords
-   and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                       '(?:error|report|issues|website|repair|redesign|upgrade|Google\s+.{0,15}find it)'
-   )
-   // website or page mention
-   and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                       "(?:site|website|page)"
-   )
- )
- // Multiple thread messages
- or (
-   length(body.links) == 0
-   // small thread with less than 5 messages
-   and length(body.previous_threads) < 5
-   // check previous messages for spam characteristics
-   and any(body.previous_threads,
-           // short previous messages less than 400 chars
-           length(.text) < 400
-           and (
-             // generic greeting
-             regex.icontains(strings.replace_confusables(.text),
-                             '(?:h(?:i|ello|ey)|morning)\b'
-             )
-             // service offering keywords
-             and regex.icontains(strings.replace_confusables(.text),
-                                 '(?:\berror(?:\s+list)?\b|screenshot|report|plan)'
-             )
-             // previous threads written in English
-             and ml.nlu_classifier(.text).language == "english"
-           )
-   )
- )
+  and not profile.by_sender().solicited
+  // no attachments
+  and length(attachments) == 0
+  // subject must contain SEO or web dev spam keywords or be short
+  and (
+    (
+      // SEO or web development service keywords
+      regex.icontains(strings.replace_confusables(subject.subject),
+                      '(?:proposal|cost|estimate|error|bug|audit|screenshot|strategy|rankings|issues|fix|website|design|review|price)'
+      )
+      or regex.icontains(subject.base,
+                         '[^\x{2600}-\x{27BF}\x{1F300}-\x{1F9FF}][\x{2600}-\x{27BF}\x{1F300}-\x{1F9FF}]\x{FE0F}?$'
+      )
+      // report and follow up keywords
+      or (
+        strings.icontains(strings.replace_confusables(subject.subject), "report")
+        and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                            "(?:free|send you|can i send|may i send|let me know|interested|get back to me|reply back|just reply)"
+        )
+      )
+      // short subject
+      or length(subject.base) < 5
+    )
+    // or a reply or forward in a thread that mentions website or screenshots
+    or (
+      (length(subject.base) < 5 or subject.is_reply or subject.is_forward)
+      and any(body.previous_threads,
+              regex.icontains(strings.replace_confusables(.text),
+                              "(?:screenshot|website)"
+              )
+      )
+    )
+  )
+  // body structure and content patterns
+  and (
+    // Single thread with no links
+    (
+      length(body.links) == 0
+      and length(body.previous_threads) == 0
+      // short message between 20 and 500 chars
+      and 20 < length(body.current_thread.text) < 500
+      // service offering keywords
+      and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                          "(?:available|screenshot|error list|plan|quote|rank|professional|price|mistake|visibility|improvement|review|emailed.{0,10}more details)"
+      )
+      // generic greeting
+      and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                          'h(?:i|ello|ey)\b'
+      )
+      // problem or urgency keywords
+      and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                          '(?:error|report|issues|website|repair|redesign|upgrade|Google\s+.{0,15}find it|glitch)'
+      )
+      // website or page mention
+      and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                          "(?:site|website|page)"
+      )
+      and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                          '(mail\.|mx|\.u)?\.?@?(aol|yahoo|hotmail|google|gmail|googlemail)\.com'
+      )
+    )
+    or any(body.links, regex.icontains(.display_text, '\.?@?(hotmail)\.com'))
+    )
+    // Single thread with unsubscribe link or $org_domains link
+    or (
+      length(body.links) <= 3
+      and (
+        // unsubscribe mailto link
+        regex.icontains(body.html.raw, "mailto:*[++unsubscribe@]")
+        // or link to found in org_domains
+        or any(body.links, .href_url.domain.root_domain in~ $org_domains)
+      )
+      and length(body.previous_threads) == 0
+      // short message between 20 and 500 chars
+      and 20 < length(body.current_thread.text) < 500
+      // service offering keywords
+      and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                          "(?:screenshot|error list|plan|quote|rank|professional|price|mistake)"
+      )
+      // generic greeting
+      and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                          '(?:h(?:i|ello|ey)|morning)\b'
+      )
+      // problem or urgency keywords
+      and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                          '(?:error|report|issues|website|repair|redesign|upgrade|Google\s+.{0,15}find it)'
+      )
+      // website or page mention
+      and regex.icontains(strings.replace_confusables(body.current_thread.text),
+                          "(?:site|website|page)"
+      )
+    // Multiple thread messages
+    or (
+      length(body.links) == 0
+      // small thread with less than 5 messages
+      and length(body.previous_threads) < 5
+      // check previous messages for spam characteristics
+      and any(body.previous_threads,
+              // short previous messages less than 400 chars
+              length(.text) < 400
+              and (
+                // generic greeting
+                regex.icontains(strings.replace_confusables(.text),
+                                '(?:h(?:i|ello|ey)|morning)\b'
+                )
+                // service offering keywords
+                and regex.icontains(strings.replace_confusables(.text),
+                                    '(?:\berror(?:\s+list)?\b|screenshot|report|plan)'
+                )
+                // previous threads written in English
+                and ml.nlu_classifier(.text).language == "english"
+              )
+      )
+    )
+  )
 tags:
   - "Attack surface reduction"
 attack_types:


### PR DESCRIPTION
# Description
Adding `body.text and display.text` to cover additional FN coverage for website error email samples. 

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/5041f686f2ac15e16516a973c94ea52459bf499ff0ea64724a3d1756c6543071)

# Associated hunts
- [NetNewCoverage90days](https://platform.sublime.security/messages/hunt?huntId=019db220-8318-7484-8061-77610c7f16e3)
