### PR TITLE
Adding condition for Adobe in detection rule

### DIFF
--- a/detection-rules/impersonation_adobe_suspicious_language_link.yml
+++ b/detection-rules/impersonation_adobe_suspicious_language_link.yml
@@ -35,6 +35,7 @@ source: |
         or strings.icontains(body.current_thread.text, 'access file')
         or strings.icontains(body.current_thread.text, 'pending document')
         or any(body.links, strings.ilike(.display_text, 'review and sign'))
+        or any(body.links, strings.ilike(.display_text, 'open document'))
       )
       and length(body.current_thread.text) < 2000
     )


### PR DESCRIPTION
# Description
Adding display text `open document` to logic in a campaign impersonating Adobe brand. 

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/5079a906826444ae54b2288bc0f2d67b294f35d42cd5d29ada40fd02e72c7842?preview_id=019e6fb9-d6b3-7492-a1a9-bde42f22fa2d)

## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e75eb-ff0c-77a9-a282-325b5aa3ef50)
- [Multi-hunt 30D](https://hunt.limeseed.email/hunts/1780b5cb-afac-4604-bb6d-8f9c8b18ff8b)
