### PR TITLE
Update close the loop with reporter automation to trigger on asa complete

### DIFF
--- a/automations/close_the_loop_with_reporter.yml
+++ b/automations/close_the_loop_with_reporter.yml
@@ -3,5 +3,16 @@ description: "Automatically notify the reporter when a report is classified."
 type: "triage_rule"
 triage_classification_changes: true
 triage_abuse_reports: true
+triage_asa_complete: true
 default_actions: ["send_user_report_results"]
-source: (triage.trigger == "abuse_report" or triage.user_reports.count > 0) and triage.classification.classification is not null
+source: |
+  (
+    (triage.trigger == "abuse_report" or triage.user_reports.count > 0)
+      and triage.classification.classification is not null
+  )
+  or
+  (
+      triage.trigger in ("asa_complete", "classification_change")
+      and triage.user_reports.count > 0
+      and triage.classification.classification is not null
+  )

--- a/automations/close_the_loop_with_reporter.yml
+++ b/automations/close_the_loop_with_reporter.yml
@@ -6,13 +6,12 @@ triage_abuse_reports: true
 triage_asa_complete: true
 default_actions: ["send_user_report_results"]
 source: |
+  triage.classification.classification is not null and
   (
     (triage.trigger == "abuse_report" or triage.user_reports.count > 0)
-      and triage.classification.classification is not null
-  )
-  or
-  (
-      triage.trigger in ("asa_complete", "classification_change")
-      and triage.user_reports.count > 0
-      and triage.classification.classification is not null
+     or
+    (
+        triage.trigger in ("asa_complete", "classification_change")
+        and triage.user_reports.count > 0
+    )
   )


### PR DESCRIPTION
# Description

We want to trigger the close the loop with reporter automation when ASA completes. This allows for the close the loop with reporter action to include the ASA simplified summary in the user report results email. 