### PR TITLE
fix: Move inline MQL comments off operator lines

### DIFF
--- a/detection-rules/abused_payoneer_callback.yml
+++ b/detection-rules/abused_payoneer_callback.yml
@@ -16,19 +16,23 @@ source: |
         or regex.icontains(strings.replace_confusables(body.current_thread.text),
                            '.*\+[ilo0-9]{1,3}[ilo0-9]{10}.*\n'
         )
-        or // +12028001238
+        // +12028001238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
         )
-        or // 202-800-1238
+        // 202-800-1238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
-        or // (202) 800-1238
+        // (202) 800-1238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
         )
-        or // (202)-800-1238
+        // (202)-800-1238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )

--- a/detection-rules/abused_payoneer_callback.yml
+++ b/detection-rules/abused_payoneer_callback.yml
@@ -17,24 +17,20 @@ source: |
                            '.*\+[ilo0-9]{1,3}[ilo0-9]{10}.*\n'
         )
         // +12028001238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
         )
         // 202-800-1238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
         // (202) 800-1238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
         )
         // (202)-800-1238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
         or ( // 8123456789
           regex.icontains(strings.replace_confusables(body.current_thread.text),

--- a/detection-rules/bec_student_loan_callback_scam.yml
+++ b/detection-rules/bec_student_loan_callback_scam.yml
@@ -25,23 +25,28 @@ source: |
     or regex.contains(strings.replace_confusables(body.current_thread.text),
                       '\+\d{1,3}[ilo0-9]{10}'
     )
-    or // +12028001238
+    // +12028001238
+    or
    regex.contains(strings.replace_confusables(body.current_thread.text),
                   '[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}'
     )
-    or // 202.800.1238
+    // 202.800.1238
+    or
    regex.contains(strings.replace_confusables(body.current_thread.text),
                   '[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}'
     )
-    or // 202-800-1238
+    // 202-800-1238
+    or
    regex.contains(strings.replace_confusables(body.current_thread.text),
                   '\([ilo0-9]{3}\)\s[ilo0-9]{3}-[ilo0-9]{4}'
     )
-    or // (202) 800-1238
+    // (202) 800-1238
+    or
    regex.contains(strings.replace_confusables(body.current_thread.text),
                   '\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}'
     )
-    or // (202)-800-1238
+    // (202)-800-1238
+    or
    regex.contains(strings.replace_confusables(body.current_thread.text),
                   '1 [ilo0-9]{3} [ilo0-9]{3} [ilo0-9]{4}'
     ) // 8123456789

--- a/detection-rules/bec_student_loan_callback_scam.yml
+++ b/detection-rules/bec_student_loan_callback_scam.yml
@@ -7,7 +7,7 @@ source: |
   // there is no HTML body
   and body.html.raw is null
   
-  // but the current thread contains what's most likely an html tag 
+  // but the current thread contains what's most likely an html tag
   // (eg. <>'s' followed by a closing </> )
   and regex.contains(body.current_thread.text, '<[^>]+>.*?</[^>]+>')
   
@@ -26,29 +26,24 @@ source: |
                       '\+\d{1,3}[ilo0-9]{10}'
     )
     // +12028001238
-    or
-   regex.contains(strings.replace_confusables(body.current_thread.text),
-                  '[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}'
+    or regex.contains(strings.replace_confusables(body.current_thread.text),
+                      '[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}'
     )
     // 202.800.1238
-    or
-   regex.contains(strings.replace_confusables(body.current_thread.text),
-                  '[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}'
+    or regex.contains(strings.replace_confusables(body.current_thread.text),
+                      '[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}'
     )
     // 202-800-1238
-    or
-   regex.contains(strings.replace_confusables(body.current_thread.text),
-                  '\([ilo0-9]{3}\)\s[ilo0-9]{3}-[ilo0-9]{4}'
+    or regex.contains(strings.replace_confusables(body.current_thread.text),
+                      '\([ilo0-9]{3}\)\s[ilo0-9]{3}-[ilo0-9]{4}'
     )
     // (202) 800-1238
-    or
-   regex.contains(strings.replace_confusables(body.current_thread.text),
-                  '\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}'
+    or regex.contains(strings.replace_confusables(body.current_thread.text),
+                      '\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}'
     )
     // (202)-800-1238
-    or
-   regex.contains(strings.replace_confusables(body.current_thread.text),
-                  '1 [ilo0-9]{3} [ilo0-9]{3} [ilo0-9]{4}'
+    or regex.contains(strings.replace_confusables(body.current_thread.text),
+                      '1 [ilo0-9]{3} [ilo0-9]{3} [ilo0-9]{4}'
     ) // 8123456789
     or regex.contains(strings.replace_confusables(body.current_thread.text),
                       '8\d{9}'

--- a/detection-rules/brand_impersonation_sharepoint_pdf_cred_theft.yml
+++ b/detection-rules/brand_impersonation_sharepoint_pdf_cred_theft.yml
@@ -27,8 +27,7 @@ source: |
         and strings.ends_with(headers.message_id, '@odspnotify>')
       )
       // negate legitimate access request to file
-      or
-   (
+      or (
         strings.starts_with(headers.message_id, '<Sharing')
         and strings.ends_with(headers.message_id, '@odspnotify>')
       )
@@ -85,7 +84,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/brand_impersonation_sharepoint_pdf_cred_theft.yml
+++ b/detection-rules/brand_impersonation_sharepoint_pdf_cred_theft.yml
@@ -26,7 +26,8 @@ source: |
         strings.starts_with(headers.message_id, '<Share-')
         and strings.ends_with(headers.message_id, '@odspnotify>')
       )
-      or // negate legitimate access request to file
+      // negate legitimate access request to file
+      or
    (
         strings.starts_with(headers.message_id, '<Sharing')
         and strings.ends_with(headers.message_id, '@odspnotify>')

--- a/detection-rules/callback_phishing_intuit.yml
+++ b/detection-rules/callback_phishing_intuit.yml
@@ -53,23 +53,28 @@ source: |
       or regex.icontains(strings.replace_confusables(body.html.inner_text),
                          '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+\+\d{1,3}[ilo0-9]{10}.*\n'
       )
-      or // +12028001238
+      // +12028001238
+      or
    regex.icontains(strings.replace_confusables(body.html.inner_text),
                    '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
       )
-      or // 202-800-1238
+      // 202-800-1238
+      or
    regex.icontains(strings.replace_confusables(body.html.inner_text),
                    '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
       )
-      or // (202) 800-1238
+      // (202) 800-1238
+      or
    regex.icontains(strings.replace_confusables(body.html.inner_text),
                    '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
       )
-      or // (202)-800-1238
+      // (202)-800-1238
+      or
    regex.icontains(strings.replace_confusables(body.html.inner_text),
                    '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
       )
-      or // 202 800 1238
+      // 202 800 1238
+      or
    regex.icontains(strings.replace_confusables(body.html.inner_text),
                    '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+1\s?[ilo0-9]{3} [ilo0-9]{3} [ilo0-9]{4}.*\n'
       ) // 8123456789

--- a/detection-rules/callback_phishing_intuit.yml
+++ b/detection-rules/callback_phishing_intuit.yml
@@ -54,29 +54,24 @@ source: |
                          '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+\+\d{1,3}[ilo0-9]{10}.*\n'
       )
       // +12028001238
-      or
-   regex.icontains(strings.replace_confusables(body.html.inner_text),
-                   '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
+      or regex.icontains(strings.replace_confusables(body.html.inner_text),
+                         '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
       )
       // 202-800-1238
-      or
-   regex.icontains(strings.replace_confusables(body.html.inner_text),
-                   '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+      or regex.icontains(strings.replace_confusables(body.html.inner_text),
+                         '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
       )
       // (202) 800-1238
-      or
-   regex.icontains(strings.replace_confusables(body.html.inner_text),
-                   '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
+      or regex.icontains(strings.replace_confusables(body.html.inner_text),
+                         '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
       )
       // (202)-800-1238
-      or
-   regex.icontains(strings.replace_confusables(body.html.inner_text),
-                   '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+      or regex.icontains(strings.replace_confusables(body.html.inner_text),
+                         '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
       )
       // 202 800 1238
-      or
-   regex.icontains(strings.replace_confusables(body.html.inner_text),
-                   '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+1\s?[ilo0-9]{3} [ilo0-9]{3} [ilo0-9]{4}.*\n'
+      or regex.icontains(strings.replace_confusables(body.html.inner_text),
+                         '(?:Sold|Bill)[\s\xa0]To(?:\:\s+|\n)[^\n]+1\s?[ilo0-9]{3} [ilo0-9]{3} [ilo0-9]{4}.*\n'
       ) // 8123456789
       or (
         regex.icontains(strings.replace_confusables(body.html.inner_text),
@@ -98,7 +93,7 @@ source: |
                 and any(file.explode(.), .scan.exiftool.page_count < 3)
                 and any(file.explode(.), length(.scan.ocr.raw) > 60)
   
-                // 4 of the following strings are found        
+                // 4 of the following strings are found
                 and (
                   any(file.explode(.),
                       4 of (
@@ -129,7 +124,7 @@ source: |
                         )
                       )
   
-                      // 1 of the following strings is found, representing common Callback brands          
+                      // 1 of the following strings is found, representing common Callback brands
                       and (
                         1 of (
                           strings.icontains(.scan.ocr.raw, "geek squad"),
@@ -164,7 +159,7 @@ source: |
     )
   )
   
-  // 
+  //
   // This rule makes use of a beta feature and is subject to change without notice
   // using the beta feature in custom rules is not suggested until it has been formally released
   //

--- a/detection-rules/callback_phishing_sumup.yml
+++ b/detection-rules/callback_phishing_sumup.yml
@@ -21,24 +21,20 @@ source: |
                            '.*\+[ilo0-9]{1,3}[ilo0-9]{10}.*\n'
         )
         // +12028001238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
         )
         // 202-800-1238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
         // (202) 800-1238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
         )
         // (202)-800-1238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
         or ( // 8123456789
           regex.icontains(strings.replace_confusables(body.current_thread.text),
@@ -112,8 +108,6 @@ source: |
       )
     )
   )
-  
-
 attack_types:
   - "BEC/Fraud"
   - "Callback Phishing"

--- a/detection-rules/callback_phishing_sumup.yml
+++ b/detection-rules/callback_phishing_sumup.yml
@@ -20,19 +20,23 @@ source: |
         or regex.icontains(strings.replace_confusables(body.current_thread.text),
                            '.*\+[ilo0-9]{1,3}[ilo0-9]{10}.*\n'
         )
-        or // +12028001238
+        // +12028001238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
         )
-        or // 202-800-1238
+        // 202-800-1238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
-        or // (202) 800-1238
+        // (202) 800-1238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
         )
-        or // (202)-800-1238
+        // (202)-800-1238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )

--- a/detection-rules/callback_phishing_zelle.yml
+++ b/detection-rules/callback_phishing_zelle.yml
@@ -19,24 +19,20 @@ source: |
                          '.*\+[ilo0-9]{1,3}[ilo0-9]{10}.*'
       )
       // +12028001238
-      or
-   regex.icontains(strings.replace_confusables(subject.subject),
-                   '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*'
+      or regex.icontains(strings.replace_confusables(subject.subject),
+                         '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*'
       )
       // 202-800-1238
-      or
-   regex.icontains(strings.replace_confusables(subject.subject),
-                   '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*'
+      or regex.icontains(strings.replace_confusables(subject.subject),
+                         '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*'
       )
       // (202) 800-1238
-      or
-   regex.icontains(strings.replace_confusables(subject.subject),
-                   '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*'
+      or regex.icontains(strings.replace_confusables(subject.subject),
+                         '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*'
       )
       // (202)-800-1238
-      or
-   regex.icontains(strings.replace_confusables(subject.subject),
-                   '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*'
+      or regex.icontains(strings.replace_confusables(subject.subject),
+                         '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*'
       )
       or ( // 8123456789
         regex.icontains(strings.replace_confusables(subject.subject),
@@ -59,24 +55,20 @@ source: |
                            '\".*\+[ilo0-9]{1,3}[ilo0-9]{10}.*\"'
         )
         // +12028001238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '\".*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\"'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '\".*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\"'
         )
         // 202-800-1238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '\".*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\"'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '\".*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\"'
         )
         // (202) 800-1238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '\".*\([ilo0-9]{3}\)\s[ilo0-9]{3}-[ilo0-9]{4}.*\"'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '\".*\([ilo0-9]{3}\)\s[ilo0-9]{3}-[ilo0-9]{4}.*\"'
         )
         // (202)-800-1238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '\".*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\"'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '\".*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\"'
         )
         or ( // 8123456789
           regex.icontains(strings.replace_confusables(body.current_thread.text),

--- a/detection-rules/callback_phishing_zelle.yml
+++ b/detection-rules/callback_phishing_zelle.yml
@@ -18,19 +18,23 @@ source: |
       or regex.icontains(strings.replace_confusables(subject.subject),
                          '.*\+[ilo0-9]{1,3}[ilo0-9]{10}.*'
       )
-      or // +12028001238
+      // +12028001238
+      or
    regex.icontains(strings.replace_confusables(subject.subject),
                    '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*'
       )
-      or // 202-800-1238
+      // 202-800-1238
+      or
    regex.icontains(strings.replace_confusables(subject.subject),
                    '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*'
       )
-      or // (202) 800-1238
+      // (202) 800-1238
+      or
    regex.icontains(strings.replace_confusables(subject.subject),
                    '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*'
       )
-      or // (202)-800-1238
+      // (202)-800-1238
+      or
    regex.icontains(strings.replace_confusables(subject.subject),
                    '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*'
       )
@@ -54,19 +58,23 @@ source: |
         or regex.icontains(strings.replace_confusables(body.current_thread.text),
                            '\".*\+[ilo0-9]{1,3}[ilo0-9]{10}.*\"'
         )
-        or // +12028001238
+        // +12028001238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '\".*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\"'
         )
-        or // 202-800-1238
+        // 202-800-1238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '\".*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\"'
         )
-        or // (202) 800-1238
+        // (202) 800-1238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '\".*\([ilo0-9]{3}\)\s[ilo0-9]{3}-[ilo0-9]{4}.*\"'
         )
-        or // (202)-800-1238
+        // (202)-800-1238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '\".*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\"'
         )

--- a/detection-rules/canva_infra_abuse.yml
+++ b/detection-rules/canva_infra_abuse.yml
@@ -21,19 +21,23 @@ source: |
         or regex.icontains(strings.replace_confusables(body.current_thread.text),
                            '.*\+[ilo0-9]{1,3}[ilo0-9]{10}.*\n'
         )
-        or // +12028001238
+        // +12028001238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
         )
-        or // 202-800-1238
+        // 202-800-1238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
-        or // (202) 800-1238
+        // (202) 800-1238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
         )
-        or // (202)-800-1238
+        // (202)-800-1238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )

--- a/detection-rules/canva_infra_abuse.yml
+++ b/detection-rules/canva_infra_abuse.yml
@@ -22,24 +22,20 @@ source: |
                            '.*\+[ilo0-9]{1,3}[ilo0-9]{10}.*\n'
         )
         // +12028001238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
         )
         // 202-800-1238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
         // (202) 800-1238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
         )
         // (202)-800-1238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
         or ( // 8123456789
           regex.icontains(strings.replace_confusables(body.current_thread.text),
@@ -113,7 +109,6 @@ source: |
       )
     )
   )
