### PR TITLE
Update attachment_pdf_link_sus_lang.yml

### DIFF
--- a/detection-rules/attachment_pdf_link_sus_lang.yml
+++ b/detection-rules/attachment_pdf_link_sus_lang.yml
@@ -1,5 +1,5 @@
 name: "Attachment: PDF with suspicious link and action-oriented language"
-description: "Detects PDF attachments containing a single link that leads to pages with language prompting users to view, review, or read documents, accounts, or business-related content such as bids, proposals, agreements, or contracts."
+description: "Detects PDF attachments containing a link that leads to pages with language prompting users to view, review, or read documents, accounts, or business-related content such as bids, proposals, agreements, or contracts."
 type: "rule"
 severity: "high"
 source: |
@@ -11,7 +11,7 @@ source: |
           and any(file.explode(.),
                   .depth == 0
                   // reduce fps by limiting the length to a single link
-                  and length(.scan.url.urls) == 1
+                  and length(.scan.url.urls) <= 2
                   and any(filter(.scan.url.urls,
                                  // remove mailto: links
                                  not strings.istarts_with(.url, 'mailto:')
@@ -39,7 +39,7 @@ source: |
                             and any(ml.link_analysis(.).final_dom.links,
                                     .href_url.domain.root_domain != ..domain.root_domain
                                     and regex.icontains(.display_text,
-                                                        '\b(?:(?:re)?view|see|read|click\s+(?:here\s+)?to)[\t\x20]*(?:\S+[\t\x20]*){0,3}[\t\x20]*(?:document|message|now|proceed)',
+                                                        '\b(?:(?:re)?view|see|read|share|click\s+(?:here\s+)?to)[\t\x20]*(?:\S+[\t\x20]*){0,3}[\t\x20]*(?:document|message|now|proceed)',
                                                         '\b(?:request|review)\b.{1,5}\b(?:bid|proposal|agreement|portfolio|contract|settlement|invoice)\b',
                                     )
                             )
@@ -48,7 +48,7 @@ source: |
                             200 <= ml.link_analysis(.).status_code < 300
                             and length(ml.link_analysis(.).final_dom.display_text) < 1050
                             and regex.icontains(ml.link_analysis(.).final_dom.display_text,
-                                                '\b(?:(?:re)?view|see|read|click\s+(?:here\s+)?to)[\t\x20]*(?:\S+[\t\x20]*){0,3}[\t\x20]*(?:document|message|now|proceed)',
+                                                '\b(?:(?:re)?view|see|read|share|click\s+(?:here\s+)?to)[\t\x20]*(?:\S+[\t\x20]*){0,3}[\t\x20]*(?:document|message|now|proceed)',
                                                 '\b(?:request|review)\b.{1,5}\b(?:bid|proposal|agreement|portfolio|contract|settlement|invoice)\b'
                             )
                             // a common fp in the .au for a payment system


### PR DESCRIPTION
# Description

Expanded length of `.scan.url.urls` from `== 1` to `<= 2`. Also updated `.display_text` regex within `final_dom.links` to include additional keywords.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507646d1f0b86c230464eda30451cb322d38e90c1df0b6f54ca2ba769ed2e682?preview_id=019e846c-a7ef-7b2e-b0c0-bb6e585f549f)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e84b8-9535-7124-9674-9f3b4d45519b)