### PR TITLE
Update suspicious_request_for_quote_or_purchase.yml

### DIFF
--- a/detection-rules/suspicious_request_for_quote_or_purchase.yml
+++ b/detection-rules/suspicious_request_for_quote_or_purchase.yml
@@ -222,6 +222,7 @@ source: |
       length(recipients.to) == 1
       and sender.email.email in map(recipients.to, .email.email)
     )
+    or (any(sender.decoders, . == "google_groups") and length(recipients.to) == 0)
   )
 attack_types:
   - "BEC/Fraud"


### PR DESCRIPTION
# Description
sender profile override for when the message arrives via a Google group and the recipient is null 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507e8bc4965adc0c3876f0a96783e6de68abec9b3c6e69361686489829bbb913?preview_id=019e8c1c-c1e6-745c-bf3a-9cb3799d2ab7)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- will need org specific hunts for this one

