### PR TITLE
Create detection rule for Spam Google share domain

### DIFF
--- a/detection-rules/service_google_share.yml
+++ b/detection-rules/service_google_share.yml
@@ -1,0 +1,24 @@
+name: "Spam: Google share domain in subject or email body"
+description: "Detects messages with links to the non-existent 'share.google' domain. The body of the email contains a share.google link with minimal text."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // Subject line is a bare URL with no other text
+  and regex.icontains(subject.base, 'https?://share.google')
+  // Current thread or any previous thread body that contains the domain share.google
+  and any(body.links,
+          regex.match(.href_url.url,
+                      "https?://share\\.google/images/[a-zA-Z0-9]+"
+          )
+  )
+
+attack_types:
+  - "Spam"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Lookalike domain"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "URL analysis"

--- a/detection-rules/service_google_share.yml
+++ b/detection-rules/service_google_share.yml
@@ -22,3 +22,4 @@ detection_methods:
   - "Content analysis"
   - "Header analysis"
   - "URL analysis"
+id: "5c86e897-9f39-5d1b-b94f-d16efc72ba95"


### PR DESCRIPTION
# Description
Detects messages with links to the non-existent 'share.google' domain. The body of the email contains a share.google link with minimal text.

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/5078aab9a1913ce1bf3cbc88a05f930e5165e21f45edeb90f0f61444b8e8a59e)
- [Sample 2](https://platform.sublime.security/messages/507dfdfdfc49dda68881c02af1e4db7d23601896db2c538ddf45a89508da2ffd?preview_id=019e84ad-9d6a-717a-b316-80d4f31eff19)

## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e8a1a-8864-701e-afff-d43ce2c318bc)
- [Multi-hunt](https://hunt.limeseed.email/hunts/822d82cd-d753-4a12-8b42-d9e86a02956e)
