### PR TITLE
test: does CI validate dlp-discovery-rules?

### DIFF
--- a/dlp-discovery-rules/dlp_test_broken_mql.yml
+++ b/dlp-discovery-rules/dlp_test_broken_mql.yml
@@ -1,0 +1,6 @@
+name: "TEST: Broken MQL"
+description: Intentionally broken rule to test CI validation.
+type: rule
+severity: high
+source: |
+  this is not valid mql at all


### PR DESCRIPTION
Intentionally broken MQL — do not merge, testing CI coverage of dlp-discovery-rules.