### PR TITLE
Create body_self_sender_bold_pdf_link.yml

### DIFF
--- a/detection-rules/body_self_sender_bold_pdf_link.yml
+++ b/detection-rules/body_self_sender_bold_pdf_link.yml
@@ -21,9 +21,7 @@ source: |
             or strings.icontains(.display_text, sender.email.domain.sld)
           )
           // we should NOT match urls
-          and coalesce(strings.parse_url(.display_text, strict=false).url,
-                       "not_url"
-          ) == "not_url"
+          and strings.parse_url(.display_text, strict=false).url is null
   )
 
 attack_types:

--- a/detection-rules/body_self_sender_bold_pdf_link.yml
+++ b/detection-rules/body_self_sender_bold_pdf_link.yml
@@ -20,7 +20,10 @@ source: |
             // OR sender domain appears as the pdf link
             or strings.icontains(.display_text, sender.email.domain.sld)
           )
-          and coalesce(strings.parse_url(.display_text).scheme, "not_url") == "not_url"
+          // we should NOT match urls
+          and coalesce(strings.parse_url(.display_text, strict=false).url,
+                       "not_url"
+          ) == "not_url"
   )
 
 attack_types:

--- a/detection-rules/body_self_sender_bold_pdf_link.yml
+++ b/detection-rules/body_self_sender_bold_pdf_link.yml
@@ -22,6 +22,7 @@ source: |
           )
           // we should NOT match urls
           and strings.parse_url(.display_text, strict=false).url is null
+          and not any(.links, strings.iends_with(.href_url.path, '.pdf'))
   )
 
 attack_types:

--- a/detection-rules/body_self_sender_bold_pdf_link.yml
+++ b/detection-rules/body_self_sender_bold_pdf_link.yml
@@ -1,0 +1,36 @@
+name: "Link: Self-sent PDF lure with subject correlation"
+description: "Detects messages sent from a user to themselves containing bold PDF links where the link text correlates with the subject line or sender domain, potentially indicating a compromised account or social engineering technique."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // self sender
+  and (
+    length(recipients.to) == 1
+    and recipients.to[0].email.email == sender.email.email
+  )
+  // bold a tags ending in PDF
+  and any(html.xpath(body.html, '//a[./b]').nodes,
+          strings.iends_with(.display_text, ".pdf")
+          and (
+            // subject appears as the .pdf link
+            any(regex.extract(subject.base, '(?P<word>\w+)'),
+                strings.contains(..display_text, .named_groups["word"])
+            )
+            // OR sender domain appears as the pdf link
+            or strings.icontains(.display_text, sender.email.domain.sld)
+          )
+          and not strings.starts_with(.display_text, "www")
+  )
+
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Evasion"
+detection_methods:
+  - "Header analysis"
+  - "HTML analysis"
+  - "Sender analysis"
+  - "Content analysis"

--- a/detection-rules/body_self_sender_bold_pdf_link.yml
+++ b/detection-rules/body_self_sender_bold_pdf_link.yml
@@ -34,3 +34,4 @@ detection_methods:
   - "HTML analysis"
   - "Sender analysis"
   - "Content analysis"
+id: "a902702f-0e69-57dd-af81-08225218cffb"

--- a/detection-rules/body_self_sender_bold_pdf_link.yml
+++ b/detection-rules/body_self_sender_bold_pdf_link.yml
@@ -20,7 +20,7 @@ source: |
             // OR sender domain appears as the pdf link
             or strings.icontains(.display_text, sender.email.domain.sld)
           )
-          and not strings.starts_with(.display_text, "www")
+          and coalesce(strings.parse_url(.display_text).scheme, "not_url") == "not_url"
   )
 
 attack_types:


### PR DESCRIPTION
# Description
Detects messages sent from a user to themselves containing bold PDF links where the link text correlates with the subject line or sender domain, potentially indicating a compromised account or social engineering technique.

Related to https://github.com/sublime-security/sublime-rules/pull/4462

## Associated samples

- [Sample 1](https://platform.sublime.security/messages/50771f6e351a86be9cdb569f14780beb757061b7858570dcb56894c9e890300d?preview_id=019e6a2c-42f2-75ae-b67b-719706719e70)
- [Sample 2](https://platform.sublime.security/rules/editor?canonical_id=5077e4fe0bc70f15ef8759b69a18ccd61d0f663ea611a5e0a8dbf137f42cb47b&message_id=019e6a2c-4129-7152-ac45-e33701007ce1)

## Associated hunts

- [Hunt 1](https://hunt.limeseed.email/hunts/02309107-219b-41ac-b4c6-9f1c7b00e45b)
- [latest hunt](https://platform.sublime.security/messages/hunt?huntId=019e9395-1d1b-77b8-902c-f92c77134418)
