### PR TITLE
Update impersonation_fedex.yml

### DIFF
--- a/detection-rules/impersonation_fedex.yml
+++ b/detection-rules/impersonation_fedex.yml
@@ -21,6 +21,7 @@ source: |
   )
   and sender.email.domain.root_domain not in~ (
     'fedex.com',
+    'fedexfreight.com', // added 2026-05-08
     'cj.com', // CJ is a global affiliate marketing network
     'sedex.com', // sedex.com is not affiliated with FedEx, but is an apparent FP
     'myworkday.com',


### PR DESCRIPTION
# Description
Adding a new Fedex domain, looks like they've started using fedexfreight[.]com to send these notifications, instead of the previous feedback and status messages we saw previously. 

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/5065cbe986c759de07e80564329884c9e9f92b4d6eb3ebaf98b8b52a3924776f?preview_id=019e0869-7418-7f3e-a9a2-9e883d09bd81)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e087b-bad0-76c4-9af0-8174ac00e9a7)
