### PR TITLE
Create link_credential_phishing_cloudflare_tunnel_recipient_targeting…

### DIFF
--- a/detection-rules/link_credential_phishing_cloudflare_tunnel_recipient_targeting.yml
+++ b/detection-rules/link_credential_phishing_cloudflare_tunnel_recipient_targeting.yml
@@ -1,0 +1,23 @@
+name: "Link: Credential theft with Cloudflare tunnel and recipient targeting"
+description: "Detects messages containing credential theft language and links to trycloudflare.com tunnels that include the recipient's email address in the URL path, indicating personalized targeting for credential harvesting."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == 'cred_theft' and .confidence != 'low'
+  )
+  and any(body.current_thread.links,
+          .href_url.domain.root_domain == 'trycloudflare.com'
+          and strings.icontains(.href_url.path, recipients.to[0].email.email)
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Evasion"
+detection_methods:
+  - "Natural Language Understanding"
+  - "Content analysis"
+  - "URL analysis"

--- a/detection-rules/link_credential_phishing_cloudflare_tunnel_recipient_targeting.yml
+++ b/detection-rules/link_credential_phishing_cloudflare_tunnel_recipient_targeting.yml
@@ -21,3 +21,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Content analysis"
   - "URL analysis"
+id: "4d8919dd-238a-5381-b683-b4f5078e00da"


### PR DESCRIPTION
# Description
Detects messages containing credential theft language and links to trycloudflare.com tunnels that include the recipient's email address in the URL path.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507e4b4a393ff95ad17440968832e47acede3ec1cb14d6f77424895e9ba0f35b?preview_id=019e8ec0-4b9a-76d0-86ad-7411e95cbe1c)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [17 customer multihunt](https://hunt.limeseed.email/hunts/ecceafc9-71b6-469c-aedc-05f47cc510bb)
- [10 customer multihunt](https://hunt.limeseed.email/hunts/b696a193-9bfd-46b6-9c79-5982a557931f)
- [30 customer multihunt](https://hunt.limeseed.email/hunts/e4d52900-3d74-4255-b2e3-e8c30820ff00)
- [SWS hunt](https://platform.sublime.security/messages/hunt?huntId=019e8f5b-9401-7a4a-9903-b745e3945e07)
