### PR TITLE
Create attachment_pdf_malicious_creator_shelbyporter.yml

### DIFF
--- a/detection-rules/attachment_pdf_malicious_creator_shelbyporter.yml
+++ b/detection-rules/attachment_pdf_malicious_creator_shelbyporter.yml
@@ -17,3 +17,4 @@ tactics_and_techniques:
 detection_methods:
   - "Exif analysis"
   - "File analysis"
+id: "526238f7-82f1-5b6f-8e0c-b90f1e06cea8"

--- a/detection-rules/attachment_pdf_malicious_creator_shelbyporter.yml
+++ b/detection-rules/attachment_pdf_malicious_creator_shelbyporter.yml
@@ -1,0 +1,19 @@
+name: "Attachment: PDF with specific author metadata"
+description: "Detects inbound messages containing PDF attachments where the EXIF metadata indicates the author or creator is 'Shelby Porter'."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and length(filter(attachments, .file_type == "pdf")) >= 1
+  and any(filter(attachments, .file_type == "pdf"),
+          beta.parse_exif(.).author == "Shelby Porter"
+          or beta.parse_exif(.).creator == "Shelby Porter"
+  )
+  
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "PDF"
+detection_methods:
+  - "Exif analysis"
+  - "File analysis"


### PR DESCRIPTION
# Description

Add quick detection for observed IOC in PDFs linking to cred theft pages.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/506ff01d3f364a0a4e269e50facdc492d74bf1773112cdd7da4101a98db60a0e?preview_id=019e3beb-8f0c-7bbf-b853-ccad521bfbc3)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e83d0-4f6b-7958-a0d7-5df2fd72b1e7)
