### PR TITLE
Create link_pdf_file_html_disguise.yml

### DIFF
--- a/detection-rules/link_pdf_file_html_disguise.yml
+++ b/detection-rules/link_pdf_file_html_disguise.yml
@@ -16,3 +16,4 @@ tactics_and_techniques:
 detection_methods:
   - "URL analysis"
   - "Content analysis"
+id: "aa1a842d-ddd9-5e0e-8f17-bbcab4818195"

--- a/detection-rules/link_pdf_file_html_disguise.yml
+++ b/detection-rules/link_pdf_file_html_disguise.yml
@@ -1,0 +1,18 @@
+name: "Link: PDF file disguised as HTML page"
+description: "Detects inbound messages containing links that appear to reference PDF files but are actually HTML pages, indicated by URLs ending with '.pdf' followed by additional characters and '.html'. This technique is commonly used to bypass security filters and deceive recipients into believing they are accessing a legitimate PDF document."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(body.current_thread.links,
+          regex.icontains(.href_url.path, '\.pdf[^/]*\.html$')
+  ) 
+attack_types:
+  - "Credential Phishing"
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Evasion"
+  - "PDF"
+detection_methods:
+  - "URL analysis"
+  - "Content analysis"


### PR DESCRIPTION
# Description
Detects inbound messages containing links that appear to reference PDF files but are actually HTML pages, indicated by URLs ending with '.pdf' followed by additional characters and '.html'. This technique is commonly used to bypass security filters and deceive recipients into believing they are accessing a legitimate PDF document.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507e8bc4965adc0c3876f0a96783e6de68abec9b3c6e69361686489829bbb913?preview_id=019e8c1c-c1e6-745c-bf3a-9cb3799d2ab7)


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e9816-66a7-7652-827e-cd65872e93e8)


