### PR TITLE
Modify self-sender rule to detect suspicious links

### DIFF
--- a/detection-rules/self_sender_french_copypaste_instructions_suspicious_domains.yml
+++ b/detection-rules/self_sender_french_copypaste_instructions_suspicious_domains.yml
@@ -1,9 +1,11 @@
-name: "Self-sender with copy/paste instructions and suspicious domains (French/Français)"
+name: "Self-sender with suspicious links (French/Français)"
 description: "Detects messages where the sender emails themselves with French text containing 'copier' (copy) and 'coller' (paste) instructions, along with suspicious domains like pages.dev or web.app. The subject line contains both the sender's email and display name, which are different values."
 type: "rule"
 severity: "medium"
 source: |
   type.inbound
+  // message is in French
+  and ml.nlu_classifier(body.current_thread.text).language == 'french'
   // self sender
   and (
     length(recipients.to) == 1
@@ -13,10 +15,6 @@ source: |
   and strings.icontains(subject.subject, sender.email.email)
   and strings.icontains(subject.subject, sender.display_name)
   and sender.email.email != sender.display_name
-  // copy
-  and strings.icontains(body.current_thread.text, 'copier')
-  // paste
-  and strings.icontains(body.current_thread.text, 'coller')
   and (
     strings.contains(body.current_thread.text, '.pages.dev')
     or strings.contains(body.current_thread.text, '.web.app')


### PR DESCRIPTION
# Description

broadening scope of the rule to include messages without the French words `copier` or `coller`, and added an NLU check to ensure the message is in French.

# Associated samples

- https://platform.sublime.security/messages/506136190f43ca1adc8a1276dbb9d9a17aff95a575742672df5ce2b76c7da041

## Associated hunts
- https://platform.sublime.security/hunts/019e46b7-ee60-77dd-9318-8e5cfdb7b2ba