### PR TITLE
Update impersonation_quickbooks.yml

### DIFF
--- a/detection-rules/impersonation_quickbooks.yml
+++ b/detection-rules/impersonation_quickbooks.yml
@@ -80,6 +80,10 @@ source: |
     or any(body.links,
            regex.icontains(.display_url.url, '(?:quickbooks|intuit)')
            and .mismatched
+           and not .href_url.domain.root_domain in (
+             "mimecast.com",
+             "mimecastprotect.com"
+           )
     )
   )
   and not (

--- a/detection-rules/impersonation_quickbooks.yml
+++ b/detection-rules/impersonation_quickbooks.yml
@@ -77,6 +77,10 @@ source: |
         )
       )
     )
+    or any(body.links,
+           regex.icontains(.display_url.url, '(?:quickbooks|intuit)')
+           and .mismatched
+    )
   )
   and not (
     sender.email.domain.root_domain in~ (


### PR DESCRIPTION
# Description

Updating logic to tag samples that include a `display_url` that contains `quickbooks` or `intuit` and the links are `.mismatched`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5079255d071cbf770344f1bdd9a382a7545f0255c221f973960d70e76086da20?preview_id=019e6f90-a492-7f3d-ba57-050b7207a42d)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e83f0-9748-70cb-bd6e-2c549938a8b8)