### PR TITLE
Create body_self_sender_bold.yml

### DIFF
--- a/detection-rules/body_self_sender_bold.yml
+++ b/detection-rules/body_self_sender_bold.yml
@@ -17,32 +17,32 @@ source: |
   and strings.parse_url(html.xpath(body.html, '//a/b').nodes[0].display_text,
                         strict=false
   ).url is null
-  and  any(html.xpath(body.html, '//a/b').nodes,
-              .display_text in~ (
-                "Read the Message",
-                "OPEN",
-                "Open in drive",
-                "Open document here",
-                "open document",
-                "open documents",
-                'view document',
-                'view documents',
-                'access document',
-                'access documents',
-                'review documents',
-                'review document',
-                // 501e5fe43fa30ccdca9469ab545a6639c9a60952b882823fa1663004de7b4df0
-                'view payment details'
-              )
-              or strings.icontains(.display_text, "Download")
-              or strings.icontains(.display_text, "Review Here")
-              or strings.iends_with(.display_text, ".pdf")
-              // 504788258b421818209543b506f4bbe7cf6615f596726c80b0775870c8764b64
-              or strings.iends_with(.display_text, ".html")
-              // displaytext == subject
-              // https://platform.sublime.security/messages/504db0811037ff63d49b62e683f3a8a0e4d8284158163708c3630ceec556aa47?preview_id=019d8d5c-f2c7-7d46-8697-f6f4632fdf24
-              or .display_text == subject.base
-              or any(.links, .href_url.domain.domain in $free_file_hosts)
+  and any(html.xpath(body.html, '//a/b').nodes,
+          .display_text in~ (
+            "Read the Message",
+            "OPEN",
+            "Open in drive",
+            "Open document here",
+            "open document",
+            "open documents",
+            'view document',
+            'view documents',
+            'access document',
+            'access documents',
+            'review documents',
+            'review document',
+            // 501e5fe43fa30ccdca9469ab545a6639c9a60952b882823fa1663004de7b4df0
+            'view payment details'
+          )
+          or strings.icontains(.display_text, "Download")
+          or strings.icontains(.display_text, "Review Here")
+          or strings.iends_with(.display_text, ".pdf")
+          // 504788258b421818209543b506f4bbe7cf6615f596726c80b0775870c8764b64
+          or strings.iends_with(.display_text, ".html")
+          // displaytext == subject
+          // https://platform.sublime.security/messages/504db0811037ff63d49b62e683f3a8a0e4d8284158163708c3630ceec556aa47?preview_id=019d8d5c-f2c7-7d46-8697-f6f4632fdf24
+          or .display_text == subject.base
+          or any(.links, .href_url.domain.domain in $free_file_hosts)
   )
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/body_self_sender_bold.yml
+++ b/detection-rules/body_self_sender_bold.yml
@@ -11,12 +11,11 @@ source: |
   )
   // sender in current thread BOLD
   and any(html.xpath(body.html, '//b').nodes,
-    .display_text == sender.display_name
+          .display_text == sender.display_name
   )
   and any(html.xpath(body.html, '//a/b').nodes,
-    .display_text == "Read the Message"
+          .display_text == "Read the Message"
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:
@@ -26,3 +25,4 @@ detection_methods:
   - "Header analysis"
   - "HTML analysis"
   - "Sender analysis"
+id: "0129a805-2fe2-5a40-81bc-b3459085aa23"

--- a/detection-rules/body_self_sender_bold.yml
+++ b/detection-rules/body_self_sender_bold.yml
@@ -13,8 +13,36 @@ source: |
   and any(html.xpath(body.html, '//b').nodes,
           .display_text == sender.display_name
   )
-  and any(html.xpath(body.html, '//a/b').nodes,
-          .display_text == "Read the Message"
+  and length(html.xpath(body.html, '//a/b').nodes) == 1
+  and strings.parse_url(html.xpath(body.html, '//a/b').nodes[0].display_text,
+                        strict=false
+  ).url is null
+  and  any(html.xpath(body.html, '//a/b').nodes,
+              .display_text in~ (
+                "Read the Message",
+                "OPEN",
+                "Open in drive",
+                "Open document here",
+                "open document",
+                "open documents",
+                'view document',
+                'view documents',
+                'access document',
+                'access documents',
+                'review documents',
+                'review document',
+                // 501e5fe43fa30ccdca9469ab545a6639c9a60952b882823fa1663004de7b4df0
+                'view payment details'
+              )
+              or strings.icontains(.display_text, "Download")
+              or strings.icontains(.display_text, "Review Here")
+              or strings.iends_with(.display_text, ".pdf")
+              // 504788258b421818209543b506f4bbe7cf6615f596726c80b0775870c8764b64
+              or strings.iends_with(.display_text, ".html")
+              // displaytext == subject
+              // https://platform.sublime.security/messages/504db0811037ff63d49b62e683f3a8a0e4d8284158163708c3630ceec556aa47?preview_id=019d8d5c-f2c7-7d46-8697-f6f4632fdf24
+              or .display_text == subject.base
+              or any(.links, .href_url.domain.domain in $free_file_hosts)
   )
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/body_self_sender_bold.yml
+++ b/detection-rules/body_self_sender_bold.yml
@@ -11,15 +11,17 @@ source: |
   )
   // sender in current thread BOLD
   and any(html.xpath(body.html, '//b').nodes,
-    .display_text == sender.display_name
+          .display_text == sender.display_name
   )
-  // we want the dashed html element to contain a link, and that link to include part of the subject (the subject is the org) 
-  and any(html.xpath(body.html, '//table//td[contains(@style, "border-style: dashed") and contains(@style, "border-width: 1pt")]//a[./b]').nodes, 
-      any(regex.extract(subject.base, '(?P<word>\w+)'),
-          any(..links,
-              strings.icontains(.href_url.url, ..named_groups["word"])
+  // we want the dashed html element to contain a link, and that link to include part of the subject (the subject is the org)
+  and any(html.xpath(body.html,
+                     '//table//td[contains(@style, "border-style: dashed") and contains(@style, "border-width: 1pt")]//a[./b]'
+          ).nodes,
+          any(regex.extract(subject.base, '(?P<word>\w+)'),
+              any(..links,
+                  strings.icontains(.href_url.url, ..named_groups["word"])
+              )
           )
-      )
   )
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/body_self_sender_bold.yml
+++ b/detection-rules/body_self_sender_bold.yml
@@ -11,38 +11,15 @@ source: |
   )
   // sender in current thread BOLD
   and any(html.xpath(body.html, '//b').nodes,
-          .display_text == sender.display_name
+    .display_text == sender.display_name
   )
-  and length(html.xpath(body.html, '//a/b').nodes) == 1
-  and strings.parse_url(html.xpath(body.html, '//a/b').nodes[0].display_text,
-                        strict=false
-  ).url is null
-  and any(html.xpath(body.html, '//a/b').nodes,
-          .display_text in~ (
-            "Read the Message",
-            "OPEN",
-            "Open in drive",
-            "Open document here",
-            "open document",
-            "open documents",
-            'view document',
-            'view documents',
-            'access document',
-            'access documents',
-            'review documents',
-            'review document',
-            // 501e5fe43fa30ccdca9469ab545a6639c9a60952b882823fa1663004de7b4df0
-            'view payment details'
+  // we want the dashed html element to contain a link, and that link to include part of the subject (the subject is the org) 
+  and any(html.xpath(body.html, '//table//td[contains(@style, "border-style: dashed") and contains(@style, "border-width: 1pt")]//a[./b]').nodes, 
+      any(regex.extract(subject.base, '(?P<word>\w+)'),
+          any(..links,
+              strings.icontains(.href_url.url, ..named_groups["word"])
           )
-          or strings.icontains(.display_text, "Download")
-          or strings.icontains(.display_text, "Review Here")
-          or strings.iends_with(.display_text, ".pdf")
-          // 504788258b421818209543b506f4bbe7cf6615f596726c80b0775870c8764b64
-          or strings.iends_with(.display_text, ".html")
-          // displaytext == subject
-          // https://platform.sublime.security/messages/504db0811037ff63d49b62e683f3a8a0e4d8284158163708c3630ceec556aa47?preview_id=019d8d5c-f2c7-7d46-8697-f6f4632fdf24
-          or .display_text == subject.base
-          or any(.links, .href_url.domain.domain in $free_file_hosts)
+      )
   )
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/body_self_sender_bold.yml
+++ b/detection-rules/body_self_sender_bold.yml
@@ -1,0 +1,28 @@
+name: "Self-impersonation: Sender matches recipient with bolded name and suspicious link"
+description: "Detects messages where the sender's email address matches the recipient's email address, with the sender's display name appearing in bold text and a suspicious 'Read the Message' link present in the body."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // sender matches recipients
+  and (
+    length(recipients.to) == 1
+    and recipients.to[0].email.email == sender.email.email
+  )
+  // sender in current thread BOLD
+  and any(html.xpath(body.html, '//b').nodes,
+    .display_text == sender.display_name
+  )
+  and any(html.xpath(body.html, '//a/b').nodes,
+    .display_text == "Read the Message"
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "Header analysis"
+  - "HTML analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description
Detects messages where the sender's email address matches the recipient's email address, with the sender's display name appearing in bold text and a suspicious 'Read the Message' link present in the body.
Observed in a few campaigns with this type of behavior. 

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/50572854550a3d49abf326db90560788247d8c6c7591b8711ae702b6fa0a7c16?preview_id=019e037c-cf97-75f5-912e-c8941f9254ec)
- [Sample 2](https://platform.sublime.security/messages/5063fed442c5c81b162c8c6487a9e369445461514dc95a03c5c109f74ae2e77e?preview_id=019e044e-6fd1-790d-be94-66af5bf4f7ef)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e044c-ae74-7bbd-8a5e-7bb60b3918c2)
- [Hunt2](https://hunt.limeseed.email/hunts/dd255b05-ef3d-4933-ae09-dfcad7ad20aa)
- [latest 60d hunt](https://platform.sublime.security/messages/hunt?huntId=019ed223-6cd6-7c3f-976a-08b2e586bcbd)
- [latest 7d multi-hunt](https://hunt.limeseed.email/hunts/9727cb59-8304-4600-a1f9-a8bf3a61e47b)
