### PR TITLE
Update attachment_pdf_link_sus_lang.yml

### DIFF
--- a/detection-rules/attachment_pdf_link_sus_lang.yml
+++ b/detection-rules/attachment_pdf_link_sus_lang.yml
@@ -39,7 +39,7 @@ source: |
                             and any(ml.link_analysis(.).final_dom.links,
                                     .href_url.domain.root_domain != ..domain.root_domain
                                     and regex.icontains(.display_text,
-                                                        '\b(?:(?:re)?view|see|read)[\t\x20]*(?:\S+[\t\x20]*){0,3}[\t\x20]*(?:document|message|now)',
+                                                        '\b(?:(?:re)?view|see|read|click\s+(?:here\s+)?to)[\t\x20]*(?:\S+[\t\x20]*){0,3}[\t\x20]*(?:document|message|now|proceed)',
                                                         '\b(?:request|review)\b.{1,5}\b(?:bid|proposal|agreement|portfolio|contract|settlement|invoice)\b',
                                     )
                             )
@@ -48,7 +48,7 @@ source: |
                             200 <= ml.link_analysis(.).status_code < 300
                             and length(ml.link_analysis(.).final_dom.display_text) < 1050
                             and regex.icontains(ml.link_analysis(.).final_dom.display_text,
-                                                '\b(?:(?:re)?view|see|read)[\t\x20]*(?:\S+[\t\x20]*){0,3}[\t\x20]*(?:document|message|now)',
+                                                '\b(?:(?:re)?view|see|read|click\s+(?:here\s+)?to)[\t\x20]*(?:\S+[\t\x20]*){0,3}[\t\x20]*(?:document|message|now|proceed)',
                                                 '\b(?:request|review)\b.{1,5}\b(?:bid|proposal|agreement|portfolio|contract|settlement|invoice)\b'
                             )
                             // a common fp in the .au for a payment system


### PR DESCRIPTION
# Description

While working on PR #4453, came across a sample this rule should have fired on. Updated keywords for `display_text` regex to fire on this sample. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50508dded213ebe66f3b0e956f5417350948969b403a0928bde27575d21b5e62?preview_id=019d9d31-22ea-7d7c-ba9c-737283fabc22)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e3c37-5425-764c-8acc-64faac2e4b57)
- [10 Customer Multi-Hunt (1)](https://hunt.limeseed.email/hunts/93d38522-fb98-44d5-83f1-17acfcde23de)
- [10 Customer Multi-Hunt (2)](https://hunt.limeseed.email/hunts/d7f365f2-fc46-4dad-a8e7-fc28e1106f34)
- [10 Customer Multi-Hunt (3)](https://hunt.limeseed.email/hunts/cd06916a-fc41-47fc-a113-49b4679b8874)