### PR TITLE
Add service abuse detection rule for Datadog alerts

### DIFF
--- a/detection-rules/service_abuse_datadog_alert.yml
+++ b/detection-rules/service_abuse_datadog_alert.yml
@@ -5,9 +5,10 @@ severity: "high"
 source: |
   type.inbound
   and sender.email.email == "alert@dtdg.co"
+  and length(body.current_thread.text) < 1000
   // links pointing to free file hosts or url shorteners
   and (
-    any(body.links,
+    any(filter(body.links, .parser == "hyperlink"),
         (
           .href_url.domain.root_domain in $url_shorteners
           or .href_url.domain.root_domain in $self_service_creation_platform_domains
@@ -23,6 +24,60 @@ source: |
               or strings.parse_domain(.).domain in $self_service_creation_platform_domains
           )
         )
+    )
+    // quarantine message lure
+    or (
+      3 of (
+        strings.ilike(body.current_thread.text, "*review*"),
+        strings.ilike(body.current_thread.text, "*incoming*"),
+        strings.ilike(body.current_thread.text, "*release*"),
+        strings.ilike(body.current_thread.text, "*quarantine*"),
+        strings.ilike(body.current_thread.text, "*messages*"),
+        strings.ilike(body.current_thread.text, "*server error*"),
+        strings.ilike(body.current_thread.text, "*blocked*"),
+        strings.ilike(body.current_thread.text, "*prevented*"),
+        strings.ilike(body.current_thread.text, "*validation*"),
+        strings.ilike(body.current_thread.text, "*notification*"),
+        strings.ilike(body.current_thread.text, "*kindly*"),
+        strings.ilike(body.current_thread.text, "*on hold*"),
+        strings.ilike(body.current_thread.text, "*held*"),
+        strings.ilike(body.current_thread.text, "*pending*"),
+        strings.ilike(body.current_thread.text, "*stuck*"),
+        strings.like(body.current_thread.text, "* MX *")
+      )
+      and (
+        any(body.links,
+            regex.icontains(.display_text,
+                            "quarantine",
+                            "security",
+                            "release",
+                            "message",
+                            "delete",
+                            "recover",
+                            "SSO",
+                            "sign in"
+            )
+        )
+        or (
+          length(body.links) < 3
+          and any(body.links,
+                  any(recipients.to,
+                      .email.domain.root_domain == ..display_url.domain.root_domain
+                      and ..mismatched
+                  )
+          )
+        )
+      )
+    )
+    // fake voicemail notification
+    or (
+      ml.nlu_classifier(body.current_thread.text).language == "english"
+      and (
+        any(ml.nlu_classifier(body.current_thread.text).topics,
+            .confidence == "high"
+            and .name == "Voicemail Call and Missed Call Notifications"
+        )
+      )
     )
   )
 

--- a/detection-rules/service_abuse_datadog_alert.yml
+++ b/detection-rules/service_abuse_datadog_alert.yml
@@ -6,77 +6,26 @@ source: |
   type.inbound
   and sender.email.email == "alert@dtdg.co"
   and length(body.current_thread.text) < 1000
