### PR TITLE
Update link_credential_phishing_cloud_service.yml

### DIFF
--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -13,12 +13,15 @@ source: |
           .name == 'cred_theft' and .confidence == 'high'
   )
   and any(ml.nlu_classifier(body.current_thread.text).topics,
-          .name == 'File Sharing and Cloud Services' and .confidence == 'high'
+          .name in ('File Sharing and Cloud Services', 'Payment Information')
+          and .confidence == 'high'
   )
   // sender domain matches no body domains
   and length(body.links) > 0
   and all(body.links,
-          .href_url.domain.root_domain != sender.email.domain.root_domain
+          .href_url.domain.root_domain != coalesce(sender.email.domain.root_domain,
+                                                   ""
+          )
   )
   // negate legit cloud companies
   and not (


### PR DESCRIPTION
# Description

Adding logic to account for when the value for sender email is empty and include `Payment Information` as a nlu topic

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5059d14b41f00a1e60d52ae1bccdfb0345891be9a365c51478347d0e7905bc19?preview_id=019dca46-401a-70a8-afc6-d69c77a6771a)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019dd4b1-be18-77a3-b40e-fd38ed88b63a)
- [L14D 50 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/90deb3e4-572e-41c1-907c-1372f1ac6c02)