### PR TITLE
Update impersonation_dhl.yml

### DIFF
--- a/detection-rules/impersonation_dhl.yml
+++ b/detection-rules/impersonation_dhl.yml
@@ -122,8 +122,8 @@ source: |
     'dhlgpi.com', // DHL Australia
     'dhlfreight-news.com'
   )
-  and (
-    sender.email.domain.tld not in ('dhl')
+  and not (
+    sender.email.domain.tld in ('dhl')
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
   and (

--- a/detection-rules/impersonation_dhl.yml
+++ b/detection-rules/impersonation_dhl.yml
@@ -120,7 +120,7 @@ source: |
     'tdhlaw.com', // dhl in domain but unrelated
     'hapibenefits.com', // DHL rewards program
     'dhlgpi.com', // DHL Australia
-    'dhlfreight-news.com',
+    'dhlfreight-news.com'
   )
   and sender.email.domain.tld not in ('dhl')
   and (

--- a/detection-rules/impersonation_dhl.yml
+++ b/detection-rules/impersonation_dhl.yml
@@ -29,7 +29,7 @@ source: |
     or any(ml.nlu_classifier(body.current_thread.text).entities,
            .name == "org"
            and (
-             .text =~ "DHL" 
+             .text =~ "DHL"
              or .text =~ "DHL Express"
              or strings.istarts_with(.text, "DHL International")
            )
@@ -120,8 +120,9 @@ source: |
     'tdhlaw.com', // dhl in domain but unrelated
     'hapibenefits.com', // DHL rewards program
     'dhlgpi.com', // DHL Australia
-    'dhlfreight-news.com'
+    'dhlfreight-news.com',
   )
+  and sender.email.domain.tld not in ('dhl')
   and (
     profile.by_sender().prevalence in ("new", "outlier")
     or (

--- a/detection-rules/impersonation_dhl.yml
+++ b/detection-rules/impersonation_dhl.yml
@@ -122,7 +122,10 @@ source: |
     'dhlgpi.com', // DHL Australia
     'dhlfreight-news.com'
   )
-  and sender.email.domain.tld not in ('dhl')
+  and (
+    sender.email.domain.tld not in ('dhl')
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
   and (
     profile.by_sender().prevalence in ("new", "outlier")
     or (


### PR DESCRIPTION
# Description

During a runner ping, we were notified that a few FPs came through so negating the sender tld for `.dhl` gTLD in rule.

There was no official escalation created but this will resolve the issue reported.

# Associated samples

- [Sample](https://platform.sublime.security/messages/50738be0578883a99098e23f6d82aebc4657d8a46e3acaf86cb7eefb3c43e634?preview_id=019e51e9-a695-7d74-87a2-238a2613d693)

## Associated hunts

- [Hunt negation between rule differences](https://platform.sublime.security/messages/hunt?huntId=019e65ad-4e45-77c5-9fa1-64c7acff932f)

