### PR TITLE
Create headers_x_source_auth_mismatch_bec.yml

### DIFF
--- a/detection-rules/headers_x_source_auth_mismatch_bec.yml
+++ b/detection-rules/headers_x_source_auth_mismatch_bec.yml
@@ -13,11 +13,8 @@ source: |
           )
   )
   // mismatched sender (from) and Reply-to
-  and any(headers.reply_to,
-          length(headers.reply_to) > 0
-          and all(headers.reply_to,
-                  .email.domain.root_domain != sender.email.domain.root_domain
-          )
+  and all(headers.reply_to,
+          .email.domain.root_domain != sender.email.domain.root_domain
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == 'bec' and .confidence != 'low'

--- a/detection-rules/headers_x_source_auth_mismatch_bec.yml
+++ b/detection-rules/headers_x_source_auth_mismatch_bec.yml
@@ -13,6 +13,7 @@ source: |
           )
   )
   // mismatched sender (from) and Reply-to
+  and length(headers.reply_to) > 0
   and all(headers.reply_to,
           .email.domain.root_domain != sender.email.domain.root_domain
   )

--- a/detection-rules/headers_x_source_auth_mismatch_bec.yml
+++ b/detection-rules/headers_x_source_auth_mismatch_bec.yml
@@ -17,6 +17,7 @@ source: |
   and all(headers.reply_to,
           .email.domain.root_domain != sender.email.domain.root_domain
   )
+  and length(ml.nlu_classifier(body.current_thread.text).intents) > 0
   and not any(ml.nlu_classifier(body.current_thread.text).intents,
               .name == 'benign' and .confidence != 'low'
   )

--- a/detection-rules/headers_x_source_auth_mismatch_bec.yml
+++ b/detection-rules/headers_x_source_auth_mismatch_bec.yml
@@ -1,5 +1,5 @@
-name: "Headers: X-Source-Auth mismatch with BEC intent and reply-to domain divergence"
-description: "Detects Business Email Compromise (BEC) attempts where the X-Source-Auth header value differs from the sender email, combined with mismatched reply-to and sender domains. This pattern indicates potential email spoofing or account compromise attempts with medium to high confidence BEC indicators."
+name: "Headers: X-Source-Auth mismatch with mismatched reply-to domain"
+description: "Detects messages where the X-Source-Auth header value doesn't match the sender's email address and the reply-to domain differs from the sender's domain, indicating potential sender spoofing or impersonation."
 type: "rule"
 severity: "high"
 source: |
@@ -17,8 +17,8 @@ source: |
   and all(headers.reply_to,
           .email.domain.root_domain != sender.email.domain.root_domain
   )
-  and any(ml.nlu_classifier(body.current_thread.text).intents,
-          .name == 'bec' and .confidence != 'low'
+  and not any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == 'benign' and .confidence != 'low'
   )
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/headers_x_source_auth_mismatch_bec.yml
+++ b/detection-rules/headers_x_source_auth_mismatch_bec.yml
@@ -18,7 +18,7 @@ source: |
           .email.domain.root_domain != sender.email.domain.root_domain
   )
   and not any(ml.nlu_classifier(body.current_thread.text).intents,
-          .name == 'benign' and .confidence != 'low'
+              .name == 'benign' and .confidence != 'low'
   )
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/headers_x_source_auth_mismatch_bec.yml
+++ b/detection-rules/headers_x_source_auth_mismatch_bec.yml
@@ -1,0 +1,30 @@
+name: "Headers: X-Source-Auth mismatch with BEC intent and reply-to domain divergence"
+description: "Detects Business Email Compromise (BEC) attempts where the X-Source-Auth header value differs from the sender email, combined with mismatched reply-to and sender domains. This pattern indicates potential email spoofing or account compromise attempts with medium to high confidence BEC indicators."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  // X-Source-Auth doesn't match sender
+  and any(headers.hops,
+          any(.fields, .name == 'X-Source-Auth' and .value != sender.email.email and strings.parse_email(.value).email is not null)
+  )
+  // mismatched sender (from) and Reply-to
+  and any(headers.reply_to,
+          length(headers.reply_to) > 0
+          and all(headers.reply_to,
+                  .email.domain.root_domain != sender.email.domain.root_domain
+          )
+  )
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+      .name == 'bec' and .confidence != 'low'
+  )
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Spoofing"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"

--- a/detection-rules/headers_x_source_auth_mismatch_bec.yml
+++ b/detection-rules/headers_x_source_auth_mismatch_bec.yml
@@ -6,7 +6,11 @@ source: |
   type.inbound
   // X-Source-Auth doesn't match sender
   and any(headers.hops,
-          any(.fields, .name == 'X-Source-Auth' and .value != sender.email.email and strings.parse_email(.value).email is not null)
+          any(.fields,
+              .name == 'X-Source-Auth'
+              and .value != sender.email.email
+              and strings.parse_email(.value).email is not null
+          )
   )
   // mismatched sender (from) and Reply-to
   and any(headers.reply_to,
@@ -16,7 +20,7 @@ source: |
           )
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents,
-      .name == 'bec' and .confidence != 'low'
+          .name == 'bec' and .confidence != 'low'
   )
 attack_types:
   - "BEC/Fraud"
@@ -28,3 +32,4 @@ detection_methods:
   - "Header analysis"
   - "Natural Language Understanding"
   - "Sender analysis"
+id: "f56e8b29-30a4-51bc-a71f-244f10bf7452"

--- a/detection-rules/headers_x_source_auth_mismatch_bec.yml
+++ b/detection-rules/headers_x_source_auth_mismatch_bec.yml
@@ -21,6 +21,8 @@ source: |
   and not any(ml.nlu_classifier(body.current_thread.text).intents,
               .name == 'benign' and .confidence != 'low'
   )
+tags:
+ - "Attack surface reduction"
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:


### PR DESCRIPTION
# Description
Detects Business Email Compromise (BEC) attempts where the X-Source-Auth header value differs from the sender email, combined with mismatched reply-to and sender domains. This pattern indicates potential email spoofing or account compromise attempts with medium to high confidence BEC indicators.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/505b310f0551038a69557f81c9ac79da36831290fa59912ba501d9d806ec7563?preview_id=019dd558-e421-74c0-b449-80598ccade69)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019de497-ed2d-7078-99bc-04abcd283a79)
- Multi-hunt in ESC-12336

## Associated hunts 05-14-2026
Hunts and mode look good. No FPs.
[Hunt 1](https://platform.sublime.security/hunts/019e2704-c76b-704a-a1dc-01e60c58cf8b)
[multi-hunt](https://hunt.limeseed.email/hunts/fd2d19a3-1569-4998-9679-9e82b27bd872)