### PR TITLE
Add in missed continue to actually ignore comments from non-members.

### DIFF
--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -400,6 +400,7 @@ jobs:
             for (const comment of comments) {
               if (comment.author_association !== "MEMBER") {
                 console.log("Ignoring comment from non-member" + comment.user.login)
+                continue
               }
 
               while ((m = exemptRegex.exec(comment.body)) !== null) {


### PR DESCRIPTION
# Description

Adds a `continue` to the conditional to skip comments from non-members. This appears to match the intent of this conditional. As it is written, I believe that it logs that it is skipping but carries on processing.