### PR TITLE
Update impersonation_docusign.yml

### DIFF
--- a/detection-rules/impersonation_docusign.yml
+++ b/detection-rules/impersonation_docusign.yml
@@ -10,10 +10,10 @@ source: |
   and (
     // orgs can have docusign.company.com
     strings.ilike(sender.email.email, '*docusign.net*', '*docusign.com*')
-
+  
     // if the above is true, you'll see a "via Docusign"
     or strings.ilike(sender.display_name, '*docusign*')
-
+  
     // detects 1 character variations,
     // such as DocuSlgn (with an "L" instead of an "I")
     or strings.ilevenshtein(sender.display_name, "docusign") == 1
@@ -53,9 +53,7 @@ source: |
                              'Please use the link above to Docusign'
         )
         or strings.icontains(body.current_thread.text, 'Review on Docusign')
-        or strings.icontains(body.current_thread.text,
-                             'Completed with Docusign'
-        )
+        or strings.icontains(body.current_thread.text, 'Completed with Docusign')
         or strings.icontains(body.current_thread.text, 'Completed on Docusign')
         or strings.icontains(body.current_thread.text, 'Complete with Docusign')
         or strings.icontains(body.current_thread.text,
@@ -83,9 +81,7 @@ source: |
         or strings.icontains(body.current_thread.text,
                              'review via DocuSign Electronic Signature'
         )
-        or strings.icontains(body.current_thread.text,
-                             'sent to you by DocuSign'
-        )
+        or strings.icontains(body.current_thread.text, 'sent to you by DocuSign')
         or strings.icontains(body.current_thread.text, 'Processed by DocuSign')
         or strings.icontains(body.current_thread.text,
                              'Please read and sign the document'
@@ -117,7 +113,7 @@ source: |
                            'Sign\s*(?:and\s*|&\s*)Return.{0,40}docusign',
                            'Sign\s*(?:and\s*|&\s*)Return.docusign.{0,40}'
         )
-
+  
         // additional context from subject.subject
         or strings.icontains(subject.subject, 'complete with docusign')
         or strings.icontains(subject.subject, 'signature request')
@@ -149,9 +145,7 @@ source: |
             regex.icontains(body.html.raw,
                             'Powered by.{0,6}(?:\s*<\/?[^\>]+\>\s*)+<img[^\>]+(?:src="https:\/\/docucdn-a\.akamaihd\.net\/[^\"]+email-logo.png"|alt="DocuSign")'
             )
-            or regex.icontains(body.current_thread.text,
-                               'Powered by\s*DocuSign'
-            )
+            or regex.icontains(body.current_thread.text, 'Powered by\s*DocuSign')
           )
           // limit it to where the powered by is within the current thread
           and strings.icontains(body.current_thread.text, 'Powered by')
@@ -200,7 +194,7 @@ source: |
         or strings.icontains(body.current_thread.text,
                              'a secure link to DocuSign'
         )
-
+  
         // footer links
         or (
           length(filter(body.links,
@@ -265,7 +259,7 @@ source: |
         )
         // image contains an alt text of docusign
         or any(html.xpath(body.html, '//img/@alt').nodes, .raw =~ "docusign")
-
+  
         // Basic variations with HTML encoding
         // use of regex extract allows
         or any(regex.iextract(body.html.raw,
@@ -279,14 +273,14 @@ source: |
                ),
                .full_match !~ "docusign"
         )
-
+  
         // Look for HTML entities for each letter in sequence
         or any(regex.iextract(body.html.raw,
                               '(?:D|&#68;|&#x44;)(?:o|о|&#111;|&#x6f;|&#1086;|&#x43e;|&#959;|&#x3bf;)(?:c|с|&#99;|&#x63;|&#1089;|&#x441;|&#1010;|&#231;|&#x67;|&#265;|&#x109;)(?:u|&#117;|&#x75;|&#1091;|&#x443;|&#965;|&#x3c5;)(?:s|&#115;|&#x73;|&#1109;|&#x455;)(?:i|і|&#105;|&#x69;|&#1110;|&#x456;|&#305;|&#x131;)(?:g|&#103;|&#x67;|&#609;|&#x261;|&#287;|&#x11f;)(?:n|&#110;|&#x6e;|&#1085;|&#x43d;|&#951;|&#x3b7;)'
                ),
                .full_match !~ "docusign"
         )
-
+  
         // Handle repeated HTML entities and variation selectors (using Unicode class)
         or any(regex.iextract(body.html.raw,
                               'D(?:&#[0-9]{1,7};)*\p{Mn}*o(?:&#[0-9]{1,7};)*\p{Mn}*c(?:&#[0-9]{1,7};)*\p{Mn}*u(?:&#[0-9]{1,7};)*\p{Mn}*[Ss](?:&#[0-9]{1,7};)*\p{Mn}*i(?:&#[0-9]{1,7};)*\p{Mn}*g(?:&#[0-9]{1,7};)*\p{Mn}*n'
@@ -316,7 +310,7 @@ source: |
       )
     )
   )
-
+  
   // identifies the main CTA in the email, eg "Review now" or "Review document"
   // this should always be a known docusign domain,
   // even with branded docusign subdomains
@@ -415,13 +409,13 @@ source: |
            )
     )
   )
