### PR TITLE
Create link_sus_binary_path.yml

### DIFF
--- a/detection-rules/link_sus_binary_path.yml
+++ b/detection-rules/link_sus_binary_path.yml
@@ -1,0 +1,17 @@
+name: "Link: Suspicious URL pattern with binary character sequence in href_url.path"
+description: "Detects inbound messages containing links with URLs that follow a specific suspicious pattern: starting with a forward slash, followed by a digit, uppercase letter, alphanumeric characters, a hyphen, more alphanumeric characters, and ending with exactly five binary digits (0s and 1s)."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(body.links,
+          regex.contains(.href_url.path,
+                         '^\/[0-9][A-Z][a-z0-9]+\-[a-z0-9]+[01]{5}$'
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+detection_methods:
+  - "URL analysis"

--- a/detection-rules/link_sus_binary_path.yml
+++ b/detection-rules/link_sus_binary_path.yml
@@ -1,4 +1,4 @@
-name: "Link: Suspicious URL pattern with binary character sequence in href_url.path"
+name: "Link: Suspicious URL path with binary character sequence"
 description: "Detects inbound messages containing links with URLs that follow a specific suspicious pattern: starting with a forward slash, followed by a digit, uppercase letter, alphanumeric characters, a hyphen, more alphanumeric characters, and ending with exactly five binary digits (0s and 1s)."
 type: "rule"
 severity: "medium"

--- a/detection-rules/link_sus_binary_path.yml
+++ b/detection-rules/link_sus_binary_path.yml
@@ -15,3 +15,4 @@ tactics_and_techniques:
   - "Evasion"
 detection_methods:
   - "URL analysis"
+id: "e366f316-6e63-593f-aaeb-330ec90fb845"


### PR DESCRIPTION
# Description

Found while looking for IOCs, this is a "sister" rule to https://github.com/sublime-security/sublime-rules/blob/main/detection-rules/link_html_frag_binary_end.yml which appears closely related. 

This rule looks for a specific pattern within the path of the link. 

This actor/tool seems to target personal email addresses instead of corporate email address. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

This sample demonstrates the actor using both style of links in the message.
- [Sample 1](https://platform.sublime.security/messages/5057bb190a1f1273ab7f486f07dd1432e28bcc17bf19eb4d2d2fd8d9404387a9?preview_id=019dc148-b1db-7888-b77c-414a01359980)


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Multihunt 1](https://hunt.limeseed.email/hunts/af7fc0ef-5d3e-420a-885a-4a4efbf68208)
