### PR TITLE
Add detection rule for suspicious PDF links in RFQ/RFP

### DIFF
--- a/detection-rules/link_pdf_suspicious_rfq.yml
+++ b/detection-rules/link_pdf_suspicious_rfq.yml
@@ -1,5 +1,5 @@
 name: "Link: PDF with suspicious Request for Quote or Purchase (RFQ|RFP)"
-description: "Detects messages with reply or forward subjects containing links that display as PDF files but redirect to free file hosting platforms or self-service creation domains, specifically targeting Request for Quotation (RFQ) or Request for Purchase (RFP) terminology."
+description: "Detects messages containing links that display as PDF files, specifically targeting Request for Quotation (RFQ) or Request for Purchase (RFP) terminology."
 type: "rule"
 severity: "high"
 source: |
@@ -44,8 +44,8 @@ source: |
     or strings.ilike(body.current_thread.text,
                      "*kindly*",
                      "*find attached*",
-                     "attachment",
-                     "*secure*"
+                     "*secure*",
+                     "*enter code*"
     )
   )
 

--- a/detection-rules/link_pdf_suspicious_rfq.yml
+++ b/detection-rules/link_pdf_suspicious_rfq.yml
@@ -1,0 +1,67 @@
+name: "Link: PDF with suspicious Request for Quote or Purchase (RFQ|RFP)"
+description: "Detects messages with reply or forward subjects containing links that display as PDF files but redirect to free file hosting platforms or self-service creation domains, specifically targeting Request for Quotation (RFQ) or Request for Purchase (RFP) terminology."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and (subject.is_reply or subject.is_forward)
+  and length(body.previous_threads) <= 1
+  and length(body.links) > 0
+  // no PDF attachments
+  and length(filter(attachments, .file_type == "pdf")) == 0
+  // the display_text ends in .pdf and goes to a free file host
+  and any(body.current_thread.links,
+          strings.iends_with(.display_text, '.pdf')
+          and (
+            (
+              .href_url.domain.domain in $free_file_hosts
+              or .href_url.domain.root_domain in $free_file_hosts
+              or .href_url.domain.domain in $self_service_creation_platform_domains
+              or .href_url.domain.root_domain in $self_service_creation_platform_domains
+              or .href_url.domain.root_domain == "html.cafe"
+            )
+            // suspicious sender behaviour
+            or (
+              sender.email.email in map(recipients.to, .email.email)
+              or (
+                length(recipients.to) == 0
+                or (
+                  all(recipients.to, .email.domain.valid == false)
+                  and all(recipients.cc, .email.domain.valid == false)
+                )
+              )
+            )
+          )
+          // the display text references a Request for Quotation (RFQ) or Request for Purchase (RFP)
+          and (
+            regex.icontains(.display_text,
+                            '(?:\bR\.?F\.?P\b|\bR\.?F\.?Q\b)|(?:Request.for.(?:Quot(e|ation)|Purchas(e|ing)))'
+            )
+          )
+          // negate links which make use of google icons inside of a bounding box
+          // filter down to the link with the same display text
+          and not any(filter(html.xpath(body.html,
+                                        '//a[img[@src] or .//img[@src]][.//div[contains(@style, "border:1px solid")] or ancestor::div[contains(@style, "border:1px solid")]]'
+                             ).nodes,
+                             // the display text is the link we're inspecting
+                             ..display_text == .display_text
+                      ),
+                      // inside this is a reference to the google icon
+                      strings.icontains(.raw, 'gstatic.com/docs/doclist/images/')
+          )
+  )
+  
+
+attack_types:
+  - "BEC/Fraud"
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Free file host"
+  - "Social engineering"
+  - "Evasion"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "HTML analysis"
+  - "Sender analysis"
+  - "URL analysis"

--- a/detection-rules/link_pdf_suspicious_rfq.yml
+++ b/detection-rules/link_pdf_suspicious_rfq.yml
@@ -4,53 +4,48 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and (subject.is_reply or subject.is_forward)
-  and length(body.previous_threads) <= 1
-  and length(body.links) > 0
+  and 0 < length(body.current_thread.links) <= 3
   // no PDF attachments
   and length(filter(attachments, .file_type == "pdf")) == 0
