### PR TITLE
Create link_base64_recipient_with_arrow.yml

### DIFF
--- a/detection-rules/link_base64_recipient_with_arrow.yml
+++ b/detection-rules/link_base64_recipient_with_arrow.yml
@@ -19,3 +19,4 @@ tactics_and_techniques:
 detection_methods:
   - "Content analysis"
   - "URL analysis"
+id: "00d7e905-938f-54f2-a395-549c2d51d156"

--- a/detection-rules/link_base64_recipient_with_arrow.yml
+++ b/detection-rules/link_base64_recipient_with_arrow.yml
@@ -1,0 +1,21 @@
+name: "Link: Base64 encoded recipient address in URL with arrow indicator"
+description: "Detects messages containing links with arrow symbols in the display text where the recipient's email address is base64 encoded within the URL path."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(body.current_thread.links,
+          strings.ends_with(.display_text, '→')
+          and any(strings.scan_base64(.href_url.path),
+                  . == recipients.to[0].email.email
+          )
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description

Detects messages containing links with arrow symbols in the display text where the recipient's email address is base64 encoded within the URL path.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507127410d1523c020d7068141021bb1a093585483358b86b0cd6991983646ca)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [12 customer multi-hunt](https://hunt.limeseed.email/hunts/90305c62-1763-49b5-a293-a39daecd78bf)
- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=019e6b11-d4f1-73f0-abf4-fadd96f0caeb)
