### PR TITLE
Update attachment_userinfo_qr.yml

### DIFF
--- a/detection-rules/attachment_userinfo_qr.yml
+++ b/detection-rules/attachment_userinfo_qr.yml
@@ -28,6 +28,9 @@ source: |
                   and not any(recipients.cc,
                               .email.domain.root_domain == ..scan.qr.url.domain.root_domain
                   )
+                  // an error to strings.parse_email returns null for the full object
+                  // this cehck ensures that the url is not a valid email address
+                  and strings.parse_email(.scan.qr.url.url).email is null
           )
   )
   and not profile.by_sender_email().any_messages_benign


### PR DESCRIPTION
# Description

Discovered during the review of #4139 this PR resolves FPs when matching on QR codes that resolve to an email address, which are determined to be a URL. 


## Associated hunts

Samples that will no longer match
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019dbb64-72e4-738c-8fd5-6f39b6fdd690)
