### PR TITLE
Update generic_pdf.yar

### DIFF
--- a/yara/generic_pdf.yar
+++ b/yara/generic_pdf.yar
@@ -297,7 +297,7 @@ rule enc_pdf_image_sizes {
 	meta:
 		author      = "kyle eaton"
 		date        = "2026-05-26"
-		description = "PDF image sizes that correlate with the images used in an encrypted PDF lure"
+		description = "matches PDF image sizes that correlate with the images used in an encrypted PDF lure"
 	strings:
 		$header = { 25 50 44 46 2D 31 2E }
 		$img1   = { 2F 49 6D 61 67 65 20 2F 57 69 64 74 68 20 32 30 32 20 2F 48 65 69 67 68 74 20 32 34 36 }

--- a/yara/generic_pdf.yar
+++ b/yara/generic_pdf.yar
@@ -293,3 +293,17 @@ rule pdf_cve_2026_34621_observed_lures {
 		$header at 0 and any of ($img_*)
 }
 
+rule enc_pdf_image_sizes {
+	meta:
+		author      = "kyle eaton"
+		date        = "2026-05-26"
+		description = "PDF image sizes that correlate with the images used in an encrypted PDF lure"
+	strings:
+		$header = { 25 50 44 46 2D 31 2E }
+		$img1   = { 2F 49 6D 61 67 65 20 2F 57 69 64 74 68 20 32 30 32 20 2F 48 65 69 67 68 74 20 32 34 36 }
+		$img2   = { 2F 49 6D 61 67 65 20 2F 57 69 64 74 68 20 31 32 33 20 2F 48 65 69 67 68 74 20 33 32 }
+	condition:
+		$header at 0
+		and all of ($img*)
+		and @img1 < @img2
+}


### PR DESCRIPTION
# Description
Matching the image sizes within encrypted PDFs, which allows us to match the lure they're using without needed to decrypt anything. The stream content of the images is too variable to be useful in this case, so we use the sizes. Working well with these samples in my test data and in VT. 

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/500f618ef0458247e5d0ec2768d199b9aa620e8e7d94ba268120352c11967deb?preview_id=019c53b0-46c9-7e44-8722-0e8a4dfccb00)


