### PR TITLE
Create headers_x_source_auth_sender_mismatch.yml

### DIFF
--- a/detection-rules/headers_x_source_auth_sender_mismatch.yml
+++ b/detection-rules/headers_x_source_auth_sender_mismatch.yml
@@ -1,0 +1,25 @@
+name: "Headers: X-Source-Auth mismatch with sender address"
+description: "Detects messages where the X-Source-Auth header contains a different email address than the sender, indicating potential spoofing or mismatched authentication."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // X-Source-Auth doesn't match sender
+  and any(headers.hops,
+          any(.fields,
+              .name == 'X-Source-Auth'
+              and .value != sender.email.email
+              and strings.parse_email(.value).email is not null
+          )
+  )
+tags:
+  - "Attack surface reduction"
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Spoofing"
+  - "Evasion"
+detection_methods:
+  - "Header analysis"
+  - "Sender analysis"

--- a/detection-rules/headers_x_source_auth_sender_mismatch.yml
+++ b/detection-rules/headers_x_source_auth_sender_mismatch.yml
@@ -23,3 +23,4 @@ tactics_and_techniques:
 detection_methods:
   - "Header analysis"
   - "Sender analysis"
+id: "7756bf2c-4ef4-5112-8109-5f91b085171f"


### PR DESCRIPTION
# Description
This is an ASR rule for when the x-source-auth doesn't match the sender email. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/505b310f0551038a69557f81c9ac79da36831290fa59912ba501d9d806ec7563?preview_id=019dd558-e421-74c0-b449-80598ccade69)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e2d95-dd8f-79db-a41b-a09209343915)
