### PR TITLE
Update credential_phishing_esign_document_notification.yml

### DIFF
--- a/detection-rules/credential_phishing_esign_document_notification.yml
+++ b/detection-rules/credential_phishing_esign_document_notification.yml
@@ -65,7 +65,9 @@ source: |
                           "Independent Contract",
                           "Contract.*signature",
                           "add your signature",
-                          "signature needed"
+                          "signature needed",
+                          "SignNow",
+                          "attn_task"
           )
           or (
             regex.icontains(strings.replace_confusables(.), "action.re?quired")
@@ -77,7 +79,7 @@ source: |
           )
   )
   and (
-    // unusual repeated patterns in HTML 
+    // unusual repeated patterns in HTML
     regex.icontains(body.html.raw, '((<br\s*/?>\s*){20,}|\n{20,})')
     or regex.icontains(body.html.raw, '(<p[^>]*>\s*<br\s*/?>\s*</p>\s*){30,}')
     or regex.icontains(body.html.raw,
@@ -129,7 +131,7 @@ source: |
                    'mailto:[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
     ) > 50
   
-    // High count of empty elements (padding) 
+    // High count of empty elements (padding)
     or regex.count(body.html.raw,
                    '<(?:p|div|span|td)[^>]*>\s*(?:&nbsp;|\s)*\s*</(?:p|div|span|td)>'
     ) > 30
@@ -164,7 +166,8 @@ source: |
                         'Review and sign',
                         'REVIEW.*DOCUMENT',
                         'Open Document',
-                        'Sign Now'
+                        'Sign Now',
+                        'complete tasks?'
         )
         // check that the display_text is all lowercase
         or (

--- a/detection-rules/credential_phishing_esign_document_notification.yml
+++ b/detection-rules/credential_phishing_esign_document_notification.yml
@@ -66,7 +66,8 @@ source: |
                           "Contract.*signature",
                           "add your signature",
                           "signature needed",
-                          "attn_task"
+                          "attn_task",
+                          "DocReq\\b"
           )
           or (
             regex.icontains(strings.replace_confusables(.), "action.re?quired")

--- a/detection-rules/credential_phishing_esign_document_notification.yml
+++ b/detection-rules/credential_phishing_esign_document_notification.yml
@@ -50,7 +50,7 @@ source: |
                           "Complete.{0,10}D[0o]cuSign",
                           "Enroll & Sign",
                           "Review and Sign",
-                          "SignReport",
+                          "Sign(?:Report|Now)",
                           "SignD[0o]c",
                           "D[0o]cxxx",
                           "d[0o]cufile",
@@ -66,7 +66,6 @@ source: |
                           "Contract.*signature",
                           "add your signature",
                           "signature needed",
-                          "SignNow",
                           "attn_task"
           )
           or (


### PR DESCRIPTION
# Description

Adding additional keywords to `subject.subject`/`sender.display_name` regex, as well as, `.display_text` regex

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5078ea3d1ffe039104009fef1f04c01abe3ed1a7ab8b57f52e80ffdad1ef4974?preview_id=019e6ac5-299f-7a9c-bb2e-ee47a4407945)
- [Sample 2](https://platform.sublime.security/messages/5079daaac18a71fbdfce1ea9466fee9d06f7d24d2606173e3338d563b7e4dec2?preview_id=019e703d-25d5-78fd-9ae3-ae2a23bf5c19)
- [Sample 3](https://platform.sublime.security/messages/50790de4319cb4fd968fd6f58f6017f268f7af91f5e041a7fca8afa915ed3b1f?preview_id=019e7037-94d4-751b-9816-31bc41f8de70)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e740a-be48-7ee3-9fa2-98c41906cb22)