### PR TITLE
Refactor keywords in Cloud service with credential theft language

### DIFF
--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -6,8 +6,7 @@ source: |
   type.inbound
   and (
     any([body.current_thread.text, body.html.inner_text],
-        strings.starts_with(., 'Cloud') 
-        or strings.icontains(., "Cloud+")
+        strings.starts_with(., 'Cloud') or strings.icontains(., "Cloud+")
     )
     // cloud emoji
     or regex.contains(body.current_thread.text, '^\x{2601}')

--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -1,12 +1,13 @@
-name: "Link: Cloud service with credential theft language"
-description: "Detects messages impersonating cloud services that contain high-confidence credential theft language and file sharing topics. The message starts with 'Cloud' or a cloud emoji, contains links to external domains not matching the sender's domain, and lacks recipient identification entities."
+name: "Impersonation Link: Cloud branding service with credential theft language"
+description: "Detects messages impersonating cloud services that contain high-confidence credential theft language and file sharing topics. The message starts with 'Cloud' or a cloud emoji or Cloud+ text, contains links to external domains not matching the sender's domain, and lacks recipient identification entities."
 type: "rule"
 severity: "medium"
 source: |
   type.inbound
   and (
     any([body.current_thread.text, body.html.inner_text],
-        strings.starts_with(., 'Cloud')
+        strings.starts_with(., 'Cloud') 
+        or strings.icontains(., "Cloud+")
     )
     // cloud emoji
     or regex.contains(body.current_thread.text, '^\x{2601}')

--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -61,6 +61,10 @@ source: |
                       and .value is not null
               )
   )
+  and not (
+    sender.email.email == "noreply@icloud.com.cn"
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/link_credential_phishing_cloud_service.yml
+++ b/detection-rules/link_credential_phishing_cloud_service.yml
@@ -6,7 +6,7 @@ source: |
   type.inbound
   and (
     any([body.current_thread.text, body.html.inner_text],
-        strings.starts_with(., 'Cloud') or strings.icontains(., "Cloud+")
+        strings.starts_with(., 'Cloud') or strings.icontains(., "Cloud+ ")
     )
     // cloud emoji
     or regex.contains(body.current_thread.text, '^\x{2601}')


### PR DESCRIPTION
# Description
Finding additional keywords that also contains a string text - `"Cloud+ "`

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/5072304b473b86130f9341c43826f284ee37ccaec490b935a490b02b5a654b6b)

## Associated hunts
- [Net-new](https://platform.sublime.security/messages/hunt?huntId=019e6f73-a688-7aec-b09d-b2c2a10b6cc2)
- [Multi-hunt 30D](https://hunt.limeseed.email/hunts/1055f882-5eb1-41c9-bd6d-405f27b0a8a4)

