### PR TITLE
Create credential_phishing_whitespace_stuffing_short_lure.yml

### DIFF
--- a/detection-rules/body_whitespace_stuffing_short_lure.yml
+++ b/detection-rules/body_whitespace_stuffing_short_lure.yml
@@ -14,7 +14,9 @@ source: |
     )
   )
   // whitespace-stuffed credphish targets single recipients
+  and length(recipients.to) == 1
   and length(recipients.cc) == 0
+  and length(recipients.bcc) == 0
   // short lure
   and length(body.current_thread.text) < 2000
   // HTML whitespace stuffing
@@ -55,7 +57,7 @@ source: |
   // negate authenticated senders with unsubscribe mechanism (marketing)
   and not (
     coalesce(headers.auth_summary.dmarc.pass, false)
-    and any(body.links,
+    and any(body.current_thread.links,
             strings.icontains(.display_text, "unsubscribe")
             or strings.icontains(.href_url.path, "unsubscribe")
     )

--- a/detection-rules/body_whitespace_stuffing_short_lure.yml
+++ b/detection-rules/body_whitespace_stuffing_short_lure.yml
@@ -1,5 +1,5 @@
-name: "Credential Phishing: HTML whitespace stuffing with short lure"
-description: "Detects credential phishing that uses HTML-based whitespace padding (repeated br tags, p-nbsp blocks, or div-br wrappers) to push content below the visible fold."
+name: "Body: HTML whitespace stuffing with short initial message"
+description: "Detects messages that uses HTML-based whitespace padding (repeated br tags, p-nbsp blocks, or div-br wrappers) to push content below the visible fold."
 type: "rule"
 severity: "medium"
 source: |

--- a/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
+++ b/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
@@ -8,16 +8,6 @@ description: |
   The thread header check (no references/in_reply_to) eliminates legitimate replies and
   compromised thread hijacks. The external link requirement (domain differs from sender)
   eliminates graymail/cold outreach that links only to the sender's own domain.
-references:
-  - "https://playground.sublimesecurity.com?id=5068429d06ff02340f5b8d50d2b74217a320cd2d5426cfe757451c972997311d"
-  - "https://playground.sublimesecurity.com?id=505eaeb56c76770c441e39ea4ccd47b86b67a274eaec4b8b066af5bf605cfb6f"
-  - "https://playground.sublimesecurity.com?id=50702274e95c4dd9028fc1d7dd4620dd2b347b019b4d8216be9818dceb2cff5f"
-  - "https://playground.sublimesecurity.com?id=50718cc0b176b053b58e60156dfe3304b7acda3f1af2a6ce29d29ddb063760aa"
-  - "https://playground.sublimesecurity.com?id=5065967dd1fdaf622fb1dcf17fb493187c592ca43f9f60a3a3addce934e7f46a"
-  - "https://playground.sublimesecurity.com?id=505d11b94b425d02376cdc9bd32d1de4c0ba3678d1f9100024924a2afd29d413"
-  - "https://playground.sublimesecurity.com?id=506308a4faabac8af34b667fb53034841fab94c9b96acbc27b85529c78b872ee"
-  - "https://playground.sublimesecurity.com?id=505497fd035a07696ad7bf528f0ef5c9f98ad4e11f1abaa594dba657fca76c7d"
-  - "https://playground.sublimesecurity.com?id=5054ba70683b29b2217b62be0a62e3b8137e70f9b9c79b8433648af640afeb07"
 type: "rule"
 severity: "high"
 source: |

--- a/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
+++ b/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
@@ -22,33 +22,34 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-
+  
   // not a legitimate thread reply — novel/unsolicited email only
-  and (
-    length(headers.references) == 0
-    and headers.in_reply_to is null
-  )
-
+  and (length(headers.references) == 0 and headers.in_reply_to is null)
+  
   // short lure
   and length(body.current_thread.text) < 2000
-
+  
   // HTML whitespace stuffing
   and (
     regex.icontains(body.html.raw, '(?:<br\s*/?\s*>\s*){30,}')
-    or regex.icontains(body.html.raw, '(?:<p>\s*(?:&nbsp;|&#160;)\s*</p>\s*){10,}')
-    or regex.icontains(body.html.raw, '(?:<div[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}')
+    or regex.icontains(body.html.raw,
+                       '(?:<p>\s*(?:&nbsp;|&#160;)\s*</p>\s*){10,}'
+    )
+    or regex.icontains(body.html.raw,
+                       '(?:<div[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}'
+    )
   )
-
+  
   // low word count excludes legitimate long threads
   and regex.count(body.html.display_text, '\S+') < 3000
-
+  
   // link in current thread pointing to external domain
   and any(body.current_thread.links,
-      .href_url.domain.root_domain != sender.email.domain.root_domain
-      and .href_url.domain.valid
-      and .href_url.scheme in ("https", "http")
+          .href_url.domain.root_domain != sender.email.domain.root_domain
+          and .href_url.domain.valid
+          and .href_url.scheme in ("https", "http")
   )
-
+  
   // negate authenticated high-trust senders
   and (
     coalesce(sender.email.domain.root_domain in $high_trust_sender_root_domains

--- a/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
+++ b/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
@@ -1,0 +1,69 @@
+name: "Credential Phishing: HTML whitespace stuffing with short lure"
+description: |
+  Detects credential phishing that uses HTML-based whitespace padding (repeated br tags,
+  p-nbsp blocks, or div-br wrappers) to push content below the visible fold. The message
+  is novel (not a reply to an existing thread), contains a short lure with an external
+  link, and has low visible word count.
+
+  The thread header check (no references/in_reply_to) eliminates legitimate replies and
+  compromised thread hijacks. The external link requirement (domain differs from sender)
+  eliminates graymail/cold outreach that links only to the sender's own domain.
+references:
+  - "https://playground.sublimesecurity.com?id=5068429d06ff02340f5b8d50d2b74217a320cd2d5426cfe757451c972997311d"
+  - "https://playground.sublimesecurity.com?id=505eaeb56c76770c441e39ea4ccd47b86b67a274eaec4b8b066af5bf605cfb6f"
+  - "https://playground.sublimesecurity.com?id=50702274e95c4dd9028fc1d7dd4620dd2b347b019b4d8216be9818dceb2cff5f"
+  - "https://playground.sublimesecurity.com?id=50718cc0b176b053b58e60156dfe3304b7acda3f1af2a6ce29d29ddb063760aa"
+  - "https://playground.sublimesecurity.com?id=5065967dd1fdaf622fb1dcf17fb493187c592ca43f9f60a3a3addce934e7f46a"
+  - "https://playground.sublimesecurity.com?id=505d11b94b425d02376cdc9bd32d1de4c0ba3678d1f9100024924a2afd29d413"
+  - "https://playground.sublimesecurity.com?id=506308a4faabac8af34b667fb53034841fab94c9b96acbc27b85529c78b872ee"
+  - "https://playground.sublimesecurity.com?id=505497fd035a07696ad7bf528f0ef5c9f98ad4e11f1abaa594dba657fca76c7d"
+  - "https://playground.sublimesecurity.com?id=5054ba70683b29b2217b62be0a62e3b8137e70f9b9c79b8433648af640afeb07"
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+
+  // not a legitimate thread reply — novel/unsolicited email only
+  and (
+    length(headers.references) == 0
+    and headers.in_reply_to is null
+  )
+
+  // short lure
+  and length(body.current_thread.text) < 2000
+
+  // HTML whitespace stuffing
+  and (
+    regex.icontains(body.html.raw, '(?:<br\s*/?\s*>\s*){30,}')
+    or regex.icontains(body.html.raw, '(?:<p>\s*(?:&nbsp;|&#160;)\s*</p>\s*){10,}')
+    or regex.icontains(body.html.raw, '(?:<div[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}')
+  )
+
+  // low word count excludes legitimate long threads
+  and regex.count(body.html.display_text, '\S+') < 3000
+
+  // link in current thread pointing to external domain
+  and any(body.current_thread.links,
+      .href_url.domain.root_domain != sender.email.domain.root_domain
+      and .href_url.domain.valid
+      and .href_url.scheme in ("https", "http")
+  )
+
+  // negate authenticated high-trust senders
+  and (
+    coalesce(sender.email.domain.root_domain in $high_trust_sender_root_domains
+             and not headers.auth_summary.dmarc.pass,
+             false
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "HTML analysis"
+  - "Header analysis"
+id: "f8a3c1d2-7e4b-4a9f-b6c8-2d1e5f3a7b9c"

--- a/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
+++ b/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
@@ -1,15 +1,7 @@
 name: "Credential Phishing: HTML whitespace stuffing with short lure"
-description: |
-  Detects credential phishing that uses HTML-based whitespace padding (repeated br tags,
-  p-nbsp blocks, or div-br wrappers) to push content below the visible fold. The message
-  is novel (not a reply to an existing thread), contains a short lure with an external
-  link, and has low visible word count.
-
-  The thread header check (no references/in_reply_to) eliminates legitimate replies and
-  compromised thread hijacks. The external link requirement (domain differs from sender)
-  eliminates graymail/cold outreach that links only to the sender's own domain.
+description: "Detects credential phishing that uses HTML-based whitespace padding (repeated br tags, p-nbsp blocks, or div-br wrappers) to push content below the visible fold."
 type: "rule"
-severity: "high"
+severity: "medium"
 source: |
   type.inbound
   // not a legitimate thread reply or is indicative of self sender
@@ -50,6 +42,8 @@ source: |
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
+tags:
+ - "Attack surface reduction"
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
+++ b/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
@@ -12,8 +12,7 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  
-  // not a legitimate thread reply — novel/unsolicited email only
+  // not a legitimate thread reply or is indicative of self sender
   and (
     (length(headers.references) == 0 and headers.in_reply_to is null)
     or (
@@ -22,13 +21,10 @@ source: |
       and sender.email.email == recipients.to[0].email.email
     )
   )
-  
   // whitespace-stuffed credphish targets single recipients
   and length(recipients.cc) == 0
-  
   // short lure
   and length(body.current_thread.text) < 2000
-  
   // HTML whitespace stuffing
   and (
     regex.icontains(body.html.raw, '(?:<br\s*/?\s*>\s*){30,}')
@@ -39,7 +35,6 @@ source: |
                        '(?:<div[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}'
     )
   )
-  
   // low word count excludes legitimate long threads
   and regex.count(body.html.display_text, '\S+') < 3000
   
@@ -50,8 +45,7 @@ source: |
           and .href_url.scheme in ("https", "http")
           and .visible == true
   )
-  
-  // negate authenticated high-trust senders
+  // negate high trust senders that pass auth
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)

--- a/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
+++ b/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
@@ -29,7 +29,7 @@ source: |
   )
   // low word count excludes legitimate long threads
   and regex.count(body.html.display_text, '\S+') < 3000
-
+  
   // visible link in current thread pointing to external domain
   and any(body.current_thread.links,
           .href_url.domain.root_domain != sender.email.domain.root_domain
@@ -37,26 +37,27 @@ source: |
           and .href_url.scheme in ("https", "http")
           and .visible == true
   )
-
+  
   // credential phishing has few visible links - newsletters have many
   and length(filter(body.current_thread.links,
-      .href_url.domain.valid
-      and .href_url.scheme in ("https", "http")
-      and .visible == true
-  )) < 10
-
+                    .href_url.domain.valid
+                    and .href_url.scheme in ("https", "http")
+                    and .visible == true
+             )
+  ) < 10
+  
   // negate high trust senders that pass auth
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
-
+  
   // negate authenticated senders with unsubscribe mechanism (marketing)
   and not (
     coalesce(headers.auth_summary.dmarc.pass, false)
     and any(body.links,
-        strings.icontains(.display_text, "unsubscribe")
-        or strings.icontains(.href_url.path, "unsubscribe")
+            strings.icontains(.display_text, "unsubscribe")
+            or strings.icontains(.href_url.path, "unsubscribe")
     )
   )
 tags:

