### PR TITLE
Update impersonation_paypal.yml

### DIFF
--- a/detection-rules/impersonation_paypal.yml
+++ b/detection-rules/impersonation_paypal.yml
@@ -16,6 +16,7 @@ source: |
     or strings.icontains(body.current_thread.text, "paypal billing team")
     or strings.icontains(body.current_thread.text, "paypal account services")
     or strings.icontains(body.current_thread.text, "securepay.pal")
+    or regex.icontains(body.current_thread.text, "paypa[i1|!]")
     or any(attachments,
            (.file_type in $file_types_images or .file_type == "pdf")
            and any(ml.logo_detect(.).brands, .name == "PayPal")

--- a/detection-rules/impersonation_paypal.yml
+++ b/detection-rules/impersonation_paypal.yml
@@ -16,7 +16,7 @@ source: |
     or strings.icontains(body.current_thread.text, "paypal billing team")
     or strings.icontains(body.current_thread.text, "paypal account services")
     or strings.icontains(body.current_thread.text, "securepay.pal")
-    or regex.icontains(body.current_thread.text, "paypa[i1|!]")
+    or regex.icontains(body.current_thread.text, '(?:paypa[i1]\b|paypa[|!])')
     or any(attachments,
            (.file_type in $file_types_images or .file_type == "pdf")
            and any(ml.logo_detect(.).brands, .name == "PayPal")


### PR DESCRIPTION
# Description

Updating logic to tag attempts of obfuscating the `L` in the keyword `PayPal`, commonly seen in PayPal billing confirmation messages abusing calendar invites. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50611149f59c55dbf740a8ed7f9cc6cb4b7c5df3e210448022a17cd20f46afe5?preview_id=019df360-5521-7715-8c08-4c3faf348a84)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e0316-239b-7582-97a4-970dd369bafb)
