### PR TITLE
Add detection rule for Square QR code abuse

### DIFF
--- a/detection-rules/service_abuse_square_QR_code.yml
+++ b/detection-rules/service_abuse_square_QR_code.yml
@@ -10,8 +10,14 @@ source: |
                  // ignore square's own free website hosting service
                  .url.domain.root_domain != "square.site"
           ),
-          .url.domain.root_domain in $self_service_creation_platform_domains
-          or .url.domain.root_domain in $free_file_hosts
+          (
+            .url.domain.root_domain in $self_service_creation_platform_domains
+            or .url.domain.domain in $self_service_creation_platform_domains
+          )
+          or (
+            .url.domain.root_domain in $free_file_hosts
+            or .url.domain.domain in $free_file_hosts
+          )
   )
 
 attack_types:

--- a/detection-rules/service_abuse_square_QR_code.yml
+++ b/detection-rules/service_abuse_square_QR_code.yml
@@ -1,0 +1,26 @@
+name: "Service abuse: Square marketing with suspicious QR code"
+description: "Detects messages from Square's marketing domain containing QR codes that redirect to self-service creation platforms, file sharing services, or image hosting services rather than legitimate Square domains."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and sender.email.domain.domain == "squaremktg.com"
+  and beta.scan_qr(file.message_screenshot()).found
+  and any(filter(beta.scan_qr(file.message_screenshot()).items,
+                 // ignore square's own free website hosting service
+                 .url.domain.root_domain != "square.site"
+          ),
+          .url.domain.root_domain in $self_service_creation_platform_domains
+          or .url.domain.root_domain in $free_file_hosts
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "QR code"
+  - "Free file host"
+detection_methods:
+  - "Computer Vision"
+  - "QR code analysis"
+  - "Sender analysis"
+  - "URL analysis"

--- a/detection-rules/service_abuse_square_QR_code.yml
+++ b/detection-rules/service_abuse_square_QR_code.yml
@@ -6,6 +6,10 @@ source: |
   type.inbound
   and sender.email.domain.domain == "squaremktg.com"
   and beta.scan_qr(file.message_screenshot()).found
+  //
+  // This rule makes use of a beta feature and is subject to change without notice
+  // using the beta feature in custom rules is not suggested until it has been formally released
+  //
   and any(filter(beta.scan_qr(file.message_screenshot()).items,
                  // ignore square's own free website hosting service
                  .url.domain.root_domain != "square.site"

--- a/detection-rules/service_abuse_square_QR_code.yml
+++ b/detection-rules/service_abuse_square_QR_code.yml
@@ -24,3 +24,4 @@ detection_methods:
   - "QR code analysis"
   - "Sender analysis"
   - "URL analysis"
+id: "079c81ff-45f6-5460-8dc5-f00dcfcdd57a"

--- a/detection-rules/service_abuse_square_QR_code.yml
+++ b/detection-rules/service_abuse_square_QR_code.yml
@@ -1,5 +1,5 @@
 name: "Service abuse: Square marketing with suspicious QR code"
-description: "Detects messages from Square's marketing domain containing QR codes that redirect to self-service creation platforms, file sharing services, or image hosting services rather than legitimate Square domains."
+description: "Detects messages from Square's marketing domain containing QR codes that redirect to self-service creation platforms, file sharing services, or image hosting services."
 type: "rule"
 severity: "high"
 source: |


### PR DESCRIPTION
# Description

This rule detects messages from Square's marketing domain that contain suspicious QR codes redirecting to non-legitimate domains.

# Associated samples
- https://platform.sublime.security/messages/50751d482a8961255bc57c28d554ad774417a9ceae7f4377bddb8204d73ea980
- https://platform.sublime.security/messages/50754e8e71a3ba4352d56e4b05466dc1703c5da13f6eb105caf0a7544902bf35
- https://platform.sublime.security/messages/50755e47ddbbe68d36f8dedc67a867a3e2186e00bae4929ad6a0af1e5584f923

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=019e6564-251d-7ecb-9d34-89cc5e2cef5b