### PR TITLE
Update attachment_office365_image.yml

### DIFF
--- a/detection-rules/attachment_office365_image.yml
+++ b/detection-rules/attachment_office365_image.yml
@@ -59,23 +59,31 @@ source: |
     not any(headers.hops,
             .authentication_results.compauth.verdict is not null
             and .authentication_results.compauth.verdict == "pass"
-            and sender.email.domain.domain in (
-              "microsoft.com",
-              "sharepointonline.com"
-            )
+    )
+    and not sender.email.domain.domain in (
+      "microsoft.com",
+      "sharepointonline.com"
     )
   )
   
   // negate angelbeat urls and microsoft disclaimer links
   and (
-    length(body.links) > 0
-    and not all(body.links,
-                .href_url.domain.root_domain in (
-                  "abeatinfo.com",
-                  "abeatinvite.com",
-                  "aka.ms",
-                  "angelbeat.com"
-                )
+    (
+      length(body.links) == 0
+      and (
+        length(body.current_thread.text) < 10 or body.current_thread.text is null
+      )
+    )
+    or (
+      length(body.links) > 0
+      and not all(body.links,
+                  .href_url.domain.root_domain in (
+                    "abeatinfo.com",
+                    "abeatinvite.com",
+                    "aka.ms",
+                    "angelbeat.com"
+                  )
+      )
     )
   )
   

--- a/detection-rules/attachment_office365_image.yml
+++ b/detection-rules/attachment_office365_image.yml
@@ -56,13 +56,10 @@ source: |
           )
   )
   and (
-    not any(headers.hops,
-            .authentication_results.compauth.verdict is not null
-            and .authentication_results.compauth.verdict == "pass"
-    )
-    and not sender.email.domain.domain in (
-      "microsoft.com",
-      "sharepointonline.com"
+    sender.email.domain.domain not in ("microsoft.com", "sharepointonline.com")
+    or not any(headers.hops,
+               .authentication_results.compauth.verdict is not null
+               and .authentication_results.compauth.verdict == "pass"
     )
   )
   


### PR DESCRIPTION
# Description

Added logic to account for when `length(body.links) == 0` to match on FNs

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50637a068295c6de0304791f0ede5fba08cb581e053fa563bc73e32f83e10e1e?preview_id=019dfdf4-2164-753c-be18-0e4e2c807da1)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e1766-725f-7a4d-afde-4906c8f0250b)