### PR TITLE
Create service_abuse_linode_objects_html.yml

### DIFF
--- a/detection-rules/service_abuse_linode_objects_html.yml
+++ b/detection-rules/service_abuse_linode_objects_html.yml
@@ -1,0 +1,19 @@
+name: "Service abuse: Linode Objects HTML file hosting"
+description: "Detects inbound messages containing links to HTML files hosted on Linode's object storage service (linodeobjects.com). This pattern is commonly used to host malicious content or bypass security controls by leveraging legitimate cloud storage infrastructure."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(body.current_thread.links,
+          .href_url.domain.root_domain == "linodeobjects.com"
+          and strings.iends_with(.href_url.path, ".html")
+  )
+attack_types:
+  - "Credential Phishing"
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Free file host"
+  - "Evasion"
+detection_methods:
+  - "URL analysis"
+  - "Content analysis"

--- a/detection-rules/service_abuse_linode_objects_html.yml
+++ b/detection-rules/service_abuse_linode_objects_html.yml
@@ -17,3 +17,4 @@ tactics_and_techniques:
 detection_methods:
   - "URL analysis"
   - "Content analysis"
+id: "7e223bac-b437-57e5-be99-f82b23c4ca61"

--- a/detection-rules/service_abuse_linode_objects_html.yml
+++ b/detection-rules/service_abuse_linode_objects_html.yml
@@ -8,6 +8,8 @@ source: |
           .href_url.domain.root_domain == "linodeobjects.com"
           and strings.iends_with(.href_url.path, ".html")
   )
+tags:
+ - "Attack surface reduction"
 attack_types:
   - "Credential Phishing"
   - "Malware/Ransomware"


### PR DESCRIPTION
# Description
Detects inbound messages containing links to HTML files hosted on Linode's object storage service (linodeobjects.com). This pattern is commonly used to host malicious content or bypass security controls by leveraging legitimate cloud storage infrastructure.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507e8bc4965adc0c3876f0a96783e6de68abec9b3c6e69361686489829bbb913?preview_id=019e8c1c-c1e6-745c-bf3a-9cb3799d2ab7)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e9814-0297-776a-afeb-34d363d45464)


