### PR TITLE
Create service_abuse_paypal_manager_callback.yml

### DIFF
--- a/detection-rules/service_abuse_paypal_manager_callback.yml
+++ b/detection-rules/service_abuse_paypal_manager_callback.yml
@@ -1,0 +1,24 @@
+name: "Service abuse: PayPal manager account creation with callback scam indicators"
+description: "Detects inbound messages spoofing PayPal's noreply address with subjects about PayPal Manager user account creation that contain callback scam or credential theft intent patterns identified through natural language analysis."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and sender.email.email == "noreply@paypal.com"
+  and strings.icontains(subject.base,
+                        "Creation of your PayPal Manager user account"
+  )
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name in ("callback_scam", "cred_theft") and .confidence != "low"
+  )
+attack_types:
+  - "Callback Phishing"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+  - "Spoofing"
+detection_methods:
+  - "Sender analysis"
+  - "Content analysis"
+  - "Natural Language Understanding"

--- a/detection-rules/service_abuse_paypal_manager_callback.yml
+++ b/detection-rules/service_abuse_paypal_manager_callback.yml
@@ -22,3 +22,4 @@ detection_methods:
   - "Sender analysis"
   - "Content analysis"
   - "Natural Language Understanding"
+id: "4f379593-37e8-5a00-a724-08eb72d90062"

--- a/detection-rules/service_abuse_paypal_manager_callback.yml
+++ b/detection-rules/service_abuse_paypal_manager_callback.yml
@@ -1,5 +1,5 @@
 name: "Service abuse: PayPal manager account creation with callback scam indicators"
-description: "Detects inbound messages spoofing PayPal's noreply address with subjects about PayPal Manager user account creation that contain callback scam or credential theft intent patterns identified through natural language analysis."
+description: "Detects inbound messages abusing PayPal's noreply address with subjects about PayPal Manager user account creation that contain callback scam intent patterns identified through natural language analysis."
 type: "rule"
 severity: "medium"
 source: |


### PR DESCRIPTION
# Description
Detects inbound messages abusing PayPal's noreply address with subjects about PayPal Manager user account creation that contain callback scam intent patterns identified through natural language analysis.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507dab38a0c65572e201d6cf16bf1f51e4b9431e77c5f35ca8590bd441a6220c?preview_id=019e8470-8e73-78aa-afc0-45de1271bd23)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e88f6-85bb-7d67-9bc7-d7967faeb9b0)
- [multihunt](https://hunt.limeseed.email/hunts/7b1a4ddf-d196-4e18-becc-740504e70d25)
