### PR TITLE
Update body_bec_mobile_solicitation.yml

### DIFF
--- a/detection-rules/body_bec_mobile_solicitation.yml
+++ b/detection-rules/body_bec_mobile_solicitation.yml
@@ -4,7 +4,16 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(body.current_thread.text) < 500
+  and (
+    length(body.current_thread.text) < 500
+    or any(map(filter(ml.nlu_classifier(body.current_thread.text).entities,
+                      .name == "disclaimer"
+               ),
+               .text
+           ),
+           (length(body.current_thread.text) - length(.)) < 500
+    )
+  )
   and length(attachments) == 0
   and regex.icontains(body.current_thread.text,
                       '(?:mobile|contact|current|reliable).{0,10}(?:phone|number|#|\bno)|whatsapp|\bcell|personalcell|(?:share|what).{0,25}number.{0,15}(?:connect|reach|text|message|contact|call)|(?:\bdrop|which|send.{0,5}your|best).{0,25}(?:number|\bnum\b|#).{0,15}(?:(?:connect|reach|contact|call).{0,5}you|text|message|works?\b)|forward.{0,25}(?:\bnum\b|#)|get (?:your.{0,25}(?:number|\bnum\b|#)|in touch.{0,15}(?:via|by|through).{0,10}(?:text|phone|cell|sms|whatsapp))|(?:provide|confirm|reply.{0,15}with).{0,25}(?:direct|preferred).{0,15}(?:text.?enabled.{0,15})?(?:phone.{0,5})?(?:number|\bnum\b|#|line)|(?:share|send).{0,25}(?:direct|preferred).{0,15}(?:text.?enabled.{0,15})?(?:phone.{0,5})(?:number|\bnum\b|#|line)|(?:share|send).{0,25}preferred.{0,15}(?:text.?enabled.{0,15})?(?:number|\bnum\b|#|line)|(?:direct|preferred).{0,15}line.{0,15}(?:for|to|via).{0,10}(?:text|call|reach|contact|sms)'


### PR DESCRIPTION
# Description

Updating rule to account for disclaimer that is inflating the output of `length(body.current_thread.text)`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/504615c1730abdbe2408a239ee5558b2b37ad015c1d6aa8a9aff39a8ff102794?preview_id=019e2176-725f-7ebc-bd39-e958a0eab494)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L90D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e2ba5-229a-7e5c-b78e-1e7b625dbeb3)
