### PR TITLE
Update phishing_simulation_knowbe4.yml

### DIFF
--- a/insights/headers/phishing_simulation_knowbe4.yml
+++ b/insights/headers/phishing_simulation_knowbe4.yml
@@ -24,7 +24,7 @@ source: |
           )
         )
         or any(headers.hops,
-              any(.fields, strings.icontains(.value, "gmailapi.google.com"))
+               any(.fields, strings.icontains(.value, "gmailapi.google.com"))
         )
       )
     )

--- a/insights/headers/phishing_simulation_knowbe4.yml
+++ b/insights/headers/phishing_simulation_knowbe4.yml
@@ -13,11 +13,19 @@ source: |
     or (
       length(headers.ips) == 0
       and length(headers.hops) == 1
-      and any(headers.hops, any(.fields, .name == "X-PHISHTEST"))
-      and headers.return_path.domain.root_domain == "knowbe4.com"
-      and not sender.email.domain.root_domain == "knowbe4.com"
-      and any(headers.hops,
-              any(.fields, strings.icontains(.value, "injector.psm.knowbe4.com"))
+      and any(headers.hops, any(.fields, strings.starts_with(.name, "X-PHISH")))
+      and (
+        (
+          headers.return_path.domain.root_domain == "knowbe4.com"
+          and any(headers.hops,
+                  any(.fields,
+                      strings.icontains(.value, "injector.psm.knowbe4.com")
+                  )
+          )
+        )
+        or any(headers.hops,
+              any(.fields, strings.icontains(.value, "gmailapi.google.com"))
+        )
       )
     )
   )


### PR DESCRIPTION
# Description

During a runner ping a sample was provided that was a phishing simulation. During this investigation I noticed the insight did not match our [exclusion](https://github.com/sublime-security/sublime-rules/blob/main/exclusions/knowbe4_phishing_simulation.yml) rule so updating it.

# Associated samples

- [sample](https://platform.sublime.security/messages/50700af4bbd3dcf7e55f839cfebc75674590b99f90ff8fda1a994b898c4312eb?preview_id=019e41fa-a499-7371-a4c1-4d3e82a1f434)


# Screenshot (insights)

<img width="1434" height="831" alt="Screenshot 2026-05-27 at 5 00 36 PM" src="https://github.com/user-attachments/assets/86b78759-e3de-4387-a1a3-030534bd92ab" />


