### PR TITLE
Update self_sender_cred_theft_auth_failures.yml

### DIFF
--- a/detection-rules/self_sender_cred_theft_auth_failures.yml
+++ b/detection-rules/self_sender_cred_theft_auth_failures.yml
@@ -18,8 +18,8 @@ source: |
   )
   // microsoft compauth pass, but spf and dmarc fail
   and any(headers.hops, any(.fields, strings.icontains(.value, 'compauth=pass')))
-  and not headers.auth_summary.dmarc.pass
-  and not headers.auth_summary.spf.pass
+  and not coalesce(headers.auth_summary.dmarc.pass, false)
+  and not coalesce(headers.auth_summary.spf.pass, false)
 tags:
   - "Attack surface reduction"
 attack_types:


### PR DESCRIPTION
# Description
re-add coalesce to account for null auth summary 
