### PR TITLE
Create evasion_excessive_image_padding_cred_theft.yml

### DIFF
--- a/detection-rules/evasion_excessive_image_padding_cred_theft.yml
+++ b/detection-rules/evasion_excessive_image_padding_cred_theft.yml
@@ -1,4 +1,4 @@
-name: "Link: Credential harvesting with image padding evasion"
+name: "Link: Credential harvesting with excess padding evasion"
 description: "Detects inbound messages containing credential-related action links with tall screenshot images and HTML padding techniques used to evade detection. The rule identifies messages with excessive empty div tags, non-breaking spaces, or large margin-top values that artificially increase content height while hiding malicious intent."
 type: "rule"
 severity: "high"

--- a/detection-rules/evasion_excessive_image_padding_cred_theft.yml
+++ b/detection-rules/evasion_excessive_image_padding_cred_theft.yml
@@ -1,0 +1,45 @@
+name: "Link: Credential harvesting with image padding evasion"
+description: "Detects inbound messages containing credential-related action links with tall screenshot images and HTML padding techniques used to evade detection. The rule identifies messages with excessive empty div tags, non-breaking spaces, or large margin-top values that artificially increase content height while hiding malicious intent."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(body.current_thread.links,
+          regex.icontains(.display_text,
+                          '(?:open|view|click|sign|log.?in|retain|credential|document|review|release|verify|confirm|secure|accept)'
+          )
+  )
+  and beta.parse_exif(file.message_screenshot()).image_height > 1500
+  and beta.parse_exif(file.message_screenshot()).image_height * 100 / regex.count(body.html.display_text,
+                                                                                  '\S+'
+  ) > 500
+  and (
+    regex.icontains(body.html.raw, '(?:<div>\s*<br\s*/?\s*>\s*</div>\s*){30,}')
+    or regex.icontains(body.html.raw,
+                       '(?:<div\s+style="[^"]+"\s*[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}'
+    )
+    or regex.icontains(body.html.raw,
+                       '(?:<p>\s*(?:&nbsp;|&#160;)\s*</p>\s*){25,}'
+    )
+    or (
+      regex.icontains(body.html.raw,
+                      'margin-top\s*:\s*(?:1[5-9]\d{2}|[2-9]\d{3}|\d{5,})px'
+      )
+      and not regex.icontains(body.html.raw,
+                              'position\s*:\s*absolute[^"]*margin-top\s*:\s*(?:1[5-9]\d{2}|[2-9]\d{3}|\d{5,})px'
+      )
+      and not regex.icontains(body.html.raw,
+                              'margin-left\s*:\s*\d{3,}px[^"]*margin-top\s*:\s*(?:1[5-9]\d{2}|[2-9]\d{3}|\d{5,})px'
+      )
+    )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "HTML analysis"
+  - "Exif analysis"
+  - "URL screenshot"

--- a/detection-rules/evasion_excessive_image_padding_cred_theft.yml
+++ b/detection-rules/evasion_excessive_image_padding_cred_theft.yml
@@ -43,3 +43,4 @@ detection_methods:
   - "HTML analysis"
   - "Exif analysis"
   - "URL screenshot"
+id: "5591f618-aed0-579d-9875-cdebdd72c6d2"

--- a/detection-rules/evasion_excessive_image_padding_cred_theft.yml
+++ b/detection-rules/evasion_excessive_image_padding_cred_theft.yml
@@ -4,7 +4,6 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  
   // CTA link with action-oriented display text pointing to a different domain than the sender
   and any(body.current_thread.links,
           regex.icontains(.display_text,
@@ -12,28 +11,23 @@ source: |
           )
           and .href_url.domain.root_domain != sender.email.domain.root_domain
   )
-  
   // tall rendered email with low word density
   and beta.parse_exif(file.message_screenshot()).image_height > 1500
   and beta.parse_exif(file.message_screenshot()).image_height * 100 / regex.count(body.html.display_text,
                                                                                   '\S+'
   ) > 500
-  
   // html whitespace stuffing patterns
   and (
     // bare div-br blocks repeated 30+ times
     regex.icontains(body.html.raw, '(?:<div>\s*<br\s*/?\s*>\s*</div>\s*){30,}')
-  
     // style div-br blocks repeated 20+ times
     or regex.icontains(body.html.raw,
                        '(?:<div\s+style="[^"]+"\s*[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}'
     )
-  
     // p-nbsp blocks repeated 25+ times
     or regex.icontains(body.html.raw,
                        '(?:<p>\s*(?:&nbsp;|&#160;)\s*</p>\s*){25,}'
     )
-  
     // css margin-top pushdown >= 1500px
     or (
       regex.icontains(body.html.raw,

--- a/detection-rules/evasion_excessive_image_padding_cred_theft.yml
+++ b/detection-rules/evasion_excessive_image_padding_cred_theft.yml
@@ -4,23 +4,37 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
+  
+  // CTA link with action-oriented display text pointing to a different domain than the sender
   and any(body.current_thread.links,
           regex.icontains(.display_text,
-                          '(?:open|view|click|sign|log.?in|retain|credential|document|review|release|verify|confirm|secure|accept)'
+                          '(?:open|sign.?in|log.?in|retain|credential|secure|confirm|accept|release|document)'
           )
+          and .href_url.domain.root_domain != sender.email.domain.root_domain
   )
+  
+  // tall rendered email with low word density
   and beta.parse_exif(file.message_screenshot()).image_height > 1500
   and beta.parse_exif(file.message_screenshot()).image_height * 100 / regex.count(body.html.display_text,
                                                                                   '\S+'
   ) > 500
+  
+  // html whitespace stuffing patterns
   and (
+    // bare div-br blocks repeated 30+ times
     regex.icontains(body.html.raw, '(?:<div>\s*<br\s*/?\s*>\s*</div>\s*){30,}')
+  
+    // style div-br blocks repeated 20+ times
     or regex.icontains(body.html.raw,
                        '(?:<div\s+style="[^"]+"\s*[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}'
     )
+  
+    // p-nbsp blocks repeated 25+ times
     or regex.icontains(body.html.raw,
                        '(?:<p>\s*(?:&nbsp;|&#160;)\s*</p>\s*){25,}'
     )
+  
+    // css margin-top pushdown >= 1500px
     or (
       regex.icontains(body.html.raw,
                       'margin-top\s*:\s*(?:1[5-9]\d{2}|[2-9]\d{3}|\d{5,})px'
@@ -33,6 +47,7 @@ source: |
       )
     )
   )
+
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description

Identified a pattern that is not fully covered by this rule but wanted to get something out the door and get a couple of other similar rules like this. This attempts to identify suspicious messages that then bury unrelated emails after a bunch of whitespace padding. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/501ffcea2660c79097e0c0b4090a073feede41332781e4eca056939ed0e446c0?preview_id=019cb4f0-0777-7679-ab14-d8f2b4de0e7b)
- [Sample 2](https://platform.sublime.security/messages/505d2c0c08569663317ae77b11b78750f34b83f11087680cddd947dd4c4517cd?preview_id=019de3f1-f58c-71db-9e65-0d450047488a)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [multihunt 30 days](https://hunt.limeseed.email/hunts/1e79892c-2317-480e-a34b-4ff3d57c3b49)
- [shared sampels matches after multihunt results have been shared L60D](https://platform.sublime.security/messages/hunt?huntId=019de4c3-797e-7867-aae9-b3d3ff5e6a0c)