### PR TITLE
Update generic_pdf.yar

### DIFF
--- a/yara/generic_pdf.yar
+++ b/yara/generic_pdf.yar
@@ -307,3 +307,31 @@ rule enc_pdf_image_sizes {
 		and all of ($img*)
 		and @img1 < @img2
 }
+
+rule w9_pdf_invoice_images {
+	meta:
+		author      = "kyle eaton"
+		date        = "2026-05-15"
+		description = "matching images within invoices in a subset of w9 pdfs"
+	strings:
+		$header                  = { 25 50 44 46 2D 31 2E }
+		$jpg_001_smaller_image   = { 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 40 00 00 00 05 05 02 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 }
+		$jpg_outline_overlap_002 = { 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 02 4F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 }
+	condition:
+		$header at 0
+		and any of ($jpg_*)
+}
+
+rule w9_pdf_service_agreement_img_objects {
+	meta:
+		author      = "kyle eaton"
+		date        = "2026-05-27"
+		description = "matching the observed service agreements used in a subset of w9 pdfs"
+	strings:
+		$header             = { 25 50 44 46 2D 31 2E }
+		$image_object       = { 2F 49 6D 61 67 65 0A 2F 57 69 64 74 68 20 35 37 32 0A 2F 48 65 69 67 68 74 20 31 35 35 0A }
+		$image_stream_bytes = { 8B 1C 37 2A FA CE 08 E2 11 51 EB 0E }
+	condition:
+		$header at 0
+		and all of them
+}


### PR DESCRIPTION
# Description
This is matching a subset of w9 pdfs which use a few specific images and objects within their PDFs.  We have coverage for their w9 PDF, but they also use up to 2 additional PDFs which we do not typically have coverage for. 

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/506c61b03c5f210dbc5ed08847d214a1fd2d0aa66795242e1cb23fefb083a651?preview_id=019e5119-3363-74e0-add8-03f797430b47)
- [Sample 2](https://platform.sublime.security/messages/50780354709d81b95e0dfef65eaf5d0df4cf3e36367b2573fd1a8e39ee04f920?preview_id=019e66ff-dc1b-7cfc-a0fb-d115830af423)

# Associated Hunt

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e69f8-7c38-7930-badc-9d02bde98e12)