### PR TITLE
FN: Add 'submit proposal' pattern to RFQ/RFP rule

### DIFF
--- a/detection-rules/suspicious_request_for_quote_or_purchase.yml
+++ b/detection-rules/suspicious_request_for_quote_or_purchase.yml
@@ -87,7 +87,7 @@ source: |
                           '(discuss.{0,15}purchas(e|ing))'
           ),
           regex.icontains(body.current_thread.text,
-                          '(sign(ed?)|view).{0,10}(purchase order)|Request for a Quot(e|ation)'
+                          '(sign(ed?)|view).{0,10}(purchase order)|Request for (a Quot(e|ation)|Proposal)'
           ),
           regex.icontains(body.current_thread.text,
                           '(please|kindly).{0,30}(?:proposal|quot(e|ation))'
@@ -107,6 +107,7 @@ source: |
           any(ml.nlu_classifier(body.current_thread.text).entities,
               .name == "financial" and regex.imatch(.text, "rfp|rfq")
           ),
+          regex.icontains(body.current_thread.text, '\bRFP\b|\bRFQ\b'),
 
           // Non-keyword indicators
           (


### PR DESCRIPTION
## Summary

These changes close a detection gap where RFP lures using "submit a proposal" language (without explicit "RFP"/"RFQ" in the subject) were evading the rule's 2-indicator threshold.

## Associated samples
- `5063352fe329bf927f07a6deccbee9c3c6743da1f38addff26372b1454a6ced5`
- [shared samples hunt](https://platform.sublime.security/messages/hunt?huntId=019e0527-6841-7cb9-8735-3490d3b8ec78)