### PR TITLE
Update brand_impersonation_booking_com.yml

### DIFF
--- a/detection-rules/brand_impersonation_booking_com.yml
+++ b/detection-rules/brand_impersonation_booking_com.yml
@@ -28,6 +28,11 @@ source: |
     )
     or strings.icontains(body.current_thread.text, ' booking.com ')
     or strings.icontains(sender.display_name, "booking.com")
+    or 2 of (
+      strings.icontains(body.current_thread.text, "Booking.com"),
+      strings.icontains(body.current_thread.text, "Oosterdokskade 163"),
+      strings.icontains(body.current_thread.text, "Amsterdam")
+    )
   )
   and (
     any(ml.nlu_classifier(body.current_thread.text).intents,


### PR DESCRIPTION
# Description
adding the Booking.com HQ address commonly seen in the footer of impersonation samples

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/5063ab06af958a06d77e1ed8b1e51faa332c8119959714f0a4a507a5ac59e932?preview_id=019dfd6d-fb11-74ff-9fbd-e8dd40c7b3e9)


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019dfdad-c9c7-7049-8bed-d574fa867666) - net new after multi hunt share
- [multi hunt](https://hunt.limeseed.email/hunts/289b4eac-7e90-46ce-986a-1cfddf2fc63c)


