### PR TITLE
Create impersonation_employee_payroll_fraud_suspicious_replyto.yml

### DIFF
--- a/detection-rules/impersonation_employee_payroll_fraud_suspicious_replyto.yml
+++ b/detection-rules/impersonation_employee_payroll_fraud_suspicious_replyto.yml
@@ -1,5 +1,5 @@
 name: "Employee impersonation with payroll context and suspicious reply-to domain"
-description: "Detects messages from senders using organizational display names with payroll-related content in the body or subject, where the reply-to address uses a suspicious TLD or free email provider that doesn't match the sender's domain."
+description: "Detects messages from senders using organizational display names with payroll-related content in the body or subject, where the reply-to address uses a suspicious TLD that doesn't match the sender's domain."
 type: "rule"
 severity: "high"
 source: |
@@ -23,10 +23,8 @@ source: |
    and length(headers.reply_to) > 0
    and all(headers.reply_to,
            .email.domain.root_domain != sender.email.domain.root_domain
-           and (
-             .email.domain.tld in $suspicious_tlds
-             or .email.domain.root_domain in $free_email_providers
-           )
+           and not any(recipients.cc, .email.domain.root_domain == ..email.domain.root_domain)
+           and .email.domain.tld in $suspicious_tlds
    )
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/impersonation_employee_payroll_fraud_suspicious_replyto.yml
+++ b/detection-rules/impersonation_employee_payroll_fraud_suspicious_replyto.yml
@@ -4,28 +4,30 @@ type: "rule"
 severity: "high"
 source: |
    type.inbound
-  
-    // ensure the display name contains a space to avoid single named process accounts eg. 'billing, payment'
-    and strings.contains(sender.display_name, " ")
-    and sender.display_name in~ $org_display_names
-    and length(attachments) == 0
-    and length(body.links) < 10
-    and length(body.current_thread.text) < 800
-    and 1 of (
-      regex.icontains(body.current_thread.text,
-                      '(?:pay\s?(?:roll|check|date|day)|direct deposit|(?:acct|account) rephrase|paid.{0,50}problems|\bACH\b|\bdd\b|gehalt|salario|salary|employee self[-\s]?service|\bESS\b.{0,30}(?:portal|access|log[-\s]?in)|access.{0,30}(?:HR|employee).{0,30}portal)'
-      ),
-      regex.icontains(subject.subject,
-                      '(?:pay\s?(?:roll|check|date|day)|direct deposit|(?:acct|account) rephrase|paid.{0,50}problems|\bACH\b|\bdd\b|gehalt|salario|salary|employee self[-\s]?service|\bESS\b.{0,15}portal)'
-      )
-    )
-    // mismatched sender (from) and Reply-to
-    and length(headers.reply_to) > 0
-    and all(headers.reply_to,
-            .email.domain.root_domain != sender.email.domain.root_domain
-            and (.email.domain.tld in $suspicious_tlds or .email.domain.root_domain in $free_email_providers)
-    )
-
+   
+   // ensure the display name contains a space to avoid single named process accounts eg. 'billing, payment'
+   and strings.contains(sender.display_name, " ")
+   and sender.display_name in~ $org_display_names
+   and length(attachments) == 0
+   and length(body.links) < 10
+   and length(body.current_thread.text) < 800
+   and 1 of (
+     regex.icontains(body.current_thread.text,
+                     '(?:pay\s?(?:roll|check|date|day)|direct deposit|(?:acct|account) rephrase|paid.{0,50}problems|\bACH\b|\bdd\b|gehalt|salario|salary|employee self[-\s]?service|\bESS\b.{0,30}(?:portal|access|log[-\s]?in)|access.{0,30}(?:HR|employee).{0,30}portal)'
+     ),
+     regex.icontains(subject.subject,
+                     '(?:pay\s?(?:roll|check|date|day)|direct deposit|(?:acct|account) rephrase|paid.{0,50}problems|\bACH\b|\bdd\b|gehalt|salario|salary|employee self[-\s]?service|\bESS\b.{0,15}portal)'
+     )
+   )
+   // mismatched sender (from) and Reply-to
+   and length(headers.reply_to) > 0
+   and all(headers.reply_to,
+           .email.domain.root_domain != sender.email.domain.root_domain
+           and (
+             .email.domain.tld in $suspicious_tlds
+             or .email.domain.root_domain in $free_email_providers
+           )
+   )
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:
@@ -36,3 +38,4 @@ detection_methods:
   - "Content analysis"
   - "Header analysis"
   - "Sender analysis"
