### PR TITLE
Create test fuzzy_attack_score rule

### DIFF
--- a/detection-rules/internal_fuzzy_attack_score_test.yml
+++ b/detection-rules/internal_fuzzy_attack_score_test.yml
@@ -1,0 +1,12 @@
+name: "Test - Internal fuzzy attack score graymail"
+description: |
+  Test rule that runs internal.fuzzy_attack_score_test on inbound messages
+  and flags when the response sets graymail to true.
+type: "rule"
+severity: "informational"
+source: |
+  type.inbound
+  and internal.fuzzy_attack_score_test().graymail
+tags:
+  - "test"
+id: "27ec41f8-ef3f-5d43-ad68-21ec38e9cf56"

--- a/detection-rules/internal_fuzzy_attack_score_test.yml
+++ b/detection-rules/internal_fuzzy_attack_score_test.yml
@@ -6,7 +6,7 @@ type: "rule"
 severity: "informational"
 source: |
   type.inbound
-  and internal.fuzzy_attack_score_test().graymail
+  and any([internal.fuzzy_attack_score_test()], .analyzed and .verdict == "never_match_this_verdict")
 tags:
   - "test"
 id: "27ec41f8-ef3f-5d43-ad68-21ec38e9cf56"

--- a/detection-rules/internal_fuzzy_attack_score_test.yml
+++ b/detection-rules/internal_fuzzy_attack_score_test.yml
@@ -6,7 +6,9 @@ type: "rule"
 severity: "informational"
 source: |
   type.inbound
-  and any([internal.fuzzy_attack_score_test()], .analyzed and .verdict == "never_match_this_verdict")
+  and any([internal.fuzzy_attack_score_test()],
+          .analyzed and .verdict == "never_match_this_verdict"
+  )
 tags:
   - "test"
 id: "27ec41f8-ef3f-5d43-ad68-21ec38e9cf56"


### PR DESCRIPTION
# Description
Adds a test rule that will exercise an internal test function version of fuzzy attack score. This is necessary for scale testing stratum w/Mjolnir.