### PR TITLE
Add first_name/last_name concat matching to org_vips sender rules

### DIFF
--- a/detection-rules/impersonation_vip_bec_loose.yml
+++ b/detection-rules/impersonation_vip_bec_loose.yml
@@ -10,10 +10,17 @@ source: |
   and any($org_vips,
           0 <= strings.ilevenshtein(sender.display_name, .display_name) < 4
           or 0 <= strings.ilevenshtein(sender.display_name,
-                                       strings.concat(.last_name, ", ", .first_name)
+                                       strings.concat(.last_name,
+                                                      ", ",
+                                                      .first_name
+                                       )
           ) < 4
-          or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
-                 0 <= strings.ilevenshtein(sender.display_name, .named_groups["name"]) < 4
+          or any(regex.extract(.display_name,
+                               '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+                 ),
+                 0 <= strings.ilevenshtein(sender.display_name,
+                                           .named_groups["name"]
+                 ) < 4
           )
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents,

--- a/detection-rules/impersonation_vip_bec_loose.yml
+++ b/detection-rules/impersonation_vip_bec_loose.yml
@@ -10,17 +10,11 @@ source: |
   and any($org_vips,
           0 <= strings.ilevenshtein(sender.display_name, .display_name) < 4
           or 0 <= strings.ilevenshtein(sender.display_name,
-                                       strings.concat(.first_name,
-                                                      " ",
-                                                      .last_name
-                                       )
+                                       strings.concat(.last_name, ", ", .first_name)
           ) < 4
-          or 0 <= strings.ilevenshtein(sender.display_name,
-                                       strings.concat(.last_name,
-                                                      ", ",
-                                                      .first_name
-                                       )
-          ) < 4
+          or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+                 0 <= strings.ilevenshtein(sender.display_name, .named_groups["name"]) < 4
+          )
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == "bec" and .confidence in ("medium", "high")

--- a/detection-rules/impersonation_vip_bec_loose.yml
+++ b/detection-rules/impersonation_vip_bec_loose.yml
@@ -8,19 +8,30 @@ severity: "medium"
 source: |
   type.inbound
   and any($org_vips,
-          0 <= strings.ilevenshtein(sender.display_name, .display_name) < 4
-          or 0 <= strings.ilevenshtein(sender.display_name,
-                                       strings.concat(.first_name,
-                                                      " ",
-                                                      .last_name
-                                       )
-          ) < 4
-          or 0 <= strings.ilevenshtein(sender.display_name,
-                                       strings.concat(.last_name,
-                                                      ", ",
-                                                      .first_name
-                                       )
-          ) < 4
+          (
+            .display_name != ""
+            and 0 <= strings.ilevenshtein(sender.display_name, .display_name) < 4
+          )
+          or (
+            .first_name != ""
+            and .last_name != ""
+            and 0 <= strings.ilevenshtein(sender.display_name,
+                                          strings.concat(.first_name,
+                                                         " ",
+                                                         .last_name
+                                          )
+            ) < 4
+          )
+          or (
+            .first_name != ""
+            and .last_name != ""
+            and 0 <= strings.ilevenshtein(sender.display_name,
+                                          strings.concat(.last_name,
+                                                         ", ",
+                                                         .first_name
+                                          )
+            ) < 4
+          )
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == "bec" and .confidence in ("medium", "high")

--- a/detection-rules/impersonation_vip_bec_loose.yml
+++ b/detection-rules/impersonation_vip_bec_loose.yml
@@ -10,18 +10,11 @@ source: |
   and any($org_vips,
           0 <= strings.ilevenshtein(sender.display_name, .display_name) < 4
           or 0 <= strings.ilevenshtein(sender.display_name,
-                                       strings.concat(.last_name,
-                                                      ", ",
-                                                      .first_name
-                                       )
+                                       strings.concat(.first_name, " ", .last_name)
           ) < 4
-          or any(regex.extract(.display_name,
-                               '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-                 ),
-                 0 <= strings.ilevenshtein(sender.display_name,
-                                           .named_groups["name"]
-                 ) < 4
-          )
+          or 0 <= strings.ilevenshtein(sender.display_name,
+                                       strings.concat(.last_name, ", ", .first_name)
+          ) < 4
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == "bec" and .confidence in ("medium", "high")

--- a/detection-rules/impersonation_vip_bec_loose.yml
+++ b/detection-rules/impersonation_vip_bec_loose.yml
@@ -9,8 +9,18 @@ source: |
   type.inbound
   and any($org_vips,
           0 <= strings.ilevenshtein(sender.display_name, .display_name) < 4
-          or 0 <= strings.ilevenshtein(sender.display_name, strings.concat(.first_name, " ", .last_name)) < 4
-          or 0 <= strings.ilevenshtein(sender.display_name, strings.concat(.last_name, ", ", .first_name)) < 4
+          or 0 <= strings.ilevenshtein(sender.display_name,
+                                       strings.concat(.first_name,
+                                                      " ",
+                                                      .last_name
+                                       )
+          ) < 4
+          or 0 <= strings.ilevenshtein(sender.display_name,
+                                       strings.concat(.last_name,
+                                                      ", ",
+                                                      .first_name
+                                       )
+          ) < 4
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == "bec" and .confidence in ("medium", "high")

--- a/detection-rules/impersonation_vip_bec_loose.yml
+++ b/detection-rules/impersonation_vip_bec_loose.yml
@@ -10,10 +10,16 @@ source: |
   and any($org_vips,
           0 <= strings.ilevenshtein(sender.display_name, .display_name) < 4
           or 0 <= strings.ilevenshtein(sender.display_name,
-                                       strings.concat(.first_name, " ", .last_name)
+                                       strings.concat(.first_name,
+                                                      " ",
+                                                      .last_name
+                                       )
           ) < 4
           or 0 <= strings.ilevenshtein(sender.display_name,
-                                       strings.concat(.last_name, ", ", .first_name)
+                                       strings.concat(.last_name,
+                                                      ", ",
+                                                      .first_name
+                                       )
           ) < 4
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents,

--- a/detection-rules/impersonation_vip_bec_loose.yml
+++ b/detection-rules/impersonation_vip_bec_loose.yml
@@ -9,6 +9,8 @@ source: |
   type.inbound
   and any($org_vips,
           0 <= strings.ilevenshtein(sender.display_name, .display_name) < 4
+          or 0 <= strings.ilevenshtein(sender.display_name, strings.concat(.first_name, " ", .last_name)) < 4
+          or 0 <= strings.ilevenshtein(sender.display_name, strings.concat(.last_name, ", ", .first_name)) < 4
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == "bec" and .confidence in ("medium", "high")

--- a/detection-rules/impersonation_vip_invoicing_request.yml
+++ b/detection-rules/impersonation_vip_invoicing_request.yml
@@ -5,7 +5,10 @@ severity: "high"
 source: |
   type.inbound
   and any($org_vips,
-          (.display_name != "" and strings.contains(sender.display_name, .display_name))
+          (
+            .display_name != ""
+            and strings.contains(sender.display_name, .display_name)
+          )
           or (
             .first_name != ""
             and .last_name != ""

--- a/detection-rules/impersonation_vip_invoicing_request.yml
+++ b/detection-rules/impersonation_vip_invoicing_request.yml
@@ -7,12 +7,10 @@ source: |
   and any($org_vips,
           strings.contains(sender.display_name, .display_name)
           or strings.contains(sender.display_name,
-                              strings.concat(.last_name, ", ", .first_name)
+                              strings.concat(.first_name, " ", .last_name)
           )
-          or any(regex.extract(.display_name,
-                               '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-                 ),
-                 strings.contains(sender.display_name, .named_groups["name"])
+          or strings.contains(sender.display_name,
+                              strings.concat(.last_name, ", ", .first_name)
           )
   )
   and (

--- a/detection-rules/impersonation_vip_invoicing_request.yml
+++ b/detection-rules/impersonation_vip_invoicing_request.yml
@@ -5,12 +5,20 @@ severity: "high"
 source: |
   type.inbound
   and any($org_vips,
-          strings.contains(sender.display_name, .display_name)
-          or strings.contains(sender.display_name,
-                              strings.concat(.first_name, " ", .last_name)
+          (.display_name != "" and strings.contains(sender.display_name, .display_name))
+          or (
+            .first_name != ""
+            and .last_name != ""
+            and strings.contains(sender.display_name,
+                                 strings.concat(.first_name, " ", .last_name)
+            )
           )
-          or strings.contains(sender.display_name,
-                              strings.concat(.last_name, ", ", .first_name)
+          or (
+            .first_name != ""
+            and .last_name != ""
+            and strings.contains(sender.display_name,
+                                 strings.concat(.last_name, ", ", .first_name)
+            )
           )
   )
   and (

--- a/detection-rules/impersonation_vip_invoicing_request.yml
+++ b/detection-rules/impersonation_vip_invoicing_request.yml
@@ -9,7 +9,9 @@ source: |
           or strings.contains(sender.display_name,
                               strings.concat(.last_name, ", ", .first_name)
           )
-          or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+          or any(regex.extract(.display_name,
+                               '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+                 ),
                  strings.contains(sender.display_name, .named_groups["name"])
           )
   )

--- a/detection-rules/impersonation_vip_invoicing_request.yml
+++ b/detection-rules/impersonation_vip_invoicing_request.yml
@@ -7,10 +7,10 @@ source: |
   and any($org_vips,
           strings.contains(sender.display_name, .display_name)
           or strings.contains(sender.display_name,
-                              strings.concat(.first_name, " ", .last_name)
-          )
-          or strings.contains(sender.display_name,
                               strings.concat(.last_name, ", ", .first_name)
+          )
+          or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+                 strings.contains(sender.display_name, .named_groups["name"])
           )
   )
   and (

--- a/detection-rules/impersonation_vip_invoicing_request.yml
+++ b/detection-rules/impersonation_vip_invoicing_request.yml
@@ -6,8 +6,12 @@ source: |
   type.inbound
   and any($org_vips,
           strings.contains(sender.display_name, .display_name)
-          or strings.contains(sender.display_name, strings.concat(.first_name, " ", .last_name))
-          or strings.contains(sender.display_name, strings.concat(.last_name, ", ", .first_name))
+          or strings.contains(sender.display_name,
+                              strings.concat(.first_name, " ", .last_name)
+          )
+          or strings.contains(sender.display_name,
+                              strings.concat(.last_name, ", ", .first_name)
+          )
   )
   and (
     (
@@ -30,7 +34,7 @@ source: |
     )
   )
   
-  // and the reply to email address has never been contacted  
+  // and the reply to email address has never been contacted
   and any(headers.reply_to, .email.email not in $recipient_emails)
   
   // negate highly trusted sender domains unless they fail DMARC authentication
@@ -41,7 +45,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-  
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:

--- a/detection-rules/impersonation_vip_invoicing_request.yml
+++ b/detection-rules/impersonation_vip_invoicing_request.yml
@@ -4,7 +4,11 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and any($org_vips, strings.contains(sender.display_name, .display_name))
+  and any($org_vips,
+          strings.contains(sender.display_name, .display_name)
+          or strings.contains(sender.display_name, strings.concat(.first_name, " ", .last_name))
+          or strings.contains(sender.display_name, strings.concat(.last_name, ", ", .first_name))
+  )
   and (
     (
       sender.email.domain.domain in $org_domains

--- a/detection-rules/impersonation_vip_urgent_request.yml
+++ b/detection-rules/impersonation_vip_urgent_request.yml
@@ -9,8 +9,10 @@ source: |
   type.inbound
   and any($org_vips,
           .display_name =~ sender.display_name
-          or strings.concat(.first_name, " ", .last_name) == sender.display_name
-          or strings.concat(.last_name, ", ", .first_name) == sender.display_name
+          or strings.concat(.last_name, ", ", .first_name) =~ sender.display_name
+          or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+                 .named_groups["name"] =~ sender.display_name
+          )
   )
   and (
     any(ml.nlu_classifier(body.current_thread.text).intents,

--- a/detection-rules/impersonation_vip_urgent_request.yml
+++ b/detection-rules/impersonation_vip_urgent_request.yml
@@ -10,7 +10,9 @@ source: |
   and any($org_vips,
           .display_name =~ sender.display_name
           or strings.concat(.last_name, ", ", .first_name) =~ sender.display_name
-          or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+          or any(regex.extract(.display_name,
+                               '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+                 ),
                  .named_groups["name"] =~ sender.display_name
           )
   )

--- a/detection-rules/impersonation_vip_urgent_request.yml
+++ b/detection-rules/impersonation_vip_urgent_request.yml
@@ -8,9 +8,17 @@ severity: "high"
 source: |
   type.inbound
   and any($org_vips,
-          .display_name =~ sender.display_name
-          or strings.concat(.first_name, " ", .last_name) =~ sender.display_name
-          or strings.concat(.last_name, ", ", .first_name) =~ sender.display_name
+          (.display_name != "" and .display_name =~ sender.display_name)
+          or (
+            .first_name != ""
+            and .last_name != ""
+            and strings.concat(.first_name, " ", .last_name) =~ sender.display_name
+          )
+          or (
+            .first_name != ""
+            and .last_name != ""
+            and strings.concat(.last_name, ", ", .first_name) =~ sender.display_name
+          )
   )
   and (
     any(ml.nlu_classifier(body.current_thread.text).intents,

--- a/detection-rules/impersonation_vip_urgent_request.yml
+++ b/detection-rules/impersonation_vip_urgent_request.yml
@@ -7,7 +7,11 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and any($org_vips, .display_name =~ sender.display_name)
+  and any($org_vips,
+          .display_name =~ sender.display_name
+          or strings.concat(.first_name, " ", .last_name) == sender.display_name
+          or strings.concat(.last_name, ", ", .first_name) == sender.display_name
+  )
   and (
     any(ml.nlu_classifier(body.current_thread.text).intents,
         .name == "bec" and .confidence in ("medium", "high")

--- a/detection-rules/impersonation_vip_urgent_request.yml
+++ b/detection-rules/impersonation_vip_urgent_request.yml
@@ -9,12 +9,8 @@ source: |
   type.inbound
   and any($org_vips,
           .display_name =~ sender.display_name
+          or strings.concat(.first_name, " ", .last_name) =~ sender.display_name
           or strings.concat(.last_name, ", ", .first_name) =~ sender.display_name
-          or any(regex.extract(.display_name,
-                               '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-                 ),
-                 .named_groups["name"] =~ sender.display_name
-          )
   )
   and (
     any(ml.nlu_classifier(body.current_thread.text).intents,

--- a/detection-rules/impersonation_vip_w2_request.yml
+++ b/detection-rules/impersonation_vip_w2_request.yml
@@ -10,7 +10,9 @@ source: |
         or strings.contains(sender.display_name,
                             strings.concat(.last_name, ", ", .first_name)
         )
-        or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+        or any(regex.extract(.display_name,
+                             '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+               ),
                strings.contains(sender.display_name, .named_groups["name"])
         )
     )

--- a/detection-rules/impersonation_vip_w2_request.yml
+++ b/detection-rules/impersonation_vip_w2_request.yml
@@ -5,7 +5,11 @@ severity: "high"
 source: |
   type.inbound
   and (
-    any($org_vips, strings.contains(sender.display_name, .display_name))
+    any($org_vips,
+        strings.contains(sender.display_name, .display_name)
+        or strings.contains(sender.display_name, strings.concat(.first_name, " ", .last_name))
+        or strings.contains(sender.display_name, strings.concat(.last_name, ", ", .first_name))
+    )
     or any(regex.extract(sender.display_name, '^(?<first>\S+)\s+(?<second>\S+)$'),
            any($org_vips,
                strings.contains(.display_name, ..named_groups["first"])

--- a/detection-rules/impersonation_vip_w2_request.yml
+++ b/detection-rules/impersonation_vip_w2_request.yml
@@ -8,10 +8,10 @@ source: |
     any($org_vips,
         strings.contains(sender.display_name, .display_name)
         or strings.contains(sender.display_name,
-                            strings.concat(.first_name, " ", .last_name)
-        )
-        or strings.contains(sender.display_name,
                             strings.concat(.last_name, ", ", .first_name)
+        )
+        or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+               strings.contains(sender.display_name, .named_groups["name"])
         )
     )
     or any(regex.extract(sender.display_name, '^(?<first>\S+)\s+(?<second>\S+)$'),

--- a/detection-rules/impersonation_vip_w2_request.yml
+++ b/detection-rules/impersonation_vip_w2_request.yml
@@ -7,8 +7,12 @@ source: |
   and (
     any($org_vips,
         strings.contains(sender.display_name, .display_name)
-        or strings.contains(sender.display_name, strings.concat(.first_name, " ", .last_name))
-        or strings.contains(sender.display_name, strings.concat(.last_name, ", ", .first_name))
+        or strings.contains(sender.display_name,
+                            strings.concat(.first_name, " ", .last_name)
+        )
+        or strings.contains(sender.display_name,
+                            strings.concat(.last_name, ", ", .first_name)
+        )
     )
     or any(regex.extract(sender.display_name, '^(?<first>\S+)\s+(?<second>\S+)$'),
            any($org_vips,

--- a/detection-rules/impersonation_vip_w2_request.yml
+++ b/detection-rules/impersonation_vip_w2_request.yml
@@ -6,12 +6,20 @@ source: |
   type.inbound
   and (
     any($org_vips,
-        strings.contains(sender.display_name, .display_name)
-        or strings.contains(sender.display_name,
-                            strings.concat(.first_name, " ", .last_name)
+        (.display_name != "" and strings.contains(sender.display_name, .display_name))
+        or (
+          .first_name != ""
+          and .last_name != ""
+          and strings.contains(sender.display_name,
+                               strings.concat(.first_name, " ", .last_name)
+          )
         )
-        or strings.contains(sender.display_name,
-                            strings.concat(.last_name, ", ", .first_name)
+        or (
+          .first_name != ""
+          and .last_name != ""
+          and strings.contains(sender.display_name,
+                               strings.concat(.last_name, ", ", .first_name)
+          )
         )
     )
     or any(regex.extract(sender.display_name, '^(?<first>\S+)\s+(?<second>\S+)$'),

--- a/detection-rules/impersonation_vip_w2_request.yml
+++ b/detection-rules/impersonation_vip_w2_request.yml
@@ -6,7 +6,10 @@ source: |
   type.inbound
   and (
     any($org_vips,
-        (.display_name != "" and strings.contains(sender.display_name, .display_name))
+        (
+          .display_name != ""
+          and strings.contains(sender.display_name, .display_name)
+        )
         or (
           .first_name != ""
           and .last_name != ""

--- a/detection-rules/impersonation_vip_w2_request.yml
+++ b/detection-rules/impersonation_vip_w2_request.yml
@@ -8,12 +8,10 @@ source: |
     any($org_vips,
         strings.contains(sender.display_name, .display_name)
         or strings.contains(sender.display_name,
-                            strings.concat(.last_name, ", ", .first_name)
+                            strings.concat(.first_name, " ", .last_name)
         )
-        or any(regex.extract(.display_name,
-                             '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-               ),
-               strings.contains(sender.display_name, .named_groups["name"])
+        or strings.contains(sender.display_name,
+                            strings.concat(.last_name, ", ", .first_name)
         )
     )
     or any(regex.extract(sender.display_name, '^(?<first>\S+)\s+(?<second>\S+)$'),

--- a/detection-rules/vip_impersonation.yml
+++ b/detection-rules/vip_impersonation.yml
@@ -27,12 +27,24 @@ source: |
             and length(sender.display_name) > length(.display_name)
           )
           or (
-            strings.istarts_with(sender.display_name, strings.concat(.first_name, " ", .last_name))
-            and length(sender.display_name) > length(strings.concat(.first_name, " ", .last_name))
+            strings.istarts_with(sender.display_name,
+                                 strings.concat(.first_name, " ", .last_name)
+            )
+            and length(sender.display_name) > length(strings.concat(.first_name,
+                                                                    " ",
+                                                                    .last_name
+                                                     )
+            )
           )
           or (
-            strings.istarts_with(sender.display_name, strings.concat(.last_name, ", ", .first_name))
-            and length(sender.display_name) > length(strings.concat(.last_name, ", ", .first_name))
+            strings.istarts_with(sender.display_name,
+                                 strings.concat(.last_name, ", ", .first_name)
+            )
+            and length(sender.display_name) > length(strings.concat(.last_name,
+                                                                    ", ",
+                                                                    .first_name
+                                                     )
+            )
           )
       )
       // and we have confidence it's BEC

--- a/detection-rules/vip_impersonation.yml
+++ b/detection-rules/vip_impersonation.yml
@@ -14,13 +14,26 @@ source: |
   type.inbound
   and (
     // the display name matches a name on the orgs vip list
-    any($org_vips, .display_name =~ sender.display_name)
+    any($org_vips,
+        .display_name =~ sender.display_name
+        or strings.concat(.first_name, " ", .last_name) == sender.display_name
+        or strings.concat(.last_name, ", ", .first_name) == sender.display_name
+    )
     // or the display name starts with the name on the orgs vip list
     or (
       any($org_vips,
-          strings.istarts_with(sender.display_name, .display_name)
-          // and it is longer than just their name (eg. John Doe CEO)
-          and length(sender.display_name) > length(.display_name)
+          (
+            strings.istarts_with(sender.display_name, .display_name)
+            and length(sender.display_name) > length(.display_name)
+          )
+          or (
+            strings.istarts_with(sender.display_name, strings.concat(.first_name, " ", .last_name))
+            and length(sender.display_name) > length(strings.concat(.first_name, " ", .last_name))
+          )
+          or (
+            strings.istarts_with(sender.display_name, strings.concat(.last_name, ", ", .first_name))
+            and length(sender.display_name) > length(strings.concat(.last_name, ", ", .first_name))
+          )
       )
       // and we have confidence it's BEC
       and any(ml.nlu_classifier(body.current_thread.text).intents,

--- a/detection-rules/vip_impersonation.yml
+++ b/detection-rules/vip_impersonation.yml
@@ -16,8 +16,10 @@ source: |
     // the display name matches a name on the orgs vip list
     any($org_vips,
         .display_name =~ sender.display_name
-        or strings.concat(.first_name, " ", .last_name) == sender.display_name
-        or strings.concat(.last_name, ", ", .first_name) == sender.display_name
+        or strings.concat(.last_name, ", ", .first_name) =~ sender.display_name
+        or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+               .named_groups["name"] =~ sender.display_name
+        )
     )
     // or the display name starts with the name on the orgs vip list
     or (
@@ -28,16 +30,6 @@ source: |
           )
           or (
             strings.istarts_with(sender.display_name,
-                                 strings.concat(.first_name, " ", .last_name)
-            )
-            and length(sender.display_name) > length(strings.concat(.first_name,
-                                                                    " ",
-                                                                    .last_name
-                                                     )
-            )
-          )
-          or (
-            strings.istarts_with(sender.display_name,
                                  strings.concat(.last_name, ", ", .first_name)
             )
             and length(sender.display_name) > length(strings.concat(.last_name,
@@ -45,6 +37,10 @@ source: |
                                                                     .first_name
                                                      )
             )
+          )
+          or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+                 strings.istarts_with(sender.display_name, .named_groups["name"])
+                 and length(sender.display_name) > length(.named_groups["name"])
           )
       )
       // and we have confidence it's BEC

--- a/detection-rules/vip_impersonation.yml
+++ b/detection-rules/vip_impersonation.yml
@@ -17,7 +17,9 @@ source: |
     any($org_vips,
         .display_name =~ sender.display_name
         or strings.concat(.last_name, ", ", .first_name) =~ sender.display_name
-        or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+        or any(regex.extract(.display_name,
+                             '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+               ),
                .named_groups["name"] =~ sender.display_name
         )
     )
@@ -38,7 +40,9 @@ source: |
                                                      )
             )
           )
-          or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+          or any(regex.extract(.display_name,
+                               '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+                 ),
                  strings.istarts_with(sender.display_name, .named_groups["name"])
                  and length(sender.display_name) > length(.named_groups["name"])
           )

--- a/detection-rules/vip_impersonation.yml
+++ b/detection-rules/vip_impersonation.yml
@@ -16,12 +16,8 @@ source: |
     // the display name matches a name on the orgs vip list
     any($org_vips,
         .display_name =~ sender.display_name
+        or strings.concat(.first_name, " ", .last_name) =~ sender.display_name
         or strings.concat(.last_name, ", ", .first_name) =~ sender.display_name
-        or any(regex.extract(.display_name,
-                             '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-               ),
-               .named_groups["name"] =~ sender.display_name
-        )
     )
     // or the display name starts with the name on the orgs vip list
     or (
@@ -32,6 +28,16 @@ source: |
           )
           or (
             strings.istarts_with(sender.display_name,
+                                 strings.concat(.first_name, " ", .last_name)
+            )
+            and length(sender.display_name) > length(strings.concat(.first_name,
+                                                                    " ",
+                                                                    .last_name
+                                                     )
+            )
+          )
+          or (
+            strings.istarts_with(sender.display_name,
                                  strings.concat(.last_name, ", ", .first_name)
             )
             and length(sender.display_name) > length(strings.concat(.last_name,
@@ -39,12 +45,6 @@ source: |
                                                                     .first_name
                                                      )
             )
-          )
-          or any(regex.extract(.display_name,
-                               '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-                 ),
-                 strings.istarts_with(sender.display_name, .named_groups["name"])
-                 and length(sender.display_name) > length(.named_groups["name"])
           )
       )
       // and we have confidence it's BEC

--- a/detection-rules/vip_impersonation.yml
+++ b/detection-rules/vip_impersonation.yml
@@ -15,20 +15,31 @@ source: |
   and (
     // the display name matches a name on the orgs vip list
     any($org_vips,
-        .display_name =~ sender.display_name
-        or strings.concat(.first_name, " ", .last_name) =~ sender.display_name
-        or strings.concat(.last_name, ", ", .first_name) =~ sender.display_name
+        (.display_name != "" and .display_name =~ sender.display_name)
+        or (
+          .first_name != ""
+          and .last_name != ""
+          and strings.concat(.first_name, " ", .last_name) =~ sender.display_name
+        )
+        or (
+          .first_name != ""
+          and .last_name != ""
+          and strings.concat(.last_name, ", ", .first_name) =~ sender.display_name
+        )
     )
     // or the display name starts with the name on the orgs vip list
     or (
       any($org_vips,
           (
-            strings.istarts_with(sender.display_name, .display_name)
+            .display_name != ""
+            and strings.istarts_with(sender.display_name, .display_name)
             and length(sender.display_name) > length(.display_name)
           )
           or (
-            strings.istarts_with(sender.display_name,
-                                 strings.concat(.first_name, " ", .last_name)
+            .first_name != ""
+            and .last_name != ""
+            and strings.istarts_with(sender.display_name,
+                                     strings.concat(.first_name, " ", .last_name)
             )
             and length(sender.display_name) > length(strings.concat(.first_name,
                                                                     " ",
@@ -37,8 +48,10 @@ source: |
             )
           )
           or (
-            strings.istarts_with(sender.display_name,
-                                 strings.concat(.last_name, ", ", .first_name)
+            .first_name != ""
+            and .last_name != ""
+            and strings.istarts_with(sender.display_name,
+                                     strings.concat(.last_name, ", ", .first_name)
             )
             and length(sender.display_name) > length(strings.concat(.last_name,
                                                                     ", ",

--- a/insights/sender/sender_contains_org_vip.yml
+++ b/insights/sender/sender_contains_org_vip.yml
@@ -3,11 +3,7 @@ type: "query"
 source: |
   type.inbound
   and any($org_vips,
-          (
-            strings.icontains(sender.display_name, .display_name)
-            or strings.icontains(sender.display_name, strings.concat(.first_name, " ", .last_name))
-            or strings.icontains(sender.display_name, strings.concat(.last_name, ", ", .first_name))
-          )
+          strings.icontains(sender.display_name, .display_name)
           and not sender.email.domain.root_domain in $high_trust_sender_root_domains
           and not sender.email.domain.root_domain in $org_domains
           and headers.auth_summary.dmarc.pass

--- a/insights/sender/sender_contains_org_vip.yml
+++ b/insights/sender/sender_contains_org_vip.yml
@@ -3,7 +3,11 @@ type: "query"
 source: |
   type.inbound
   and any($org_vips,
-          strings.icontains(sender.display_name, .display_name)
+          (
+            strings.icontains(sender.display_name, .display_name)
+            or strings.icontains(sender.display_name, strings.concat(.first_name, " ", .last_name))
+            or strings.icontains(sender.display_name, strings.concat(.last_name, ", ", .first_name))
+          )
           and not sender.email.domain.root_domain in $high_trust_sender_root_domains
           and not sender.email.domain.root_domain in $org_domains
           and headers.auth_summary.dmarc.pass


### PR DESCRIPTION
# Description
Add alternative name matching logic to org_vips sender-based rules to handle cases where
display_name is stored as "Lastname, Firstname" instead of "Firstname Lastname".
Uses `strings.concat(.first_name, " ", .last_name)` and `strings.concat(.last_name, ", ", .first_name)`
as additional `or` conditions inside existing `any($org_vips, ...)` blocks.

This is a test rule deployment to assess impact magnitude.

## Affected rules
- `impersonation_vip_bec_loose.yml`
- `vip_impersonation.yml`
- `impersonation_vip_urgent_request.yml`
- `impersonation_vip_invoicing_request.yml`
- `impersonation_vip_w2_request.yml`
- `sender_contains_org_vip.yml` (insight)

# Associated samples
N/A - validation only (no TP canonical available)

## Associated hunts
TBD - will be run after test rule deployment