### PR TITLE
Update spam_fake_photo_share.yml

### DIFF
--- a/detection-rules/spam_fake_photo_share.yml
+++ b/detection-rules/spam_fake_photo_share.yml
@@ -14,7 +14,16 @@ source: |
             length(body.html.display_text) < 500
             and length(body.current_thread.text) == 0
           )
-          or (length(body.current_thread.text) < 500)
+          or (
+            length(body.current_thread.text) < 500
+            or any(map(filter(ml.nlu_classifier(body.current_thread.text).entities,
+                              .name == "disclaimer"
+                       ),
+                       .text
+                   ),
+                   (length(body.current_thread.text) - length(.)) < 500
+            )
+          )
         )
         and strings.ilike(subject.subject,
                           "*picture*",
@@ -23,7 +32,9 @@ source: |
                           "*sad news*",
                           "*sad announcement*",
                           "*sad update*",
-                          "*new pics*"
+                          "*new pics*",
+                          "*Reunion*",
+                          "*planing*"
         )
       )
       or (
@@ -124,6 +135,15 @@ source: |
             or (
               length(.display_text) == 1
               and .href_url.domain.root_domain in ("facebook.com", "youtube.com")
+            )
+            or (
+              // short random subdomain (4-6 chars)
+              regex.icontains(.href_url.url, 'https?://[a-z]{4,6}\.[a-z]+\.')
+              // subdomain contains 3+ consecutive consonants
+              and regex.icontains(.href_url.url,
+                                  'https?://[a-z]*[b-df-hj-np-tv-z]{3,}[a-z]*\.'
+              )
+              and network.whois(.href_url.domain).days_old < 365
             )
     )
   )

