### PR TITLE
Update credential_phishing_one_drive_impersonation.yml

### DIFF
--- a/detection-rules/credential_phishing_one_drive_impersonation.yml
+++ b/detection-rules/credential_phishing_one_drive_impersonation.yml
@@ -95,7 +95,7 @@ source: |
       "sharepointonline.com",
       "yammer.com",
     )
-    and headers.auth_summary.dmarc.pass
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
   
   // negate highly trusted sender domains unless they fail DMARC authentication

--- a/detection-rules/credential_phishing_one_drive_impersonation.yml
+++ b/detection-rules/credential_phishing_one_drive_impersonation.yml
@@ -13,20 +13,32 @@ source: |
                                   "one?drive"
       ) < 2
       or any(attachments,
-             regex.icontains(.file_name, '[0o]ne\s?dr[il1]ve')
-             and not any(file.explode(.),
-                         any(.scan.exiftool.fields,
-                             .key == "Model"
-                             or (
-                               .key == "Software"
-                               and strings.starts_with(.value, "Android")
-                             )
-                         )
-                         // exclude images taken with mobile cameras and screenshots from Apple
-                         or any(.scan.exiftool.fields,
-                                .key == "DeviceManufacturer"
-                                and .value == "Apple Computer Inc."
-                         )
+             (
+               regex.icontains(.file_name, '[0o]ne\s?dr[il1]ve')
+               and not any(file.explode(.),
+                           any(.scan.exiftool.fields,
+                               .key == "Model"
+                               or (
+                                 .key == "Software"
+                                 and strings.starts_with(.value, "Android")
+                               )
+                           )
+                           // exclude images taken with mobile cameras and screenshots from Apple
+                           or any(.scan.exiftool.fields,
+                                  .key == "DeviceManufacturer"
+                                  and .value == "Apple Computer Inc."
+                           )
+               )
+             )
+             // pdf with OneDrive impersonation
+             or (
+               .file_type == "pdf"
+               and any(ml.logo_detect(.).brands, .name == "Microsoft")
+               and any(file.explode(.),
+                       any(.scan.strings.strings,
+                           strings.icontains(., "shared a file")
+                       )
+               )
              )
       )
     )
@@ -71,28 +83,28 @@ source: |
     )
   )
   and length(body.links) < 10
-  and sender.email.domain.root_domain not in (
-    "bing.com",
-    "microsoft.com",
-    "microsoftonline.com",
-    "microsoftsupport.com",
-    "microsoft365.com",
-    "office.com",
-    "onedrive.com",
-    "sharepointonline.com",
-    "yammer.com",
+  and not (
+    sender.email.domain.root_domain in (
+      "bing.com",
+      "microsoft.com",
+      "microsoftonline.com",
+      "microsoftsupport.com",
+      "microsoft365.com",
+      "office.com",
+      "onedrive.com",
+      "sharepointonline.com",
+      "yammer.com",
+    )
+    and headers.auth_summary.dmarc.pass
   )
   
   // negate highly trusted sender domains unless they fail DMARC authentication
-  and (
-    (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and not headers.auth_summary.dmarc.pass
-    )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
   
-  // excludes docusign senders that contain "via" in the display name 
+  // excludes docusign senders that contain "via" in the display name
   and not (
     any(headers.hops,
         any(.fields,
@@ -102,6 +114,7 @@ source: |
     and strings.contains(sender.display_name, "via")
   )
   and not profile.by_sender().any_messages_benign
+
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description
added an additional OR statement looking for OneDrive impersonation in PDF files, added auth check to sender root domain negation and updated high trust root domain negation to commonly used snippet

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

[- Sample 1](https://platform.sublime.security/messages/50564645acfb18b83fd23979f513e6032a0ffa5e3c0faec8dba53694a37f382f)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019dceed-4162-7bcb-8ac9-508f3dc0fd87)

