### PR TITLE
Update whitespace stuffing regex and generic document sharing thread exclusion

### DIFF
--- a/detection-rules/credential_phishing_generic_document_sharing.yml
+++ b/detection-rules/credential_phishing_generic_document_sharing.yml
@@ -8,7 +8,15 @@ severity: "medium"
 source: |
   type.inbound
   // exclude if it's a reply to an existing conversation
-  and not length(body.previous_threads) > 0
+  and (
+    not length(body.previous_threads) > 0
+    // allow through if self-sender BCC pattern (compromised account thread replay)
+    or (
+      length(recipients.to) == 1
+      and length(recipients.cc) == 0
+      and sender.email.email == recipients.to[0].email.email
+    )
+  )
   and (
     // subject contains document sharing language
     regex.icontains(subject.base,

--- a/detection-rules/credential_phishing_generic_document_sharing.yml
+++ b/detection-rules/credential_phishing_generic_document_sharing.yml
@@ -10,7 +10,7 @@ source: |
   // exclude if it's a reply to an existing conversation
   and (
     not length(body.previous_threads) > 0
-    // allow through if self-sender BCC pattern (compromised account thread replay)
+    // still match if self-sender BCC pattern
     or (
       length(recipients.to) == 1
       and length(recipients.cc) == 0

--- a/detection-rules/evasion_excessive_image_padding_cred_theft.yml
+++ b/detection-rules/evasion_excessive_image_padding_cred_theft.yml
@@ -24,6 +24,10 @@ source: |
     or regex.icontains(body.html.raw,
                        '(?:<div\s+style="[^"]+"\s*[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}'
     )
+    // class-attributed div-br blocks repeated 20+ times (Outlook elementToProof pattern)
+    or regex.icontains(body.html.raw,
+                       '(?:<div\s+class="[^"]*"[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}'
+    )
     // p-nbsp blocks repeated 25+ times
     or regex.icontains(body.html.raw,
                        '(?:<p>\s*(?:&nbsp;|&#160;)\s*</p>\s*){25,}'


### PR DESCRIPTION
# Description

Two updates to improve detection of compromised-account phishing that uses real thread history and whitespace padding:

1. **`evasion_excessive_image_padding_cred_theft.yml`** — Add class-attributed div-br regex pattern to catch Outlook `elementToProof` whitespace stuffing variant. The existing regex only matches bare `<div>` or `<div style=...>` (style as first attribute), missing the common Outlook pattern `<div class="elementToProof" style="..."><br></div>` repeated 100+ times.

2. **`credential_phishing_generic_document_sharing.yml`** — Add self-sender BCC carve-out to the `previous_threads` exclusion. Compromised accounts replay real thread history to bypass this check. The carve-out requires all three: `length(recipients.to) == 1`, `length(recipients.cc) == 0`, and `sender.email.email == recipients.to[0].email.email`.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/506b5d3ae7b585097ddb317dda5dabde4d9c99db4d57c51edfb89d2835cec56c)

## Associated hunts

- [generic doc sharing multihunt dif](https://hunt.limeseed.email/hunts/f7a52a30-a70c-4a37-97cc-8ff7ee28c3e4)