### PR TITLE
Create attachment_svg_pointer_cursor_with_link.yml

### DIFF
--- a/detection-rules/attachment_svg_pointer_cursor_with_link.yml
+++ b/detection-rules/attachment_svg_pointer_cursor_with_link.yml
@@ -1,0 +1,26 @@
+name: "Attachment: SVG file with hyperlinks and cursor styling"
+description: "Detects inbound messages containing SVG attachments that include clickable hyperlink elements and CSS pointer cursor styling, which may be used to deceive recipients into clicking malicious links disguised as legitimate images."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(attachments,
+          (
+            .file_extension == "svg"
+            or .content_type in ("image/svg+xml")
+            or .file_type == "svg"
+          )
+          and any(file.explode(.), any(.scan.xml.tags, . == "a"))
+          and regex.icontains(file.parse_text(., encodings=["ascii", "utf8"]).text,
+                              'cursor\s*=\s*["\x27]pointer'
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Image as content"
+detection_methods:
+  - "File analysis"
+  - "XML analysis"
+  - "Content analysis"

--- a/detection-rules/attachment_svg_pointer_cursor_with_link.yml
+++ b/detection-rules/attachment_svg_pointer_cursor_with_link.yml
@@ -24,3 +24,4 @@ detection_methods:
   - "File analysis"
   - "XML analysis"
   - "Content analysis"
+id: "01347141-5757-5bb6-a7ee-0930cee86d16"


### PR DESCRIPTION
# Description

Creating a rule to detect SVG attachments with cursor pointer styling and a clickable link

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50637a068295c6de0304791f0ede5fba08cb581e053fa563bc73e32f83e10e1e?preview_id=019dfdf4-2164-753c-be18-0e4e2c807da1)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e41bd-7458-763b-b168-9353d4145191)
- [L7D Multi-Hunt](https://hunt.limeseed.email/hunts/1185db90-18b4-495b-a2ee-bbf41152aec5)