-  // links pointing to free file hosts or url shorteners
   and (
-    any(filter(body.links, .parser == "hyperlink"),
-        (
-          .href_url.domain.root_domain in $url_shorteners
-          or .href_url.domain.root_domain in $self_service_creation_platform_domains
-        )
-        or (
-          .href_url.domain.domain in $url_shorteners
-          or .href_url.domain.domain in $self_service_creation_platform_domains
-        )
-        // account for rewritten links
-        or (
-          any(.href_url.query_params_decoded["domain"],
-              strings.parse_domain(.).domain in $url_shorteners
-              or strings.parse_domain(.).domain in $self_service_creation_platform_domains
+    (
+      any(filter(body.links,
+          .parser == "hyperlink"
+          and not any(.href_url.query_params_decoded["domain"],
+                      strings.parse_domain(.).root_domain == "datadoghq.com"
           )
-        )
-    )
-    // quarantine message lure
-    or (
-      3 of (
-        strings.ilike(body.current_thread.text, "*review*"),
-        strings.ilike(body.current_thread.text, "*incoming*"),
-        strings.ilike(body.current_thread.text, "*release*"),
-        strings.ilike(body.current_thread.text, "*quarantine*"),
-        strings.ilike(body.current_thread.text, "*messages*"),
-        strings.ilike(body.current_thread.text, "*server error*"),
-        strings.ilike(body.current_thread.text, "*blocked*"),
-        strings.ilike(body.current_thread.text, "*prevented*"),
-        strings.ilike(body.current_thread.text, "*validation*"),
-        strings.ilike(body.current_thread.text, "*notification*"),
-        strings.ilike(body.current_thread.text, "*kindly*"),
-        strings.ilike(body.current_thread.text, "*on hold*"),
-        strings.ilike(body.current_thread.text, "*held*"),
-        strings.ilike(body.current_thread.text, "*pending*"),
-        strings.ilike(body.current_thread.text, "*stuck*"),
-        strings.like(body.current_thread.text, "* MX *")
+      ),
+          .href_url.domain.root_domain != "datadoghq.com"
+          and .href_url.domain.root_domain != "aka.ms"
       )
-      and (
-        any(body.links,
-            regex.icontains(.display_text,
-                            "quarantine",
-                            "security",
-                            "release",
-                            "message",
-                            "delete",
-                            "recover",
-                            "SSO",
-                            "sign in"
-            )
-        )
-        or (
-          length(body.links) < 3
-          and any(body.links,
-                  any(recipients.to,
-                      .email.domain.root_domain == ..display_url.domain.root_domain
-                      and ..mismatched
-                  )
-          )
-        )
+      and regex.icontains(body.current_thread.text,
+          'quarantine|held for.{0,10}review|secure message|voice\s?mail'
       )
     )
-    // fake voicemail notification
     or (
       ml.nlu_classifier(body.current_thread.text).language == "english"
-      and (
-        any(ml.nlu_classifier(body.current_thread.text).topics,
-            .confidence == "high"
-            and .name == "Voicemail Call and Missed Call Notifications"
-        )
+      and any(ml.nlu_classifier(body.current_thread.text).topics,
+              .confidence == "high"
+              and .name == "Voicemail Call and Missed Call Notifications"
       )
     )
   )

--- a/detection-rules/service_abuse_datadog_alert.yml
+++ b/detection-rules/service_abuse_datadog_alert.yml
@@ -35,3 +35,4 @@ tactics_and_techniques:
 detection_methods:
   - "Sender analysis"
   - "URL analysis"
+id: "0808411b-5765-5bef-ad52-5d55bd0f36dd"

--- a/detection-rules/service_abuse_datadog_alert.yml
+++ b/detection-rules/service_abuse_datadog_alert.yml
@@ -9,16 +9,16 @@ source: |
   and (
     (
       any(filter(body.links,
-          .parser == "hyperlink"
-          and not any(.href_url.query_params_decoded["domain"],
-                      strings.parse_domain(.).root_domain == "datadoghq.com"
-          )
-      ),
+                 .parser == "hyperlink"
+                 and not any(.href_url.query_params_decoded["domain"],
+                             strings.parse_domain(.).root_domain == "datadoghq.com"
+                 )
+          ),
           .href_url.domain.root_domain != "datadoghq.com"
           and .href_url.domain.root_domain != "aka.ms"
       )
       and regex.icontains(body.current_thread.text,
-          'quarantine|held for.{0,10}review|secure message|voice\s?mail'
+                          'quarantine|held for.{0,10}review|secure message|voice\s?mail'
       )
     )
     or (
@@ -29,7 +29,6 @@ source: |
       )
     )
   )
-
 attack_types:
   - "Credential Phishing"
   - "Malware/Ransomware"

--- a/detection-rules/service_abuse_datadog_alert.yml
+++ b/detection-rules/service_abuse_datadog_alert.yml
@@ -1,0 +1,37 @@
+name: "Service abuse: Suspicious Datadog alert"
+description: "Message from alert@dtdg.co containing links to URL shorteners or self-service creation platforms."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and sender.email.email == "alert@dtdg.co"
+  // links pointing to free file hosts or url shorteners
+  and (
+    any(body.links,
+        (
+          .href_url.domain.root_domain in $url_shorteners
+          or .href_url.domain.root_domain in $self_service_creation_platform_domains
+        )
+        or (
+          .href_url.domain.domain in $url_shorteners
+          or .href_url.domain.domain in $self_service_creation_platform_domains
+        )
+        // account for rewritten links
+        or (
+          any(.href_url.query_params_decoded["domain"],
+              strings.parse_domain(.).domain in $url_shorteners
+              or strings.parse_domain(.).domain in $self_service_creation_platform_domains
+          )
+        )
+    )
+  )
+
+attack_types:
+  - "Credential Phishing"
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Evasion"
+  - "Free subdomain host"
+detection_methods:
+  - "Sender analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description

This rule detects suspicious Datadog alerts from 'alert@dtdg.co' containing links to URL shorteners or self-service creation platforms, indicating potential service abuse.

# Associated samples
- https://platform.sublime.security/messages/5079dfb858ebf6743c7583a788ff79b8e904f0276b500c5451d66cda56c83978
- https://platform.sublime.security/messages/5079b63e174bfc00611867384fddeb9623e9511516236e8f31982f2e6b3c0d68
- https://platform.sublime.security/messages/5079406f77349bfd3c4c23b44fb983e210cd541f71dca996e3cccac1158bbd9b
- https://platform.sublime.security/messages/5079d96f7bed86908d0f55f056df564a0441f724d003345c58031deed5ac37ba

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=019e726c-4bad-7b20-b346-59b8acde1fa4
