### PR TITLE
Update attachment_pdf_skia_headless.yml

### DIFF
--- a/detection-rules/attachment_pdf_skia_headless.yml
+++ b/detection-rules/attachment_pdf_skia_headless.yml
@@ -9,16 +9,26 @@ source: |
           and beta.parse_exif(.).page_count == 1
           and (
             // MD5 filename, 32 hex chars and .html
-            regex.imatch(beta.parse_exif(.).title, '^[a-f0-9]{32}\.html$')
-            or 
-            // about:blank and Windows HeadlessChrome 
             (
-              beta.parse_exif(.).title == "about:blank"
-              and strings.istarts_with(beta.parse_exif(.).producer, "Skia/PDF")
-              and strings.icontains(beta.parse_exif(.).creator, "Windows")
+              regex.imatch(beta.parse_exif(.).title, '^[a-f0-9]{32}\.html$')
+              or 
+              // about:blank and Windows HeadlessChrome
+              (
+                beta.parse_exif(.).title == "about:blank"
+                and strings.istarts_with(beta.parse_exif(.).producer, "Skia/PDF")
+                and strings.icontains(beta.parse_exif(.).creator, "Windows")
+              )
+              // cred theft intents on the message and Windows Headless Chrome
+              or (
+                any(ml.nlu_classifier(body.current_thread.text).intents,
+                    .name == "cred_theft" and .confidence != "low"
+                )
+                and strings.istarts_with(beta.parse_exif(.).producer, "Skia/PDF")
+                and strings.icontains(beta.parse_exif(.).creator, "Windows")
+              )
             )
+            and not strings.icontains(beta.parse_exif(.).producer, "Google Docs")
           )
-          and not strings.icontains(beta.parse_exif(.).producer, "Google Docs")
   )
   and not (
     sender.email.domain.root_domain in (
@@ -29,6 +39,7 @@ source: |
     )
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
+
 tags:
 - "Attack surface reduction"
 attack_types:


### PR DESCRIPTION
# Description
adding an additional OR statement to look for NLU cred theft intents with an attached headless Chrome PDF 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/eml-analyzer?message_id=019dd523-bddf-7d2f-9acd-2d9038385728&attachment_sha_256=e8a9f49372abd6530da1896932a63890c2e439846612a5afe752817ad93d4830)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019ddfb3-25b8-7397-a7f7-df6184f80e79) - net new hunts
- [multihunt results](https://hunt.limeseed.email/hunts/new?from=0cf034dd-c933-4114-ae3b-f7db0aaeb8dc)

