### PR TITLE
Update link_credential_phishing_cloud_service.yml

### DIFF
--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -15,7 +15,11 @@ source: |
           .name == 'cred_theft' and .confidence == 'high'
   )
   and any(ml.nlu_classifier(body.current_thread.text).topics,
-          .name in ('File Sharing and Cloud Services', 'Payment Information')
+          .name in (
+            'File Sharing and Cloud Services',
+            'Payment Information',
+            'Financial Communications'
+          )
           and .confidence != 'low'
   )
   // sender domain matches no body domains


### PR DESCRIPTION
# Description

Adding the nlu topic of `Financial Communications` to match on additional false negatives.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/506b8994ea4e21150ee353ed3c108f2acd20f9942fd31d3e8975a05bcd736ed1?preview_id=019e26f8-6ae3-7244-90bf-0dc72a35d575)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e3b91-9e59-7d6e-92c0-d2e2a1995818)