### PR TITLE
Create link_copy_paste_dropbox_paper.yml

### DIFF
--- a/detection-rules/link_copy_paste_dropbox_paper.yml
+++ b/detection-rules/link_copy_paste_dropbox_paper.yml
@@ -1,0 +1,22 @@
+name: "Service abuse: Dropbox Paper with copy-paste instructions"
+description: "Detects messages containing copy-paste instructions with links to Dropbox Paper documents, commonly used to bypass security controls by instructing users to manually navigate to malicious content."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and strings.icontains(body.current_thread.text, 'copy')
+  and strings.icontains(body.current_thread.text, 'paste')
+  and any(body.current_thread.links,
+          strings.icontains(.display_url.url, 'https://www.dropbox.com/scl/fi/')
+          and strings.icontains(.display_url.url, '.paper')
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Free file host"
+  - "Evasion"
+detection_methods:
+  - "Content analysis"
+  - "URL analysis"

--- a/detection-rules/link_copy_paste_dropbox_paper.yml
+++ b/detection-rules/link_copy_paste_dropbox_paper.yml
@@ -20,3 +20,4 @@ tactics_and_techniques:
 detection_methods:
   - "Content analysis"
   - "URL analysis"
+id: "5b03f8e6-222f-5112-b111-faff54305b0b"


### PR DESCRIPTION
# Description
Detects messages containing copy-paste instructions with links to Dropbox Paper documents, commonly used to bypass security controls by instructing users to manually navigate to malicious content.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/505dac3caeb1343a5a67da69c53c4f40f68766b04ebf7d5c023e97a328fd28a8)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019df40c-6abf-71de-a61a-852135c84f3e)
- multi-hunts in ESC-12522
