### PR TITLE
Update impersonation_fedex.yml

### DIFF
--- a/detection-rules/impersonation_fedex.yml
+++ b/detection-rules/impersonation_fedex.yml
@@ -18,8 +18,8 @@ source: |
         any(ml.nlu_classifier(body.current_thread.text).entities,
             .name == "request" and strings.icontains(.text, "signature")
         )
-        or any(ml.nlu_classifier(body.current_thread.text).entities,
-               .name == "org" and strings.icontains(.text, "FedEx")
+        or any([subject.subject, body.current_thread.text],
+               strings.istarts_with(., 'FedEx')
         )
       )
     )

--- a/detection-rules/impersonation_fedex.yml
+++ b/detection-rules/impersonation_fedex.yml
@@ -8,14 +8,23 @@ severity: "low"
 source: |
   type.inbound
   and (
-    sender.display_name in~ ('fedex', 'fedex shipment', 'fedex tracking updates')
+    sender.display_name in~ (
+      'fedex',
+      'fedex shipment',
+      'fedex tracking updates'
+    )
     or strings.ilevenshtein(sender.display_name, 'fedex') <= 1
     or regex.icontains(sender.display_name, '^Fed-?ex')
     or strings.ilike(sender.email.domain.domain, '*fedex*')
     or (
       any(ml.logo_detect(file.message_screenshot()).brands, .name == "FedEx")
-      and any(ml.nlu_classifier(body.current_thread.text).entities,
-              .name == "request" and strings.icontains(.text, "signature")
+      and (
+        any(ml.nlu_classifier(body.current_thread.text).entities,
+            .name == "request" and strings.icontains(.text, "signature")
+        )
+        or any(ml.nlu_classifier(body.current_thread.text).entities,
+               .name == "org" and strings.icontains(.text, "FedEx")
+        )
       )
     )
   )
@@ -34,7 +43,7 @@ source: |
     not profile.by_sender().any_messages_benign
     and not profile.by_sender().solicited
   )
-  
+
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (

--- a/detection-rules/impersonation_fedex.yml
+++ b/detection-rules/impersonation_fedex.yml
@@ -18,9 +18,7 @@ source: |
         any(ml.nlu_classifier(body.current_thread.text).entities,
             .name == "request" and strings.icontains(.text, "signature")
         )
-        or any([subject.subject, body.current_thread.text],
-               strings.istarts_with(., 'FedEx')
-        )
+        or strings.istarts_with(body.current_thread.text, 'FedEx')
       )
     )
   )

--- a/detection-rules/impersonation_fedex.yml
+++ b/detection-rules/impersonation_fedex.yml
@@ -8,11 +8,7 @@ severity: "low"
 source: |
   type.inbound
   and (
-    sender.display_name in~ (
-      'fedex',
-      'fedex shipment',
-      'fedex tracking updates'
-    )
+    sender.display_name in~ ('fedex', 'fedex shipment', 'fedex tracking updates')
     or strings.ilevenshtein(sender.display_name, 'fedex') <= 1
     or regex.icontains(sender.display_name, '^Fed-?ex')
     or strings.ilike(sender.email.domain.domain, '*fedex*')
@@ -43,7 +39,7 @@ source: |
     not profile.by_sender().any_messages_benign
     and not profile.by_sender().solicited
   )
-
+  
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (

--- a/detection-rules/impersonation_fedex.yml
+++ b/detection-rules/impersonation_fedex.yml
@@ -46,6 +46,7 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
+
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description

Adding an additional `or` statement with `strings.istarts_with` within `ml.logo_detect` logic to tag samples that start with FedEx in the body

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507f8754f6b3480ecfcd2248e64dac0d6ccc1d8fe045d5e93c065e20a2b193ef?preview_id=019e8e5c-028d-7528-9601-1df949bf0cc2)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019e9841-339b-7d27-9685-5314445883eb)
- [84 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/4d42c3bf-35c5-4c98-bca6-52f5d0e86dae)