### PR TITLE
Create link_googletagmanager_debugcookie.yml

### DIFF
--- a/detection-rules/link_googletagmanager_debugcookie.yml
+++ b/detection-rules/link_googletagmanager_debugcookie.yml
@@ -22,3 +22,4 @@ tactics_and_techniques:
 detection_methods:
   - "URL analysis"
   - "Content analysis"
+id: "a69a939a-7c2d-537d-b476-ac99daf6d3d9"

--- a/detection-rules/link_googletagmanager_debugcookie.yml
+++ b/detection-rules/link_googletagmanager_debugcookie.yml
@@ -1,0 +1,24 @@
+name: "Service abuse: Google Tag Manager debug cookie clearing with open redirect potential"
+description: "Detects messages containing links to Google Tag Manager's debug cookie clearing endpoint with suspicious URL parameters that may be exploited for open redirects, or links that have been rewritten through Google Tag Manager encoding methods."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(body.links,
+          (
+            .href_url.domain.root_domain == "googletagmanager.com"
+            and .href_url.path == "/debug/clearcookies"
+            and any(.href_url.query_params_decoded["url"],
+                    strings.parse_url(.).domain.valid
+            )
+          )
+          or any(.href_url.rewrite.encoders, . == "google_tag_manager")
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Open redirect"
+  - "Service abuse"
+detection_methods:
+  - "URL analysis"
+  - "Content analysis"

--- a/detection-rules/link_googletagmanager_debugcookie.yml
+++ b/detection-rules/link_googletagmanager_debugcookie.yml
@@ -12,7 +12,7 @@ source: |
                     strings.parse_url(.).domain.valid
             )
           )
-          or any(.href_url.rewrite.encoders, . == "google_tag_manager")
+          or 'google_tag_manager' in .href_url.rewrite.encoders
   )
 attack_types:
   - "Credential Phishing"


### PR DESCRIPTION
# Description

Add detection rule for observed Google Tag Manager abuse with open redirect

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/505a7ac5b742c75d641a304406bfebad14532e5c19fce51b25751f0506d60105?preview_id=019dcd11-915e-7341-a902-e42aa85b2db0)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt L365](https://platform.sublime.security/messages/hunt?huntId=019dcf7e-5b70-70dc-91ca-1747dbd0e399)
- [Multihunt](https://hunt.limeseed.email/hunts/ea815ab1-d4e3-45c2-a682-3642b2dbf44a)
