### PR TITLE
Update link_credential_phishing_cloud_service.yml

### DIFF
--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -25,7 +25,10 @@ source: |
   )
   // negate legit cloud companies
   and not (
-    coalesce(sender.email.domain.root_domain, "") in ("cloud-cme.com", "cloudcounting.online")
+    coalesce(sender.email.domain.root_domain, "") in (
+      "cloud-cme.com",
+      "cloudcounting.online"
+    )
     // check for SPF or DMARC passed
     and (headers.auth_summary.spf.pass or headers.auth_summary.dmarc.pass)
   )

--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -25,7 +25,7 @@ source: |
   )
   // negate legit cloud companies
   and not (
-    sender.email.domain.root_domain in ("cloud-cme.com", "cloudcounting.online")
+    coalesce(sender.email.domain.root_domain, "") in ("cloud-cme.com", "cloudcounting.online")
     // check for SPF or DMARC passed
     and (headers.auth_summary.spf.pass or headers.auth_summary.dmarc.pass)
   )


### PR DESCRIPTION
# Description

`sender.email.domain.root_domain` can be null causing `negate legit cloud companies` to not work. This update adds `coalesce` to handle null cases. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5047e498ffc8ec3253a30287fd445ecc44e971c9b96a87ea8f2125dc5e8084bd)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e17a3-d23c-7638-8126-63529999f7d7)
- [Net new](https://platform.sublime.security/messages/hunt?huntId=019e17cc-57e4-74d9-8aa8-df5cfbef6224)
- [multi-hunt net new](https://hunt.limeseed.email/hunts/cfba9c57-adc7-4b05-b641-8ab5d3cd09ae)
