### PR TITLE
Update generic_pdf.yar

### DIFF
--- a/yara/generic_pdf.yar
+++ b/yara/generic_pdf.yar
@@ -335,3 +335,16 @@ rule w9_pdf_service_agreement_img_objects {
 		$header at 0
 		and all of them
 }
+
+rule adobe_sign_lure_banner_images {
+	meta:
+		author      = "brandon murphy"
+		date        = "2026-06-01"
+		description = "mathces on observed width/height of abused adobe sign header/footer in a PDF"
+    strings:
+        $hdr = /\/Subtype[ ]?\/Image[^>]{0,80}\/Width[ ]?(1119|1120|1121)[ ]?\/Height[ ]?(372|373|374)/
+        $ftr = /\/Subtype[ ]?\/Image[^>]{0,80}\/Width[ ]?(1063|1064|1065)[ ]?\/Height[ ]?(340|341|342)/
+    condition:
+        uint32(0) == 0x46445025 and  // "%PDF"
+        $hdr and $ftr
+}


### PR DESCRIPTION
# Description

Add yara rule to detect the existence of two images in a PDF with observed sizes of Adobe Sign header/footer lure.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/506ff01d3f364a0a4e269e50facdc492d74bf1773112cdd7da4101a98db60a0e?preview_id=019e3beb-8f0c-7bbf-b853-ccad521bfbc3)

