### PR TITLE
Update attachment_adobe_image_lure.yml

### DIFF
--- a/detection-rules/attachment_adobe_image_lure.yml
+++ b/detection-rules/attachment_adobe_image_lure.yml
@@ -102,6 +102,11 @@ source: |
     // exclude solicited senders
     not profile.by_sender_email().solicited
     or profile.by_sender_email().prevalence == "new"
+    // exclude solicited senders where prevelance is rare
+    or (
+      profile.by_sender_email().prevalence == "rare"
+      and profile.by_sender_email().solicited
+    )
     or length(recipients.to) == 0
     // domains for recipients to/cc must be valid
     or (

--- a/detection-rules/attachment_adobe_image_lure.yml
+++ b/detection-rules/attachment_adobe_image_lure.yml
@@ -102,7 +102,7 @@ source: |
     // exclude solicited senders
     not profile.by_sender_email().solicited
     or profile.by_sender_email().prevalence == "new"
-    // exclude solicited senders where prevelance is rare
+    // include solicited senders where prevelance is rare
     or (
       profile.by_sender_email().prevalence == "rare"
       and profile.by_sender_email().solicited


### PR DESCRIPTION
# Description

This updates the `Attachment: Adobe image lure in body or attachment with suspicious link` rule to include senders that are soliticed but have rare prevalence with the recipient.  This spanned because of a runner ping.

# Associated samples

- [Sample](https://platform.sublime.security/messages/506ff01d3f364a0a4e269e50facdc492d74bf1773112cdd7da4101a98db60a0e?preview_id=019e3beb-8f0c-7bbf-b853-ccad521bfbc3)

## Associated hunts

- [Hunt diff between rule changes](https://platform.sublime.security/messages/hunt?huntId=019e45b1-c741-7168-ba60-12a552a77702) -> won't show much because dependent on sender profile config
