### PR TITLE
Create link_self_sender_cred_theft_external_domains.yml

### DIFF
--- a/detection-rules/link_self_sender_cred_theft_external_domains.yml
+++ b/detection-rules/link_self_sender_cred_theft_external_domains.yml
@@ -17,8 +17,8 @@ source: |
   )
   // A few fps with this pattern that approve data migration systems
   and not any(filter(body.links, .href_url.path is not null),
-          strings.icontains(.href_url.path, '/consent/')
-          or strings.icontains(.href_url.path, '/approvals')
+              strings.icontains(.href_url.path, '/consent/')
+              or strings.icontains(.href_url.path, '/approvals')
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == "cred_theft" and .confidence != "low"
@@ -40,3 +40,4 @@ detection_methods:
   - "Header analysis"
   - "URL analysis"
   - "Content analysis"
+id: "ea16ad7e-a93a-51aa-ae13-76721e6cbca8"

--- a/detection-rules/link_self_sender_cred_theft_external_domains.yml
+++ b/detection-rules/link_self_sender_cred_theft_external_domains.yml
@@ -1,0 +1,42 @@
+name: "Link: Self-sender credential theft with external domains"
+description: "Detects messages where the sender and recipient are the same address, containing external links and classified as credential theft by NLU analysis. The rule identifies self-sent messages from non-free email providers that pass DMARC authentication but contain 1-4 links to external domains, with machine learning classification indicating credential theft intent."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  // self sender
+  and sender.email.email == recipients.to[0].email.email
+  // auth passes
+  and coalesce(headers.auth_summary.dmarc.pass, false)
+  // not free email
+  and sender.email.domain.root_domain not in $free_email_providers
+  // at least one link but less than 5
+  and 0 < length(body.links) < 5
+  and any(body.links,
+          .href_url.domain.root_domain != sender.email.domain.root_domain
+  )
+  // A few fps with this pattern that approve data migration systems
+  and not any(filter(body.links, .href_url.path is not null),
+          strings.icontains(.href_url.path, '/consent/')
+          or strings.icontains(.href_url.path, '/approvals')
+  )
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "cred_theft" and .confidence != "low"
+  )
+  // Not password reset, compromised account emails
+  and not (
+    strings.icontains(body.current_thread.text, "compromised")
+    or strings.icontains(body.current_thread.text, "password")
+  )
+  // under 2000 characters
+  and length(body.current_thread.text) < 2000
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Natural Language Understanding"
+  - "Sender analysis"
+  - "Header analysis"
+  - "URL analysis"
+  - "Content analysis"


### PR DESCRIPTION
# Description

Detects messages where the sender and recipient are the same address, containing external links and classified as credential theft by NLU analysis. The rule identifies self-sent messages from non-free email providers that pass DMARC authentication but contain 1-4 links to external domains, with machine learning classification indicating credential theft intent.

# Associated samples

- [OG sample](https://platform.sublime.security/messages/506fed9161ef783f3cc0694b5a06d0959f634225ed455aef3d3a16cde94f8eb6?preview_id=019e3c19-dae6-776b-8333-1df0bf3b5daf)
- [largest outlier of 2000 character limit](https://platform.sublime.security/messages/50648aa7fe7816a25bf9ac72fa2ee2f95ebfb3585216482bd1cac1eff076a25e?preview_id=019e04dd-ec70-7245-86a2-e8041d9a4c72)

## Associated hunts

- [Hunt 180 days](https://platform.sublime.security/messages/hunt?huntId=019e4344-3dd4-78a3-84c6-2f0dbbf237eb)
- [Hunt negating 2000 character limit](https://platform.sublime.security/messages/hunt?huntId=019e4338-340b-7985-af6c-6f78cd925fec)
- 
