### PR TITLE
Update brand_impersonation_procore.yml

### DIFF
--- a/detection-rules/brand_impersonation_procore.yml
+++ b/detection-rules/brand_impersonation_procore.yml
@@ -9,8 +9,10 @@ source: |
     or 2 of (
       strings.icontains(body.current_thread.text, 'Procore'),
       strings.icontains(body.current_thread.text, '6309 Carpinteria Ave'),
-      strings.icontains(body.current_thread.text, 'Carpinteria, CA 93013')
+      strings.icontains(body.current_thread.text, 'Carpinteria, CA 93013'),
+      strings.icontains(body.current_thread.text, 'Build America, Buy America')
     )
+    or strings.iends_with(sender.display_name, 'via Procore')
   )
   and not (
     sender.email.domain.root_domain in ("procore.com", "procoretech.com")

--- a/detection-rules/brand_impersonation_procore.yml
+++ b/detection-rules/brand_impersonation_procore.yml
@@ -9,10 +9,14 @@ source: |
     or 2 of (
       strings.icontains(body.current_thread.text, 'Procore'),
       strings.icontains(body.current_thread.text, '6309 Carpinteria Ave'),
-      strings.icontains(body.current_thread.text, 'Carpinteria, CA 93013'),
-      strings.icontains(body.current_thread.text, 'Build America, Buy America')
+      strings.icontains(body.current_thread.text, 'Carpinteria, CA 93013')
     )
-    or strings.iends_with(sender.display_name, 'via Procore')
+    or (
+      strings.iends_with(sender.display_name, 'via Procore')
+      and any(body.current_thread.links,
+              .href_url.domain.root_domain in $free_subdomain_hosts
+      )
+    )
   )
   and not (
     sender.email.domain.root_domain in ("procore.com", "procoretech.com")

--- a/detection-rules/brand_impersonation_procore.yml
+++ b/detection-rules/brand_impersonation_procore.yml
@@ -14,7 +14,7 @@ source: |
     or (
       strings.iends_with(sender.display_name, 'via Procore')
       and any(body.current_thread.links,
-              .href_url.domain.root_domain in $free_subdomain_hosts
+              .href_url.domain.root_domain == "blogspot.com"
       )
     )
   )
@@ -22,7 +22,7 @@ source: |
     sender.email.domain.root_domain in ("procore.com", "procoretech.com")
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
-  
+
   // negating legit replies/forwards
   and not (
     (


### PR DESCRIPTION
# Description

Adding logic to look at if `sender.display_name` ends with `via Procore` and contains a link with a free_subdomain_host root_domain

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5073693100de9c31688badcf2dd01430c5d8a9e80c9775ea6e8014ac8b4d31a9?preview_id=019e50a3-04ac-7132-80d2-4fdfe6614bcc)
- [Sample 2](https://platform.sublime.security/messages/50733a85c9e981a0ffc9b1b5bb13d8bfe79d19ad65a4e3b8881caaed47b06c70?preview_id=019e50dd-3e9c-76c7-a7ad-192f4d776849)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e5141-b061-7e30-9632-50caa7ca5eca)
- [84 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/b372cc94-26f2-4964-bab4-87c942bbcfa3)