### PR TITLE
Update impersonation_quickbooks.yml

### DIFF
--- a/detection-rules/impersonation_quickbooks.yml
+++ b/detection-rules/impersonation_quickbooks.yml
@@ -47,6 +47,7 @@ source: |
     or strings.icontains(body.current_thread.text,
                          "Secured by QuickBooks Payments"
     )
+    or strings.icontains(body.current_thread.text, "QuickBooks Support Center")
     // phone number and update language
     or (
       regex.icontains(body.current_thread.text,

--- a/detection-rules/impersonation_quickbooks.yml
+++ b/detection-rules/impersonation_quickbooks.yml
@@ -29,8 +29,13 @@ source: |
     )
     // contains the address and copyright
     or (
-      strings.icontains(body.current_thread.text,
-                        '2800 E. Commerce Center Place, Tucson, AZ 85706'
+      (
+        strings.icontains(body.current_thread.text,
+                          '2800 E. Commerce Center Place, Tucson, AZ 85706'
+        )
+        or strings.icontains(body.current_thread.text,
+                             '2700 Coast Ave, Mountain View, CA 94043'
+        )
       )
       and regex.icontains(body.current_thread.text, '©\s*(?:\d+)\s*Intuit')
     )
@@ -39,6 +44,9 @@ source: |
                          'QuickBooks and Intuit are trademarks of Intuit Inc.'
     )
     or strings.icontains(body.current_thread.text, "QuickBooks Cloud Services")
+    or strings.icontains(body.current_thread.text,
+                         "Secured by QuickBooks Payments"
+    )
     // phone number and update language
     or (
       regex.icontains(body.current_thread.text,


### PR DESCRIPTION
# Description

Adding a second address to current logic, as well as, another keyword match to `body.current_thread.text`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/506d2fd0a54cbb11018fe95beab4480f5f1ae3ddcfb69df65cf3fce2f3e20c94?preview_id=019e32a4-43ae-72c7-b640-85695e5e7c4d)
- [Sample 2](https://platform.sublime.security/messages/506c522c2aefd6bc350202f6521e1325d934282511ccc9766a569272e5045250?preview_id=019e2ca7-79d9-78b4-9503-731b0f8e0d36)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e468f-7d2a-74cc-89a4-45f959c0e2e0)