### PR TITLE
Refactor suspicious_request_for_quote_or_purchase.yml

### DIFF
--- a/detection-rules/suspicious_request_for_quote_or_purchase.yml
+++ b/detection-rules/suspicious_request_for_quote_or_purchase.yml
@@ -29,8 +29,6 @@ source: |
       and all(headers.reply_to,
               .email.domain.root_domain != sender.email.domain.root_domain
               and not .email.domain.root_domain in $org_domains
-              // wetransfer includes user specific reply-to's & link display text which triggers NLU logic further within the rule
-              and not sender.email.domain.root_domain == "wetransfer.com"
       )
     )
     or (
@@ -52,35 +50,35 @@ source: |
   and (
     // Group the keyword patterns that specifically indicate RFQ/RFP
     (
-      1 of (
+      (
         // RFQ/RFP specific language patterns
         regex.icontains(body.current_thread.text,
                         '(discuss.{0,15}purchas(e|ing))'
-        ),
-        regex.icontains(body.current_thread.text,
-                        '(sign(ed?)|view).{0,10}(purchase order)|Request for (a Quot(e|ation)|Proposal)'
-        ),
-        regex.icontains(body.current_thread.text,
-                        '(please|kindly).{0,30}(?:proposal|quot(e|ation))'
-        ),
-        regex.icontains(subject.subject,
-                        '(request for (purchase|quot(e|ation))|\bRFQ\b|\bRFP\b|bid invit(e|ation))'
-        ),
-        any(attachments,
-            regex.icontains(.file_name, "(purchase.?order|Quot(e|ation))")
-        ),
-        any(ml.nlu_classifier(body.current_thread.text).tags,
-            .name == "purchase_order" and .confidence == "high"
-        ),
-        any(ml.nlu_classifier(body.current_thread.text).entities,
-            .name == "financial" and regex.imatch(.text, "rfp|rfq")
-        ),
-        any(ml.nlu_classifier(body.current_thread.text).entities,
-            .name == "request" and strings.icontains(.text, 'submit bid')
+        )
+        or regex.icontains(body.current_thread.text,
+                           '(sign(ed?)|view).{0,10}(purchase order)|Request for (a Quot(e|ation)|Proposal)'
+        )
+        or regex.icontains(body.current_thread.text,
+                           '(please|kindly).{0,30}(?:proposal|quot(e|ation))'
+        )
+        or regex.icontains(subject.subject,
+                           '(request for (purchase|quot(e|ation))|\bRFQ\b|\bRFP\b|bid invit(e|ation))'
+        )
+        or any(attachments,
+               regex.icontains(.file_name, "(purchase.?order|Quot(e|ation))")
+        )
+        or any(ml.nlu_classifier(body.current_thread.text).tags,
+               .name == "purchase_order" and .confidence == "high"
+        )
+        or any(ml.nlu_classifier(body.current_thread.text).entities,
+               .name == "financial" and regex.imatch(.text, "rfp|rfq")
+        )
+        or any(ml.nlu_classifier(body.current_thread.text).entities,
+               .name == "request" and strings.icontains(.text, 'submit bid')
         )
       )
       // Required: at least one RFQ/RFP keyword pattern
-  
+
       // Optional: at least one additional indicator (can be another keyword pattern or a non-keyword indicator)
       and (
         2 of (
@@ -109,7 +107,7 @@ source: |
           any(ml.nlu_classifier(body.current_thread.text).entities,
               .name == "financial" and regex.imatch(.text, "rfp|rfq")
           ),
-  
+
           // Non-keyword indicators
           (
             any(ml.nlu_classifier(body.current_thread.text).entities,
@@ -118,7 +116,7 @@ source: |
             and any(ml.nlu_classifier(body.current_thread.text).entities,
                     .name == "urgency"
             )
-            and not any(beta.ml_topic(body.current_thread.text).topics,
+            and not any(ml.nlu_classifier(body.current_thread.text).topics,
                         .name == "Advertising and Promotions"
                         and .confidence == "high"
             )
@@ -186,8 +184,20 @@ source: |
               )
       )
     )
+    // fake PDF file icon used as a link lure with bid solicitation language
+    or (
+      regex.icontains(subject.subject, 'project\s+summary')
+      and any(html.xpath(body.html, '//div[.//img[contains(@src,"pdf")]]//a').nodes,
+              regex.icontains(.display_text, 'project\s+summary')
+      )
+      and regex.icontains(body.current_thread.text,
+                          '(put a bid|\bbid\s+(for|on)\b|submit.{1,20}(bid|quot(e|ation))|request for (purchase|quot(e|ation))|\bRFQ\b|\bRFP\b|project\s+summary)'
+      )
+    )
   )
-  
+  // wetransfer includes user specific reply-to's & link display text which triggers NLU logic further within the rule
+  and not sender.email.domain.root_domain == "wetransfer.com"
+
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (

--- a/detection-rules/suspicious_request_for_quote_or_purchase.yml
+++ b/detection-rules/suspicious_request_for_quote_or_purchase.yml
@@ -196,7 +196,10 @@ source: |
     )
   )
   // wetransfer includes user specific reply-to's & link display text which triggers NLU logic further within the rule
-  and not sender.email.domain.root_domain == "wetransfer.com"
+  and not (
+    sender.email.domain.root_domain == "wetransfer.com"
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
 
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (


### PR DESCRIPTION
# Description

noticed these fns sneaking through the cracks that should be hitting the RFP/RFQ rule. I might create some net-new coverage for this but we're good for the time being getting coverage out the door in this rule. also updating some deprecated function calls, reformatting a 1 of, and moving an arrant negation from within an "or" to the negations section of the rule. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50419b72c2d047e1ead62dc84469b6dacb6afc6825d260d41a9a7df5439f8ed5?preview_id=019dca3c-d063-7c49-8f14-de67891f6036)
- [Sample 2](https://platform.sublime.security/messages/4f98c90397efdd0dc63ba0d2afd69c56f41d53c0d480bc9a019ff535c7f35b30?preview_id=0199e929-ab5a-73a4-b1a5-ebe4e2a3a35f)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Net new multihunt](https://hunt.limeseed.email/hunts/b4a4c93d-8bd9-4491-b12c-ea65764fd982)
- [Net new hunt in shared samples L60D](https://platform.sublime.security/messages/hunt?huntId=019dcae3-95af-7f38-923a-9295701f3d9e)