### PR TITLE
Update link_credential_phishing_cloud_service.yml

### DIFF
--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -27,7 +27,11 @@ source: |
   )
   // negate legit cloud companies
   and not (
-    sender.email.domain.root_domain in ("cloud-cme.com", "cloudcounting.online", "cloudhealthtech.com")
+    sender.email.domain.root_domain in (
+      "cloud-cme.com",
+      "cloudcounting.online",
+      "cloudhealthtech.com"
+    )
     // check for SPF or DMARC passed
     and (headers.auth_summary.spf.pass or headers.auth_summary.dmarc.pass)
   )

--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -27,7 +27,7 @@ source: |
   )
   // negate legit cloud companies
   and not (
-    sender.email.domain.root_domain in (
+    coalesce(sender.email.domain.root_domain, "") in (
       "cloud-cme.com",
       "cloudcounting.online",
       "cloudhealthtech.com"

--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -27,7 +27,7 @@ source: |
   )
   // negate legit cloud companies
   and not (
-    sender.email.domain.root_domain in ("cloud-cme.com", "cloudcounting.online")
+    sender.email.domain.root_domain in ("cloud-cme.com", "cloudcounting.online", "cloudhealthtech.com")
     // check for SPF or DMARC passed
     and (headers.auth_summary.spf.pass or headers.auth_summary.dmarc.pass)
   )

--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -5,7 +5,9 @@ severity: "medium"
 source: |
   type.inbound
   and (
-    strings.starts_with(body.current_thread.text, 'Cloud')
+    any([body.current_thread.text, body.html.inner_text],
+        strings.starts_with(., 'Cloud')
+    )
     // cloud emoji
     or regex.contains(body.current_thread.text, '^\x{2601}')
   )


### PR DESCRIPTION
# Description

Updated `starts_with` logic to look for `Cloud` in either `body.current_thread.text` OR `body.html.inner_text`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5067328b82d4a381334e98a691db0fc1396cceede9eb7b212fc987ba9ad1dee1?preview_id=019e1448-9e55-76c1-a284-4c4949119f2e)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L90D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e2154-7542-7d2b-9703-cb86c2c51a28)