--- a/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
+++ b/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
@@ -12,13 +12,23 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  
+
   // not a legitimate thread reply — novel/unsolicited email only
-  and (length(headers.references) == 0 and headers.in_reply_to is null)
-  
+  and (
+    (length(headers.references) == 0 and headers.in_reply_to is null)
+    or (
+      length(recipients.to) == 1
+      and length(recipients.cc) == 0
+      and sender.email.email == recipients.to[0].email.email
+    )
+  )
+
+  // whitespace-stuffed credphish targets single recipients
+  and length(recipients.cc) == 0
+
   // short lure
   and length(body.current_thread.text) < 2000
-  
+
   // HTML whitespace stuffing
   and (
     regex.icontains(body.html.raw, '(?:<br\s*/?\s*>\s*){30,}')
@@ -29,24 +39,22 @@ source: |
                        '(?:<div[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}'
     )
   )
-  
+
   // low word count excludes legitimate long threads
   and regex.count(body.html.display_text, '\S+') < 3000
-  
-  // link in current thread pointing to external domain
+
+  // visible link in current thread pointing to external domain
   and any(body.current_thread.links,
-          .href_url.domain.root_domain != sender.email.domain.root_domain
-          and .href_url.domain.valid
-          and .href_url.scheme in ("https", "http")
+      .href_url.domain.root_domain != sender.email.domain.root_domain
+      and .href_url.domain.valid
+      and .href_url.scheme in ("https", "http")
+      and .visible == true
   )
