### PR TITLE
Update callback_phishing_calendar_invite.yml

### DIFF
--- a/detection-rules/callback_phishing_calendar_invite.yml
+++ b/detection-rules/callback_phishing_calendar_invite.yml
@@ -15,8 +15,9 @@ source: |
                         any(ml.nlu_classifier(.description).intents,
                             .name == "callback_scam"
                         )
-                        or any(ml.nlu_classifier(strings.parse_html(.description).display_text).intents,
-                            .name == "callback_scam"
+                        or any(ml.nlu_classifier(strings.parse_html(.description).display_text
+                               ).intents,
+                               .name == "callback_scam"
                         )
                         or (
                           any(ml.nlu_classifier(.description).topics,

--- a/detection-rules/callback_phishing_calendar_invite.yml
+++ b/detection-rules/callback_phishing_calendar_invite.yml
@@ -15,6 +15,9 @@ source: |
                         any(ml.nlu_classifier(.description).intents,
                             .name == "callback_scam"
                         )
+                        or any(ml.nlu_classifier(strings.parse_html(.description).display_text).intents,
+                            .name == "callback_scam"
+                        )
                         or (
                           any(ml.nlu_classifier(.description).topics,
                               .name == "Request to View Invoice"


### PR DESCRIPTION
# Description
HTML can sometimes throw off NLU. This change allows us to parse the HTML in the calendar description to get the display_text for callback_scam intent. Will check `Request to View Invoice` in another PR to make things eaiser on the reviewer. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/4fad2f1e46ce8a25608936e6d1ecc19d4f9491a93f231275d0040a7923089e42)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->


Regression callback scam just html.parse | https://platform.sublime.security/messages/hunt?huntId=019e0346-2b68-7d8e-b2c6-999becdcfa3a
-- | --
Net new callback scam use html.parse | https://platform.sublime.security/messages/hunt?huntId=019e0347-72e9-776f-bf75-3704e5a69746
Net new callback scam use html.parse or raw | https://platform.sublime.security/messages/hunt?huntId=019e0359-a8e9-7948-8bd4-1f5c50293936
Regression callback scam use html.parse or raw | https://platform.sublime.security/messages/hunt?huntId=019e0365-18cc-7cf0-907d-9746db1c04a7

Net new multi-hunt: https://hunt.limeseed.email/hunts/ba33573b-ef1d-4141-8bb2-ac3651b1cce9

