### PR TITLE
Update body_extortion.yml

### DIFF
--- a/detection-rules/body_extortion.yml
+++ b/detection-rules/body_extortion.yml
@@ -62,11 +62,11 @@ source: |
     or 3 of (
       // malware terms
       regex.icontains(strings.replace_confusables(body.current_thread.text),
-                      "(?:(?:spy|[mṁ][aȁ]l)[wŵ][aȁ][rŗ]e|[tŢ][rŗȓ][oố]j[aǻ][nņ]|[rȓ]emote (?:entry|cont[rř]o[lĺ])|infiltrat(?:ed|ion)|backdoor|vi[rṙ]us|intruder|(?:your|the).{0,15}(?:device|system|computer|phone).{0,10}(?:became|was|got|is).{0,5}comprom[ḯiïíįī]sed|prov[ḯiïíįī]d[ḯiïíįī]ng.{0,20}full [aảǡą]ccess)"
+                      "(?:(?:spy|[mṁ][aȁḁ]l)[wŵ][aȁḁ][rŗ]e|[tŢ][rŗȓ][oốởộ]j[aǻä][nņ]|[rȓ]emote (?:entry|cont[rř]o[lĺ])|infiltrat(?:ed|ion)|backdoor|vi[rṙ]us|intruder|(?:your|the).{0,15}(?:device|system|computer|phone).{0,10}(?:became|was|got|is).{0,5}comprom[ḯiïíįī]sed|prov[ḯiïíįī]d[ḯiïíįī]ng.{0,20}full [aảǡą]ccess)"
       ),
       // actions recorded
       regex.icontains(strings.replace_confusables(body.current_thread.text),
-                      "(?:p[oộ][rŗ]n|a[dȡ]ult (?:web)?site|webcam|mastu[rŗ]bating|je[rŗ]king off|pleasu[rŗȑ]i[nŋ]g you[rŗṛ]self|getting off|expli[cƈ]it|cl[ḯiïíįī]ps.{0,20}screenshots)"
+                      "(?:p[oộ][rŗ]n|a[dȡ]ult (?:web)?site|webcam|mastu[rŗ]bating|je[rŗ]king off|pleasu[rŗȑ]i[nŋ]g you[rŗṛ]self|getting off|expli[cƈ]it|cl[ḯiïíįī]ps.{0,20}screenshots|NSFW|gr[aǻẳ]phic c[oỡở]ntent)"
       ),
       regex.icontains(strings.replace_confusables(body.current_thread.text),
                       "(?:pe[rŗ]ve[rŗ]t|pe[rŗ]ve[rŗ]sion|mastu[rŗ]bat)"
@@ -74,7 +74,7 @@ source: |
       // a timeframe to pay
       regex.icontains(strings.replace_confusables(body.current_thread.text),
                       '[ilo0-9]{2} (?:hou[rŗṝ][sṣ]|uu[rŗ])',
-                      '(?:one|tw[oờ]|2|th[rŗ]ee|\d) [dḍ][aảǡą]y[sṣ]?',
+                      '(?:one|tw[oờȍ]|2|th[rŗ]ee|\d) [dḍ][aảǡą]y[sṣ]?',
                       'set a timer'
       ),
       // a promise from the actor
@@ -83,7 +83,7 @@ source: |
       ),
       // a threat from the actor
       regex.icontains(strings.replace_confusables(body.current_thread.text),
-                      '(?:\bsen[dt]|forward|expose)\s*(?:[\p{L}\p{N}]+\s*){0,5}\s*to\s*(?:[\p{L}\p{N}]+\s*){0,5}(?:contacts|media|family|f[rŗ]iends|coworkers|associates)'
+                      '(?:\bsen[dt]|forward|expose|share)\s*(?:[\p{L}\p{N}]+\s*){0,5}\s*to\s*(?:[\p{L}\p{N}]+\s*){0,5}(?:contacts|media|family|f[rŗ]iends|coworkers|co-workers|associates|kin\b)'
       ),
       // bitcoin language (excluding newsletters)
       (
@@ -118,9 +118,12 @@ source: |
       regex.icontains(strings.replace_confusables(body.current_thread.text),
                       'bc1q.{0,50}\b'
       ),
-      regex.count(body.current_thread.text,
-                  '[\x{0300}-\x{036F}\x{1AB0}-\x{1AFF}\x{1DC0}-\x{1DFF}\x{0100}-\x{024F}\x{1E00}-\x{1EFF}]'
-      ) > 10
+      (
+        regex.count(body.current_thread.text,
+                    '[\x{0300}-\x{036F}\x{1AB0}-\x{1AFF}\x{1DC0}-\x{1DFF}\x{0100}-\x{024F}\x{1E00}-\x{1EFF}]'
+        ) > 20
+        and length(body.links) == 0
+      )
     )
   )
   and (

--- a/detection-rules/body_extortion.yml
+++ b/detection-rules/body_extortion.yml
@@ -122,7 +122,7 @@ source: |
         regex.count(body.current_thread.text,
                     '[\x{0300}-\x{036F}\x{1AB0}-\x{1AFF}\x{1DC0}-\x{1DFF}\x{0100}-\x{024F}\x{1E00}-\x{1EFF}]'
         ) > 20
-        and length(body.links) == 0
+        and length(body.current_thread.links) == 0
       )
     )
   )

--- a/detection-rules/body_extortion.yml
+++ b/detection-rules/body_extortion.yml
@@ -117,7 +117,10 @@ source: |
       ),
       regex.icontains(strings.replace_confusables(body.current_thread.text),
                       'bc1q.{0,50}\b'
-      )
+      ),
+      regex.count(body.current_thread.text,
+                  '[\x{0300}-\x{036F}\x{1AB0}-\x{1AFF}\x{1DC0}-\x{1DFF}\x{0100}-\x{024F}\x{1E00}-\x{1EFF}]'
+      ) > 10
     )
   )
   and (


### PR DESCRIPTION
# Description

Updating this rule to add another condition in the `3 of` logic to tag the use of heavy unicode obfuscation

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/506d7848df46134aea4ebdfa91c23af5adb8ddb0a7dbd11e554cdbe8e84fcb04?preview_id=019e3299-2324-7942-8bf1-54e9ab24d777)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e45c3-b195-77cf-be9c-6b3ce5d2df35)