### PR TITLE
Enhance UPS impersonation detection rules

### DIFF
--- a/detection-rules/impersonation_ups.yml
+++ b/detection-rules/impersonation_ups.yml
@@ -19,11 +19,16 @@ source: |
     or regex.icontains(sender.display_name,
                        "U[^a-zA-Z]P[^a-zA-Z]S(?:[^a-zA-Z]|$)"
     )
+    or strings.icontains(body.html.raw, 'background-color:#351d20')
+    or strings.icontains(body.html.raw, 'background-color: #351d20')
   )
   and (
     // Observed in the "footer" of impersation messages
     // added this due to the UPS image not loading on some emails
     strings.icontains(body.current_thread.text, "United Parcel Service of")
+    or regex.icontains(body.current_thread.text,
+                       "(©|®).{0,15}(?:U.?P.?S.?|United Parcel Service)"
+    )
     or any(ml.logo_detect(file.message_screenshot()).brands, .name is not null)
   )
   and sender.email.email not in $recipient_emails


### PR DESCRIPTION
# Description

Added additional conditions to detect UPS impersonation emails based on suspicious background colors and footer text.

# Associated samples
- https://platform.sublime.security/messages/502cf3840636bc8b31bbe269acc407c328ef0083a33b2299997cdc04d1d536c9?preview_id=019ce3eb-3537-7b55-9693-9a8b4ebd65d0

## Associated hunts
- 