-
 attack_types:
   - "BEC/Fraud"
   - "Callback Phishing"

--- a/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
+++ b/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
@@ -12,7 +12,8 @@ source: |
   )
   
   // and contains html or url encoded strings, hex escaped strings, opening or closing html tags, or escaped non word characters
-  and // subject contains common event handlers
+  // subject contains common event handlers
+  and
    regex.icontains(subject.subject,
                    '(?:\b|%[a-f0-9]{2})(?:on(?:abort|blur|change|click|dblclick|error|focus|load|mouse(?:over|out|move|down|up)|key(?:down|up|press)|reset|select|submit|unload)|srcdoc|src\s*(?:=|%(?:25)?3d))',
                    // subject contains javascript funcitons

--- a/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
+++ b/detection-rules/credential_phishing_cross_site_scripting_in_sub.yml
@@ -13,13 +13,12 @@ source: |
   
   // and contains html or url encoded strings, hex escaped strings, opening or closing html tags, or escaped non word characters
   // subject contains common event handlers
-  and
-   regex.icontains(subject.subject,
-                   '(?:\b|%[a-f0-9]{2})(?:on(?:abort|blur|change|click|dblclick|error|focus|load|mouse(?:over|out|move|down|up)|key(?:down|up|press)|reset|select|submit|unload)|srcdoc|src\s*(?:=|%(?:25)?3d))',
-                   // subject contains javascript funcitons
-                   '(?:\b|%(?:25)?[a-f0-9]{2})(?:javascript|eval|settimeout|setinterval|document\.(?:cookie|write|location|createElement|body|appendChild)|fetch|constructor|__proto__|prototype|atob|getScript|script(?:\s|%(?:25)?20)src)(?:\b|%(?:25)?[a-f0-9]{2})',
-                   // url encoded forms of script src
-                   '(?:\b|%(?:25)?[a-f0-9]{2})script(?:\s|%(?:25)?20)src(?:\b|%(?:25)?[a-f0-9]{2})'
+  and regex.icontains(subject.subject,
+                      '(?:\b|%[a-f0-9]{2})(?:on(?:abort|blur|change|click|dblclick|error|focus|load|mouse(?:over|out|move|down|up)|key(?:down|up|press)|reset|select|submit|unload)|srcdoc|src\s*(?:=|%(?:25)?3d))',
+                      // subject contains javascript funcitons
+                      '(?:\b|%(?:25)?[a-f0-9]{2})(?:javascript|eval|settimeout|setinterval|document\.(?:cookie|write|location|createElement|body|appendChild)|fetch|constructor|__proto__|prototype|atob|getScript|script(?:\s|%(?:25)?20)src)(?:\b|%(?:25)?[a-f0-9]{2})',
+                      // url encoded forms of script src
+                      '(?:\b|%(?:25)?[a-f0-9]{2})script(?:\s|%(?:25)?20)src(?:\b|%(?:25)?[a-f0-9]{2})'
   )
   and regex.icontains(subject.subject,
                       // Pattern 1: Quote followed by various special characters in encoded/literal forms:
@@ -50,7 +49,7 @@ source: |
                       '%[a-f0-9]{2}',
   
                       // Pattern 6: Unicode/hex escapes
-                      // e.g., \u003C for <, \x3C for 
+                      // e.g., \u003C for <, \x3C for
                       '\\[xXuU][a-f0-9]{4}',
                       // New patterns for this type of payload
                       '</[^>]+/[^>]+>', // Matches closing tags with slash delimiters

--- a/detection-rules/impersonation_capitalone.yml
+++ b/detection-rules/impersonation_capitalone.yml
@@ -54,7 +54,8 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-  and // suspicious indicators here
+  // suspicious indicators here
+  and
    (
     // // password theme
     (

--- a/detection-rules/impersonation_capitalone.yml
+++ b/detection-rules/impersonation_capitalone.yml
@@ -55,8 +55,7 @@ source: |
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
   // suspicious indicators here
-  and
-   (
+  and (
     // // password theme
     (
       strings.icontains(body.current_thread.text, "new password")
@@ -73,7 +72,7 @@ source: |
       or strings.icontains(body.current_thread.text, "security breach")
       or (
         strings.icontains(body.current_thread.text, "security alert")
-        // some capital one notiifcaitons include directions to 
+        // some capital one notiifcaitons include directions to
         // change notificaiton preferences to only security alerts
         and (
           strings.icount(body.current_thread.text, "security alert") > strings.icount(body.current_thread.text,
@@ -128,7 +127,7 @@ source: |
                           '(?:ready|posted|review|available|online)\s*(?:\w+\s+){0,3}\s*document'
       )
     )
-    // // account/profile details 
+    // // account/profile details
     or (
       strings.icontains(body.current_thread.text, "about your account")
       or strings.icontains(body.current_thread.text, "action required")
@@ -184,7 +183,7 @@ source: |
   and not any(beta.ml_topic(body.html.display_text).topics,
               (
                 .name in (
-                  // lots of newsletters talk about capital one 
+                  // lots of newsletters talk about capital one
                   "Newsletters and Digests",
                   // lots of recruiting mention oppurtunties at capital one, often including the logo
                   "Professional and Career Development",

--- a/detection-rules/impersonation_sharepoint_body_credential_theft.yml
+++ b/detection-rules/impersonation_sharepoint_body_credential_theft.yml
@@ -100,8 +100,7 @@ source: |
         and strings.ends_with(headers.message_id, '@odspnotify>')
       )
       // negate legitimate access request to file
-      or
-   (
+      or (
         strings.starts_with(headers.message_id, '<Sharing')
         and strings.ends_with(headers.message_id, '@odspnotify>')
       )

--- a/detection-rules/impersonation_sharepoint_body_credential_theft.yml
+++ b/detection-rules/impersonation_sharepoint_body_credential_theft.yml
@@ -99,7 +99,8 @@ source: |
         strings.starts_with(headers.message_id, '<Share-')
         and strings.ends_with(headers.message_id, '@odspnotify>')
       )
-      or // negate legitimate access request to file
+      // negate legitimate access request to file
+      or
    (
         strings.starts_with(headers.message_id, '<Sharing')
         and strings.ends_with(headers.message_id, '@odspnotify>')

--- a/detection-rules/impersonation_suspected_supplier_payment_request.yml
+++ b/detection-rules/impersonation_suspected_supplier_payment_request.yml
@@ -49,7 +49,8 @@ source: |
   //  not solicited, nor ever communicated with
   and (
     not profile.by_sender_domain().solicited
-    or // reply-to is not in $recipient_emails
+    // reply-to is not in $recipient_emails
+    or
    any(headers.reply_to, .email.email not in $recipient_emails)
   )
   and (

--- a/detection-rules/impersonation_suspected_supplier_payment_request.yml
+++ b/detection-rules/impersonation_suspected_supplier_payment_request.yml
@@ -50,8 +50,7 @@ source: |
   and (
     not profile.by_sender_domain().solicited
     // reply-to is not in $recipient_emails
-    or
-   any(headers.reply_to, .email.email not in $recipient_emails)
+    or any(headers.reply_to, .email.email not in $recipient_emails)
   )
   and (
     2 of (
@@ -67,7 +66,7 @@ source: |
                 .name == "financial"
         )
       ),
-      // payment tag high confidence 
+      // payment tag high confidence
       any(ml.nlu_classifier(coalesce(body.plain.raw, body.current_thread.text)).tags,
           .name == "payment" and .confidence == "high"
       ),

--- a/detection-rules/paypal_invoice_abuse.yml
+++ b/detection-rules/paypal_invoice_abuse.yml
@@ -31,11 +31,13 @@ source: |
                      or regex.icontains(strings.replace_confusables(.display_text),
                                         '\+[ilo0-9]{1,3}[ilo0-9]{10}'
                      )
-                     or // +12028001238
+                     // +12028001238
+                     or
    regex.icontains(strings.replace_confusables(.display_text),
                    '[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}'
                      )
-                     or // 202-800-1238
+                     // 202-800-1238
+                     or
    regex.icontains(strings.replace_confusables(.display_text),
                    '[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}'
                      )
@@ -46,7 +48,8 @@ source: |
                      or regex.icontains(strings.replace_confusables(.display_text),
                                         '\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}'
                      )
-                     or // (202)-800-1238
+                     // (202)-800-1238
+                     or
    regex.icontains(strings.replace_confusables(.display_text),
                    '\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}'
                      )

--- a/detection-rules/paypal_invoice_abuse.yml
+++ b/detection-rules/paypal_invoice_abuse.yml
@@ -32,14 +32,12 @@ source: |
                                         '\+[ilo0-9]{1,3}[ilo0-9]{10}'
                      )
                      // +12028001238
-                     or
-   regex.icontains(strings.replace_confusables(.display_text),
-                   '[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}'
+                     or regex.icontains(strings.replace_confusables(.display_text),
+                                        '[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}'
                      )
                      // 202-800-1238
-                     or
-   regex.icontains(strings.replace_confusables(.display_text),
-                   '[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}'
+                     or regex.icontains(strings.replace_confusables(.display_text),
+                                        '[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}'
                      )
                      // (202) 800-1238
                      // (202) -800 -1238
@@ -49,9 +47,8 @@ source: |
                                         '\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}'
                      )
                      // (202)-800-1238
-                     or
-   regex.icontains(strings.replace_confusables(.display_text),
-                   '\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}'
+                     or regex.icontains(strings.replace_confusables(.display_text),
+                                        '\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}'
                      )
                      or ( // 8123456789
                        regex.icontains(strings.replace_confusables(.display_text),

--- a/detection-rules/venmo_payment_abuse.yml
+++ b/detection-rules/venmo_payment_abuse.yml
@@ -18,24 +18,20 @@ source: |
                            '.*\+[ilo0-9]{1,3}[ilo0-9]{10}.*\n'
         )
         // +12028001238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
         )
         // 202-800-1238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
         // (202) 800-1238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
         )
         // (202)-800-1238
-        or
-   regex.icontains(strings.replace_confusables(body.current_thread.text),
-                   '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
+        or regex.icontains(strings.replace_confusables(body.current_thread.text),
+                           '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
         or ( // 8123456789
           regex.icontains(strings.replace_confusables(body.current_thread.text),
@@ -98,7 +94,6 @@ source: |
       )
     )
   )
-
 attack_types:
   - "Callback Phishing"
   - "BEC/Fraud"

--- a/detection-rules/venmo_payment_abuse.yml
+++ b/detection-rules/venmo_payment_abuse.yml
@@ -17,19 +17,23 @@ source: |
         or regex.icontains(strings.replace_confusables(body.current_thread.text),
                            '.*\+[ilo0-9]{1,3}[ilo0-9]{10}.*\n'
         )
-        or // +12028001238
+        // +12028001238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '.*[ilo0-9]{3}\.[ilo0-9]{3}\.[ilo0-9]{4}.*\n'
         )
-        or // 202-800-1238
+        // 202-800-1238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '.*[ilo0-9]{3}-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )
-        or // (202) 800-1238
+        // (202) 800-1238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '.*\([ilo0-9]{3}\)[\s-]+[ilo0-9]{3}[\s-]+[ilo0-9]{4}.*\n'
         )
-        or // (202)-800-1238
+        // (202)-800-1238
+        or
    regex.icontains(strings.replace_confusables(body.current_thread.text),
                    '.*\([ilo0-9]{3}\)-[ilo0-9]{3}-[ilo0-9]{4}.*\n'
         )


### PR DESCRIPTION
## Summary
- The upstream MQL format API (`play.sublime.security/v1/rules/format`) changed behavior around 15:40 UTC on 2026-05-01
- It now reformats `or // comment` and `and // comment` inline patterns in a way that breaks the validation API
- This moves all 42 inline comments from 13 affected files to their own line above the operator, which is valid MQL regardless of formatter behavior
- This should unblock all PR CI runs that are currently failing

## Affected files
- `abused_payoneer_callback.yml`
- `bec_student_loan_callback_scam.yml`
- `brand_impersonation_sharepoint_pdf_cred_theft.yml`
- `callback_phishing_intuit.yml`
- `callback_phishing_sumup.yml`
- `callback_phishing_zelle.yml`
- `canva_infra_abuse.yml`
- `credential_phishing_cross_site_scripting_in_sub.yml`
- `impersonation_capitalone.yml`
- `impersonation_sharepoint_body_credential_theft.yml`
- `impersonation_suspected_supplier_payment_request.yml`
- `paypal_invoice_abuse.yml`
- `venmo_payment_abuse.yml`

## Test plan
- [x] Validated fixed MQL compiles via `validateRule` API
- [x] Verified no remaining `or //` or `and //` inline patterns in the repo
- [x] CI should pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)