### PR TITLE
Create brand_impersonation_morgan_stanley.yml

### DIFF
--- a/detection-rules/brand_impersonation_morgan_stanley.yml
+++ b/detection-rules/brand_impersonation_morgan_stanley.yml
@@ -21,7 +21,7 @@ source: |
     )
   )
   and strings.icontains(body.current_thread.text, "Morgan Stanley")
-  and 2 of (
+  and 3 of (
     strings.icontains(body.current_thread.text, "Client Service Center"),
     regex.icontains(body.current_thread.text,
                     'Financial Advis?or\s*[|/]\s*(?:Portfolio\s+)?Manager'
@@ -50,6 +50,7 @@ source: |
     sender.email.domain.root_domain in (
       "adobesign.com",
       "docusign.net",
+      "compass.com",
       "etrade.com",
       "etradefinancial.com",
       "etradefrommorganstanley.com",

--- a/detection-rules/brand_impersonation_morgan_stanley.yml
+++ b/detection-rules/brand_impersonation_morgan_stanley.yml
@@ -36,8 +36,6 @@ source: |
     regex.icontains(body.current_thread.text,
                     'Morgan Stanley\s+(?:Smith Barney|Wealth Management|\w+\s+Team)'
     ),
-    strings.icontains(body.current_thread.text, "Member SIPC"),
-    regex.icontains(body.current_thread.text, '©\s*20[0-9]{2}\s*Morgan Stanley'),
     strings.icontains(body.current_thread.text, "one-time registration"),
     regex.icontains(body.current_thread.text,
                     'link will expire on \d{4}-\d{2}-\d{2}'
@@ -74,6 +72,15 @@ source: |
       "zoom.us"
     )
     and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+  and not (
+    any(headers.hops,
+        any(.fields,
+            .name == "X-ProofpointSecure"
+            and strings.icontains(.value, "Encrypted")
+        )
+    )
+    and any(headers.domains, .root_domain == "pphosted.com")
   )
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/brand_impersonation_morgan_stanley.yml
+++ b/detection-rules/brand_impersonation_morgan_stanley.yml
@@ -48,20 +48,26 @@ source: |
   )
   and not (
     sender.email.domain.root_domain in (
-      "morganstanley.com",
-      "morganstanley.net",
-      "ms.com",
+      "adobesign.com",
+      "docusign.net",
       "etrade.com",
       "etradefinancial.com",
-      "etrademail.com",
       "etradefrommorganstanley.com",
-      "smithbarney.com",
-      "morganstanleypwm.com",
+      "etrademail.com",
+      "icapitalnetwork.com",
+      "morganstanley.com",
+      "morganstanley.net",
+      "morganstanleyatwork.com",
       "morganstanleymufg.com",
-      "msgraystone.com",
+      "morganstanleypwm.com",
+      "ms.com",
       "msfundservices.com",
+      "msgraystone.com",
+      "myworkday.com",
+      "proxyvote.com",
+      "smithbarney.com",
       "ultimusleverpoint.com",
-      "icapitalnetwork.com"
+      "zoom.us"
     )
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )

--- a/detection-rules/brand_impersonation_morgan_stanley.yml
+++ b/detection-rules/brand_impersonation_morgan_stanley.yml
@@ -54,6 +54,7 @@ source: |
       "etradefinancial.com",
       "etradefrommorganstanley.com",
       "etrademail.com",
+      "fidelity.com",
       "icapitalnetwork.com",
       "morganstanley.com",
       "morganstanley.net",
@@ -67,6 +68,8 @@ source: |
       "proxyvote.com",
       "smithbarney.com",
       "ultimusleverpoint.com",
+      "webcasts.com",
+      "zendesk.com",
       "zoom.us"
     )
     and coalesce(headers.auth_summary.dmarc.pass, false)

--- a/detection-rules/brand_impersonation_morgan_stanley.yml
+++ b/detection-rules/brand_impersonation_morgan_stanley.yml
@@ -74,3 +74,4 @@ detection_methods:
   - "Content analysis"
   - "Natural Language Understanding"
   - "Sender analysis"
+id: "3bb49b76-bf8f-598c-9854-7b8f3aadf3df"

--- a/detection-rules/brand_impersonation_morgan_stanley.yml
+++ b/detection-rules/brand_impersonation_morgan_stanley.yml
@@ -1,5 +1,5 @@
 name: "Brand impersonation: Morgan Stanley"
-description: "Detects messages impersonating Morgan Stanley that contain multiple indicators of credential theft or callback scams, including references to secure email systems, client service centers, financial advisors, and registration processes. The rule identifies spoofed communications by checking for Morgan Stanley branding elements while excluding legitimate domains."
+description: "Detects messages impersonating Morgan Stanley that contain indicators of credential theft or callback scams, including references to secure email systems, client service centers, financial advisors, and registration processes. The rule identifies spoofed communications by checking for Morgan Stanley branding elements while excluding legitimate domains."
 type: "rule"
 severity: "medium"
 source: |

--- a/detection-rules/brand_impersonation_morgan_stanley.yml
+++ b/detection-rules/brand_impersonation_morgan_stanley.yml
@@ -37,6 +37,7 @@ source: |
                     'Morgan Stanley\s+(?:Smith Barney|Wealth Management|\w+\s+Team)'
     ),
     strings.icontains(body.current_thread.text, "one-time registration"),
+    strings.icontains(body.current_thread.text, "see payment activity"),
     regex.icontains(body.current_thread.text,
                     'link will expire on \d{4}-\d{2}-\d{2}'
     ),
@@ -45,32 +46,7 @@ source: |
     )
   )
   and not (
-    sender.email.domain.root_domain in (
-      "adobesign.com",
-      "docusign.net",
-      "compass.com",
-      "etrade.com",
-      "etradefinancial.com",
-      "etradefrommorganstanley.com",
-      "etrademail.com",
-      "fidelity.com",
-      "icapitalnetwork.com",
-      "morganstanley.com",
-      "morganstanley.net",
-      "morganstanleyatwork.com",
-      "morganstanleymufg.com",
-      "morganstanleypwm.com",
-      "ms.com",
-      "msfundservices.com",
-      "msgraystone.com",
-      "myworkday.com",
-      "proxyvote.com",
-      "smithbarney.com",
-      "ultimusleverpoint.com",
-      "webcasts.com",
-      "zendesk.com",
-      "zoom.us"
-    )
+    sender.email.domain.root_domain in ("docusign.net", "morganstanley.com", )
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
   and not (

--- a/detection-rules/brand_impersonation_morgan_stanley.yml
+++ b/detection-rules/brand_impersonation_morgan_stanley.yml
@@ -1,0 +1,76 @@
+name: "Brand impersonation: Morgan Stanley"
+description: "Detects messages impersonating Morgan Stanley that contain multiple indicators of credential theft or callback scams, including references to secure email systems, client service centers, financial advisors, and registration processes. The rule identifies spoofed communications by checking for Morgan Stanley branding elements while excluding legitimate domains."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+    strings.ilike(strings.replace_confusables(sender.display_name),
+                  '*morgan stanley*',
+                  '*morganstanley*'
+    )
+    or strings.ilevenshtein(strings.replace_confusables(sender.display_name),
+                            'morgan stanley'
+    ) <= 2
+    or any(ml.nlu_classifier(body.current_thread.text).entities,
+           .name in ("org", "sender")
+           and strings.icontains(.text, 'Morgan Stanley')
+    )
+    or strings.icontains(body.current_thread.text,
+                         'secure.emailhelp@morganstanley.com'
+    )
+  )
+  and strings.icontains(body.current_thread.text, "Morgan Stanley")
+  and 2 of (
+    strings.icontains(body.current_thread.text, "Client Service Center"),
+    regex.icontains(body.current_thread.text,
+                    'Financial Advis?or\s*[|/]\s*(?:Portfolio\s+)?Manager'
+    ),
+    regex.icontains(body.current_thread.text, 'Secure (?:E-)?Mail'),
+    strings.icontains(body.current_thread.text, "Click here to view"),
+    strings.icontains(body.current_thread.text, "encrypted messages"),
+    strings.icontains(body.current_thread.text, "1-800-780-0256"),
+    strings.icontains(body.current_thread.text,
+                      "secure.emailhelp@morganstanley.com"
+    ),
+    regex.icontains(body.current_thread.text,
+                    'Morgan Stanley\s+(?:Smith Barney|Wealth Management|\w+\s+Team)'
+    ),
+    strings.icontains(body.current_thread.text, "Member SIPC"),
+    regex.icontains(body.current_thread.text, '©\s*20[0-9]{2}\s*Morgan Stanley'),
+    strings.icontains(body.current_thread.text, "one-time registration"),
+    regex.icontains(body.current_thread.text,
+                    'link will expire on \d{4}-\d{2}-\d{2}'
+    ),
+    any(ml.nlu_classifier(body.current_thread.text).intents,
+        .name in ("cred_theft", "callback_scam") and .confidence == "high"
+    )
+  )
+  and not (
+    sender.email.domain.root_domain in (
+      "morganstanley.com",
+      "morganstanley.net",
+      "ms.com",
+      "etrade.com",
+      "etradefinancial.com",
+      "etrademail.com",
+      "etradefrommorganstanley.com",
+      "smithbarney.com",
+      "morganstanleypwm.com",
+      "morganstanleymufg.com",
+      "msgraystone.com",
+      "msfundservices.com",
+      "ultimusleverpoint.com",
+      "icapitalnetwork.com"
+    )
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

Creating brand impersonation rule to detect impersonation attempts of Morgan Stanley by looking at sender display name, body content, and NLU output.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507084e9037c3185019863c0b0656eb8c4eda8f6b3a5d403b821eadd9c1b9178?preview_id=019e41fb-5e0b-734b-a61e-984bb636de38)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=019e8eb1-484f-7b5f-b32f-c36e15f16878)