### PR TITLE
Update recon_short_generic_greeting.yml

### DIFF
--- a/detection-rules/recon_short_generic_greeting.yml
+++ b/detection-rules/recon_short_generic_greeting.yml
@@ -42,7 +42,7 @@ source: |
   // no attachments or links
   and length(attachments) == 0
   and length(body.current_thread.links) == 0
-
+  
   // not where the sender and mailbox display_anames indicate this might be a personal email --> work email
   // impersonation is covered by other core feed rules
   and not (
@@ -50,7 +50,6 @@ source: |
     and strings.icontains(sender.display_name, mailbox.first_name)
     and strings.icontains(sender.display_name, mailbox.last_name)
   )
-  
   and (
     // auth failed (or absent) - ignore the profile
     coalesce(headers.auth_summary.dmarc.pass, false) == false
@@ -70,8 +69,6 @@ source: |
       )
     )
   )
-
-
 tags:
  - "Attack surface reduction"
 attack_types:

--- a/detection-rules/recon_short_generic_greeting.yml
+++ b/detection-rules/recon_short_generic_greeting.yml
@@ -49,7 +49,9 @@ source: |
     sum([length(recipients.to), length(recipients.bcc), length(recipients.cc)]) == 1
     // use coalesce to deal with either the sender.display_name or the mailbox element being null
     // if either are null, the function returns false, as it cannot be true if either is null
-    and coalesce(strings.icontains(sender.display_name, mailbox.first_name), false)
+    and coalesce(strings.icontains(sender.display_name, mailbox.first_name),
+                 false
+    )
     and coalesce(strings.icontains(sender.display_name, mailbox.last_name), false)
   )
   and (

--- a/detection-rules/recon_short_generic_greeting.yml
+++ b/detection-rules/recon_short_generic_greeting.yml
@@ -47,8 +47,10 @@ source: |
   // impersonation is covered by other core feed rules
   and not (
     sum([length(recipients.to), length(recipients.bcc), length(recipients.cc)]) == 1
-    and strings.icontains(sender.display_name, mailbox.first_name)
-    and strings.icontains(sender.display_name, mailbox.last_name)
+    // use coalesce to deal with either the sender.display_name or the mailbox element being null
+    // if either are null, the function returns false, as it cannot be true if either is null
+    and coalesce(strings.icontains(sender.display_name, mailbox.first_name), false)
+    and coalesce(strings.icontains(sender.display_name, mailbox.last_name), false)
   )
   and (
     // auth failed (or absent) - ignore the profile

--- a/detection-rules/recon_short_generic_greeting.yml
+++ b/detection-rules/recon_short_generic_greeting.yml
@@ -42,27 +42,35 @@ source: |
   // no attachments or links
   and length(attachments) == 0
   and length(body.current_thread.links) == 0
-  // negate sender profiles completely if auth is failing
+
+  // not where the sender and mailbox display_anames indicate this might be a personal email --> work email
+  // impersonation is covered by other core feed rules
+  and not (
+    sum([length(recipients.to), length(recipients.bcc), length(recipients.cc)]) == 1
+    and strings.icontains(sender.display_name, mailbox.first_name)
+    and strings.icontains(sender.display_name, mailbox.last_name)
+  )
+  
   and (
-    (
-      not (
-        coalesce(headers.auth_summary.dmarc.pass, false)
-        or headers.auth_summary.spf.pass == false
-      )
-      and (
-        not profile.by_sender().solicited
-        or (
-          profile.by_sender().any_messages_malicious_or_spam
-          and not profile.by_sender().any_messages_benign
-        )
-      )
-      and not profile.by_sender().any_messages_benign
-    )
+    // auth failed (or absent) - ignore the profile
+    coalesce(headers.auth_summary.dmarc.pass, false) == false
+    or coalesce(headers.auth_summary.spf.pass, false) == false
+    // auth passed - use the profile
     or (
-      coalesce(headers.auth_summary.dmarc.pass, false)
-      or headers.auth_summary.spf.pass == false
+      // no benign messages
+      not profile.by_sender_email().any_messages_benign
+      and (
+        // not soliticed OR common
+        not (
+          profile.by_sender_email().solicited
+          or profile.by_sender_email().prevalence == "common"
+        )
+        // or HAS been spam_malicious
+        or profile.by_sender_email().any_messages_malicious_or_spam
+      )
     )
   )
+
 
 tags:
  - "Attack surface reduction"


### PR DESCRIPTION
# Description
Objective: Reduce FPs

1. Address bug in sender profile logic as it related to dmarc
2. simplify profile logic
3. reduce FPs for employee --> work message by comparing sender display_name to mailbox first_name and mailbox.last_name (handle for when sender display_name/mailbox elements are null)
4. add negation for common senders

see ESC for details