### PR TITLE
Create zoom_freemail_rcpt_email_greet.yml

### DIFF
--- a/detection-rules/zoom_freemail_rcpt_email_greet.yml
+++ b/detection-rules/zoom_freemail_rcpt_email_greet.yml
@@ -11,12 +11,12 @@ source: |
   // the reply-to address is new 
   and beta.profile.by_reply_to().prevalence == "new"
   and not beta.profile.by_reply_to().solicited
-  // the "greeting" line contains the recipient's email address
+  // the "greeting" line contains an email address matching the recipient's email root domain
   // this is normally a name
   and any(regex.iextract(body.current_thread.text,
                          '^\S+\s+(?P<last_word>\S+?),?(?:\n|\z)'
           ),
-          .named_groups["last_word"] == recipients.to[0].email.email
+          strings.parse_email(.named_groups["last_word"]).domain.root_domain == recipients.to[0].email.domain.root_domain
   )
 attack_types:
   - "Spam"

--- a/detection-rules/zoom_freemail_rcpt_email_greet.yml
+++ b/detection-rules/zoom_freemail_rcpt_email_greet.yml
@@ -27,3 +27,4 @@ detection_methods:
   - "Sender analysis"
   - "Header analysis"
   - "Content analysis"
+id: "d582b240-8126-540f-8934-d9914780cebb"

--- a/detection-rules/zoom_freemail_rcpt_email_greet.yml
+++ b/detection-rules/zoom_freemail_rcpt_email_greet.yml
@@ -1,0 +1,29 @@
+name: "Service Abuse: Zoom with freemail reply-to and recipient address in greeting"
+description: "Detects messages impersonating Zoom that use a freemail provider for the reply-to address, have a new and unsolicited reply-to profile, and contain the recipient's email address in the greeting line where a name would normally appear."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // is from zoom
+  and sender.email.email == "no-reply@zoom.us"
+  // has a freemail for a reply-to address
+  and headers.reply_to[0].email.domain.domain in $free_email_providers
+  // the reply-to address is new 
+  and beta.profile.by_reply_to().prevalence == "new"
+  and not beta.profile.by_reply_to().solicited
+  // the "greeting" line contains the recipient's email address
+  // this is normally a name
+  and any(regex.iextract(body.current_thread.text,
+                         '^\S+\s+(?P<last_word>\S+?),?(?:\n|\z)'
+          ),
+          .named_groups["last_word"] == recipients.to[0].email.email
+  )
+attack_types:
+  - "Spam"
+tactics_and_techniques:
+  - "Free email provider"
+  - "Social engineering"
+detection_methods:
+  - "Sender analysis"
+  - "Header analysis"
+  - "Content analysis"


### PR DESCRIPTION
# Description

actors have been using zoom to send spam. This rule adds coverage for an observed technique where the reply-to address is a freemail provider, and the greeting (which is normally a name) is the recipient's email address. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50469f31e9d356c3421261636bdb46f0cbcbde280b06218a313478d326fda5fe?preview_id=019df478-37e4-7659-b549-ca7d73494673)
- [Sample 2](https://platform.sublime.security/messages/504daa6956cb9bbf4610ada41c36666f7f603bc3c58d118ac045e8a945e0ce81?preview_id=019df478-5ad0-7abf-b2a2-6bf6882fca64)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019df4a4-c754-79a7-84c3-60b1ff2968e8)
- [Multihunt](https://hunt.limeseed.email/hunts/303f1450-3462-470d-b5a7-e5b0c3d21054)
