### PR TITLE
Create detection rule for BEC tax document requests

### DIFF
--- a/detection-rules/tax_w2_impersonation.yml
+++ b/detection-rules/tax_w2_impersonation.yml
@@ -4,7 +4,6 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(body.current_thread.text) < 500
   and sender.email.local_part in~ (
     "contact",
     "no-reply",
@@ -35,10 +34,17 @@ source: |
   )
   // body text containing variations of "W2"
   and (
-    strings.icontains(body.current_thread.text, "w2")
-    or strings.icontains(body.current_thread.text, "W-2")
-    or strings.icontains(body.current_thread.text, "Ẇ-2's")
-    or strings.icontains(body.current_thread.text, "wage")
+    (
+      strings.icontains(body.current_thread.text, "w2")
+      or strings.icontains(body.current_thread.text, "W-2")
+      or strings.icontains(body.current_thread.text, "Ẇ-2")
+      or strings.icontains(body.current_thread.text, "wage statements")
+    )
+    or (
+      length(headers.reply_to) > 0
+      and all(headers.reply_to, network.whois(.email.domain).days_old <= 60)
+      and strings.icontains(body.current_thread.text, "W-2")
+    )
   )
   and any(ml.nlu_classifier(body.current_thread.text).entities,
           .name == "request"

--- a/detection-rules/tax_w2_impersonation.yml
+++ b/detection-rules/tax_w2_impersonation.yml
@@ -4,6 +4,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
+  // searching for common sender emails
   and sender.email.local_part in~ (
     "contact",
     "no-reply",
@@ -11,58 +12,59 @@ source: |
     "info",
     "admin"
   )
-  and not (
-    sender.email.domain.domain in $org_domains
-    and coalesce(headers.auth_summary.dmarc.pass, false)
-  )
-  
-  // mismatched From and Reply-to
+  // sender emails unmatched
   and (
     length(headers.reply_to) > 0
     and all(headers.reply_to,
             .email.domain.root_domain != sender.email.domain.root_domain
     )
   )
-  
-  // W-2 Language with a request
+  // subject lines with words correlating to (tax information)
   and (
-    strings.contains(subject.base, 'W-2')
-    or strings.icontains(subject.base, 'wage')
-    or strings.icontains(subject.base, 'tax form')
-    or strings.icontains(subject.base, 'irs')
-    or regex.icontains(subject.base, 'w2\b')
+    strings.icontains(subject.base, 'wage')
+    or strings.icontains(subject.base,
+                         'Ŵ-2'
+    ) // contains a diacritical mark
+    or regex.icontains(subject.base, 'tax (?:form|state?ment|year)')
+    or regex.icontains(subject.base, '\bw-?2?\b')
+    or regex.icontains(strings.replace_confusables(subject.base), '\birs\b')
   )
-  // body text containing variations of "W2"
+  // body text containing variations of "w2" or "wage statements"
   and (
     (
-      strings.icontains(body.current_thread.text, "w2")
-      or regex.icontains(body.current_thread.text, 'w-2\b')
-      or strings.icontains(body.current_thread.text, "Ẇ-2")
-      or regex.icontains(body.current_thread.text, 'w-2[a-z]?\b')
+      strings.icontains(body.current_thread.text,
+                        "Ẇ-2"
+      ) // contains a diacritical mark
       or strings.icontains(body.current_thread.text, "wage statements")
-    )
-    or (
-      length(headers.reply_to) > 0
-      and all(headers.reply_to, network.whois(.email.domain).days_old <= 60)
-      and strings.icontains(body.current_thread.text, "w-2")
+      or regex.icontains(body.current_thread.text, 'w-?2[a-z]?\b')
     )
   )
+  // ml classifying for requests
   and any(ml.nlu_classifier(body.current_thread.text).entities,
           .name == "request"
   )
-  and sender.email.domain.root_domain not in (
-    "excel.com",
-    "sharepoint.com",
-    "sharepointonline.com",
-    "powerpoint.com",
-    "onenote.com",
-    "microsoft.com"
-  )
+  // exclude legitimate senders or domains
   and not any(ml.nlu_classifier(body.current_thread.text).intents,
               .name == "benign" and .confidence == "high"
   )
-  
-  // negate highly trusted sender domains unless they fail DMARC authentication
+  and not (
+    sender.email.domain.domain in $org_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+  and not (
+    sender.email.domain.root_domain in (
+      "excel.com",
+      "sharepoint.com",
+      "sharepointonline.com",
+      "powerpoint.com",
+      "onenote.com",
+      "microsoft.com",
+      "jotform.com",
+      "wetrasnfer.com"
+    )
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+  // // negate highly trusted sender domains unless they fail DMARC authentication
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)

--- a/detection-rules/tax_w2_impersonation.yml
+++ b/detection-rules/tax_w2_impersonation.yml
@@ -1,10 +1,10 @@
-name: "BEC Impersonation: Tax document request"
+name: "BEC: Tax document request"
 description: "Detects messages requesting W-2 tax documents or related tax information that exhibit authentication failures such as DMARC or SPF failures, or mismatched reply-to addresses. The rule identifies senders using common administrative local parts and filters for messages containing W-2 language combined with request entities detected through natural language processing."
 type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  // and 150 < length(body.current_thread.text) < 750
+  and length(body.current_thread.text) < 500
   and sender.email.local_part in~ (
     "contact",
     "no-reply",
@@ -19,25 +19,27 @@ source: |
   
   // mismatched From and Reply-to
   and (
-    (
-      length(headers.reply_to) > 0
-      and all(headers.reply_to,
-              .email.domain.root_domain != sender.email.domain.root_domain
-      )
+    length(headers.reply_to) > 0
+    and all(headers.reply_to,
+            .email.domain.root_domain != sender.email.domain.root_domain
     )
-    or not headers.auth_summary.dmarc.pass
-    or not headers.auth_summary.spf.pass
   )
   
   // W-2 Language with a request
   and (
-    strings.contains(strings.replace_confusables(subject.base), 'W-2')
-    or strings.icontains(subject.base, 'w2')
+    strings.contains(subject.base, 'W-2')
     or strings.icontains(subject.base, 'wage')
     or strings.icontains(subject.base, 'tax form')
     or strings.icontains(subject.base, 'irs')
+    or regex.icontains(subject.base, 'w2\b')
   )
-  and strings.contains(body.current_thread.text, 'W-2')
+  // body text containing variations of "W2"
+  and (
+    strings.icontains(body.current_thread.text, "w2")
+    or strings.icontains(body.current_thread.text, "W-2")
+    or strings.icontains(body.current_thread.text, "Ẇ-2's")
+    or strings.icontains(body.current_thread.text, "wage")
+  )
   and any(ml.nlu_classifier(body.current_thread.text).entities,
           .name == "request"
   )
@@ -49,7 +51,6 @@ source: |
                   "*OneNote*",
                   "*Microsoft*"
     )
-    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
   and not any(ml.nlu_classifier(body.current_thread.text).intents,
               .name == "benign" and .confidence == "high"

--- a/detection-rules/tax_w2_impersonation.yml
+++ b/detection-rules/tax_w2_impersonation.yml
@@ -36,14 +36,15 @@ source: |
   and (
     (
       strings.icontains(body.current_thread.text, "w2")
-      or strings.icontains(body.current_thread.text, "W-2")
+      or regex.icontains(body.current_thread.text, 'w-2\b')
       or strings.icontains(body.current_thread.text, "Ẇ-2")
+      or regex.icontains(body.current_thread.text, 'w-2[a-z]?\b')
       or strings.icontains(body.current_thread.text, "wage statements")
     )
     or (
       length(headers.reply_to) > 0
       and all(headers.reply_to, network.whois(.email.domain).days_old <= 60)
-      and strings.icontains(body.current_thread.text, "W-2")
+      and strings.icontains(body.current_thread.text, "w-2")
     )
   )
   and any(ml.nlu_classifier(body.current_thread.text).entities,

--- a/detection-rules/tax_w2_impersonation.yml
+++ b/detection-rules/tax_w2_impersonation.yml
@@ -49,14 +49,13 @@ source: |
   and any(ml.nlu_classifier(body.current_thread.text).entities,
           .name == "request"
   )
-  and not (
-    strings.ilike(sender.display_name,
-                  "*Excel*",
-                  "*SharePoint*",
-                  "*PowerPoint*",
-                  "*OneNote*",
-                  "*Microsoft*"
-    )
+  and sender.email.domain.root_domain not in (
+    "excel.com",
+    "sharepoint.com",
+    "sharepointonline.com",
+    "powerpoint.com",
+    "onenote.com",
+    "microsoft.com"
   )
   and not any(ml.nlu_classifier(body.current_thread.text).intents,
               .name == "benign" and .confidence == "high"

--- a/detection-rules/tax_w2_impersonation.yml
+++ b/detection-rules/tax_w2_impersonation.yml
@@ -63,6 +63,7 @@ source: |
   )
   
 
+
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:

--- a/detection-rules/tax_w2_impersonation.yml
+++ b/detection-rules/tax_w2_impersonation.yml
@@ -70,8 +70,6 @@ source: |
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
   
-
-
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:

--- a/detection-rules/tax_w2_impersonation.yml
+++ b/detection-rules/tax_w2_impersonation.yml
@@ -1,0 +1,74 @@
+name: "BEC Impersonation: Tax document request"
+description: "Detects messages requesting W-2 tax documents or related tax information that exhibit authentication failures such as DMARC or SPF failures, or mismatched reply-to addresses. The rule identifies senders using common administrative local parts and filters for messages containing W-2 language combined with request entities detected through natural language processing."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // and 150 < length(body.current_thread.text) < 750
+  and sender.email.local_part in~ (
+    "contact",
+    "no-reply",
+    "noreply",
+    "info",
+    "admin"
+  )
+  and not (
+    sender.email.domain.domain in $org_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+  
+  // mismatched From and Reply-to
+  and (
+    (
+      length(headers.reply_to) > 0
+      and all(headers.reply_to,
+              .email.domain.root_domain != sender.email.domain.root_domain
+      )
+    )
+    or not headers.auth_summary.dmarc.pass
+    or not headers.auth_summary.spf.pass
+  )
+  
+  // W-2 Language with a request
+  and (
+    strings.contains(strings.replace_confusables(subject.base), 'W-2')
+    or strings.icontains(subject.base, 'w2')
+    or strings.icontains(subject.base, 'wage')
+    or strings.icontains(subject.base, 'tax form')
+    or strings.icontains(subject.base, 'irs')
+  )
+  and strings.contains(body.current_thread.text, 'W-2')
+  and any(ml.nlu_classifier(body.current_thread.text).entities,
+          .name == "request"
+  )
+  and not (
+    strings.ilike(sender.display_name,
+                  "*Excel*",
+                  "*SharePoint*",
+                  "*PowerPoint*",
+                  "*OneNote*",
+                  "*Microsoft*"
+    )
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+  and not any(ml.nlu_classifier(body.current_thread.text).intents,
+              .name == "benign" and .confidence == "high"
+  )
+  
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+  
+
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Spoofing"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"

--- a/detection-rules/tax_w2_impersonation.yml
+++ b/detection-rules/tax_w2_impersonation.yml
@@ -72,3 +72,4 @@ detection_methods:
   - "Header analysis"
   - "Natural Language Understanding"
   - "Sender analysis"
+id: "4834a45e-6d70-5ad9-9043-024eea995e95"

--- a/detection-rules/tax_w2_impersonation.yml
+++ b/detection-rules/tax_w2_impersonation.yml
@@ -19,12 +19,10 @@ source: |
             .email.domain.root_domain != sender.email.domain.root_domain
     )
   )
-  // subject lines with words correlating to (tax information)
+  // subject lines with words correlating to tax information
   and (
     strings.icontains(subject.base, 'wage')
-    or strings.icontains(subject.base,
-                         'Ŵ-2'
-    ) // contains a diacritical mark
+    or strings.icontains(strings.replace_confusables(subject.base), 'Ŵ-2')
     or regex.icontains(subject.base, 'tax (?:form|state?ment|year)')
     or regex.icontains(subject.base, '\bw-?2?\b')
     or regex.icontains(strings.replace_confusables(subject.base), '\birs\b')
@@ -32,9 +30,9 @@ source: |
   // body text containing variations of "w2" or "wage statements"
   and (
     (
-      strings.icontains(body.current_thread.text,
-                        "Ẇ-2"
-      ) // contains a diacritical mark
+      strings.icontains(strings.replace_confusables(body.current_thread.text),
+                        'Ẇ-2'
+      )
       or strings.icontains(body.current_thread.text, "wage statements")
       or regex.icontains(body.current_thread.text, 'w-?2[a-z]?\b')
     )
@@ -64,7 +62,7 @@ source: |
     )
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
-  // // negate highly trusted sender domains unless they fail DMARC authentication
+  // negate highly trusted sender domains unless they fail DMARC authentication
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)


### PR DESCRIPTION
# Description
Detects messages requesting W-2 tax documents or related tax information. 

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/5079a5f44796f931c713a22b4f920c1e3e20cc548294fd0ca35be0f7f76b3304)

## Associated hunts
- [Hunt 1 - 365 Days](https://platform.sublime.security/hunts/019faf94-113c-70a4-8663-90ae0e338a73)
- [Multi-Hunt 30D](https://hunt.limeseed.email/hunts/0f8e23e5-4ab8-4721-8792-fa468912a534)