### PR TITLE
Create link_storage_google_slugstamp.yml

### DIFF
--- a/detection-rules/link_storage_google_slugstamp.yml
+++ b/detection-rules/link_storage_google_slugstamp.yml
@@ -19,3 +19,4 @@ tactics_and_techniques:
   - "Evasion"
 detection_methods:
   - "URL analysis"
+id: "1005e483-9e29-5a6b-b360-49b35d87054b"

--- a/detection-rules/link_storage_google_slugstamp.yml
+++ b/detection-rules/link_storage_google_slugstamp.yml
@@ -1,0 +1,21 @@
+name: "Link: Google Cloud Storage with suspicious URL pattern"
+description: "Detects inbound messages containing links to Google Cloud Storage (storage.googleapis.com) with suspicious URL path patterns that follow a specific actor-controlled structure commonly used for hosting malicious content."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(body.links,
+          // storage.googleapis.com
+          .href_url.domain.domain == "storage.googleapis.com"
+          // observed pattern in actor controlled url path
+          and regex.contains(.href_url.path,
+                             '^\/[a-z0-9]+-[a-z0-9]+-\d{8}\-[0-9a-f]+\/[^\.]+\.html'
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Free file host"
+  - "Evasion"
+detection_methods:
+  - "URL analysis"


### PR DESCRIPTION
# Description

Create coverage for observed actor url path when using storage.googleapis.com to host cred theft landing pages

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/502a4a86d7c49b036a33fcaf1cc3af7e2310ef74ad7069a245ef5c76db9ab996?preview_id=019cd90c-2981-75e0-a9bf-388eca4fdc7c)
- [Sample 2](https://platform.sublime.security/messages/4fc7a77a3d9a15b4eb4389dd550195883f3bc68d9ae151708e2ad0dc5e365570?preview_id=019b2198-30a9-7509-84c6-5a1ed9f7bdc1)
- [Sample 3](https://platform.sublime.security/messages/4fd0eb0f98eb3bbd7a0941daebaac80500344e58888137cf4b193cc2e18f878e?preview_id=019b2198-71db-7c68-951c-8dbd4aa84fa0)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e2ca2-0f49-75f1-9cf4-795f8d16b934)

# Screenshot (insights)
<!-- 
**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
-->
