### PR TITLE
Update generic_pdf.yar

### DIFF
--- a/yara/generic_pdf.yar
+++ b/yara/generic_pdf.yar
@@ -308,20 +308,6 @@ rule enc_pdf_image_sizes {
 		and @img1 < @img2
 }
 
-rule w9_pdf_invoice_images {
-	meta:
-		author      = "kyle eaton"
-		date        = "2026-05-15"
-		description = "matching images within invoices in a subset of w9 pdfs"
-	strings:
-		$header                  = { 25 50 44 46 2D 31 2E }
-		$jpg_001_smaller_image   = { 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 40 00 00 00 05 05 02 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 84 21 08 42 10 }
-		$jpg_outline_overlap_002 = { 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 02 4F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 F0 F8 7C 3E 1F 0F 87 C3 E1 }
-	condition:
-		$header at 0
-		and any of ($jpg_*)
-}
-
 rule w9_pdf_service_agreement_img_objects {
 	meta:
 		author      = "kyle eaton"


### PR DESCRIPTION
Removing w9_pdf_invoice_images.
This is a noisier rule than expected. It seems to be an artifact of the skia/chrome -> pdf pipeline on certain web pages. We could tighten up the rule with something like (any -> all on L322), but again, it's not an artifact of the actor's creation. 


# Associated samples

- [Sample 1](https://platform.sublime.security/messages/50784e57e4ae972eab556086995481edb1942dfb7461f0f66ea27a7c1e7130ca?preview_id=019e8434-fad1-7351-96aa-1d872c96ea7e)
