### PR TITLE
Create link_button_style_excessive_padding.yml

### DIFF
--- a/detection-rules/link_button_style_excessive_padding.yml
+++ b/detection-rules/link_button_style_excessive_padding.yml
@@ -4,9 +4,23 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  // button-styled link pointing to external domain
+  // is a fake thread
   and (
-    // inline button: anchor with background-color with short text
+    regex.icontains(subject.subject, '\b(?:RE|FWD?)\s*:')
+    or any([body.current_thread.text, body.html.display_text, body.plain.raw],
+           3 of (
+             strings.icontains(., "from:"),
+             strings.icontains(., "to:"),
+             strings.icontains(., "sent:"),
+             strings.icontains(., "date:"),
+             strings.icontains(., "cc:"),
+             strings.icontains(., "subject:")
+           )
+    )
+  )
+  and (length(headers.references) == 0 or headers.in_reply_to is null)
+  // button-styled link pointing to external domain, present in current thread
+  and (
     any(filter(html.xpath(body.html, '//a[@href]').nodes,
                regex.icontains(.raw,
                                '(?:background(?:-color)?)\s*[:\s]\s*(?:#[0-9a-f]{6}|rgb)'
@@ -19,15 +33,20 @@ source: |
         ),
         any(.links,
             .href_url.domain.root_domain != sender.email.domain.root_domain
+            and any(body.current_thread.links,
+                    .href_url.domain.root_domain == ..href_url.domain.root_domain
+            )
         )
     )
-    // td with bgcolor with border-radius and box-shadow containing a link
     or any(filter(html.xpath(body.html, '//td[@bgcolor]').nodes,
                   regex.icontains(.raw, 'border-radius')
                   and regex.icontains(.raw, 'box-shadow')
            ),
            any(.links,
                .href_url.domain.root_domain != sender.email.domain.root_domain
+               and any(body.current_thread.links,
+                       .href_url.domain.root_domain == ..href_url.domain.root_domain
+               )
            )
     )
   )
@@ -35,33 +54,33 @@ source: |
   // tall rendered email
   and beta.parse_exif(file.message_screenshot()).image_height > 1500
   and (
-    // bare div-br blocks repeated 30+ times
     regex.icontains(body.html.raw, '(?:<div>\s*<br\s*/?\s*>\s*</div>\s*){30,}')
-    // styled div-br blocks repeated 20+ times (Outlook Web App pattern)
     or regex.icontains(body.html.raw,
                        '(?:<div\s+style="[^"]+"\s*[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}'
     )
-    // p-nbsp blocks repeated 25+ times
     or regex.icontains(body.html.raw,
                        '(?:<p>\s*(?:&nbsp;|&#160;)\s*</p>\s*){25,}'
     )
-    // consecutive br tags 30+ times
     or regex.icontains(body.html.raw, '(?:<br\s*/?\s*>\s*){30,}')
-  
-    // css margin-top pushdown >= 1500px
     or (
       regex.icontains(body.html.raw,
                       'margin-top\s*:\s*(?:1[5-9]\d{2}|[2-9]\d{3}|\d{5,})px'
       )
-      // not absolute-positioned
       and not regex.icontains(body.html.raw,
                               'position\s*:\s*absolute[^"]*margin-top\s*:\s*(?:1[5-9]\d{2}|[2-9]\d{3}|\d{5,})px'
       )
-      // no left-margined elements
       and not regex.icontains(body.html.raw,
                               'margin-left\s*:\s*\d{3,}px[^"]*margin-top\s*:\s*(?:1[5-9]\d{2}|[2-9]\d{3}|\d{5,})px'
       )
     )
+  )
+  // negate high-trust authenticated senders
+  and (
+    coalesce(sender.email.domain.root_domain in $high_trust_sender_root_domains
+             and not headers.auth_summary.dmarc.pass,
+             false
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
   // negate unsubscriptions
   and not (
@@ -69,7 +88,6 @@ source: |
         strings.icontains(.display_text, "unsubscribe")
         and (
           strings.icontains(.href_url.path, "unsubscribe")
-          // handle mimecast URL rewrites
           or (
             .href_url.domain.root_domain == 'mimecastprotect.com'
             and strings.icontains(.href_url.query_params,

--- a/detection-rules/link_button_style_excessive_padding.yml
+++ b/detection-rules/link_button_style_excessive_padding.yml
@@ -88,3 +88,4 @@ detection_methods:
   - "HTML analysis"
   - "URL analysis"
   - "Exif analysis"
+id: "2cfae0f3-5ccc-5929-80d3-25be6bb7745c"

--- a/detection-rules/link_button_style_excessive_padding.yml
+++ b/detection-rules/link_button_style_excessive_padding.yml
@@ -1,0 +1,90 @@
+name: "Link: Button-styled external redirect with excessive padding"
+description: "Detects emails containing button-styled links that redirect to external domains, combined with excessive vertical spacing techniques to push content below the preview pane. The rule identifies styled anchor tags or table cells with background colors, borders, and padding that link externally, while also detecting various HTML padding methods including repeated div-br blocks, consecutive break tags, CSS margin manipulation, or non-breaking space repetition that creates emails taller than 1500 pixels."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // button-styled link pointing to external domain
+  and (
+    // inline button: anchor with background-color with short text
+    any(filter(html.xpath(body.html, '//a[@href]').nodes,
+               regex.icontains(.raw,
+                               '(?:background(?:-color)?)\s*[:\s]\s*(?:#[0-9a-f]{6}|rgb)'
+               )
+               and regex.count(.display_text, '\S+') < 10
+               and (
+                 regex.icontains(.raw, 'border-radius')
+                 or regex.icontains(.raw, 'padding')
+               )
+        ),
+        any(.links,
+            .href_url.domain.root_domain != sender.email.domain.root_domain
+        )
+    )
+    // td with bgcolor with border-radius and box-shadow containing a link
+    or any(filter(html.xpath(body.html, '//td[@bgcolor]').nodes,
+                  regex.icontains(.raw, 'border-radius')
+                  and regex.icontains(.raw, 'box-shadow')
+           ),
+           any(.links,
+               .href_url.domain.root_domain != sender.email.domain.root_domain
+           )
+    )
+  )
+  
+  // tall rendered email
+  and beta.parse_exif(file.message_screenshot()).image_height > 1500
+  and (
+    // bare div-br blocks repeated 30+ times
+    regex.icontains(body.html.raw, '(?:<div>\s*<br\s*/?\s*>\s*</div>\s*){30,}')
+    // styled div-br blocks repeated 20+ times (Outlook Web App pattern)
+    or regex.icontains(body.html.raw,
+                       '(?:<div\s+style="[^"]+"\s*[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}'
+    )
+    // p-nbsp blocks repeated 25+ times
+    or regex.icontains(body.html.raw,
+                       '(?:<p>\s*(?:&nbsp;|&#160;)\s*</p>\s*){25,}'
+    )
+    // consecutive br tags 30+ times
+    or regex.icontains(body.html.raw, '(?:<br\s*/?\s*>\s*){30,}')
+  
+    // css margin-top pushdown >= 1500px
+    or (
+      regex.icontains(body.html.raw,
+                      'margin-top\s*:\s*(?:1[5-9]\d{2}|[2-9]\d{3}|\d{5,})px'
+      )
+      // not absolute-positioned
+      and not regex.icontains(body.html.raw,
+                              'position\s*:\s*absolute[^"]*margin-top\s*:\s*(?:1[5-9]\d{2}|[2-9]\d{3}|\d{5,})px'
+      )
+      // no left-margined elements
+      and not regex.icontains(body.html.raw,
+                              'margin-left\s*:\s*\d{3,}px[^"]*margin-top\s*:\s*(?:1[5-9]\d{2}|[2-9]\d{3}|\d{5,})px'
+      )
+    )
+  )
+  // negate unsubscriptions
+  and not (
+    any(body.links,
+        strings.icontains(.display_text, "unsubscribe")
+        and (
+          strings.icontains(.href_url.path, "unsubscribe")
+          // handle mimecast URL rewrites
+          or (
+            .href_url.domain.root_domain == 'mimecastprotect.com'
+            and strings.icontains(.href_url.query_params,
+                                  sender.email.domain.root_domain
+            )
+          )
+        )
+    )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "HTML analysis"
+  - "URL analysis"
+  - "Exif analysis"


### PR DESCRIPTION
# Description

<!-- 
Explain your change and why. For example, "negating legitimate replies," or "adding additional credential theft keywords."

If it's a new rule or insight, explain what the rule is designed to catch/what the insight should fire on.
-->

Expanding on the coverage of the excessive padding suite of rules I've been working on, this one is specifically looking for excessive padding, and a button.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5054ba70683b29b2217b62be0a62e3b8137e70f9b9c79b8433648af640afeb07?preview_id=019de418-3248-753a-9814-f6968f622ca0)
- [Sample 2](https://platform.sublime.security/messages/504d949a87ab768f6fdcd259b3b451778aa871a838f7a07fb53027e3624e7a3c?preview_id=019e05de-cc26-71a0-bbec-9a28b3e839ce)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [shared samples hunt L60D](https://platform.sublime.security/messages/hunt?huntId=019e080d-2cea-70ec-99ea-6c0f9d3c8757)