### PR TITLE
Update attachment_svg_evasion.yml

### DIFF
--- a/detection-rules/attachment_svg_evasion.yml
+++ b/detection-rules/attachment_svg_evasion.yml
@@ -1,5 +1,5 @@
 name: "Attachment: SVG files with evasion elements"
-description: "This rule identifies incoming SVG vector graphics files containing specific patterns: circle elements combined with either embedded images, QR codes, or filenames that match recipient information. Limited to three attachments. SVG circle elements have been used to obfuscate QR codes and bypass automated QR code scanning methods."
+description: "This rule identifies incoming SVG vector graphics files containing specific patterns: circle elements combined with either embedded images, hyperlinks, QR codes, or filenames that match recipient information. Limited to three attachments. SVG circle elements have been used to obfuscate QR codes and bypass automated QR code scanning methods."
 type: "rule"
 severity: "high"
 source: |
@@ -14,7 +14,7 @@ source: |
           and any(file.explode(.),
                   any(.scan.xml.tags, . == "circle")
                   and 1 of (
-                    any(.scan.xml.tags, . == "image"),
+                    any(.scan.xml.tags, . in ("image", "a")),
                     .scan.qr.data is not null,
                     any(recipients.to,
                         strings.icontains(..file_name, .email.local_part)


### PR DESCRIPTION
# Description

Updated the rule to look for anchor tags within the `file.explode()` logic 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50637a068295c6de0304791f0ede5fba08cb581e053fa563bc73e32f83e10e1e?preview_id=019dfdf4-2164-753c-be18-0e4e2c807da1)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L14D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e080e-1141-74ac-88be-26fc40c90d66)