-  
+
   // negate authenticated high-trust senders
-  and (
-    coalesce(sender.email.domain.root_domain in $high_trust_sender_root_domains
-             and not headers.auth_summary.dmarc.pass,
-             false
-    )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
+++ b/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
@@ -12,7 +12,7 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-
+  
   // not a legitimate thread reply — novel/unsolicited email only
   and (
     (length(headers.references) == 0 and headers.in_reply_to is null)
@@ -22,13 +22,13 @@ source: |
       and sender.email.email == recipients.to[0].email.email
     )
   )
-
+  
   // whitespace-stuffed credphish targets single recipients
   and length(recipients.cc) == 0
-
+  
   // short lure
   and length(body.current_thread.text) < 2000
-
+  
   // HTML whitespace stuffing
   and (
     regex.icontains(body.html.raw, '(?:<br\s*/?\s*>\s*){30,}')
@@ -39,18 +39,18 @@ source: |
                        '(?:<div[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}'
     )
   )
-
+  
   // low word count excludes legitimate long threads
   and regex.count(body.html.display_text, '\S+') < 3000
-
+  
   // visible link in current thread pointing to external domain
   and any(body.current_thread.links,
-      .href_url.domain.root_domain != sender.email.domain.root_domain
-      and .href_url.domain.valid
-      and .href_url.scheme in ("https", "http")
-      and .visible == true
+          .href_url.domain.root_domain != sender.email.domain.root_domain
+          and .href_url.domain.valid
+          and .href_url.scheme in ("https", "http")
+          and .visible == true
   )
