### PR TITLE
Update link_google_form_cred_theft_new_sender.yml

### DIFF
--- a/detection-rules/link_google_form_cred_theft_new_sender.yml
+++ b/detection-rules/link_google_form_cred_theft_new_sender.yml
@@ -10,8 +10,11 @@ source: |
   )
   // google form link
   and any(body.current_thread.links,
-          .href_url.domain.domain == "docs.google.com"
-          and strings.istarts_with(.href_url.path, '/form')
+          (
+            .href_url.domain.domain == "docs.google.com"
+            and strings.istarts_with(.href_url.path, '/form')
+          )
+          or .href_url.domain.root_domain == "forms.gle"
   )
   // new sender
   and profile.by_sender_email().prevalence == "new"


### PR DESCRIPTION
# Description

Adding `forms.gle` to `body.current_thread.links` logic to look for shortened Google Forms links

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5063c0a6499e15b4e0d45f9d9ff997509fd9c2a921d2fe8943ccb496cfc54d08?preview_id=019e0201-2a08-78c1-ae76-a5db341134f4)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e1749-0f0f-745e-92b6-146b1b229a5d)