### PR TITLE
Update spam_website_errors_solicitation.yml

### DIFF
--- a/detection-rules/spam_website_errors_solicitation.yml
+++ b/detection-rules/spam_website_errors_solicitation.yml
@@ -41,7 +41,6 @@ source: |
   and (
     // Single thread with no links
     (
-      // Single thread with no links
       length(filter(body.current_thread.links,
                     not (.href_url.scheme == "mailto" and .parser == "plain")
              )

--- a/detection-rules/spam_website_errors_solicitation.yml
+++ b/detection-rules/spam_website_errors_solicitation.yml
@@ -19,11 +19,8 @@ source: |
       )
       // report and follow up keywords
       or (
-        strings.icontains(strings.replace_confusables(subject.subject),
-                          "report"
-        )
-        and regex.icontains(strings.replace_confusables(body.current_thread.text
-                            ),
+        strings.icontains(strings.replace_confusables(subject.subject), "report")
+        and regex.icontains(strings.replace_confusables(body.current_thread.text),
                             "(?:free|send you|can i send|may i send|let me know|interested|get back to me|reply back|just reply)"
         )
       )

--- a/detection-rules/spam_website_errors_solicitation.yml
+++ b/detection-rules/spam_website_errors_solicitation.yml
@@ -19,8 +19,11 @@ source: |
       )
       // report and follow up keywords
       or (
-        strings.icontains(strings.replace_confusables(subject.subject), "report")
-        and regex.icontains(strings.replace_confusables(body.current_thread.text),
+        strings.icontains(strings.replace_confusables(subject.subject),
+                          "report"
+        )
+        and regex.icontains(strings.replace_confusables(body.current_thread.text
+                            ),
                             "(?:free|send you|can i send|may i send|let me know|interested|get back to me|reply back|just reply)"
         )
       )
@@ -39,6 +42,7 @@ source: |
   )
   // body structure and content patterns
   and (
+    // Single thread with no links
     (
       // Single thread with no links
       length(filter(body.current_thread.links,
@@ -67,17 +71,12 @@ source: |
     )
     // Single thread with unsubscribe link or $org_domains link
     or (
-      length(filter(body.current_thread.links,
-                    not (.href_url.scheme == "mailto" and .parser == "plain")
-             )
-      ) == 0
+      length(body.links) <= 3
       and (
         // unsubscribe mailto link
         regex.icontains(body.html.raw, "mailto:*[++unsubscribe@]")
         // or link to found in org_domains
-        or any(body.current_thread.links,
-               .href_url.domain.root_domain in~ $org_domains
-        )
+        or any(body.links, .href_url.domain.root_domain in~ $org_domains)
       )
       and length(body.previous_threads) == 0
       // short message between 20 and 500 chars
@@ -101,10 +100,7 @@ source: |
     )
     // Multiple thread messages
     or (
-      length(filter(body.current_thread.links,
-                    not (.href_url.scheme == "mailto" and .parser == "plain")
-             )
-      ) == 0
+      length(body.links) == 0
       // small thread with less than 5 messages
       and length(body.previous_threads) < 5
       // check previous messages for spam characteristics

--- a/detection-rules/spam_website_errors_solicitation.yml
+++ b/detection-rules/spam_website_errors_solicitation.yml
@@ -19,8 +19,11 @@ source: |
       )
       // report and follow up keywords
       or (
-        strings.icontains(strings.replace_confusables(subject.subject), "report")
-        and regex.icontains(strings.replace_confusables(body.current_thread.text),
+        strings.icontains(strings.replace_confusables(subject.subject),
+                          "report"
+        )
+        and regex.icontains(strings.replace_confusables(body.current_thread.text
+                            ),
                             "(?:free|send you|can i send|may i send|let me know|interested|get back to me|reply back|just reply)"
         )
       )
@@ -39,9 +42,12 @@ source: |
   )
   // body structure and content patterns
   and (
-    // Single thread with no links
     (
-      length(body.links) == 0
+      // Single thread with no links
+      length(filter(body.current_thread.links,
+                    not (.href_url.scheme == "mailto" and .parser == "plain")
+             )
+      ) == 0
       and length(body.previous_threads) == 0
       // short message between 20 and 500 chars
       and 20 < length(body.current_thread.text) < 500
@@ -64,12 +70,17 @@ source: |
     )
     // Single thread with unsubscribe link or $org_domains link
     or (
-      length(body.links) <= 3
+      length(filter(body.current_thread.links,
+                    not (.href_url.scheme == "mailto" and .parser == "plain")
+             )
+      ) == 0
       and (
         // unsubscribe mailto link
         regex.icontains(body.html.raw, "mailto:*[++unsubscribe@]")
         // or link to found in org_domains
-        or any(body.links, .href_url.domain.root_domain in~ $org_domains)
+        or any(body.current_thread.links,
+               .href_url.domain.root_domain in~ $org_domains
+        )
       )
       and length(body.previous_threads) == 0
       // short message between 20 and 500 chars
@@ -93,7 +104,10 @@ source: |
     )
     // Multiple thread messages
     or (
-      length(body.links) == 0
+      length(filter(body.current_thread.links,
+                    not (.href_url.scheme == "mailto" and .parser == "plain")
+             )
+      ) == 0 
       // small thread with less than 5 messages
       and length(body.previous_threads) < 5
       // check previous messages for spam characteristics
@@ -115,7 +129,6 @@ source: |
       )
     )
   )
-
 tags:
   - "Attack surface reduction"
 attack_types:

--- a/detection-rules/spam_website_errors_solicitation.yml
+++ b/detection-rules/spam_website_errors_solicitation.yml
@@ -19,11 +19,8 @@ source: |
       )
       // report and follow up keywords
       or (
-        strings.icontains(strings.replace_confusables(subject.subject),
-                          "report"
-        )
-        and regex.icontains(strings.replace_confusables(body.current_thread.text
-                            ),
+        strings.icontains(strings.replace_confusables(subject.subject), "report")
+        and regex.icontains(strings.replace_confusables(body.current_thread.text),
                             "(?:free|send you|can i send|may i send|let me know|interested|get back to me|reply back|just reply)"
         )
       )
@@ -107,7 +104,7 @@ source: |
       length(filter(body.current_thread.links,
                     not (.href_url.scheme == "mailto" and .parser == "plain")
              )
-      ) == 0 
+      ) == 0
       // small thread with less than 5 messages
       and length(body.previous_threads) < 5
       // check previous messages for spam characteristics


### PR DESCRIPTION
# Description

Enabled more coverage by  calculating the length of the body links to not included "plain text floating email addresses" to count towards the count

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/505ad1c31bb24d24c09536097dc41cc5b612b3a11a09554727a5b7828a76a8bf?preview_id=019dcfe1-26f1-708a-8510-092ee8293481)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Net New Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019dd3f1-9052-744c-9b01-39458e07bd83)

