### PR TITLE
Update impersonation_fake_copyright_infringement_notice_from_unsolicited_sender.yml

### DIFF
--- a/detection-rules/impersonation_fake_copyright_infringement_notice_from_unsolicited_sender.yml
+++ b/detection-rules/impersonation_fake_copyright_infringement_notice_from_unsolicited_sender.yml
@@ -7,7 +7,7 @@ source: |
   and length(body.previous_threads) == 0
   and length(body.current_thread.text) < 5000
   and 0 < length(body.links) < 10
-  
+
   // common strings in subject or base
   and (
     2 of (
@@ -46,7 +46,7 @@ source: |
       strings.ilike(sender.display_name, '*Advisory*'),
     )
   )
-  
+
   // common strings in email current thread
   and 15 of (
     strings.ilike(body.current_thread.text, '*copyright*'),
@@ -109,28 +109,26 @@ source: |
     strings.ilike(body.current_thread.text, '*dissemination*'),
     strings.ilike(body.current_thread.text, '*counter-notice*'),
     strings.ilike(body.current_thread.text, '*exploitation*'),
-    strings.ilike(body.current_thread.text, '*dispute*'),
     strings.ilike(body.current_thread.text, '*remedial*'),
     strings.ilike(body.current_thread.text, '*particulars*'),
     strings.ilike(body.current_thread.text, '*fingerprint*'),
     strings.ilike(body.current_thread.text, '*confidentiality*'),
     strings.ilike(body.current_thread.text, '*assertion*'),
     strings.ilike(body.current_thread.text, '*counsel*'),
-    strings.ilike(body.current_thread.text, '*prohibited*'),
     strings.ilike(body.current_thread.text, '*privileged*'),
     strings.ilike(body.current_thread.text, '*directive*'),
   )
-  
+
   // remove phrase from legitimate complaint
   and not regex.icontains(body.current_thread.text,
                           '(?:we are passing the notice below|content has been removed|removed from our website|notice of intended action|I have not granted|I am the original creator|content you reported has been removed|complaint will be carefully reviewed|provide a list of violations|document confirming your right to act)'
   )
-  
+
   // not copyright reports
   and not regex.icontains(body.current_thread.text,
                           '(?:confirmation|received).{0,100}copyright report'
   )
-  
+
   // verified dmca receiving/sending address
   and not any([recipients.cc, recipients.to, recipients.bcc],
               any(.,

--- a/detection-rules/impersonation_fake_copyright_infringement_notice_from_unsolicited_sender.yml
+++ b/detection-rules/impersonation_fake_copyright_infringement_notice_from_unsolicited_sender.yml
@@ -26,6 +26,7 @@ source: |
       strings.ilike(subject.base, '*Intellectual*'),
       strings.ilike(subject.base, '*Concerning*'),
       strings.ilike(subject.base, '*Notice*'),
+      strings.ilike(subject.base, '*Licensing*'),
       strings.ilike(subject.base, '*Clarification*'),
       strings.ilike(subject.base, '*Matter*'),
       strings.ilike(subject.base, '*Conflict*'),
@@ -40,7 +41,9 @@ source: |
       strings.ilike(sender.display_name, '*Intellectual*'),
       strings.ilike(sender.display_name, '*Notice*'),
       strings.ilike(sender.display_name, '*Matter*'),
-      strings.ilike(sender.display_name, '*Advisory*')
+      strings.ilike(sender.display_name, '*Dispute*'),
+      strings.ilike(sender.display_name, '*Resolution*'),
+      strings.ilike(sender.display_name, '*Advisory*'),
     )
   )
   
@@ -105,7 +108,17 @@ source: |
     strings.ilike(body.current_thread.text, '*notice*'),
     strings.ilike(body.current_thread.text, '*dissemination*'),
     strings.ilike(body.current_thread.text, '*counter-notice*'),
-    strings.ilike(body.current_thread.text, '*exploitation*')
+    strings.ilike(body.current_thread.text, '*exploitation*'),
+    strings.ilike(body.current_thread.text, '*dispute*'),
+    strings.ilike(body.current_thread.text, '*remedial*'),
+    strings.ilike(body.current_thread.text, '*particulars*'),
+    strings.ilike(body.current_thread.text, '*fingerprint*'),
+    strings.ilike(body.current_thread.text, '*confidentiality*'),
+    strings.ilike(body.current_thread.text, '*assertion*'),
+    strings.ilike(body.current_thread.text, '*counsel*'),
+    strings.ilike(body.current_thread.text, '*prohibited*'),
+    strings.ilike(body.current_thread.text, '*privileged*'),
+    strings.ilike(body.current_thread.text, '*directive*'),
   )
   
   // remove phrase from legitimate complaint


### PR DESCRIPTION
# Description

Updated `subject.base` and `body.current_thread.text` keywords to match on additional samples

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507e20ca6684cf91fde1ae8009a177823043d048249a1fb7b33074581d4bc6f5?preview_id=019e8992-ce4b-79a8-868b-d33c50123a28)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e9434-be0d-7314-af95-e2463d1e28f1)