### PR TITLE
Update impersonation_spotify.yml

### DIFF
--- a/detection-rules/impersonation_spotify.yml
+++ b/detection-rules/impersonation_spotify.yml
@@ -11,6 +11,12 @@ source: |
     strings.ilike(sender.display_name, '*spotify*')
     or strings.ilevenshtein(sender.display_name, 'spotify') <= 1
     or strings.ilike(sender.email.domain.domain, '*spotify*')
+    or (
+      strings.icontains(body.current_thread.text, 'Spotify AB')
+      and any(ml.logo_detect(file.message_screenshot()).brands,
+              .name == "Spotify" and .confidence != "low"
+      )
+    )
   )
   and sender.email.domain.root_domain not in~ (
     'spotify.com',

--- a/detection-rules/impersonation_spotify.yml
+++ b/detection-rules/impersonation_spotify.yml
@@ -12,7 +12,7 @@ source: |
     or strings.ilevenshtein(sender.display_name, 'spotify') <= 1
     or strings.ilike(sender.email.domain.domain, '*spotify*')
     or (
-      strings.icontains(body.current_thread.text, 'Spotify AB')
+      regex.icontains(body.current_thread.text, 'Spotify AB\b')
       and any(ml.logo_detect(file.message_screenshot()).brands,
               .name == "Spotify" and .confidence != "low"
       )


### PR DESCRIPTION
# Description

Adding condition to look for `Spotify AB` and a Spotify logo in the `body.current_thread.text`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5057a9723d19b0f31cac5808224836c7c97b363afc563b56ebd14d699b08bd48?preview_id=019dbcd8-d035-74e5-9811-e6c6a0e0f0ec)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L60D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019dcf64-4523-7a9f-b578-60ad65ed74c3)
- [L14D 50 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/5ae1b626-1322-446a-b3cd-0668119061e3)