-
+  
   // negate authenticated high-trust senders
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains

--- a/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
+++ b/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
@@ -29,7 +29,7 @@ source: |
   )
   // low word count excludes legitimate long threads
   and regex.count(body.html.display_text, '\S+') < 3000
-  
+
   // visible link in current thread pointing to external domain
   and any(body.current_thread.links,
           .href_url.domain.root_domain != sender.email.domain.root_domain
@@ -37,10 +37,27 @@ source: |
           and .href_url.scheme in ("https", "http")
           and .visible == true
   )
+
+  // credential phishing has few visible links - newsletters have many
+  and length(filter(body.current_thread.links,
+      .href_url.domain.valid
+      and .href_url.scheme in ("https", "http")
+      and .visible == true
+  )) < 10
+
   // negate high trust senders that pass auth
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+
+  // negate authenticated senders with unsubscribe mechanism (marketing)
+  and not (
+    coalesce(headers.auth_summary.dmarc.pass, false)
+    and any(body.links,
+        strings.icontains(.display_text, "unsubscribe")
+        or strings.icontains(.href_url.path, "unsubscribe")
+    )
   )
 tags:
  - "Attack surface reduction"


### PR DESCRIPTION
# Description

New simplified whitespace stuffing detection rule targeting credential phishing that uses HTML padding (br tags, p-nbsp blocks, div-br wrappers) to push content below the visible fold.

Key approach: instead of complex button detection, CTA keyword matching, and image_height checks (already covered by `_button_link.yml` and `_suspicious_cta.yml`), this rule uses two strong structural filters:

1. **Thread header absence** (`references == 0 and in_reply_to is null`) — eliminates legitimate thread replies and compromised thread hijacks (~480 FPs killed)
2. **External link in current thread** (link domain != sender domain) — eliminates graymail/cold outreach linking only to sender's own domain

Tested against hunt `019e6f2b-6c15-7d8f-abec-7edfe2a271f5` (1435 matches over 14 days). The two filters eliminate ~500 FPs while retaining all phishing TPs.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/5054ba70683b29b2217b62be0a62e3b8137e70f9b9c79b8433648af640afeb07)
- [Sample 2](https://platform.sublime.security/messages/5068429d06ff02340f5b8d50d2b74217a320cd2d5426cfe757451c972997311d)
- [Sample 3](https://platform.sublime.security/messages/505eaeb56c76770c441e39ea4ccd47b86b67a274eaec4b8b066af5bf605cfb6f)
- [Sample 4](https://platform.sublime.security/messages/50702274e95c4dd9028fc1d7dd4620dd2b347b019b4d8216be9818dceb2cff5f)

## Associated hunts

- [multihunt](https://hunt.limeseed.email/hunts/a03dfe4c-82d7-4aac-acd3-14a0e3602ca3)