### PR TITLE
Update credential_phishing_one_drive_impersonation.yml

### DIFF
--- a/detection-rules/credential_phishing_one_drive_impersonation.yml
+++ b/detection-rules/credential_phishing_one_drive_impersonation.yml
@@ -9,8 +9,7 @@ source: |
     (
       regex.icontains(sender.display_name, '[0o]ne\s?dr[il1]ve')
       or regex.icontains(sender.email.local_part, '[0o]ne\s?dr[il1]ve')
-      or 0 < strings.ilevenshtein(strings.replace_confusables(sender.display_name
-                                  ),
+      or 0 < strings.ilevenshtein(strings.replace_confusables(sender.display_name),
                                   "one?drive"
       ) < 2
       or any(attachments,
@@ -75,7 +74,7 @@ source: |
       ) > 0.5
     )
   )
-
+  
   // and body language is med/high confidence cred theft
   and (
     any(ml.nlu_classifier(body.current_thread.text).intents,
@@ -100,13 +99,13 @@ source: |
     )
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
-
+  
   // negate highly trusted sender domains unless they fail DMARC authentication
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
-
+  
   // excludes docusign senders that contain "via" in the display name
   and not (
     any(headers.hops,
@@ -117,7 +116,6 @@ source: |
     and strings.contains(sender.display_name, "via")
   )
   and not profile.by_sender().any_messages_benign
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/credential_phishing_one_drive_impersonation.yml
+++ b/detection-rules/credential_phishing_one_drive_impersonation.yml
@@ -9,7 +9,8 @@ source: |
     (
       regex.icontains(sender.display_name, '[0o]ne\s?dr[il1]ve')
       or regex.icontains(sender.email.local_part, '[0o]ne\s?dr[il1]ve')
-      or 0 < strings.ilevenshtein(strings.replace_confusables(sender.display_name),
+      or 0 < strings.ilevenshtein(strings.replace_confusables(sender.display_name
+                                  ),
                                   "one?drive"
       ) < 2
       or any(attachments,
@@ -42,7 +43,9 @@ source: |
              )
       )
     )
-    or regex.imatch(body.current_thread.text, '[0o]ne\s?dr[il1]ve.*')
+    or regex.imatch(strings.replace_confusables(body.current_thread.text),
+                    '[0o]ne\s?dr[il1]ve.*'
+    )
     // or one drive is in the subject with a freefile host, additional suspicious language, or suspicious display text
     or (
       regex.icontains(strings.replace_confusables(subject.subject),
@@ -72,7 +75,7 @@ source: |
       ) > 0.5
     )
   )
-  
+
   // and body language is med/high confidence cred theft
   and (
     any(ml.nlu_classifier(body.current_thread.text).intents,
@@ -97,13 +100,13 @@ source: |
     )
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
-  
+
   // negate highly trusted sender domains unless they fail DMARC authentication
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
-  
+
   // excludes docusign senders that contain "via" in the display name
   and not (
     any(headers.hops,


### PR DESCRIPTION
# Description

Updating `regex.icontains(body.current_thread.text)` logic to utilize `strings.replace_confusables`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5073ae0c4cea8c3a75d9c22a77bb13923ee0da96478c2203ea1f0448baf72fc3?preview_id=019e50fd-d51d-76a9-a90e-463672a5745d)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e646c-a0be-7c43-82f1-feca9df64719)