### PR TITLE
Update abuse_microsoft_subject_stuffing.yml

### DIFF
--- a/detection-rules/abuse_microsoft_subject_stuffing.yml
+++ b/detection-rules/abuse_microsoft_subject_stuffing.yml
@@ -11,7 +11,7 @@ source: |
   and strings.icontains(subject.subject, 'account email verification code')
   and (
     // phone number regex
-    regex.icontains(subject.base,
+    regex.icontains(strings.replace_confusables(subject.base),
                     '\+?(?:[ilo0-9]{1}.)?\(?[ilo0-9]{3}?\)?.[ilo0-9]{3}.?[ilo0-9]{4}',
                     '\+?(?:[ilo0-9]{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}[ilo0-9]{3}[\s\.\-⋅]{0,5}[ilo0-9]{4}'
     )


### PR DESCRIPTION
# Description

For a call back scam the threat actor was using a confusable instead of 0. Using replace_confusables for phone number regex fixes this issue. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/506417d3d5fdd06265e5a3376e4af1ed38ab28ef404b2fdd5f1da477cbaa0fe9?preview_id=019e03ea-d1b0-761b-a3be-c7e5ea366149)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Net new multi-hunt](https://hunt.limeseed.email/hunts/196e9b83-3a69-4219-b250-df14744c7b0d)
- [Net new SWS](https://platform.sublime.security/messages/hunt?huntId=019e3b92-b08c-7289-a92b-73655b0fd54f)
