### PR TITLE
Update credential_theft_cloud_storage_impersonation.yml

### DIFF
--- a/detection-rules/credential_theft_cloud_storage_impersonation.yml
+++ b/detection-rules/credential_theft_cloud_storage_impersonation.yml
@@ -36,7 +36,7 @@ source: |
           or regex.icontains(.href_url.path, '^\/[a-z0-9]{20,}$')
           or (
             strings.icontains(.href_url.path, '.html')
-            and coalesce(.href_url.domain.root_domain, "null") != sender.email.domain.root_domain
+            and coalesce(.href_url.domain.root_domain, "null") != coalesce(sender.email.domain.root_domain, "")
           )
         )
     )

--- a/detection-rules/credential_theft_cloud_storage_impersonation.yml
+++ b/detection-rules/credential_theft_cloud_storage_impersonation.yml
@@ -36,7 +36,9 @@ source: |
           or regex.icontains(.href_url.path, '^\/[a-z0-9]{20,}$')
           or (
             strings.icontains(.href_url.path, '.html')
-            and coalesce(.href_url.domain.root_domain, "null") != coalesce(sender.email.domain.root_domain, "")
+            and coalesce(.href_url.domain.root_domain, "null") != coalesce(sender.email.domain.root_domain,
+                                                                           ""
+            )
           )
         )
     )


### PR DESCRIPTION
# Description
`sender.email.domain.root_domain` is null in some samples. Add `coalesce` to account for this. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5047e498ffc8ec3253a30287fd445ecc44e971c9b96a87ea8f2125dc5e8084bd?preview_id=019d97e5-56e1-742c-9c50-51ae5c929cd0)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Updated rule](https://platform.sublime.security/messages/hunt?huntId=019e1839-faf2-73fd-b16b-3fb4dc999ee1)
- [net new](https://platform.sublime.security/messages/hunt?huntId=019e183f-baf7-7cce-8f44-9fe67038e337)
- [multi-hunt](https://hunt.limeseed.email/hunts/0b72ccd5-ee46-4de7-8e5e-967bdb0866c8)