### PR TITLE
Modify Callback phishing rule 

### DIFF
--- a/detection-rules/callback_phishing_nlu_body_or_attachments.yml
+++ b/detection-rules/callback_phishing_nlu_body_or_attachments.yml
@@ -49,12 +49,12 @@ source: |
         (
           270 < length(body.current_thread.text) < 1750
           or (
-            75 < length(body.current_thread.text) < 1750
+            75 < length(body.current_thread.text) < 2000
             and (
               strings.ilike(body.current_thread.text,
                             "*PayPal*",
                             "*Norton*",
-                            "*GeekSquad*",
+                            "*Geek Squad*",
                             "*Ebay*",
                             "*McAfee*",
                             "*=1"


### PR DESCRIPTION
# Description
Revised a few changes - body text length `< 2000`

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/5064e078bb60f5ade2cdac7d24df0bd6be8ed17299ec14263c24b63d6be10f21?preview_id=019e0278-c0f7-7d7f-a00b-b5a85b03b8ea)

## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e6a88-9400-787d-8777-4faf6c93eaae)
- [Multi-hunt](https://hunt.limeseed.email/hunts/f8fb2a23-eda4-4148-b279-7e94fe1c2098)