### PR TITLE
Create link_numeric_ip_obfuscation.yml

### DIFF
--- a/detection-rules/link_numeric_ip_obfuscation.yml
+++ b/detection-rules/link_numeric_ip_obfuscation.yml
@@ -1,0 +1,14 @@
+name: "Link: Numeric IP obfuscation in URL"
+description: "Detects inbound messages containing links where the host is a numeric-only IP representation, commonly used to bypass domain-based URL filtering."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(body.links, regex.icontains(.href_url.url, 'https?://[0-9]{7,12}/.+'))
+attack_types:
+  - "Credential Phishing"
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Evasion"
+detection_methods:
+  - "URL analysis"

--- a/detection-rules/link_numeric_ip_obfuscation.yml
+++ b/detection-rules/link_numeric_ip_obfuscation.yml
@@ -12,3 +12,4 @@ tactics_and_techniques:
   - "Evasion"
 detection_methods:
   - "URL analysis"
+id: "7d639d89-02ee-5729-8d6d-67a963fa5861"


### PR DESCRIPTION
# Description

Creating a rule to detect messages that attempt to obfuscate URLs by using numeric IP representations instead of standard domains.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/506ef5ba40240f146161d88d9289dbce88ec67db86f7fec7f6281e7a18a44783?preview_id=019e5070-5fb7-77b7-ab96-5a0500edf489)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=019e6ece-c232-7a4f-a892-1b9c41a38873)
- [84 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/40902cf7-f8d0-405a-b071-60a2012b90bf)