### PR TITLE
Update body_extortion.yml

### DIFF
--- a/detection-rules/body_extortion.yml
+++ b/detection-rules/body_extortion.yml
@@ -155,14 +155,6 @@ source: |
     and length(body.current_thread.text) > 2000
   )
   and length(body.current_thread.text) < 8000
-  // negate highly trusted sender domains unless they fail DMARC authentication
-  and (
-    (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and not headers.auth_summary.dmarc.pass
-    )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
-  )
 
 attack_types:
   - "Extortion"


### PR DESCRIPTION
# Description

Taking out `high_trust` negation due to high trust sender abuse

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50659893d9fd28900c7a560fba96af827d73fa8fbb7694e42666c3d9fed00f30?preview_id=019e08f8-6340-75a4-816b-bfb94da9d64c)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e08e0-4d9b-7326-9979-7ee1d5f643c3)