### PR TITLE
Create attachment_svg_entity_encoded_href.yml

### DIFF
--- a/detection-rules/attachment_svg_entity_encoded_href.yml
+++ b/detection-rules/attachment_svg_entity_encoded_href.yml
@@ -1,0 +1,27 @@
+name: "Attachment: SVG file with HTML entity encoded href attributes"
+description: "Detects SVG file attachments containing href attributes with three or more consecutive HTML numeric entity references, a technique used to obfuscate malicious URLs and evade security scanning."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(attachments,
+          (
+            .file_extension == "svg"
+            or .content_type in ("image/svg+xml")
+            or .file_type == "svg"
+          )
+          // href value starting with 3+ HTML numeric entity references
+          and regex.icontains(
+            file.parse_text(., encodings=["ascii", "utf8", "utf16-le"]).text,
+            'href\s*=\s*["\x27]\s*(?:&#x?[0-9a-f]+;\s*){3,}'
+          )
+  )
+attack_types:
+  - "Malware/Ransomware"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "HTML smuggling"
+detection_methods:
+  - "File analysis"
+  - "Content analysis"

--- a/detection-rules/attachment_svg_entity_encoded_href.yml
+++ b/detection-rules/attachment_svg_entity_encoded_href.yml
@@ -11,9 +11,14 @@ source: |
             or .file_type == "svg"
           )
           // href value starting with 3+ HTML numeric entity references
-          and regex.icontains(
-            file.parse_text(., encodings=["ascii", "utf8", "utf16-le"]).text,
-            'href\s*=\s*["\x27]\s*(?:&#x?[0-9a-f]+;\s*){3,}'
+          and regex.icontains(file.parse_text(.,
+                                              encodings=[
+                                                "ascii",
+                                                "utf8",
+                                                "utf16-le"
+                                              ]
+                              ).text,
+                              'href\s*=\s*["\x27]\s*(?:&#x?[0-9a-f]+;\s*){3,}'
           )
   )
 attack_types:
@@ -25,3 +30,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "Content analysis"
+id: "cc527e8e-893c-50b2-957f-2a205712a77f"


### PR DESCRIPTION
# Description

Creating a rule to detect SVG attachments that contain obfuscated `href` attributes

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50637a068295c6de0304791f0ede5fba08cb581e053fa563bc73e32f83e10e1e?preview_id=019dfdf4-2164-753c-be18-0e4e2c807da1)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e41bc-b864-7a6c-960b-9e0fdbeaad51)
- [L7D 17 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/67e9b7bc-ae21-468b-8cec-4e4b4cdb25c9)