### PR TITLE
Add condition for 'Fax Message Delivered' in detection rule

### DIFF
--- a/detection-rules/link_fake_fax_low_reputation.yml
+++ b/detection-rules/link_fake_fax_low_reputation.yml
@@ -29,6 +29,7 @@ source: |
             or strings.icontains(., "e-Fax Document")
             or strings.icontains(., "Fax Status")
             or strings.icontains(., "Fax ID")
+            or strings.icontains(., "Fax Message Delivered")
             or strings.icontains(., "Incoming Fax")
             or strings.icontains(., "New Fax Document")
             or strings.istarts_with(., 'Fax message')


### PR DESCRIPTION
# Description

adding `Fax Message Delivered` as a suspicious keywork to cover missed samples

# Associated samples
- https://platform.sublime.security/messages/5071d97df584422858cd5ed9abc48474f47b52069799ffcccdd7df13a2ada0de?preview_id=019e42ed-7d26-7113-9bb3-ee45f7fe7965
- https://platform.sublime.security/messages/5026fe2bed01124385def1dfea8238ac9112a3f5a2c11f2c0455a563719733ac?preview_id=019cd383-6053-75e0-9ec5-22f5f6423fda
- https://platform.sublime.security/messages/502623e76d8272ae30e4077ff2c35d7215957d35bb052a99f5b05c0c54f78585?preview_id=019cd383-3f37-77c9-95b9-c7a49d44a33f

## Associated hunts
- https://platform.sublime.security/hunts/019ed272-6020-708a-be7f-7c8d373142b9