-  // the display_text ends in .pdf and goes to a free file host
+  // link display_text ends in .pdf
   and any(body.current_thread.links,
           strings.iends_with(.display_text, '.pdf')
-          and (
-            (
-              .href_url.domain.domain in $free_file_hosts
-              or .href_url.domain.root_domain in $free_file_hosts
-              or .href_url.domain.domain in $self_service_creation_platform_domains
-              or .href_url.domain.root_domain in $self_service_creation_platform_domains
-              or .href_url.domain.root_domain == "html.cafe"
-            )
-            // suspicious sender behaviour
-            or (
-              sender.email.email in map(recipients.to, .email.email)
-              or (
-                length(recipients.to) == 0
-                or (
-                  all(recipients.to, .email.domain.valid == false)
-                  and all(recipients.cc, .email.domain.valid == false)
-                )
-              )
-            )
-          )
           // the display text references a Request for Quotation (RFQ) or Request for Purchase (RFP)
           and (
             regex.icontains(.display_text,
                             '(?:\bR\.?F\.?P\b|\bR\.?F\.?Q\b)|(?:Request.for.(?:Quot(e|ation)|Purchas(e|ing)))'
             )
+            or any(ml.nlu_classifier(.display_text).tags,
+                   .name == "purchase_order" and .confidence == "high"
+            )
           )
-          // negate links which make use of google icons inside of a bounding box
-          // filter down to the link with the same display text
-          and not any(filter(html.xpath(body.html,
-                                        '//a[img[@src] or .//img[@src]][.//div[contains(@style, "border:1px solid")] or ancestor::div[contains(@style, "border:1px solid")]]'
-                             ).nodes,
-                             // the display text is the link we're inspecting
-                             ..display_text == .display_text
-                      ),
-                      // inside this is a reference to the google icon
-                      strings.icontains(.raw, 'gstatic.com/docs/doclist/images/')
+          and (
+            // suspicious link destination
+            (
+              .href_url.domain.domain in $free_file_hosts
+              or .href_url.domain.root_domain in $free_file_hosts
+              or .href_url.domain.domain in $self_service_creation_platform_domains
+              or .href_url.domain.root_domain in $self_service_creation_platform_domains
+            )
+            // suspicious sender behaviour
+            or (
+              sender.email.domain.root_domain in $free_email_providers
+              or sender.email.email in map(recipients.to, .email.email)
+              or length(recipients.to) == 0
+              or (
+                all(recipients.to, .email.domain.valid == false)
+                and all(recipients.cc, .email.domain.valid == false)
+              )
+            )
           )
   )
-  
+  // additional suspicious indicator
+  and (
+    any(ml.nlu_classifier(body.current_thread.text).intents,
+        .name in ("cred_theft", "bec") and .confidence != "low"
+    )
+    or strings.ilike(body.current_thread.text, "*kindly*", "*find attached*", "attachment", "*secure*")
+  )
 
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/link_pdf_suspicious_rfq.yml
+++ b/detection-rules/link_pdf_suspicious_rfq.yml
@@ -15,9 +15,6 @@ source: |
             regex.icontains(.display_text,
                             '(?:\bR\.?F\.?P\b|\bR\.?F\.?Q\b)|(?:Request.for.(?:Quot(e|ation)|Purchas(e|ing)))'
             )
-            or any(ml.nlu_classifier(.display_text).tags,
-                   .name == "purchase_order" and .confidence == "high"
-            )
           )
           and (
             // suspicious link destination
@@ -51,6 +48,7 @@ source: |
                      "*secure*"
     )
   )
+
 attack_types:
   - "BEC/Fraud"
   - "Malware/Ransomware"

--- a/detection-rules/link_pdf_suspicious_rfq.yml
+++ b/detection-rules/link_pdf_suspicious_rfq.yml
@@ -44,9 +44,13 @@ source: |
     any(ml.nlu_classifier(body.current_thread.text).intents,
         .name in ("cred_theft", "bec") and .confidence != "low"
     )
-    or strings.ilike(body.current_thread.text, "*kindly*", "*find attached*", "attachment", "*secure*")
+    or strings.ilike(body.current_thread.text,
+                     "*kindly*",
+                     "*find attached*",
+                     "attachment",
+                     "*secure*"
+    )
   )
-
 attack_types:
   - "BEC/Fraud"
   - "Malware/Ransomware"

--- a/detection-rules/link_pdf_suspicious_rfq.yml
+++ b/detection-rules/link_pdf_suspicious_rfq.yml
@@ -65,3 +65,4 @@ detection_methods:
   - "HTML analysis"
   - "Sender analysis"
   - "URL analysis"
+id: "9b0e6a27-5f3f-5e9f-ab63-e481e4bd30c1"


### PR DESCRIPTION
# Description

This rule detects messages with reply or forward subjects that contain links appearing as PDF files but redirect to potentially malicious domains, specifically targeting RFQ or RFP terminology.

# Associated samples
- https://platform.sublime.security/messages/504cfe0687a1b6a3d3d0fe73a21cca84d92e6029d5c930db4adac8e7743da502
- https://platform.sublime.security/messages/5078481f96e7cc2ed5737bee7d54954bb9aaba037c61c83fc9bbcf0fb0658a95?preview_id=019e6bcb-f4cb-752b-b6c3-22d2ca800559

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=019e70c2-1cde-73c5-953e-7ff467767c32
