### PR TITLE
Update impersonation_usps.yml

### DIFF
--- a/detection-rules/impersonation_usps.yml
+++ b/detection-rules/impersonation_usps.yml
@@ -7,6 +7,7 @@ source: |
   and (
     any(ml.logo_detect(file.message_screenshot()).brands, .name == "USPS")
     or strings.icontains(sender.display_name, "USPS")
+    or strings.icontains(sender.display_name, "United States Postal Service")
     or regex.contains(body.html.display_text, 'USPS\s*\.\s*COM')
     or strings.icontains(body.current_thread.text, 'USPS Delivery Team')
   )
@@ -19,7 +20,9 @@ source: |
                       "*package*",
                       '*view your order*',
                       "*update*",
-                      '*delivery address*'
+                      '*delivery address*',
+                      "*parcel allocation*",
+                      "*claim your parcel*"
         )
     ),
     strings.ilike(body.current_thread.text,
@@ -30,7 +33,8 @@ source: |
                   '*receiver address*',
                   '*package details*',
                   '*sorry tolet*',
-                  '*Due to an incorrect*'
+                  '*Due to an incorrect*',
+                  '*remain undeliverable*'
     ),
     // impersonal greeting
     any(ml.nlu_classifier(body.current_thread.text).entities,
@@ -41,6 +45,9 @@ source: |
     ),
     // free email sender
     sender.email.domain.root_domain in $free_email_providers,
+    network.whois(sender.email.domain).days_old < 30,
+    not network.whois(sender.email.domain).found,
+  
     // contains link to recently registered domain
     any(body.links, network.whois(.href_url.domain).days_old < 15),
     (
@@ -50,7 +57,8 @@ source: |
       and not regex.icontains(body.html.display_text,
                               '\b(?:usps|shipping|delivery)\b'
       )
-    )
+    ),
+    any(body.links, regex.icontains(.href_url.url, 'https?://[0-9]{7,12}/.+')),
   )
   and (
     sender.email.domain.root_domain not in (


### PR DESCRIPTION
# Description

Updating `sender.display_name`, `.display_text`, and `body.current_thread.text` keyword matching and adding additional `3 of` logic conditions

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/506ef5ba40240f146161d88d9289dbce88ec67db86f7fec7f6281e7a18a44783?preview_id=019e5070-5fb7-77b7-ab96-5a0500edf489)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e745d-f6e0-734f-adeb-0d8b2323bf11)
