### PR TITLE
Update attachment_pdf_sus_string_single_url.yml

### DIFF
--- a/detection-rules/attachment_pdf_sus_string_single_url.yml
+++ b/detection-rules/attachment_pdf_sus_string_single_url.yml
@@ -67,7 +67,8 @@ source: |
                                                 )
                                     )
                                     and not .domain.root_domain in (
-                                      'pdf-tools.com'
+                                      'pdf-tools.com',
+                                      'gamma.app'
                                     )
                              )
                   ) == 1

--- a/detection-rules/attachment_pdf_sus_string_single_url.yml
+++ b/detection-rules/attachment_pdf_sus_string_single_url.yml
@@ -67,8 +67,10 @@ source: |
                                                 )
                                     )
                                     and not .domain.root_domain in (
-                                      'pdf-tools.com',
-                                      'gamma.app'
+                                      'pdf-tools.com'
+                                    )
+                                    and not .url in (
+                                      'https://gamma.app/?utm_source=made-with-gamma'
                                     )
                              )
                   ) == 1


### PR DESCRIPTION
# Description

Filter out gamma.app when counting links. This link is automatically added by gamma when creating the pdf. This PR is a continuation of this [closed PR](https://github.com/sublime-security/sublime-rules/pull/4238).

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/506f8e5a89112d5850a77bc4c7897c18cd3325f4398e6fc559d54e780d0ebde5)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [updated rule](https://platform.sublime.security/messages/hunt?huntId=019e899d-5fca-782b-b22a-b88fb5d23a48)
- [net new](https://platform.sublime.security/messages/hunt?huntId=019e89a3-1c0b-72d0-bc5c-c68e4eb6bb96)
- [regression](https://platform.sublime.security/messages/hunt?huntId=019e89b2-4380-7911-a031-80c120fede60) 
### Updated logic
- [updated rule](https://platform.sublime.security/messages/hunt?huntId=019e8dd2-483c-75ba-a6cd-49425acb37f5)
- [net new](https://platform.sublime.security/messages/hunt?huntId=019e8dd3-c1c2-7d4a-88fd-33ba2779ba1e)
- [regression](https://platform.sublime.security/messages/hunt?huntId=019e8ddd-5014-7649-b831-79632b3f8a9e)