-
+  
   // negate highly trusted sender domains if they pass DMARC authentication
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
-
+  
   // negation for messages traversing docusign.net
   // happens with custom sender domains
   and not (
@@ -429,7 +423,7 @@ source: |
     and headers.auth_summary.spf.pass
     and headers.auth_summary.dmarc.pass
   )
-
+  
   // adding negation for messages originating from docusigns api
   // and the sender.display.name contains "via"
   and not (

--- a/detection-rules/impersonation_docusign.yml
+++ b/detection-rules/impersonation_docusign.yml
@@ -10,10 +10,10 @@ source: |
   and (
     // orgs can have docusign.company.com
     strings.ilike(sender.email.email, '*docusign.net*', '*docusign.com*')
-  
+
     // if the above is true, you'll see a "via Docusign"
     or strings.ilike(sender.display_name, '*docusign*')
-  
+
     // detects 1 character variations,
     // such as DocuSlgn (with an "L" instead of an "I")
     or strings.ilevenshtein(sender.display_name, "docusign") == 1
@@ -53,7 +53,9 @@ source: |
                              'Please use the link above to Docusign'
         )
         or strings.icontains(body.current_thread.text, 'Review on Docusign')
-        or strings.icontains(body.current_thread.text, 'Completed with Docusign')
+        or strings.icontains(body.current_thread.text,
+                             'Completed with Docusign'
+        )
         or strings.icontains(body.current_thread.text, 'Completed on Docusign')
         or strings.icontains(body.current_thread.text, 'Complete with Docusign')
         or strings.icontains(body.current_thread.text,
@@ -81,7 +83,9 @@ source: |
         or strings.icontains(body.current_thread.text,
                              'review via DocuSign Electronic Signature'
         )
-        or strings.icontains(body.current_thread.text, 'sent to you by DocuSign')
+        or strings.icontains(body.current_thread.text,
+                             'sent to you by DocuSign'
+        )
         or strings.icontains(body.current_thread.text, 'Processed by DocuSign')
         or strings.icontains(body.current_thread.text,
                              'Please read and sign the document'
@@ -113,7 +117,7 @@ source: |
                            'Sign\s*(?:and\s*|&\s*)Return.{0,40}docusign',
                            'Sign\s*(?:and\s*|&\s*)Return.docusign.{0,40}'
         )
-  
+
         // additional context from subject.subject
         or strings.icontains(subject.subject, 'complete with docusign')
         or strings.icontains(subject.subject, 'signature request')
@@ -145,7 +149,9 @@ source: |
             regex.icontains(body.html.raw,
                             'Powered by.{0,6}(?:\s*<\/?[^\>]+\>\s*)+<img[^\>]+(?:src="https:\/\/docucdn-a\.akamaihd\.net\/[^\"]+email-logo.png"|alt="DocuSign")'
             )
-            or regex.icontains(body.current_thread.text, 'Powered by\s*DocuSign')
+            or regex.icontains(body.current_thread.text,
+                               'Powered by\s*DocuSign'
+            )
           )
           // limit it to where the powered by is within the current thread
           and strings.icontains(body.current_thread.text, 'Powered by')
@@ -194,7 +200,7 @@ source: |
         or strings.icontains(body.current_thread.text,
                              'a secure link to DocuSign'
         )
-  
+
         // footer links
         or (
           length(filter(body.links,
@@ -259,7 +265,7 @@ source: |
         )
         // image contains an alt text of docusign
         or any(html.xpath(body.html, '//img/@alt').nodes, .raw =~ "docusign")
-  
+
         // Basic variations with HTML encoding
         // use of regex extract allows
         or any(regex.iextract(body.html.raw,
@@ -273,14 +279,14 @@ source: |
                ),
                .full_match !~ "docusign"
         )
-  
+
         // Look for HTML entities for each letter in sequence
         or any(regex.iextract(body.html.raw,
                               '(?:D|&#68;|&#x44;)(?:o|о|&#111;|&#x6f;|&#1086;|&#x43e;|&#959;|&#x3bf;)(?:c|с|&#99;|&#x63;|&#1089;|&#x441;|&#1010;|&#231;|&#x67;|&#265;|&#x109;)(?:u|&#117;|&#x75;|&#1091;|&#x443;|&#965;|&#x3c5;)(?:s|&#115;|&#x73;|&#1109;|&#x455;)(?:i|і|&#105;|&#x69;|&#1110;|&#x456;|&#305;|&#x131;)(?:g|&#103;|&#x67;|&#609;|&#x261;|&#287;|&#x11f;)(?:n|&#110;|&#x6e;|&#1085;|&#x43d;|&#951;|&#x3b7;)'
                ),
                .full_match !~ "docusign"
         )
-  
+
         // Handle repeated HTML entities and variation selectors (using Unicode class)
         or any(regex.iextract(body.html.raw,
                               'D(?:&#[0-9]{1,7};)*\p{Mn}*o(?:&#[0-9]{1,7};)*\p{Mn}*c(?:&#[0-9]{1,7};)*\p{Mn}*u(?:&#[0-9]{1,7};)*\p{Mn}*[Ss](?:&#[0-9]{1,7};)*\p{Mn}*i(?:&#[0-9]{1,7};)*\p{Mn}*g(?:&#[0-9]{1,7};)*\p{Mn}*n'
@@ -301,8 +307,16 @@ source: |
         )
       )
     )
+    or (
+      strings.icontains(body.current_thread.text, 'Docusign')
+      and (
+        regex.icontains(body.html.raw, '<title>[^<]*Easearch[^<]*</title>')
+        or regex.icontains(body.html.raw, '<spacing>[^<]*(?:Docusign|Document)')
+        or regex.icontains(body.html.raw, '{(?:domain|randomNumber\d?)}')
+      )
+    )
   )
-  
+
   // identifies the main CTA in the email, eg "Review now" or "Review document"
   // this should always be a known docusign domain,
   // even with branded docusign subdomains
@@ -347,6 +361,8 @@ source: |
                      or strings.icontains(.display_text, "Document")
                    )
                  )
+                 or strings.icontains(.display_text, "complete tasks")
+                 or strings.icontains(.display_text, "View and complete")
                )
         ),
         // ensure those links aren't legit
@@ -399,13 +415,13 @@ source: |
            )
     )
   )
-  
+
   // negate highly trusted sender domains if they pass DMARC authentication
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
-  
+
   // negation for messages traversing docusign.net
   // happens with custom sender domains
   and not (
@@ -413,7 +429,7 @@ source: |
     and headers.auth_summary.spf.pass
     and headers.auth_summary.dmarc.pass
   )
-  
+
   // adding negation for messages originating from docusigns api
   // and the sender.display.name contains "via"
   and not (


### PR DESCRIPTION
# Description

Adding additional coverage to an active campaign. Added an additional condition to tag html snippets seen in each sample and additional `.display_text` keywords

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50790de4319cb4fd968fd6f58f6017f268f7af91f5e041a7fca8afa915ed3b1f?preview_id=019e7037-94d4-751b-9816-31bc41f8de70)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e8372-b72d-7587-85f7-0fa87a4a8bf4)