### PR TITLE
Update abuse_hellosign_sus_names.yml

### DIFF
--- a/detection-rules/abuse_hellosign_sus_names.yml
+++ b/detection-rules/abuse_hellosign_sus_names.yml
@@ -119,7 +119,7 @@ source: |
       )
       // Invoice Themes
       or regex.icontains(subject.subject,
-                         '(INV\b|\bACH\b|Wire Confirmation|P[O0]\W+?\d+\"|P[O0](?:\W+?|\d+)|Purchase Order|Past Due|Remit(?:tance)?).*(?: - Signature Requested by| is awaiting your signature)'
+                         '(?:INV\b|\bACH\b|Wire Confirmation|\bP[O0]\W+?\d+\"|\bP[O0](?:\W+?|\d+)|Purchase Order|Past Due|Remit(?:tance)?).*(?: - Signature Requested by| is awaiting your signature)'
       )
       // Payment Themes
       or regex.icontains(subject.subject,


### PR DESCRIPTION
# Description
reduce FPs by no longer matching the `po` in things like `expo` or `tempo`.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/5079bb7452c87ee8aae86ad9f65ec7638f343545fd37f1c8dd6258c3b7bf60db?preview_id=019e6fdb-ad8d-75a7-b638-b47b83bbf86f)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Samples that will no longer match](https://platform.sublime.security/messages/hunt?huntId=019e709c-fa8b-702c-9024-7c20ad68a649)
