### PR TITLE
Update generic_pdf.yar

### DIFF
--- a/yara/generic_pdf.yar
+++ b/yara/generic_pdf.yar
@@ -49,20 +49,6 @@ rule w9_pdf_IDs {
         and any of ($id*)
 }
 
-rule w9_pdf_images {
-    meta:
-        author      = "kyle eaton"
-        date        = "2026-05-12"
-        description = "pdfs with images associated with FAKE w9s and invoices, often the signatures or fake company logos"
-    strings:
-        $header           = { 25 50 44 46 2D 31 2E }
-        $jpg_signature_01 = { 60 1E 46 70 7A 8A 00 D5 A2 8A 28 00 A2 8A 28 00 A2 8A 28 00 A8 16 EA D5 EE 1E D1 25 46 9A 30 0B 46 }
-        $jpg_signature_02 = { B7 D2 2E 00 3D EB E0 AF FC 15 F3 F6 EB F8 DF F0 8F E1 97 C6 BF 86 9F F0 45 5F DA 83 E2 07 C2 4F }
-    condition:
-        $header at 0
-        and any of ($jpg_*)
-}
-
 rule w9_pdf_fonts {
     meta:
         author      = "kyle eaton"


### PR DESCRIPTION
removing w9_pdf_invoice_images. This image is used in the malicious invoices, however, it seems to be a generated image from the skia/chrome->pdf process, not necessarily something specific to these malicious invoices.  We could probably tighten up the rule (any -> all in the L63 condition), but given that the image isn't specific to the group I think we can remove it for now. We have pretty solid coverage on the w9 file, and the current service agreement they use. 


# Associated samples
- [Sample 1](https://platform.sublime.security/messages/50784e57e4ae972eab556086995481edb1942dfb7461f0f66ea27a7c1e7130ca?preview_id=019e8434-fad1-7351-96aa-1d872c96ea7e)
