### PR TITLE
Update spam_website_errors_solicitation.yml

### DIFF
--- a/detection-rules/spam_website_errors_solicitation.yml
+++ b/detection-rules/spam_website_errors_solicitation.yml
@@ -47,7 +47,16 @@ source: |
       ) == 0
       and length(body.previous_threads) == 0
       // short message between 20 and 500 chars
-      and 20 < length(body.current_thread.text) < 500
+      and (
+        20 < length(body.current_thread.text) < 500
+        or any(map(filter(ml.nlu_classifier(body.current_thread.text).entities,
+                          .name == "disclaimer"
+                   ),
+                   .text
+               ),
+               20 < (length(body.current_thread.text) - length(.)) < 500
+        )
+      )
       // service offering keywords
       and regex.icontains(strings.replace_confusables(body.current_thread.text),
                           "(?:screenshot|error list|plan|quote|rank|professional|price|mistake|visibility|improvement|review|emailed.{0,10}more details)"

--- a/detection-rules/spam_website_errors_solicitation.yml
+++ b/detection-rules/spam_website_errors_solicitation.yml
@@ -25,7 +25,7 @@ source: |
         )
       )
       // short subject
-      or length(subject.base) < 5
+      or length(subject.base) <= 5
     )
     // or a reply or forward in a thread that mentions website or screenshots
     or (


### PR DESCRIPTION
# Description

Updating rule to account for when the `disclaimer` of a sample inflates the output of `length(body.current_thread.text)` and `length(subject.base) <= 5`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5069fea89968b092422177d849d09a4ff57d07292fd081ae04ff23473f90e854?preview_id=019e1cfe-89e1-7e15-8127-9a7e551d05d0)
- [Sample 2](https://platform.sublime.security/messages/506814c361544ccde946263f79dc6112b23c386048690f02a17c017ab6d674cf?preview_id=019e1847-5ccd-7641-820a-d4edf47ae483)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e26ec-d00c-761f-a30f-2007e04ff3b3)