### PR TITLE
Create attachment_pdf_adobe_banner_images.yml

### DIFF
--- a/detection-rules/attachment_pdf_adobe_banner_images.yml
+++ b/detection-rules/attachment_pdf_adobe_banner_images.yml
@@ -6,12 +6,9 @@ source: |
   type.inbound
   and any(filter(attachments, .file_type == "pdf"),
           any(file.explode(.),
-              any(.scan.yara.matches,
-                  .name == 'adobe_sign_lure_banner_images'
-              )
+              any(.scan.yara.matches, .name == 'adobe_sign_lure_banner_images')
           )
   )
-  
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:
@@ -20,3 +17,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "YARA"
+id: "f27f40ff-3349-50a6-ade3-182b069775c2"

--- a/detection-rules/attachment_pdf_adobe_banner_images.yml
+++ b/detection-rules/attachment_pdf_adobe_banner_images.yml
@@ -1,0 +1,22 @@
+name: "Attachment: Adobe Sign lure PDF with embedded banner images"
+description: "Detects inbound messages containing PDF attachments that contain embedded banner images mimicking Adobe Sign branding, commonly used to deceive recipients into believing the document is legitimate."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(filter(attachments, .file_type == "pdf"),
+          any(file.explode(.),
+              any(.scan.yara.matches,
+                  .name == 'adobe_sign_lure_banner_images'
+              )
+          )
+  )
+  
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "PDF"
+  - "Impersonation: Brand"
+detection_methods:
+  - "File analysis"
+  - "YARA"


### PR DESCRIPTION
# Description

Add MQL coverage for #4580.  detects embedded images of specific dimensions observed in adobe sign impersonation
 
# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/506ff01d3f364a0a4e269e50facdc492d74bf1773112cdd7da4101a98db60a0e?preview_id=019e3beb-8f0c-7bbf-b853-ccad521bfbc3)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->
- [Multihunt](https://hunt.limeseed.email/hunts/7bce357c-e72b-428f-883f-0f03149a9e48)
- [L180D Hunt](https://platform.sublime.security/messages/hunt?huntId=019e8582-8a44-7331-a692-764002b80f47)
