### PR TITLE
Update service_abuse_google_oauth_with_suspicious_redirect_destinatio…

### DIFF
--- a/detection-rules/service_abuse_google_oauth_with_suspicious_redirect_destination.yml
+++ b/detection-rules/service_abuse_google_oauth_with_suspicious_redirect_destination.yml
@@ -5,7 +5,8 @@ severity: "medium"
 source: |
   type.inbound
   and any(body.links,
-          .href_url.domain.domain == "accounts.google.com"
+          .href_url.domain.subdomain == "accounts"
+          and .href_url.domain.sld == "google"
           and strings.istarts_with(.href_url.path, '/o/oauth2/v2/auth')
           and strings.icontains(.href_url.url, 'prompt=none')
   )


### PR DESCRIPTION
# Description

Provide coverage to extend to other TLD domains besides .com (accounts.google.co.jp as an exaple)

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5062fb6ec477ec51c113d5ce983fe8c30d427af19abeb28b0eb8ecee668371c9?preview_id=019e037c-cffb-7f15-b744-73e2cca3f89c)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Net New L30 Hunt](https://platform.sublime.security/messages/hunt?huntId=019e6a50-85e8-72e3-8ab1-8ffd155fac5a)
- [Net new multihunt](https://hunt.limeseed.email/hunts/e6f4c1e6-7850-46c8-86c2-4dafeb2675d8)
- [L90 Hunt](https://platform.sublime.security/messages/hunt?huntId=019e6a54-7c8e-7bba-8aa9-b6c37cc4c9ec)