--- a/detection-rules/spam_fake_photo_share.yml
+++ b/detection-rules/spam_fake_photo_share.yml
@@ -137,8 +137,10 @@ source: |
               and .href_url.domain.root_domain in ("facebook.com", "youtube.com")
             )
             or (
-              // short random subdomain
-              regex.icontains(.href_url.url, 'https?://[a-z]{5}\.[a-z]+\.')
+              // random 5-character subdomain
+              regex.icontains(.href_url.url,
+                              'https?://[a-z]{5}\.[a-z]{5,}\.[a-z]+'
+              )
               // subdomain contains 3+ consecutive consonants
               and regex.icontains(.href_url.url,
                                   'https?://[a-z]*[b-df-hj-np-tv-z]{3,}[a-z]*\.'

--- a/detection-rules/spam_fake_photo_share.yml
+++ b/detection-rules/spam_fake_photo_share.yml
@@ -14,15 +14,13 @@ source: |
             length(body.html.display_text) < 500
             and length(body.current_thread.text) == 0
           )
-          or (
-            length(body.current_thread.text) < 500
-            or any(map(filter(ml.nlu_classifier(body.current_thread.text).entities,
+          or length(body.current_thread.text) < 500
+          or any(map(filter(ml.nlu_classifier(body.current_thread.text).entities,
                               .name == "disclaimer"
                        ),
                        .text
                    ),
                    (length(body.current_thread.text) - length(.)) < 500
-            )
           )
         )
         and strings.ilike(subject.subject,
@@ -138,12 +136,12 @@ source: |
             )
             or (
               // random 5-character subdomain
-              regex.icontains(.href_url.url,
-                              'https?://[a-z]{5}\.[a-z]{5,}\.[a-z]+'
+              regex.icontains(.href_url.domain.domain,
+                              '^[a-z]{5}\.[a-z]{5,}\.[a-z]+'
               )
               // subdomain contains 3+ consecutive consonants
-              and regex.icontains(.href_url.url,
-                                  'https?://[a-z]*[b-df-hj-np-tv-z]{3,}[a-z]*\.'
+              and regex.icontains(.href_url.domain.domain,
+                                  '^[a-z]*[b-df-hj-np-tv-z]{3,}[a-z]*\.'
               )
               and network.whois(.href_url.domain).days_old < 365
             )

--- a/detection-rules/spam_fake_photo_share.yml
+++ b/detection-rules/spam_fake_photo_share.yml
@@ -9,10 +9,7 @@ source: |
     (
       (
         (
-          (
-            length(body.plain.raw) < 500
-            and length(body.current_thread.text) == 0
-          )
+          (length(body.plain.raw) < 500 and length(body.current_thread.text) == 0)
           or (
             length(body.html.display_text) < 500
             and length(body.current_thread.text) == 0
@@ -57,10 +54,7 @@ source: |
           )
         )
         or (
-          (
-            length(body.plain.raw) < 500
-            and length(body.current_thread.text) == 0
-          )
+          (length(body.plain.raw) < 500 and length(body.current_thread.text) == 0)
           and strings.ilike(body.plain.raw,
                             "*picture*",
                             "*photo*",
@@ -140,10 +134,7 @@ source: |
             )
             or (
               length(.display_text) == 1
-              and .href_url.domain.root_domain in (
-                "facebook.com",
-                "youtube.com"
-              )
+              and .href_url.domain.root_domain in ("facebook.com", "youtube.com")
             )
             or (
               // short random subdomain

--- a/detection-rules/spam_fake_photo_share.yml
+++ b/detection-rules/spam_fake_photo_share.yml
@@ -16,11 +16,11 @@ source: |
           )
           or length(body.current_thread.text) < 500
           or any(map(filter(ml.nlu_classifier(body.current_thread.text).entities,
-                              .name == "disclaimer"
-                       ),
-                       .text
-                   ),
-                   (length(body.current_thread.text) - length(.)) < 500
+                            .name == "disclaimer"
+                     ),
+                     .text
+                 ),
+                 (length(body.current_thread.text) - length(.)) < 500
           )
         )
         and strings.ilike(subject.subject,

--- a/detection-rules/spam_fake_photo_share.yml
+++ b/detection-rules/spam_fake_photo_share.yml
@@ -9,7 +9,10 @@ source: |
     (
       (
         (
-          (length(body.plain.raw) < 500 and length(body.current_thread.text) == 0)
+          (
+            length(body.plain.raw) < 500
+            and length(body.current_thread.text) == 0
+          )
           or (
             length(body.html.display_text) < 500
             and length(body.current_thread.text) == 0
@@ -54,7 +57,10 @@ source: |
           )
         )
         or (
-          (length(body.plain.raw) < 500 and length(body.current_thread.text) == 0)
+          (
+            length(body.plain.raw) < 500
+            and length(body.current_thread.text) == 0
+          )
           and strings.ilike(body.plain.raw,
                             "*picture*",
                             "*photo*",
@@ -134,11 +140,14 @@ source: |
             )
             or (
               length(.display_text) == 1
-              and .href_url.domain.root_domain in ("facebook.com", "youtube.com")
+              and .href_url.domain.root_domain in (
+                "facebook.com",
+                "youtube.com"
+              )
             )
             or (
-              // short random subdomain (4-6 chars)
-              regex.icontains(.href_url.url, 'https?://[a-z]{4,6}\.[a-z]+\.')
+              // short random subdomain
+              regex.icontains(.href_url.url, 'https?://[a-z]{5}\.[a-z]+\.')
               // subdomain contains 3+ consecutive consonants
               and regex.icontains(.href_url.url,
                                   'https?://[a-z]*[b-df-hj-np-tv-z]{3,}[a-z]*\.'


### PR DESCRIPTION
# Description

Updated logic to look for links that appear to have a randomized subdomain and 3+ consecutive consonants, additional keywords in the subject logic, and updated `length` logic to exclude the disclaimer of a sample.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507e7bc6252e300623c5b633d580098cb02021f9721867a1852ef28c29e6c1e2?preview_id=019e881c-b407-7502-a8d3-1db0cd3e2495)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e92cd-9689-799f-adc8-f334a2a654cd)