### PR TITLE
Update credential_phishing_whitespace_stuffing_short_lure: reduce FPs

### DIFF
--- a/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
+++ b/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
@@ -25,9 +25,16 @@ source: |
 
   // not a legitimate thread reply — novel/unsolicited email only
   and (
-    length(headers.references) == 0
-    and headers.in_reply_to is null
+    (length(headers.references) == 0 and headers.in_reply_to is null)
+    or (
+      length(recipients.to) == 1
+      and length(recipients.cc) == 0
+      and sender.email.email == recipients.to[0].email.email
+    )
   )
+
+  // whitespace-stuffed credphish targets single recipients
+  and length(recipients.cc) == 0
 
   // short lure
   and length(body.current_thread.text) < 2000
@@ -35,27 +42,29 @@ source: |
   // HTML whitespace stuffing
   and (
     regex.icontains(body.html.raw, '(?:<br\s*/?\s*>\s*){30,}')
-    or regex.icontains(body.html.raw, '(?:<p>\s*(?:&nbsp;|&#160;)\s*</p>\s*){10,}')
-    or regex.icontains(body.html.raw, '(?:<div[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}')
+    or regex.icontains(body.html.raw,
+                       '(?:<p>\s*(?:&nbsp;|&#160;)\s*</p>\s*){10,}'
+    )
+    or regex.icontains(body.html.raw,
+                       '(?:<div[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}'
+    )
   )
 
   // low word count excludes legitimate long threads
   and regex.count(body.html.display_text, '\S+') < 3000
 
-  // link in current thread pointing to external domain
+  // visible link in current thread pointing to external domain
   and any(body.current_thread.links,
       .href_url.domain.root_domain != sender.email.domain.root_domain
       and .href_url.domain.valid
       and .href_url.scheme in ("https", "http")
+      and .visible == true
   )
 
   // negate authenticated high-trust senders
-  and (
-    coalesce(sender.email.domain.root_domain in $high_trust_sender_root_domains
-             and not headers.auth_summary.dmarc.pass,
-             false
-    )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
+++ b/detection-rules/credential_phishing_whitespace_stuffing_short_lure.yml
@@ -1,0 +1,69 @@
+name: "Credential Phishing: HTML whitespace stuffing with short lure"
+description: |
+  Detects credential phishing that uses HTML-based whitespace padding (repeated br tags,
+  p-nbsp blocks, or div-br wrappers) to push content below the visible fold. The message
+  is novel (not a reply to an existing thread), contains a short lure with an external
+  link, and has low visible word count.
+
+  The thread header check (no references/in_reply_to) eliminates legitimate replies and
+  compromised thread hijacks. The external link requirement (domain differs from sender)
+  eliminates graymail/cold outreach that links only to the sender's own domain.
+references:
+  - "https://playground.sublimesecurity.com?id=5068429d06ff02340f5b8d50d2b74217a320cd2d5426cfe757451c972997311d"
+  - "https://playground.sublimesecurity.com?id=505eaeb56c76770c441e39ea4ccd47b86b67a274eaec4b8b066af5bf605cfb6f"
+  - "https://playground.sublimesecurity.com?id=50702274e95c4dd9028fc1d7dd4620dd2b347b019b4d8216be9818dceb2cff5f"
+  - "https://playground.sublimesecurity.com?id=50718cc0b176b053b58e60156dfe3304b7acda3f1af2a6ce29d29ddb063760aa"
+  - "https://playground.sublimesecurity.com?id=5065967dd1fdaf622fb1dcf17fb493187c592ca43f9f60a3a3addce934e7f46a"
+  - "https://playground.sublimesecurity.com?id=505d11b94b425d02376cdc9bd32d1de4c0ba3678d1f9100024924a2afd29d413"
+  - "https://playground.sublimesecurity.com?id=506308a4faabac8af34b667fb53034841fab94c9b96acbc27b85529c78b872ee"
+  - "https://playground.sublimesecurity.com?id=505497fd035a07696ad7bf528f0ef5c9f98ad4e11f1abaa594dba657fca76c7d"
+  - "https://playground.sublimesecurity.com?id=5054ba70683b29b2217b62be0a62e3b8137e70f9b9c79b8433648af640afeb07"
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+
+  // not a legitimate thread reply — novel/unsolicited email only
+  and (
+    length(headers.references) == 0
+    and headers.in_reply_to is null
+  )
+
+  // short lure
+  and length(body.current_thread.text) < 2000
+
+  // HTML whitespace stuffing
+  and (
+    regex.icontains(body.html.raw, '(?:<br\s*/?\s*>\s*){30,}')
+    or regex.icontains(body.html.raw, '(?:<p>\s*(?:&nbsp;|&#160;)\s*</p>\s*){10,}')
+    or regex.icontains(body.html.raw, '(?:<div[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}')
+  )
+
+  // low word count excludes legitimate long threads
+  and regex.count(body.html.display_text, '\S+') < 3000
+
+  // link in current thread pointing to external domain
+  and any(body.current_thread.links,
+      .href_url.domain.root_domain != sender.email.domain.root_domain
+      and .href_url.domain.valid
+      and .href_url.scheme in ("https", "http")
+  )
+
+  // negate authenticated high-trust senders
+  and (
+    coalesce(sender.email.domain.root_domain in $high_trust_sender_root_domains
+             and not headers.auth_summary.dmarc.pass,
+             false
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "HTML analysis"
+  - "Header analysis"
+id: "f8a3c1d2-7e4b-4a9f-b6c8-2d1e5f3a7b9c"


### PR DESCRIPTION
## Summary
- Add `.visible == true` to the link check — eliminates FPs from hidden tracking pixels (e.g., golf scorecard notifications)
- Add `length(recipients.cc) == 0` — whitespace-stuffed credphish always targets single recipients; eliminates FPs from multi-recipient business emails and mailing lists
- Update thread reply check to handle self-sender bounce edge case
- Simplify high-trust sender negation to cleaner `and not (...)` pattern

## Associated samples

**FPs eliminated:**
- `5075f4353758d562b941f01328e59d376b803f1d6674b25660f806ff641f62fd` (golf scorecard — only hidden tracking link)
- `5077e31a274aa3b1995e21fb3980f6c6f64e9fed334eace49236cc1a50fe0919` (FNF signing confirmation — 4 CC recipients)
- `5076b21c95ec136504a37d0688bf9df96b3052764cc606127e61000d4c07ddea` (academic mailing list — 2 CC recipients)

**TPs confirmed still matching:**
- `506cc4ab6dafe939d075829d5efd685fdbb21f7ba7cec6d631589dc3e82e7ff3` (malicious To-Do List lure)
- `50795259cec849a6bb1d6bd996a938b21639ca73598377e8d591543760b17876` (Mailbox Service Shutdown)
- `50770b9a177bd40d807ed9f206308f41328e7511890a3ef84d9e6c4fc8bc98fc` (Delivery expired notice)
- `5072edf1e0e5841fc3f3a1d59ac3273a8355587aba8f7475ec42ac67cd656cbd` (HR Benefits doc lure)

## Associated hunts
- `019e6f71-4006-7090-a725-fbb2b0448169` — 435 matches, 10 benign verdicts (several are actually malicious)