### PR TITLE
Create impersonation rule for AFP

### DIFF
--- a/detection-rules/impersonation_afp_australian_federal_police.yml
+++ b/detection-rules/impersonation_afp_australian_federal_police.yml
@@ -4,13 +4,12 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and 0 < length(body.links) < 5
-  
-  // common strings in subject or base
+  and (
+    strings.ilike(subject.base, '*afp*')
+    or strings.ilike(subject.base, '*australian federal police*')
+  )
   and (
     2 of (
-      strings.ilike(subject.base, '*afp*'),
-      strings.ilike(subject.base, '*australian federal police*'),
       strings.ilike(subject.base, '*case*'),
       strings.ilike(subject.base, '*investigation*'),
       strings.ilike(subject.base, '*law enforcement*'),
@@ -18,63 +17,10 @@ source: |
       strings.ilike(subject.base, '*notice*'),
       strings.ilike(subject.base, '*reference*')
     )
-    and (
-      2 of (
-        strings.ilike(sender.display_name, '*afp*'),
-        strings.ilike(sender.display_name, '*australian federal police*'),
-        strings.ilike(sender.display_name, '*case*'),
-        strings.ilike(sender.display_name, '*investigation*'),
-        strings.ilike(sender.display_name, '*law enforcement*'),
-        strings.ilike(sender.display_name, '*management*'),
-        strings.ilike(sender.display_name, '*notice*'),
-        strings.ilike(sender.display_name, '*reference*')
-      )
-    )
   )
-  
-  // body strings with nlu enrichment
   and (
-    (
-      regex.icontains(body.current_thread.text, 'investigation|correspondence')
-      and regex.icontains(body.current_thread.text, 'case (?:reference|type)')
-    )
-    and 3 of (
-      // representation
-      regex.icontains(body.current_thread.text,
-                      'assigned.{0,10}officer|australian federal police|operation firestorm'
-      ),
-  
-      // threat
-      regex.icontains(body.current_thread.text,
-                      'failure to meet|(?:official|formal) (?:noti(?:ce|fication)|declaration|correspondence)|(?:noti(?:fy|fies)|informs?) you'
-      ),
-  
-      // demand
-      regex.icontains(body.current_thread.text,
-                      'cooperate|obstruct|mislead|interfere|\breview\b'
-      ),
-      regex.icontains(body.current_thread.text,
-                      'acknowledge.{0,20}this notice|respond'
-      ),
-  
-      // secrecy
-      regex.icontains(body.current_thread.text, 'confidential|disclose'),
-    )
-    and (
-      any(ml.nlu_classifier(body.current_thread.text).topics,
-          .name == "Legal and Compliance"
-      )
-      and not any(ml.nlu_classifier(body.current_thread.text).topics,
-                  .name == "Events and Webinars"
-      )
-    )
-  )
-  
-  // negate legitimate conversations
-  and not (
-    (length(headers.references) > 0 or headers.in_reply_to is not null)
-    and (subject.is_forward or subject.is_reply)
-    and length(body.previous_threads) >= 1
+    regex.icontains(body.current_thread.text, 'investigation|correspondence')
+    and regex.icontains(body.current_thread.text, 'case (?:reference|type)')
   )
 
 attack_types:

--- a/detection-rules/impersonation_afp_australian_federal_police.yml
+++ b/detection-rules/impersonation_afp_australian_federal_police.yml
@@ -88,3 +88,4 @@ detection_methods:
   - "Header analysis"
   - "Natural Language Understanding"
   - "Sender analysis"
+id: "1f712b4c-597b-53a4-b9b8-fc3d77d9086e"

--- a/detection-rules/impersonation_afp_australian_federal_police.yml
+++ b/detection-rules/impersonation_afp_australian_federal_police.yml
@@ -1,0 +1,90 @@
+name: "Impersonation: Australian Federal Police with criminal case language"
+description: "Detects messages impersonating the Australian Federal Police using law enforcement terminology in the subject and sender display name, combined with official correspondence language including case references, investigation details, and compliance demands."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and 0 < length(body.links) < 5
+  
+  // common strings in subject or base
+  and (
+    2 of (
+      strings.ilike(subject.base, '*afp*'),
+      strings.ilike(subject.base, '*australian federal police*'),
+      strings.ilike(subject.base, '*case*'),
+      strings.ilike(subject.base, '*investigation*'),
+      strings.ilike(subject.base, '*law enforcement*'),
+      strings.ilike(subject.base, '*management*'),
+      strings.ilike(subject.base, '*notice*'),
+      strings.ilike(subject.base, '*reference*')
+    )
+    and (
+      2 of (
+        strings.ilike(sender.display_name, '*afp*'),
+        strings.ilike(sender.display_name, '*australian federal police*'),
+        strings.ilike(sender.display_name, '*case*'),
+        strings.ilike(sender.display_name, '*investigation*'),
+        strings.ilike(sender.display_name, '*law enforcement*'),
+        strings.ilike(sender.display_name, '*management*'),
+        strings.ilike(sender.display_name, '*notice*'),
+        strings.ilike(sender.display_name, '*reference*')
+      )
+    )
+  )
+  
+  // body strings with nlu enrichment
+  and (
+    (
+      regex.icontains(body.current_thread.text, 'investigation|correspondence')
+      and regex.icontains(body.current_thread.text, 'case (?:reference|type)')
+    )
+    and 3 of (
+      // representation
+      regex.icontains(body.current_thread.text,
+                      'assigned.{0,10}officer|australian federal police|operation firestorm'
+      ),
+  
+      // threat
+      regex.icontains(body.current_thread.text,
+                      'failure to meet|(?:official|formal) (?:noti(?:ce|fication)|declaration|correspondence)|(?:noti(?:fy|fies)|informs?) you'
+      ),
+  
+      // demand
+      regex.icontains(body.current_thread.text,
+                      'cooperate|obstruct|mislead|interfere|\breview\b'
+      ),
+      regex.icontains(body.current_thread.text,
+                      'acknowledge.{0,20}this notice|respond'
+      ),
+  
+      // secrecy
+      regex.icontains(body.current_thread.text, 'confidential|disclose'),
+    )
+    and (
+      any(ml.nlu_classifier(body.current_thread.text).topics,
+          .name == "Legal and Compliance"
+      )
+      and not any(ml.nlu_classifier(body.current_thread.text).topics,
+                  .name == "Events and Webinars"
+      )
+    )
+  )
+  
+  // negate legitimate conversations
+  and not (
+    (length(headers.references) > 0 or headers.in_reply_to is not null)
+    and (subject.is_forward or subject.is_reply)
+    and length(body.previous_threads) >= 1
+  )
+
+attack_types:
+  - "BEC/Fraud"
+  - "Extortion"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

This rule detects impersonation attempts using Australian Federal Police terminology in emails, focusing on specific phrases in the subject and sender's display name, as well as content in the body.

# Associated samples

[- Sample 1](https://platform.sublime.security/messages/50629fb0d6dd8bc75b5135dffb3440918c82464a13c3495ddf6e6991593cea2c?preview_id=019e1ad7-a435-7b64-9ade-d1d10aeea3f1)

## Associated hunts


[- Hunt 1 (Shared Samples)](https://platform.sublime.security/messages/hunt?huntId=019e1ce1-bf17-7cc2-8652-fcaf2fb617bc)
[- Hunt 2 (Multi-hunt)](https://hunt.limeseed.email/hunts/94247e7c-22cb-4306-b7fa-0341a5b8b562)