### PR TITLE
Update body_business_email_compromise_new_sender.yml

### DIFF
--- a/detection-rules/body_business_email_compromise_new_sender.yml
+++ b/detection-rules/body_business_email_compromise_new_sender.yml
@@ -6,7 +6,7 @@ severity: "medium"
 source: |
   type.inbound
   and any(ml.nlu_classifier(body.current_thread.text).intents,
-          .name in ("bec") and .confidence == "high"
+          .name in ("bec") and .confidence in ("high", "medium")
   )
   // negating legit replies
   and not (


### PR DESCRIPTION
# Description
Increasing the scope/threshold for NLU confidence to help cover FNs.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/507ec8c991a9d141ec1d83e1b87f58193eef58b854944487f7ee081c2391ff3e?preview_id=019e8d1a-9545-723a-9ba8-ddc45c653c7b)
- [Sample 2](https://platform.sublime.security/messages/507d69da8e745f236ff02d6d5dc354a4ed62454cd458a8e9d5697e0f3f8b9356?preview_id=019e83da-018e-7843-ac1d-f38bde399ca7)

## Associated hunts
- [Hunt with only "medium"](https://platform.sublime.security/messages/hunt?huntId=019e8f32-ee3f-7309-8a07-454250613f87)
- [Hunt with only "high"](https://platform.sublime.security/messages/hunt?huntId=019e8f32-f5e4-7817-8f2a-4d1413e2716d)

These show roughly the same number of hits (obviously different messages).
