### PR TITLE
Add first_name/last_name concat matching to org_vips body/subject rules

### DIFF
--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -124,7 +124,9 @@ source: |
           or strings.icontains(body.html.inner_text,
                                strings.concat(.last_name, ", ", .first_name)
           )
-          or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+          or any(regex.extract(.display_name,
+                               '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+                 ),
                  strings.icontains(body.html.inner_text, .named_groups["name"])
           )
       )
@@ -133,7 +135,9 @@ source: |
              or strings.icontains(body.plain.raw,
                                   strings.concat(.last_name, ", ", .first_name)
              )
-             or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+             or any(regex.extract(.display_name,
+                                  '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+                    ),
                     strings.icontains(body.plain.raw, .named_groups["name"])
              )
       )

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -120,21 +120,39 @@ source: |
     // body contains name of VIP
     (
       any($org_vips,
-          strings.icontains(body.html.inner_text, .display_name)
-          or strings.icontains(body.html.inner_text,
-                               strings.concat(.first_name, " ", .last_name)
+          .display_name != ""
+          and strings.icontains(body.html.inner_text, .display_name)
+          or (
+            .first_name != ""
+            and .last_name != ""
+            and strings.icontains(body.html.inner_text,
+                                  strings.concat(.first_name, " ", .last_name)
+            )
           )
-          or strings.icontains(body.html.inner_text,
-                               strings.concat(.last_name, ", ", .first_name)
+          or (
+            .first_name != ""
+            and .last_name != ""
+            and strings.icontains(body.html.inner_text,
+                                  strings.concat(.last_name, ", ", .first_name)
+            )
           )
       )
       or any($org_vips,
-             strings.icontains(body.plain.raw, .display_name)
-             or strings.icontains(body.plain.raw,
-                                  strings.concat(.first_name, " ", .last_name)
+             .display_name != ""
+             and strings.icontains(body.plain.raw, .display_name)
+             or (
+               .first_name != ""
+               and .last_name != ""
+               and strings.icontains(body.plain.raw,
+                                     strings.concat(.first_name, " ", .last_name)
+               )
              )
-             or strings.icontains(body.plain.raw,
-                                  strings.concat(.last_name, ", ", .first_name)
+             or (
+               .first_name != ""
+               and .last_name != ""
+               and strings.icontains(body.plain.raw,
+                                     strings.concat(.last_name, ", ", .first_name)
+               )
              )
       )
     ),

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -121,13 +121,21 @@ source: |
     (
       any($org_vips,
           strings.icontains(body.html.inner_text, .display_name)
-          or strings.icontains(body.html.inner_text, strings.concat(.first_name, " ", .last_name))
-          or strings.icontains(body.html.inner_text, strings.concat(.last_name, ", ", .first_name))
+          or strings.icontains(body.html.inner_text,
+                               strings.concat(.first_name, " ", .last_name)
+          )
+          or strings.icontains(body.html.inner_text,
+                               strings.concat(.last_name, ", ", .first_name)
+          )
       )
       or any($org_vips,
              strings.icontains(body.plain.raw, .display_name)
-             or strings.icontains(body.plain.raw, strings.concat(.first_name, " ", .last_name))
-             or strings.icontains(body.plain.raw, strings.concat(.last_name, ", ", .first_name))
+             or strings.icontains(body.plain.raw,
+                                  strings.concat(.first_name, " ", .last_name)
+             )
+             or strings.icontains(body.plain.raw,
+                                  strings.concat(.last_name, ", ", .first_name)
+             )
       )
     ),
   

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -122,23 +122,19 @@ source: |
       any($org_vips,
           strings.icontains(body.html.inner_text, .display_name)
           or strings.icontains(body.html.inner_text,
-                               strings.concat(.last_name, ", ", .first_name)
+                               strings.concat(.first_name, " ", .last_name)
           )
-          or any(regex.extract(.display_name,
-                               '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-                 ),
-                 strings.icontains(body.html.inner_text, .named_groups["name"])
+          or strings.icontains(body.html.inner_text,
+                               strings.concat(.last_name, ", ", .first_name)
           )
       )
       or any($org_vips,
              strings.icontains(body.plain.raw, .display_name)
              or strings.icontains(body.plain.raw,
-                                  strings.concat(.last_name, ", ", .first_name)
+                                  strings.concat(.first_name, " ", .last_name)
              )
-             or any(regex.extract(.display_name,
-                                  '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-                    ),
-                    strings.icontains(body.plain.raw, .named_groups["name"])
+             or strings.icontains(body.plain.raw,
+                                  strings.concat(.last_name, ", ", .first_name)
              )
       )
     ),

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -122,19 +122,19 @@ source: |
       any($org_vips,
           strings.icontains(body.html.inner_text, .display_name)
           or strings.icontains(body.html.inner_text,
-                               strings.concat(.first_name, " ", .last_name)
-          )
-          or strings.icontains(body.html.inner_text,
                                strings.concat(.last_name, ", ", .first_name)
+          )
+          or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+                 strings.icontains(body.html.inner_text, .named_groups["name"])
           )
       )
       or any($org_vips,
              strings.icontains(body.plain.raw, .display_name)
              or strings.icontains(body.plain.raw,
-                                  strings.concat(.first_name, " ", .last_name)
-             )
-             or strings.icontains(body.plain.raw,
                                   strings.concat(.last_name, ", ", .first_name)
+             )
+             or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+                    strings.icontains(body.plain.raw, .named_groups["name"])
              )
       )
     ),

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -119,8 +119,16 @@ source: |
   
     // body contains name of VIP
     (
-      any($org_vips, strings.icontains(body.html.inner_text, .display_name))
-      or any($org_vips, strings.icontains(body.plain.raw, .display_name))
+      any($org_vips,
+          strings.icontains(body.html.inner_text, .display_name)
+          or strings.icontains(body.html.inner_text, strings.concat(.first_name, " ", .last_name))
+          or strings.icontains(body.html.inner_text, strings.concat(.last_name, ", ", .first_name))
+      )
+      or any($org_vips,
+             strings.icontains(body.plain.raw, .display_name)
+             or strings.icontains(body.plain.raw, strings.concat(.first_name, " ", .last_name))
+             or strings.icontains(body.plain.raw, strings.concat(.last_name, ", ", .first_name))
+      )
     ),
   
     // new body domain

--- a/detection-rules/impersonation_google_groups_suspicious.yml
+++ b/detection-rules/impersonation_google_groups_suspicious.yml
@@ -11,36 +11,30 @@ source: |
     any(headers.reply_to,
         any($org_vips,
             strings.contains(.display_name, ..display_name)
-            or strings.contains(strings.concat(.last_name, ", ", .first_name),
+            or strings.contains(strings.concat(.first_name, " ", .last_name),
                                 ..display_name
             )
-            or any(regex.extract(.display_name,
-                                 '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-                   ),
-                   strings.contains(.named_groups["name"], ...display_name)
+            or strings.contains(strings.concat(.last_name, ", ", .first_name),
+                                ..display_name
             )
         )
     )
     or any($org_vips,
            strings.contains(subject.subject, .display_name)
            or strings.contains(subject.subject,
-                               strings.concat(.last_name, ", ", .first_name)
+                               strings.concat(.first_name, " ", .last_name)
            )
-           or any(regex.extract(.display_name,
-                                '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-                  ),
-                  strings.contains(subject.subject, .named_groups["name"])
+           or strings.contains(subject.subject,
+                               strings.concat(.last_name, ", ", .first_name)
            )
     )
     or any($org_vips,
            strings.contains(sender.display_name, .display_name)
            or strings.contains(sender.display_name,
-                               strings.concat(.last_name, ", ", .first_name)
+                               strings.concat(.first_name, " ", .last_name)
            )
-           or any(regex.extract(.display_name,
-                                '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-                  ),
-                  strings.contains(sender.display_name, .named_groups["name"])
+           or strings.contains(sender.display_name,
+                               strings.concat(.last_name, ", ", .first_name)
            )
     )
   )

--- a/detection-rules/impersonation_google_groups_suspicious.yml
+++ b/detection-rules/impersonation_google_groups_suspicious.yml
@@ -10,31 +10,64 @@ source: |
   and (
     any(headers.reply_to,
         any($org_vips,
-            strings.contains(.display_name, ..display_name)
-            or strings.contains(strings.concat(.first_name, " ", .last_name),
-                                ..display_name
+            (
+              ..display_name != ""
+              and strings.contains(.display_name, ..display_name)
             )
-            or strings.contains(strings.concat(.last_name, ", ", .first_name),
-                                ..display_name
+            or (
+              .first_name != ""
+              and .last_name != ""
+              and strings.contains(strings.concat(.first_name, " ", .last_name),
+                                   ..display_name
+              )
+            )
+            or (
+              .first_name != ""
+              and .last_name != ""
+              and strings.contains(strings.concat(.last_name, ", ", .first_name),
+                                   ..display_name
+              )
             )
         )
     )
     or any($org_vips,
-           strings.contains(subject.subject, .display_name)
-           or strings.contains(subject.subject,
-                               strings.concat(.first_name, " ", .last_name)
+           (
+             .display_name != ""
+             and strings.contains(subject.subject, .display_name)
            )
-           or strings.contains(subject.subject,
-                               strings.concat(.last_name, ", ", .first_name)
+           or (
+             .first_name != ""
+             and .last_name != ""
+             and strings.contains(subject.subject,
+                                  strings.concat(.first_name, " ", .last_name)
+             )
+           )
+           or (
+             .first_name != ""
+             and .last_name != ""
+             and strings.contains(subject.subject,
+                                  strings.concat(.last_name, ", ", .first_name)
+             )
            )
     )
     or any($org_vips,
-           strings.contains(sender.display_name, .display_name)
-           or strings.contains(sender.display_name,
-                               strings.concat(.first_name, " ", .last_name)
+           (
+             .display_name != ""
+             and strings.contains(sender.display_name, .display_name)
            )
-           or strings.contains(sender.display_name,
-                               strings.concat(.last_name, ", ", .first_name)
+           or (
+             .first_name != ""
+             and .last_name != ""
+             and strings.contains(sender.display_name,
+                                  strings.concat(.first_name, " ", .last_name)
+             )
+           )
+           or (
+             .first_name != ""
+             and .last_name != ""
+             and strings.contains(sender.display_name,
+                                  strings.concat(.last_name, ", ", .first_name)
+             )
            )
     )
   )

--- a/detection-rules/impersonation_google_groups_suspicious.yml
+++ b/detection-rules/impersonation_google_groups_suspicious.yml
@@ -11,19 +11,31 @@ source: |
     any(headers.reply_to,
         any($org_vips,
             strings.contains(.display_name, ..display_name)
-            or strings.contains(strings.concat(.first_name, " ", .last_name), ..display_name)
-            or strings.contains(strings.concat(.last_name, ", ", .first_name), ..display_name)
+            or strings.contains(strings.concat(.first_name, " ", .last_name),
+                                ..display_name
+            )
+            or strings.contains(strings.concat(.last_name, ", ", .first_name),
+                                ..display_name
+            )
         )
     )
     or any($org_vips,
            strings.contains(subject.subject, .display_name)
-           or strings.contains(subject.subject, strings.concat(.first_name, " ", .last_name))
-           or strings.contains(subject.subject, strings.concat(.last_name, ", ", .first_name))
+           or strings.contains(subject.subject,
+                               strings.concat(.first_name, " ", .last_name)
+           )
+           or strings.contains(subject.subject,
+                               strings.concat(.last_name, ", ", .first_name)
+           )
     )
     or any($org_vips,
            strings.contains(sender.display_name, .display_name)
-           or strings.contains(sender.display_name, strings.concat(.first_name, " ", .last_name))
-           or strings.contains(sender.display_name, strings.concat(.last_name, ", ", .first_name))
+           or strings.contains(sender.display_name,
+                               strings.concat(.first_name, " ", .last_name)
+           )
+           or strings.contains(sender.display_name,
+                               strings.concat(.last_name, ", ", .first_name)
+           )
     )
   )
   and any(headers.hops,
@@ -65,7 +77,7 @@ source: |
       )
     ),
   
-    // reply-to is freemail 
+    // reply-to is freemail
     any(headers.reply_to, .email.domain.domain in $free_email_providers),
   
     // reply-to is not in $recipient_emails

--- a/detection-rules/impersonation_google_groups_suspicious.yml
+++ b/detection-rules/impersonation_google_groups_suspicious.yml
@@ -9,10 +9,22 @@ source: |
   // subject, sender or reply to contains a VIP
   and (
     any(headers.reply_to,
-        any($org_vips, strings.contains(.display_name, ..display_name))
+        any($org_vips,
+            strings.contains(.display_name, ..display_name)
+            or strings.contains(strings.concat(.first_name, " ", .last_name), ..display_name)
+            or strings.contains(strings.concat(.last_name, ", ", .first_name), ..display_name)
+        )
     )
-    or any($org_vips, strings.contains(subject.subject, .display_name))
-    or any($org_vips, strings.contains(sender.display_name, .display_name))
+    or any($org_vips,
+           strings.contains(subject.subject, .display_name)
+           or strings.contains(subject.subject, strings.concat(.first_name, " ", .last_name))
+           or strings.contains(subject.subject, strings.concat(.last_name, ", ", .first_name))
+    )
+    or any($org_vips,
+           strings.contains(sender.display_name, .display_name)
+           or strings.contains(sender.display_name, strings.concat(.first_name, " ", .last_name))
+           or strings.contains(sender.display_name, strings.concat(.last_name, ", ", .first_name))
+    )
   )
   and any(headers.hops,
           any(.fields,

--- a/detection-rules/impersonation_google_groups_suspicious.yml
+++ b/detection-rules/impersonation_google_groups_suspicious.yml
@@ -11,30 +11,30 @@ source: |
     any(headers.reply_to,
         any($org_vips,
             strings.contains(.display_name, ..display_name)
-            or strings.contains(strings.concat(.first_name, " ", .last_name),
-                                ..display_name
-            )
             or strings.contains(strings.concat(.last_name, ", ", .first_name),
                                 ..display_name
+            )
+            or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+                   strings.contains(.named_groups["name"], ...display_name)
             )
         )
     )
     or any($org_vips,
            strings.contains(subject.subject, .display_name)
            or strings.contains(subject.subject,
-                               strings.concat(.first_name, " ", .last_name)
-           )
-           or strings.contains(subject.subject,
                                strings.concat(.last_name, ", ", .first_name)
+           )
+           or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+                  strings.contains(subject.subject, .named_groups["name"])
            )
     )
     or any($org_vips,
            strings.contains(sender.display_name, .display_name)
            or strings.contains(sender.display_name,
-                               strings.concat(.first_name, " ", .last_name)
-           )
-           or strings.contains(sender.display_name,
                                strings.concat(.last_name, ", ", .first_name)
+           )
+           or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+                  strings.contains(sender.display_name, .named_groups["name"])
            )
     )
   )

--- a/detection-rules/impersonation_google_groups_suspicious.yml
+++ b/detection-rules/impersonation_google_groups_suspicious.yml
@@ -14,7 +14,9 @@ source: |
             or strings.contains(strings.concat(.last_name, ", ", .first_name),
                                 ..display_name
             )
-            or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+            or any(regex.extract(.display_name,
+                                 '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+                   ),
                    strings.contains(.named_groups["name"], ...display_name)
             )
         )
@@ -24,7 +26,9 @@ source: |
            or strings.contains(subject.subject,
                                strings.concat(.last_name, ", ", .first_name)
            )
-           or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+           or any(regex.extract(.display_name,
+                                '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+                  ),
                   strings.contains(subject.subject, .named_groups["name"])
            )
     )
@@ -33,7 +37,9 @@ source: |
            or strings.contains(sender.display_name,
                                strings.concat(.last_name, ", ", .first_name)
            )
-           or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+           or any(regex.extract(.display_name,
+                                '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+                  ),
                   strings.contains(sender.display_name, .named_groups["name"])
            )
     )

--- a/detection-rules/service_abuse_trello_board_invite_vip.yml
+++ b/detection-rules/service_abuse_trello_board_invite_vip.yml
@@ -27,7 +27,11 @@ source: |
     // org_sld as the start of the board name with the org_vip as the sender
     any(html.xpath(body.html, '//h2').nodes,
         // org vip
-        any($org_vips, strings.icontains(..display_text, .display_name))
+        any($org_vips,
+            strings.icontains(..display_text, .display_name)
+            or strings.icontains(..display_text, strings.concat(.first_name, " ", .last_name))
+            or strings.icontains(..display_text, strings.concat(.last_name, ", ", .first_name))
+        )
         // org sld as the board name
         and any($org_slds,
                 strings.icontains(..display_text,
@@ -41,7 +45,11 @@ source: |
            ).nodes,
            strings.starts_with(.display_text, 'A note from ')
            and strings.iends_with(.display_text, 'From')
-           and any($org_vips, strings.icontains(..display_text, .display_name))
+           and any($org_vips,
+                   strings.icontains(..display_text, .display_name)
+                   or strings.icontains(..display_text, strings.concat(.first_name, " ", .last_name))
+                   or strings.icontains(..display_text, strings.concat(.last_name, ", ", .first_name))
+           )
     )
   )
 attack_types:

--- a/detection-rules/service_abuse_trello_board_invite_vip.yml
+++ b/detection-rules/service_abuse_trello_board_invite_vip.yml
@@ -30,12 +30,10 @@ source: |
         any($org_vips,
             strings.icontains(..display_text, .display_name)
             or strings.icontains(..display_text,
-                                 strings.concat(.last_name, ", ", .first_name)
+                                 strings.concat(.first_name, " ", .last_name)
             )
-            or any(regex.extract(.display_name,
-                                 '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-                   ),
-                   strings.icontains(...display_text, .named_groups["name"])
+            or strings.icontains(..display_text,
+                                 strings.concat(.last_name, ", ", .first_name)
             )
         )
         // org sld as the board name
@@ -54,17 +52,16 @@ source: |
            and any($org_vips,
                    strings.icontains(..display_text, .display_name)
                    or strings.icontains(..display_text,
+                                        strings.concat(.first_name,
+                                                       " ",
+                                                       .last_name
+                                        )
+                   )
+                   or strings.icontains(..display_text,
                                         strings.concat(.last_name,
                                                        ", ",
                                                        .first_name
                                         )
-                   )
-                   or any(regex.extract(.display_name,
-                                        '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-                          ),
-                          strings.icontains(...display_text,
-                                            .named_groups["name"]
-                          )
                    )
            )
     )

--- a/detection-rules/service_abuse_trello_board_invite_vip.yml
+++ b/detection-rules/service_abuse_trello_board_invite_vip.yml
@@ -28,12 +28,23 @@ source: |
     any(html.xpath(body.html, '//h2').nodes,
         // org vip
         any($org_vips,
-            strings.icontains(..display_text, .display_name)
-            or strings.icontains(..display_text,
-                                 strings.concat(.first_name, " ", .last_name)
+            (
+              .display_name != ""
+              and strings.icontains(..display_text, .display_name)
             )
-            or strings.icontains(..display_text,
-                                 strings.concat(.last_name, ", ", .first_name)
+            or (
+              .first_name != ""
+              and .last_name != ""
+              and strings.icontains(..display_text,
+                                    strings.concat(.first_name, " ", .last_name)
+              )
+            )
+            or (
+              .first_name != ""
+              and .last_name != ""
+              and strings.icontains(..display_text,
+                                    strings.concat(.last_name, ", ", .first_name)
+              )
             )
         )
         // org sld as the board name
@@ -50,18 +61,29 @@ source: |
            strings.starts_with(.display_text, 'A note from ')
            and strings.iends_with(.display_text, 'From')
            and any($org_vips,
-                   strings.icontains(..display_text, .display_name)
-                   or strings.icontains(..display_text,
-                                        strings.concat(.first_name,
-                                                       " ",
-                                                       .last_name
-                                        )
+                   (
+                     .display_name != ""
+                     and strings.icontains(..display_text, .display_name)
                    )
-                   or strings.icontains(..display_text,
-                                        strings.concat(.last_name,
-                                                       ", ",
-                                                       .first_name
-                                        )
+                   or (
+                     .first_name != ""
+                     and .last_name != ""
+                     and strings.icontains(..display_text,
+                                           strings.concat(.first_name,
+                                                          " ",
+                                                          .last_name
+                                           )
+                     )
+                   )
+                   or (
+                     .first_name != ""
+                     and .last_name != ""
+                     and strings.icontains(..display_text,
+                                           strings.concat(.last_name,
+                                                          ", ",
+                                                          .first_name
+                                           )
+                     )
                    )
            )
     )

--- a/detection-rules/service_abuse_trello_board_invite_vip.yml
+++ b/detection-rules/service_abuse_trello_board_invite_vip.yml
@@ -29,8 +29,12 @@ source: |
         // org vip
         any($org_vips,
             strings.icontains(..display_text, .display_name)
-            or strings.icontains(..display_text, strings.concat(.first_name, " ", .last_name))
-            or strings.icontains(..display_text, strings.concat(.last_name, ", ", .first_name))
+            or strings.icontains(..display_text,
+                                 strings.concat(.first_name, " ", .last_name)
+            )
+            or strings.icontains(..display_text,
+                                 strings.concat(.last_name, ", ", .first_name)
+            )
         )
         // org sld as the board name
         and any($org_slds,
@@ -47,8 +51,18 @@ source: |
            and strings.iends_with(.display_text, 'From')
            and any($org_vips,
                    strings.icontains(..display_text, .display_name)
-                   or strings.icontains(..display_text, strings.concat(.first_name, " ", .last_name))
-                   or strings.icontains(..display_text, strings.concat(.last_name, ", ", .first_name))
+                   or strings.icontains(..display_text,
+                                        strings.concat(.first_name,
+                                                       " ",
+                                                       .last_name
+                                        )
+                   )
+                   or strings.icontains(..display_text,
+                                        strings.concat(.last_name,
+                                                       ", ",
+                                                       .first_name
+                                        )
+                   )
            )
     )
   )

--- a/detection-rules/service_abuse_trello_board_invite_vip.yml
+++ b/detection-rules/service_abuse_trello_board_invite_vip.yml
@@ -30,10 +30,10 @@ source: |
         any($org_vips,
             strings.icontains(..display_text, .display_name)
             or strings.icontains(..display_text,
-                                 strings.concat(.first_name, " ", .last_name)
-            )
-            or strings.icontains(..display_text,
                                  strings.concat(.last_name, ", ", .first_name)
+            )
+            or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+                   strings.icontains(...display_text, .named_groups["name"])
             )
         )
         // org sld as the board name
@@ -52,16 +52,13 @@ source: |
            and any($org_vips,
                    strings.icontains(..display_text, .display_name)
                    or strings.icontains(..display_text,
-                                        strings.concat(.first_name,
-                                                       " ",
-                                                       .last_name
-                                        )
-                   )
-                   or strings.icontains(..display_text,
                                         strings.concat(.last_name,
                                                        ", ",
                                                        .first_name
                                         )
+                   )
+                   or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+                          strings.icontains(...display_text, .named_groups["name"])
                    )
            )
     )

--- a/detection-rules/service_abuse_trello_board_invite_vip.yml
+++ b/detection-rules/service_abuse_trello_board_invite_vip.yml
@@ -32,7 +32,9 @@ source: |
             or strings.icontains(..display_text,
                                  strings.concat(.last_name, ", ", .first_name)
             )
-            or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+            or any(regex.extract(.display_name,
+                                 '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+                   ),
                    strings.icontains(...display_text, .named_groups["name"])
             )
         )
@@ -57,8 +59,12 @@ source: |
                                                        .first_name
                                         )
                    )
-                   or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
-                          strings.icontains(...display_text, .named_groups["name"])
+                   or any(regex.extract(.display_name,
+                                        '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+                          ),
+                          strings.icontains(...display_text,
+                                            .named_groups["name"]
+                          )
                    )
            )
     )

--- a/detection-rules/vip_impersonation_charity.yml
+++ b/detection-rules/vip_impersonation_charity.yml
@@ -18,21 +18,43 @@ source: |
   )
   and (
     any($org_vips,
-        strings.icontains(body.html.inner_text, .display_name)
-        or strings.icontains(body.html.inner_text,
-                             strings.concat(.first_name, " ", .last_name)
+        (
+          .display_name != ""
+          and strings.icontains(body.html.inner_text, .display_name)
         )
-        or strings.icontains(body.html.inner_text,
-                             strings.concat(.last_name, ", ", .first_name)
+        or (
+          .first_name != ""
+          and .last_name != ""
+          and strings.icontains(body.html.inner_text,
+                                strings.concat(.first_name, " ", .last_name)
+          )
+        )
+        or (
+          .first_name != ""
+          and .last_name != ""
+          and strings.icontains(body.html.inner_text,
+                                strings.concat(.last_name, ", ", .first_name)
+          )
         )
     )
     or any($org_vips,
-           strings.icontains(body.plain.raw, .display_name)
-           or strings.icontains(body.plain.raw,
-                                strings.concat(.first_name, " ", .last_name)
+           (
+             .display_name != ""
+             and strings.icontains(body.plain.raw, .display_name)
            )
-           or strings.icontains(body.plain.raw,
-                                strings.concat(.last_name, ", ", .first_name)
+           or (
+             .first_name != ""
+             and .last_name != ""
+             and strings.icontains(body.plain.raw,
+                                   strings.concat(.first_name, " ", .last_name)
+             )
+           )
+           or (
+             .first_name != ""
+             and .last_name != ""
+             and strings.icontains(body.plain.raw,
+                                   strings.concat(.last_name, ", ", .first_name)
+             )
            )
     )
   )

--- a/detection-rules/vip_impersonation_charity.yml
+++ b/detection-rules/vip_impersonation_charity.yml
@@ -20,19 +20,19 @@ source: |
     any($org_vips,
         strings.icontains(body.html.inner_text, .display_name)
         or strings.icontains(body.html.inner_text,
-                             strings.concat(.first_name, " ", .last_name)
-        )
-        or strings.icontains(body.html.inner_text,
                              strings.concat(.last_name, ", ", .first_name)
+        )
+        or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+               strings.icontains(body.html.inner_text, .named_groups["name"])
         )
     )
     or any($org_vips,
            strings.icontains(body.plain.raw, .display_name)
            or strings.icontains(body.plain.raw,
-                                strings.concat(.first_name, " ", .last_name)
-           )
-           or strings.icontains(body.plain.raw,
                                 strings.concat(.last_name, ", ", .first_name)
+           )
+           or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+                  strings.icontains(body.plain.raw, .named_groups["name"])
            )
     )
   )

--- a/detection-rules/vip_impersonation_charity.yml
+++ b/detection-rules/vip_impersonation_charity.yml
@@ -20,23 +20,19 @@ source: |
     any($org_vips,
         strings.icontains(body.html.inner_text, .display_name)
         or strings.icontains(body.html.inner_text,
-                             strings.concat(.last_name, ", ", .first_name)
+                             strings.concat(.first_name, " ", .last_name)
         )
-        or any(regex.extract(.display_name,
-                             '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-               ),
-               strings.icontains(body.html.inner_text, .named_groups["name"])
+        or strings.icontains(body.html.inner_text,
+                             strings.concat(.last_name, ", ", .first_name)
         )
     )
     or any($org_vips,
            strings.icontains(body.plain.raw, .display_name)
            or strings.icontains(body.plain.raw,
-                                strings.concat(.last_name, ", ", .first_name)
+                                strings.concat(.first_name, " ", .last_name)
            )
-           or any(regex.extract(.display_name,
-                                '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-                  ),
-                  strings.icontains(body.plain.raw, .named_groups["name"])
+           or strings.icontains(body.plain.raw,
+                                strings.concat(.last_name, ", ", .first_name)
            )
     )
   )

--- a/detection-rules/vip_impersonation_charity.yml
+++ b/detection-rules/vip_impersonation_charity.yml
@@ -22,7 +22,9 @@ source: |
         or strings.icontains(body.html.inner_text,
                              strings.concat(.last_name, ", ", .first_name)
         )
-        or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+        or any(regex.extract(.display_name,
+                             '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+               ),
                strings.icontains(body.html.inner_text, .named_groups["name"])
         )
     )
@@ -31,7 +33,9 @@ source: |
            or strings.icontains(body.plain.raw,
                                 strings.concat(.last_name, ", ", .first_name)
            )
-           or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+           or any(regex.extract(.display_name,
+                                '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+                  ),
                   strings.icontains(body.plain.raw, .named_groups["name"])
            )
     )

--- a/detection-rules/vip_impersonation_charity.yml
+++ b/detection-rules/vip_impersonation_charity.yml
@@ -19,13 +19,21 @@ source: |
   and (
     any($org_vips,
         strings.icontains(body.html.inner_text, .display_name)
-        or strings.icontains(body.html.inner_text, strings.concat(.first_name, " ", .last_name))
-        or strings.icontains(body.html.inner_text, strings.concat(.last_name, ", ", .first_name))
+        or strings.icontains(body.html.inner_text,
+                             strings.concat(.first_name, " ", .last_name)
+        )
+        or strings.icontains(body.html.inner_text,
+                             strings.concat(.last_name, ", ", .first_name)
+        )
     )
     or any($org_vips,
            strings.icontains(body.plain.raw, .display_name)
-           or strings.icontains(body.plain.raw, strings.concat(.first_name, " ", .last_name))
-           or strings.icontains(body.plain.raw, strings.concat(.last_name, ", ", .first_name))
+           or strings.icontains(body.plain.raw,
+                                strings.concat(.first_name, " ", .last_name)
+           )
+           or strings.icontains(body.plain.raw,
+                                strings.concat(.last_name, ", ", .first_name)
+           )
     )
   )
   and (
@@ -65,7 +73,6 @@ source: |
     or profile.by_sender().days_known > 30
   )
   and not profile.by_sender().any_messages_benign
-
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:

--- a/detection-rules/vip_impersonation_charity.yml
+++ b/detection-rules/vip_impersonation_charity.yml
@@ -17,8 +17,16 @@ source: |
           .name == "request"
   )
   and (
-    any($org_vips, strings.icontains(body.html.inner_text, .display_name))
-    or any($org_vips, strings.icontains(body.plain.raw, .display_name))
+    any($org_vips,
+        strings.icontains(body.html.inner_text, .display_name)
+        or strings.icontains(body.html.inner_text, strings.concat(.first_name, " ", .last_name))
+        or strings.icontains(body.html.inner_text, strings.concat(.last_name, ", ", .first_name))
+    )
+    or any($org_vips,
+           strings.icontains(body.plain.raw, .display_name)
+           or strings.icontains(body.plain.raw, strings.concat(.first_name, " ", .last_name))
+           or strings.icontains(body.plain.raw, strings.concat(.last_name, ", ", .first_name))
+    )
   )
   and (
     (

--- a/detection-rules/vip_impersonation_fake_thread.yml
+++ b/detection-rules/vip_impersonation_fake_thread.yml
@@ -18,7 +18,9 @@ source: |
                                                 " <"
                                  )
             )
-            or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+            or any(regex.extract(.display_name,
+                                 '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+                   ),
                    strings.icontains(body.html.display_text,
                                      strings.concat("From: ",
                                                     .named_groups["name"],
@@ -47,7 +49,9 @@ source: |
                                                 ">"
                                  )
             )
-            or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+            or any(regex.extract(.display_name,
+                                 '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+                   ),
                    strings.icontains(body.html.display_text,
                                      strings.concat("From: ",
                                                     .named_groups["name"],

--- a/detection-rules/vip_impersonation_fake_thread.yml
+++ b/detection-rules/vip_impersonation_fake_thread.yml
@@ -11,22 +11,21 @@ source: |
             )
             or strings.icontains(body.html.display_text,
                                  strings.concat("From: ",
+                                                strings.concat(.first_name,
+                                                               " ",
+                                                               .last_name
+                                                ),
+                                                " <"
+                                 )
+            )
+            or strings.icontains(body.html.display_text,
+                                 strings.concat("From: ",
                                                 strings.concat(.last_name,
                                                                ", ",
                                                                .first_name
                                                 ),
                                                 " <"
                                  )
-            )
-            or any(regex.extract(.display_name,
-                                 '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-                   ),
-                   strings.icontains(body.html.display_text,
-                                     strings.concat("From: ",
-                                                    .named_groups["name"],
-                                                    " <"
-                                     )
-                   )
             )
           )
           and not (
@@ -40,6 +39,17 @@ source: |
             )
             or strings.icontains(body.html.display_text,
                                  strings.concat("From: ",
+                                                strings.concat(.first_name,
+                                                               " ",
+                                                               .last_name
+                                                ),
+                                                " <",
+                                                .email,
+                                                ">"
+                                 )
+            )
+            or strings.icontains(body.html.display_text,
+                                 strings.concat("From: ",
                                                 strings.concat(.last_name,
                                                                ", ",
                                                                .first_name
@@ -48,18 +58,6 @@ source: |
                                                 .email,
                                                 ">"
                                  )
-            )
-            or any(regex.extract(.display_name,
-                                 '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-                   ),
-                   strings.icontains(body.html.display_text,
-                                     strings.concat("From: ",
-                                                    .named_groups["name"],
-                                                    " <",
-                                                    ..email,
-                                                    ">"
-                                     )
-                   )
             )
           )
   )

--- a/detection-rules/vip_impersonation_fake_thread.yml
+++ b/detection-rules/vip_impersonation_fake_thread.yml
@@ -11,21 +11,20 @@ source: |
             )
             or strings.icontains(body.html.display_text,
                                  strings.concat("From: ",
-                                                strings.concat(.first_name,
-                                                               " ",
-                                                               .last_name
-                                                ),
-                                                " <"
-                                 )
-            )
-            or strings.icontains(body.html.display_text,
-                                 strings.concat("From: ",
                                                 strings.concat(.last_name,
                                                                ", ",
                                                                .first_name
                                                 ),
                                                 " <"
                                  )
+            )
+            or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+                   strings.icontains(body.html.display_text,
+                                     strings.concat("From: ",
+                                                    .named_groups["name"],
+                                                    " <"
+                                     )
+                   )
             )
           )
           and not (
@@ -39,17 +38,6 @@ source: |
             )
             or strings.icontains(body.html.display_text,
                                  strings.concat("From: ",
-                                                strings.concat(.first_name,
-                                                               " ",
-                                                               .last_name
-                                                ),
-                                                " <",
-                                                .email,
-                                                ">"
-                                 )
-            )
-            or strings.icontains(body.html.display_text,
-                                 strings.concat("From: ",
                                                 strings.concat(.last_name,
                                                                ", ",
                                                                .first_name
@@ -58,6 +46,16 @@ source: |
                                                 .email,
                                                 ">"
                                  )
+            )
+            or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+                   strings.icontains(body.html.display_text,
+                                     strings.concat("From: ",
+                                                    .named_groups["name"],
+                                                    " <",
+                                                    ..email,
+                                                    ">"
+                                     )
+                   )
             )
           )
   )

--- a/detection-rules/vip_impersonation_fake_thread.yml
+++ b/detection-rules/vip_impersonation_fake_thread.yml
@@ -5,16 +5,42 @@ severity: "medium"
 source: |
   type.inbound
   and any($org_vips,
-          strings.icontains(body.html.display_text,
-                            strings.concat("From: ", .display_name, " <")
+          (
+            strings.icontains(body.html.display_text,
+                              strings.concat("From: ", .display_name, " <")
+            )
+            or strings.icontains(body.html.display_text,
+                                 strings.concat("From: ", strings.concat(.first_name, " ", .last_name), " <")
+            )
+            or strings.icontains(body.html.display_text,
+                                 strings.concat("From: ", strings.concat(.last_name, ", ", .first_name), " <")
+            )
           )
-          and not strings.icontains(body.html.display_text,
-                                    strings.concat("From: ",
-                                                   .display_name,
-                                                   " <",
-                                                   .email,
-                                                   ">"
-                                    )
+          and not (
+            strings.icontains(body.html.display_text,
+                              strings.concat("From: ",
+                                             .display_name,
+                                             " <",
+                                             .email,
+                                             ">"
+                              )
+            )
+            or strings.icontains(body.html.display_text,
+                                 strings.concat("From: ",
+                                                strings.concat(.first_name, " ", .last_name),
+                                                " <",
+                                                .email,
+                                                ">"
+                                 )
+            )
+            or strings.icontains(body.html.display_text,
+                                 strings.concat("From: ",
+                                                strings.concat(.last_name, ", ", .first_name),
+                                                " <",
+                                                .email,
+                                                ">"
+                                 )
+            )
           )
   )
   and any([body.current_thread.text, body.html.display_text, body.plain.raw],

--- a/detection-rules/vip_impersonation_fake_thread.yml
+++ b/detection-rules/vip_impersonation_fake_thread.yml
@@ -10,10 +10,22 @@ source: |
                               strings.concat("From: ", .display_name, " <")
             )
             or strings.icontains(body.html.display_text,
-                                 strings.concat("From: ", strings.concat(.first_name, " ", .last_name), " <")
+                                 strings.concat("From: ",
+                                                strings.concat(.first_name,
+                                                               " ",
+                                                               .last_name
+                                                ),
+                                                " <"
+                                 )
             )
             or strings.icontains(body.html.display_text,
-                                 strings.concat("From: ", strings.concat(.last_name, ", ", .first_name), " <")
+                                 strings.concat("From: ",
+                                                strings.concat(.last_name,
+                                                               ", ",
+                                                               .first_name
+                                                ),
+                                                " <"
+                                 )
             )
           )
           and not (
@@ -27,7 +39,10 @@ source: |
             )
             or strings.icontains(body.html.display_text,
                                  strings.concat("From: ",
-                                                strings.concat(.first_name, " ", .last_name),
+                                                strings.concat(.first_name,
+                                                               " ",
+                                                               .last_name
+                                                ),
                                                 " <",
                                                 .email,
                                                 ">"
@@ -35,7 +50,10 @@ source: |
             )
             or strings.icontains(body.html.display_text,
                                  strings.concat("From: ",
-                                                strings.concat(.last_name, ", ", .first_name),
+                                                strings.concat(.last_name,
+                                                               ", ",
+                                                               .first_name
+                                                ),
                                                 " <",
                                                 .email,
                                                 ">"

--- a/detection-rules/vip_impersonation_fake_thread.yml
+++ b/detection-rules/vip_impersonation_fake_thread.yml
@@ -6,26 +6,37 @@ source: |
   type.inbound
   and any($org_vips,
           (
-            strings.icontains(body.html.display_text,
-                              strings.concat("From: ", .display_name, " <")
+            (
+              .display_name != ""
+              and strings.icontains(body.html.display_text,
+                                    strings.concat("From: ", .display_name, " <")
+              )
             )
-            or strings.icontains(body.html.display_text,
-                                 strings.concat("From: ",
-                                                strings.concat(.first_name,
-                                                               " ",
-                                                               .last_name
-                                                ),
-                                                " <"
-                                 )
+            or (
+              .first_name != ""
+              and .last_name != ""
+              and strings.icontains(body.html.display_text,
+                                    strings.concat("From: ",
+                                                   strings.concat(.first_name,
+                                                                  " ",
+                                                                  .last_name
+                                                   ),
+                                                   " <"
+                                    )
+              )
             )
-            or strings.icontains(body.html.display_text,
-                                 strings.concat("From: ",
-                                                strings.concat(.last_name,
-                                                               ", ",
-                                                               .first_name
-                                                ),
-                                                " <"
-                                 )
+            or (
+              .first_name != ""
+              and .last_name != ""
+              and strings.icontains(body.html.display_text,
+                                    strings.concat("From: ",
+                                                   strings.concat(.last_name,
+                                                                  ", ",
+                                                                  .first_name
+                                                   ),
+                                                   " <"
+                                    )
+              )
             )
           )
           and not (

--- a/detection-rules/vip_impersonation_subject.yml
+++ b/detection-rules/vip_impersonation_subject.yml
@@ -16,10 +16,10 @@ source: |
           (
             strings.contains(subject.subject, .display_name)
             or strings.contains(subject.subject,
-                                strings.concat(.first_name, " ", .last_name)
-            )
-            or strings.contains(subject.subject,
                                 strings.concat(.last_name, ", ", .first_name)
+            )
+            or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+                   strings.contains(subject.subject, .named_groups["name"])
             )
           )
           and strings.contains(.display_name, " ")
@@ -34,16 +34,13 @@ source: |
                   and (
                     strings.contains(subject.subject, .display_name)
                     or strings.contains(subject.subject,
-                                        strings.concat(.first_name,
-                                                       " ",
-                                                       .last_name
-                                        )
-                    )
-                    or strings.contains(subject.subject,
                                         strings.concat(.last_name,
                                                        ", ",
                                                        .first_name
                                         )
+                    )
+                    or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+                           strings.contains(subject.subject, .named_groups["name"])
                     )
                   )
                   and strings.contains(.display_name, " ")

--- a/detection-rules/vip_impersonation_subject.yml
+++ b/detection-rules/vip_impersonation_subject.yml
@@ -16,12 +16,10 @@ source: |
           (
             strings.contains(subject.subject, .display_name)
             or strings.contains(subject.subject,
-                                strings.concat(.last_name, ", ", .first_name)
+                                strings.concat(.first_name, " ", .last_name)
             )
-            or any(regex.extract(.display_name,
-                                 '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-                   ),
-                   strings.contains(subject.subject, .named_groups["name"])
+            or strings.contains(subject.subject,
+                                strings.concat(.last_name, ", ", .first_name)
             )
           )
           and strings.contains(.display_name, " ")
@@ -36,17 +34,16 @@ source: |
                   and (
                     strings.contains(subject.subject, .display_name)
                     or strings.contains(subject.subject,
+                                        strings.concat(.first_name,
+                                                       " ",
+                                                       .last_name
+                                        )
+                    )
+                    or strings.contains(subject.subject,
                                         strings.concat(.last_name,
                                                        ", ",
                                                        .first_name
                                         )
-                    )
-                    or any(regex.extract(.display_name,
-                                         '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
-                           ),
-                           strings.contains(subject.subject,
-                                            .named_groups["name"]
-                           )
                     )
                   )
                   and strings.contains(.display_name, " ")

--- a/detection-rules/vip_impersonation_subject.yml
+++ b/detection-rules/vip_impersonation_subject.yml
@@ -18,7 +18,9 @@ source: |
             or strings.contains(subject.subject,
                                 strings.concat(.last_name, ", ", .first_name)
             )
-            or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
+            or any(regex.extract(.display_name,
+                                 '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+                   ),
                    strings.contains(subject.subject, .named_groups["name"])
             )
           )
@@ -39,8 +41,12 @@ source: |
                                                        .first_name
                                         )
                     )
-                    or any(regex.extract(.display_name, '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'),
-                           strings.contains(subject.subject, .named_groups["name"])
+                    or any(regex.extract(.display_name,
+                                         '\A(?P<name>.+?)\s*[\(（][^)）]*[)）]\s*\z'
+                           ),
+                           strings.contains(subject.subject,
+                                            .named_groups["name"]
+                           )
                     )
                   )
                   and strings.contains(.display_name, " ")

--- a/detection-rules/vip_impersonation_subject.yml
+++ b/detection-rules/vip_impersonation_subject.yml
@@ -15,8 +15,12 @@ source: |
   and any($org_vips,
           (
             strings.contains(subject.subject, .display_name)
-            or strings.contains(subject.subject, strings.concat(.first_name, " ", .last_name))
-            or strings.contains(subject.subject, strings.concat(.last_name, ", ", .first_name))
+            or strings.contains(subject.subject,
+                                strings.concat(.first_name, " ", .last_name)
+            )
+            or strings.contains(subject.subject,
+                                strings.concat(.last_name, ", ", .first_name)
+            )
           )
           and strings.contains(.display_name, " ")
   )
@@ -29,8 +33,18 @@ source: |
                   .email == ..email.email
                   and (
                     strings.contains(subject.subject, .display_name)
-                    or strings.contains(subject.subject, strings.concat(.first_name, " ", .last_name))
-                    or strings.contains(subject.subject, strings.concat(.last_name, ", ", .first_name))
+                    or strings.contains(subject.subject,
+                                        strings.concat(.first_name,
+                                                       " ",
+                                                       .last_name
+                                        )
+                    )
+                    or strings.contains(subject.subject,
+                                        strings.concat(.last_name,
+                                                       ", ",
+                                                       .first_name
+                                        )
+                    )
                   )
                   and strings.contains(.display_name, " ")
               )
@@ -85,7 +99,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
 tags:
   - "Attack surface reduction"
 attack_types:

--- a/detection-rules/vip_impersonation_subject.yml
+++ b/detection-rules/vip_impersonation_subject.yml
@@ -13,7 +13,11 @@ severity: "medium"
 source: |
   type.inbound
   and any($org_vips,
-          strings.contains(subject.subject, .display_name)
+          (
+            strings.contains(subject.subject, .display_name)
+            or strings.contains(subject.subject, strings.concat(.first_name, " ", .last_name))
+            or strings.contains(subject.subject, strings.concat(.last_name, ", ", .first_name))
+          )
           and strings.contains(.display_name, " ")
   )
   // not being sent to said VIP
@@ -23,7 +27,11 @@ source: |
       and all(recipients.to,
               any($org_vips,
                   .email == ..email.email
-                  and strings.contains(subject.subject, .display_name)
+                  and (
+                    strings.contains(subject.subject, .display_name)
+                    or strings.contains(subject.subject, strings.concat(.first_name, " ", .last_name))
+                    or strings.contains(subject.subject, strings.concat(.last_name, ", ", .first_name))
+                  )
                   and strings.contains(.display_name, " ")
               )
       )

--- a/detection-rules/vip_impersonation_subject.yml
+++ b/detection-rules/vip_impersonation_subject.yml
@@ -15,11 +15,19 @@ source: |
   and any($org_vips,
           (
             strings.contains(subject.subject, .display_name)
-            or strings.contains(subject.subject,
-                                strings.concat(.first_name, " ", .last_name)
+            or (
+              .first_name != ""
+              and .last_name != ""
+              and strings.contains(subject.subject,
+                                   strings.concat(.first_name, " ", .last_name)
+              )
             )
-            or strings.contains(subject.subject,
-                                strings.concat(.last_name, ", ", .first_name)
+            or (
+              .first_name != ""
+              and .last_name != ""
+              and strings.contains(subject.subject,
+                                   strings.concat(.last_name, ", ", .first_name)
+              )
             )
           )
           and strings.contains(.display_name, " ")
@@ -33,17 +41,25 @@ source: |
                   .email == ..email.email
                   and (
                     strings.contains(subject.subject, .display_name)
-                    or strings.contains(subject.subject,
-                                        strings.concat(.first_name,
-                                                       " ",
-                                                       .last_name
-                                        )
+                    or (
+                      .first_name != ""
+                      and .last_name != ""
+                      and strings.contains(subject.subject,
+                                           strings.concat(.first_name,
+                                                          " ",
+                                                          .last_name
+                                           )
+                      )
                     )
-                    or strings.contains(subject.subject,
-                                        strings.concat(.last_name,
-                                                       ", ",
-                                                       .first_name
-                                        )
+                    or (
+                      .first_name != ""
+                      and .last_name != ""
+                      and strings.contains(subject.subject,
+                                           strings.concat(.last_name,
+                                                          ", ",
+                                                          .first_name
+                                           )
+                      )
                     )
                   )
                   and strings.contains(.display_name, " ")


### PR DESCRIPTION
# Description
Add alternative name matching logic to org_vips body/subject/HTML-based rules to handle cases where
display_name is stored as "Lastname, Firstname" instead of "Firstname Lastname".
Uses `strings.concat(.first_name, " ", .last_name)` and `strings.concat(.last_name, ", ", .first_name)`
as additional `or` conditions inside existing `any($org_vips, ...)` blocks.

This is a test rule deployment to assess impact magnitude.

## Affected rules
- `vip_impersonation_charity.yml`
- `fake_thread_suspicious_indicators.yml`
- `vip_impersonation_subject.yml`
- `vip_impersonation_fake_thread.yml`
- `impersonation_google_groups_suspicious.yml`
- `service_abuse_trello_board_invite_vip.yml`

# Associated samples
N/A - validation only (no TP canonical available)

## Associated hunts
TBD - will be run after test rule deployment