### PR TITLE
Revise DHL impersonation detection regex

### DIFF
--- a/detection-rules/impersonation_dhl.yml
+++ b/detection-rules/impersonation_dhl.yml
@@ -10,6 +10,7 @@ source: |
   type.inbound
   and (
     regex.icontains(sender.display_name, '\bDHL\b')
+    or regex.contains(sender.display_name, '\bD.{0,2}H.{0,2}L.{0,2}\b')
     or (
       strings.ilike(sender.email.domain.domain, '*DHL*')
       and length(sender.email.domain.domain) < 15


### PR DESCRIPTION
# Description
Adding additional logic for sender display to search for the keyword `DHL`. 

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/507efb21e750196aa3bec4338d90af2f51b0f2dfbbc93ad68ec06f9d310744be?preview_id=019e89d6-6ef7-77c8-abe4-2f7fa88dcf76)

## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e8dd9-b413-7b61-8b52-9771c18622eb)
- [Multi-hunt](https://hunt.limeseed.email/hunts/465e8b5f-4750-4c0a-ba5c-8a65cdf39ee2)