### PR TITLE
Update impersonation_fake_copyright_infringement_notice_from_unsolicted_sender.yml

### DIFF
--- a/detection-rules/impersonation_fake_copyright_infringement_notice_from_unsolicited_sender.yml
+++ b/detection-rules/impersonation_fake_copyright_infringement_notice_from_unsolicited_sender.yml
@@ -28,6 +28,8 @@ source: |
       strings.ilike(subject.base, '*Notice*'),
       strings.ilike(subject.base, '*Clarification*'),
       strings.ilike(subject.base, '*Matter*'),
+      strings.ilike(subject.base, '*Conflict*'),
+      strings.ilike(subject.base, '*Ownership*'),
       strings.ilike(sender.display_name, '*Content*'),
       strings.ilike(sender.display_name, '*Copyright*'),
       strings.ilike(sender.display_name, '*Review*'),
@@ -37,7 +39,8 @@ source: |
       strings.ilike(sender.display_name, '*Law*'),
       strings.ilike(sender.display_name, '*Intellectual*'),
       strings.ilike(sender.display_name, '*Notice*'),
-      strings.ilike(sender.display_name, '*Matter*')
+      strings.ilike(sender.display_name, '*Matter*'),
+      strings.ilike(sender.display_name, '*Advisory*')
     )
   )
   
@@ -99,7 +102,10 @@ source: |
     strings.ilike(body.current_thread.text, '*interests*'),
     strings.ilike(body.current_thread.text, '*appeal*'),
     strings.ilike(body.current_thread.text, '*clarification*'),
-    strings.ilike(body.current_thread.text, '*notice*')
+    strings.ilike(body.current_thread.text, '*notice*'),
+    strings.ilike(body.current_thread.text, '*dissemination*'),
+    strings.ilike(body.current_thread.text, '*counter-notice*'),
+    strings.ilike(body.current_thread.text, '*exploitation*')
   )
   
   // remove phrase from legitimate complaint


### PR DESCRIPTION
# Description

Adding additional keywords to `subject.base`, `sender.display_name`, and `body.current_thread.text` to match on additional samples

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1
](https://platform.sublime.security/messages/5070e8c5b01af364d30c36595dad72141369614eacc5e7df4109f9225c446317?preview_id=019e4168-effc-79f7-8d03-1d4ba400082a)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L14D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e4aef-4570-7456-a54f-e150b01ef90f)