+id: "5c1a5b88-b00f-544e-a257-fa7a05d843d1"

--- a/detection-rules/impersonation_employee_payroll_fraud_suspicious_replyto.yml
+++ b/detection-rules/impersonation_employee_payroll_fraud_suspicious_replyto.yml
@@ -23,7 +23,9 @@ source: |
    and length(headers.reply_to) > 0
    and all(headers.reply_to,
            .email.domain.root_domain != sender.email.domain.root_domain
-           and not any(recipients.cc, .email.domain.root_domain == ..email.domain.root_domain)
+           and not any(recipients.cc,
+                       .email.domain.root_domain == ..email.domain.root_domain
+           )
            and .email.domain.tld in $suspicious_tlds
    )
 attack_types:

--- a/detection-rules/impersonation_employee_payroll_fraud_suspicious_replyto.yml
+++ b/detection-rules/impersonation_employee_payroll_fraud_suspicious_replyto.yml
@@ -1,0 +1,38 @@
+name: "Employee impersonation with payroll context and suspicious reply-to domain"
+description: "Detects messages from senders using organizational display names with payroll-related content in the body or subject, where the reply-to address uses a suspicious TLD or free email provider that doesn't match the sender's domain."
+type: "rule"
+severity: "high"
+source: |
+   type.inbound
+  
+    // ensure the display name contains a space to avoid single named process accounts eg. 'billing, payment'
+    and strings.contains(sender.display_name, " ")
+    and sender.display_name in~ $org_display_names
+    and length(attachments) == 0
+    and length(body.links) < 10
+    and length(body.current_thread.text) < 800
+    and 1 of (
+      regex.icontains(body.current_thread.text,
+                      '(?:pay\s?(?:roll|check|date|day)|direct deposit|(?:acct|account) rephrase|paid.{0,50}problems|\bACH\b|\bdd\b|gehalt|salario|salary|employee self[-\s]?service|\bESS\b.{0,30}(?:portal|access|log[-\s]?in)|access.{0,30}(?:HR|employee).{0,30}portal)'
+      ),
+      regex.icontains(subject.subject,
+                      '(?:pay\s?(?:roll|check|date|day)|direct deposit|(?:acct|account) rephrase|paid.{0,50}problems|\bACH\b|\bdd\b|gehalt|salario|salary|employee self[-\s]?service|\bESS\b.{0,15}portal)'
+      )
+    )
+    // mismatched sender (from) and Reply-to
+    and length(headers.reply_to) > 0
+    and all(headers.reply_to,
+            .email.domain.root_domain != sender.email.domain.root_domain
+            and (.email.domain.tld in $suspicious_tlds or .email.domain.root_domain in $free_email_providers)
+    )
+
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Impersonation: Employee"
+  - "Free email provider"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description
Detects messages from senders using organizational display names with payroll-related content in the body or subject, where the reply-to address uses a suspicious TLD or free email provider that doesn't match the sender's domain.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/505b310f0551038a69557f81c9ac79da36831290fa59912ba501d9d806ec7563?preview_id=019dd558-e421-74c0-b449-80598ccade69)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://hunt.limeseed.email/hunts/9d18551a-8677-44c3-98ad-57e1e57aa7ba)
- [Hunt 2](https://hunt.limeseed.email/hunts/1122bf63-8ece-4d71-95ce-3eac745a9cbf)

### May 20 Hunts
[SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=019e46d7-4535-73aa-b00f-bcf2fcf67705)