### PR TITLE
Update spam_website_errors_solicitation.yml

### DIFF
--- a/detection-rules/spam_website_errors_solicitation.yml
+++ b/detection-rules/spam_website_errors_solicitation.yml
@@ -25,7 +25,7 @@ source: |
         )
       )
       // short subject
-      or length(subject.base) <= 5
+      or length(subject.base) <= 10
     )
     // or a reply or forward in a thread that mentions website or screenshots
     or (
@@ -59,7 +59,7 @@ source: |
       )
       // service offering keywords
       and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          "(?:screenshot|error list|plan|quote|rank|professional|price|mistake|visibility|improvement|review|emailed.{0,10}more details)"
+                          "(?:screenshot|errors? (?:list|report)|plan|quote|rank|professional|price|mistake|visibility|improvement|review|emailed.{0,10}more details)"
       )
       // generic greeting
       and regex.icontains(strings.replace_confusables(body.current_thread.text),
@@ -67,7 +67,7 @@ source: |
       )
       // problem or urgency keywords
       and regex.icontains(strings.replace_confusables(body.current_thread.text),
-                          '(?:error|report|issues|website|repair|redesign|upgrade|Google\s+.{0,15}find it|glitch|send you|SEO)'
+                          '(?:errors?|report|issues|website|repair|redesign|upgrade|Google\s+.{0,15}find it|glitch|send you|SEO|broken)'
       )
       // website or page mention
       and regex.icontains(strings.replace_confusables(body.current_thread.text),

--- a/detection-rules/spam_website_errors_solicitation.yml
+++ b/detection-rules/spam_website_errors_solicitation.yml
@@ -25,7 +25,7 @@ source: |
         )
       )
       // short subject
-      or length(subject.base) <= 10
+      or length(subject.base) < 7
     )
     // or a reply or forward in a thread that mentions website or screenshots
     or (


### PR DESCRIPTION
# Description

Updating rule by increasing `length` logic to be `<= 10`, also updated `body.current_thread.text` regex to include additional keywords

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50789fad7d9b5641ff47bfd53ec6e7f0e25e22c062961709f7c55dbb6d3dc8f7?preview_id=019e6a86-1a5b-788c-a316-c20ccd663bdf)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e748a-e223-7778-9632-93fb76926948)