### PR TITLE
Update attachment_pdf_sus_string_single_url.yml

### DIFF
--- a/detection-rules/attachment_pdf_sus_string_single_url.yml
+++ b/detection-rules/attachment_pdf_sus_string_single_url.yml
@@ -33,6 +33,7 @@ source: |
                                       'DOCUMENT PREVIEW',
                                       'PREVIEW DOCUMENT',
                                       'VIEW REMITTANCE COPY HERE',
+                                      'shared a file with you'
                       )
                   )
                   // fake error messages


### PR DESCRIPTION
# Description

add "shared a file" to the sus phrases on PDFs with a single link. 

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New](https://platform.sublime.security/messages/hunt?huntId=019dd0cb-b85d-7240-b690-640d7741fbe5)
- [L30D Multihunt](https://hunt.limeseed.email/hunts/dbdfb0fc-c6f8-445b-97e7-dc59146ebedf)