### PR TITLE
Create credential_phishing_lambda_url.yml

### DIFF
--- a/detection-rules/credential_phishing_lambda_url.yml
+++ b/detection-rules/credential_phishing_lambda_url.yml
@@ -17,3 +17,4 @@ tactics_and_techniques:
 detection_methods:
   - "URL analysis"
   - "Content analysis"
+id: "b5775c73-ca5f-5244-ac21-201332efd313"

--- a/detection-rules/credential_phishing_lambda_url.yml
+++ b/detection-rules/credential_phishing_lambda_url.yml
@@ -4,7 +4,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and any(recipients.to, sender.email.local_part == .email.domain.sld)
+  and recipients.to[0].email.domain.sld == sender.email.local_part
   and any(body.links,
           strings.icontains(.href_url.domain.domain, "lambda-url")
           and strings.icontains(.href_url.fragment, recipients.to[0].email.email)

--- a/detection-rules/credential_phishing_lambda_url.yml
+++ b/detection-rules/credential_phishing_lambda_url.yml
@@ -1,0 +1,19 @@
+name: "Credential phishing: AWS Lambda URL with recipient targeting"
+description: "Detects messages containing AWS Lambda URLs with the recipient's email address embedded in the fragment, indicating potential abuse of AWS Lambda services for targeted malicious activities."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(recipients.to, sender.email.local_part == .email.domain.sld)
+  and any(body.links,
+          strings.icontains(.href_url.domain.domain, "lambda-url")
+          and strings.icontains(.href_url.fragment, recipients.to[0].email.email)
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Free subdomain host"
+  - "Social engineering"
+detection_methods:
+  - "URL analysis"
+  - "Content analysis"


### PR DESCRIPTION
# Description
found while IOC hunting, targeted campaign using AWS Lambda URLs that contains the recipient's address and has the recipient's SLD in the local part of the sender address

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50785e10f1a27c6bfb7d642a5889198ef7e518e92839685578ef041b3f2a124f?preview_id=019e6a51-8756-7d73-9dec-e4205d572eab)


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e6f16-faec-7a00-9e9a-3c852d74b958)
- [multi hunt](https://hunt.limeseed.email/hunts/c5fcc9f4-488a-41db-b0f3-a33832bd8aa1)


