### PR TITLE
Update body_advance_fee_new_sender.yml

### DIFF
--- a/detection-rules/body_advance_fee_new_sender.yml
+++ b/detection-rules/body_advance_fee_new_sender.yml
@@ -27,6 +27,12 @@ source: |
     )
     or sender.email.domain.tld in $suspicious_tlds
     or any(["jp", "jo"], strings.iends_with(sender.email.domain.tld, .))
+    or (
+      length(recipients.to) == 0
+      and any(headers.reply_to,
+              .email.domain.root_domain != sender.email.domain.root_domain
+      )
+    )
   )
   and (
     any(ml.nlu_classifier(body.current_thread.text).intents,


### PR DESCRIPTION
# Description

Adding logic to look for sender/reply-to mismatch and `length` of `recipients.to` is equal to `0`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507e53260892da5ae359edd80acca54beeca97f2ab4ff17ebd3b6bb9dba9e6f9?preview_id=019e8988-94bf-7789-b774-7016a2c643a4)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e9862-116a-7995-a87e-6b4ec5d52989)