### PR TITLE
Create subject_fake_zoom_link.yml

### DIFF
--- a/detection-rules/subject_fake_zoom_link.yml
+++ b/detection-rules/subject_fake_zoom_link.yml
@@ -1,7 +1,7 @@
 name: "Subject: Fake Zoom meeting link"
 description: "Detects messages with Zoom meeting links containing password parameters in the subject line from non-Zoom domains, commonly used to impersonate legitimate Zoom invitations."
 type: "rule"
-severity: ""
+severity: "high"
 source: |
   type.inbound
   and regex.icontains(subject.subject, 'https://[^\s]*zoom[^\s]*pwd=')

--- a/detection-rules/subject_fake_zoom_link.yml
+++ b/detection-rules/subject_fake_zoom_link.yml
@@ -16,3 +16,4 @@ detection_methods:
   - "Content analysis"
   - "Header analysis"
   - "URL analysis"
+id: "a6887acc-a539-51dd-98b3-70cc59389334"

--- a/detection-rules/subject_fake_zoom_link.yml
+++ b/detection-rules/subject_fake_zoom_link.yml
@@ -1,0 +1,18 @@
+name: "Subject: Fake Zoom meeting link"
+description: "Detects messages with Zoom meeting links containing password parameters in the subject line from non-Zoom domains, commonly used to impersonate legitimate Zoom invitations."
+type: "rule"
+severity: ""
+source: |
+  type.inbound
+  and regex.icontains(subject.subject, 'https://[^\s]*zoom[^\s]*pwd=')
+  and not strings.icontains(subject.subject, 'zoom.us')
+
+attack_types:
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "URL analysis"

--- a/detection-rules/subject_fake_zoom_link.yml
+++ b/detection-rules/subject_fake_zoom_link.yml
@@ -5,7 +5,8 @@ severity: "high"
 source: |
   type.inbound
   and regex.icontains(subject.subject, 'https://[^\s]*zoom[^\s]*pwd=')
-  and not strings.icontains(subject.subject, 'zoom.us')
+  // negate real zoom links
+  and not regex.icontains(subject.subject, 'https://(?:[a-z0-9-]+\.)?zoom\.us/j/[0-9]{9,11}\?pwd=\S+')
 
 attack_types:
   - "Malware/Ransomware"
@@ -17,3 +18,4 @@ detection_methods:
   - "Header analysis"
   - "URL analysis"
 id: "a6887acc-a539-51dd-98b3-70cc59389334"
+https://test.zoom.us/j/81040211814?pwd=abZ1D4Gyya94K6NRI8c5EEhCm1OqTa.1&jst=2

--- a/detection-rules/subject_fake_zoom_link.yml
+++ b/detection-rules/subject_fake_zoom_link.yml
@@ -6,8 +6,9 @@ source: |
   type.inbound
   and regex.icontains(subject.subject, 'https://[^\s]*zoom[^\s]*pwd=')
   // negate real zoom links
-  and not regex.icontains(subject.subject, 'https://(?:[a-z0-9-]+\.)?zoom\.us/j/[0-9]{9,11}\?pwd=\S+')
-
+  and not regex.icontains(subject.subject,
+                          'https://(?:[a-z0-9-]+\.)?zoom\.us/j/[0-9]{9,11}\?pwd=\S+'
+  )
 attack_types:
   - "Malware/Ransomware"
 tactics_and_techniques:

--- a/detection-rules/subject_fake_zoom_link.yml
+++ b/detection-rules/subject_fake_zoom_link.yml
@@ -18,4 +18,3 @@ detection_methods:
   - "Header analysis"
   - "URL analysis"
 id: "a6887acc-a539-51dd-98b3-70cc59389334"
-https://test.zoom.us/j/81040211814?pwd=abZ1D4Gyya94K6NRI8c5EEhCm1OqTa.1&jst=2


### PR DESCRIPTION
# Description
Detects messages with Zoom meeting links containing password parameters in the subject line from non-Zoom domains, commonly used to impersonate legitimate Zoom invitations.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50555d88e52c7eab460accb287a1b8423da96da33f51382334720365c53d9f28)


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019dbc43-c40c-7c6f-911a-5bade116b7b0)
- Multi-hunts are in ESC-11810

