### PR TITLE
Update attachment_pdf_sus_string_single_url.yml

### DIFF
--- a/detection-rules/attachment_pdf_sus_string_single_url.yml
+++ b/detection-rules/attachment_pdf_sus_string_single_url.yml
@@ -50,7 +50,30 @@ source: |
                     and 'Some additional information here' in~ .scan.strings.strings
                   )
           )
-          and any(file.explode(.), .depth == 0 and length(.scan.url.urls) == 1)
+          and any(file.explode(.),
+                  .depth == 0
+                  and length(filter(.scan.url.urls,
+                                         // remove mailto: links
+                                         not strings.istarts_with(.url, 'mailto:')
+                                         and not strings.istarts_with(.url,
+                                                                      'email:'
+                                         )
+                                         // remove links found in exiftool output producer/creator
+                                         and not any([
+                                                       ..scan.exiftool.producer,
+                                                       ..scan.exiftool.creator
+                                                     ],
+                                                     . is not null
+                                                     and strings.icontains(.,
+                                                                           ..domain.domain
+                                                     )
+                                         )
+                                         and not .domain.root_domain in (
+                                           'pdf-tools.com'
+                                         )
+                                  )
+                  ) == 1
+          )
   )
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/attachment_pdf_sus_string_single_url.yml
+++ b/detection-rules/attachment_pdf_sus_string_single_url.yml
@@ -53,25 +53,23 @@ source: |
           and any(file.explode(.),
                   .depth == 0
                   and length(filter(.scan.url.urls,
-                                         // remove mailto: links
-                                         not strings.istarts_with(.url, 'mailto:')
-                                         and not strings.istarts_with(.url,
-                                                                      'email:'
-                                         )
-                                         // remove links found in exiftool output producer/creator
-                                         and not any([
-                                                       ..scan.exiftool.producer,
-                                                       ..scan.exiftool.creator
-                                                     ],
-                                                     . is not null
-                                                     and strings.icontains(.,
-                                                                           ..domain.domain
-                                                     )
-                                         )
-                                         and not .domain.root_domain in (
-                                           'pdf-tools.com'
-                                         )
-                                  )
+                                    // remove mailto: links
+                                    not strings.istarts_with(.url, 'mailto:')
+                                    and not strings.istarts_with(.url, 'email:')
+                                    // remove links found in exiftool output producer/creator
+                                    and not any([
+                                                  ..scan.exiftool.producer,
+                                                  ..scan.exiftool.creator
+                                                ],
+                                                . is not null
+                                                and strings.icontains(.,
+                                                                      ..domain.domain
+                                                )
+                                    )
+                                    and not .domain.root_domain in (
+                                      'pdf-tools.com'
+                                    )
+                             )
                   ) == 1
           )
   )


### PR DESCRIPTION
# Description

increase rule coverage by not counting URLs found in exif data, or that are emails towards the "single url" count

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5077cb7e073b92df1634b76a2e79abb8e1348e3b9a1686f3919a6aec15261c26?preview_id=019e8492-347e-75d5-bd5f-1c0d9c8e3267)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Net New Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e8496-c50a-723e-9c7b-16d1f43eacab)
- [Net New Multihunt](https://hunt.limeseed.email/hunts/9338ba6c-25ef-471d-8a3d-7635f3977df3)
