### PR TITLE
Update Paperless Post impersonation rule

### DIFF
--- a/detection-rules/brand_impersonation_paperlesspost.yml
+++ b/detection-rules/brand_impersonation_paperlesspost.yml
@@ -10,14 +10,20 @@ source: |
                     strings.parse_url(.raw).domain.root_domain == 'ppassets.com'
              )
   ) >= 2
-  and length(filter(body.links,
-                    .href_url.domain.domain == "links.paperlesspost.com"
-                    or (
-                      .href_url.domain.root_domain == "paperlesspost.com"
-                      and strings.istarts_with(.href_url.path, '/go/')
-                    )
-             )
-  ) < 2
+  and (
+    length(filter(body.links,
+                  .href_url.domain.domain == "links.paperlesspost.com"
+                  or (
+                    .href_url.domain.root_domain == "paperlesspost.com"
+                    and strings.istarts_with(.href_url.path, '/go/')
+                  )
+           )
+    ) < 2
+    or any(body.links,
+           regex.icontains(.display_text, '(?:view the card|view and reply)')
+           and .href_url.domain.root_domain != "paperlesspost.com"
+    )
+  )
   and not (
     (subject.is_forward or subject.is_reply)
     and (
@@ -29,6 +35,7 @@ source: |
     sender.email.domain.root_domain == "paperlesspost.com"
     and headers.auth_summary.dmarc.pass
   )
+
 attack_types:
   - "Credential Phishing"
   - "Malware/Ransomware"


### PR DESCRIPTION
# Description

Adding logic to look for action link that does not lead to paperlesspost.com root domain

# Associated samples

[- Sample 1](https://platform.sublime.security/messages/50676d17f0dfee2fc05a2f61cdcd5096fdfdafb56cb5f8192079c4113fbf2e8f?preview_id=019e1790-dd8c-76f3-ab52-6c0550486aea)

## Associated hunts

[- Hunt 1 (Shared Samples - New logic)](https://platform.sublime.security/messages/hunt?huntId=019e18d0-c862-783d-8d29-e3c71b7ecd5a) - 4 net new samps L30D
[- Hunt 2 (Shared Samples - Comparative)](https://platform.sublime.security/messages/hunt?huntId=019e17c0-2a6a-7189-bf0d-519e5169a1c1) -  9 new samps L30D
[- Hunt 3 (Multi-hunt)](https://hunt.limeseed.email/hunts/04db8238-b929-4640-96df-d8c3b8c19eb0)