### PR TITLE
Update link_credential_phishing_secure_message.yml

### DIFF
--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -49,7 +49,8 @@ source: |
                            'secured? (?:message|directory|document) access'
            )
            or regex.icontains(ml.link_analysis(.).final_dom.inner_text,
-                           'secured? (?:message|directory|document) access'
+                              'secured? (?:message|directory|document) access'
+           )
     )
     or (
       length(filter(ml.nlu_classifier(body.current_thread.text).entities,

--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -48,6 +48,9 @@ source: |
            regex.icontains(ml.link_analysis(.).final_dom.display_text,
                            'secured? (message|directory|document) access'
            )
+           or regex.icontains(ml.link_analysis(.).final_dom.inner_text,
+                           'secured? (message|directory|document) access'
+           )
     )
     or (
       length(filter(ml.nlu_classifier(body.current_thread.text).entities,

--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -46,10 +46,10 @@ source: |
     )
     or any(body.current_thread.links,
            regex.icontains(ml.link_analysis(.).final_dom.display_text,
-                           'secured? (message|directory|document) access'
+                           'secured? (?:message|directory|document) access'
            )
            or regex.icontains(ml.link_analysis(.).final_dom.inner_text,
-                           'secured? (message|directory|document) access'
+                           'secured? (?:message|directory|document) access'
     )
     or (
       length(filter(ml.nlu_classifier(body.current_thread.text).entities,

--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -45,9 +45,11 @@ source: |
            or strings.icontains(.text, "protected message")
     )
     or any(body.current_thread.links,
-          regex.icontains(coalesce(ml.link_analysis(.).final_dom.display_text, ml.link_analysis(.).final_dom.inner_text),
-                          'secured? (?:message|directory|document) access'
-          )
+           regex.icontains(coalesce(ml.link_analysis(.).final_dom.display_text,
+                                    ml.link_analysis(.).final_dom.inner_text
+                           ),
+                           'secured? (?:message|directory|document) access'
+           )
     )
     or (
       length(filter(ml.nlu_classifier(body.current_thread.text).entities,

--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -45,12 +45,9 @@ source: |
            or strings.icontains(.text, "protected message")
     )
     or any(body.current_thread.links,
-           regex.icontains(ml.link_analysis(.).final_dom.display_text,
-                           'secured? (message|directory|document) access'
-           )
-           or regex.icontains(ml.link_analysis(.).final_dom.inner_text,
-                              'secured? (message|directory|document) access'
-           )
+          regex.icontains(coalesce(ml.link_analysis(.).final_dom.display_text, ml.link_analysis(.).final_dom.inner_text),
+                          'secured? (?:message|directory|document) access'
+          )
     )
     or (
       length(filter(ml.nlu_classifier(body.current_thread.text).entities,

--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -45,11 +45,11 @@ source: |
            or strings.icontains(.text, "protected message")
     )
     or any(body.current_thread.links,
-           regex.icontains(coalesce(ml.link_analysis(.).final_dom.display_text,
-                                    ml.link_analysis(.).final_dom.inner_text
-                           ),
-                           'secured? (?:message|directory|document) access'
+           regex.icontains(ml.link_analysis(.).final_dom.display_text,
+                           'secured? (message|directory|document) access'
            )
+           or regex.icontains(ml.link_analysis(.).final_dom.inner_text,
+                           'secured? (message|directory|document) access'
     )
     or (
       length(filter(ml.nlu_classifier(body.current_thread.text).entities,

--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -49,7 +49,7 @@ source: |
                            'secured? (message|directory|document) access'
            )
            or regex.icontains(ml.link_analysis(.).final_dom.inner_text,
-                           'secured? (message|directory|document) access'
+                              'secured? (message|directory|document) access'
            )
     )
     or (
@@ -184,7 +184,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description
adds use of final DOM inner text for when display text isn't present 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507e8bc4965adc0c3876f0a96783e6de68abec9b3c6e69361686489829bbb913?preview_id=019e8c1c-c1e6-745c-bf3a-9cb3799d2ab7)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e930e-f834-70f2-8363-977841c8ad5b) - samples where inner text is present, display text is not 
- [multihunt](https://hunt.limeseed.email/hunts/d09a28b8-0b45-4f3e-b5b2-40f393a93a6c)

