### PR TITLE
Create open_redirect_mailtrack_korea.yml

### DIFF
--- a/detection-rules/open_redirect_mailtrack_korea.yml
+++ b/detection-rules/open_redirect_mailtrack_korea.yml
@@ -1,0 +1,24 @@
+name: "Open redirect: Mailtrack Korea"
+description: "Detects messages containing links to mailtrack.ksd.or.kr tracking service that redirect to external domains, potentially bypassing security controls through the legitimate Korean mail tracking infrastructure."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(body.links,
+          .href_url.domain.domain == "mailtrack.ksd.or.kr"
+          and .href_url.path == "/TMS/tracking"
+          and "url" in~ keys(.href_url.query_params_decoded)
+          and not any(regex.iextract(.href_url.query_params,
+                                     'url=([^&]+)(?:\&|\/|$)'
+                      ),
+                      strings.parse_url(.groups[0]).domain.root_domain == ..href_url.domain.root_domain
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Open redirect"
+  - "Evasion"
+detection_methods:
+  - "URL analysis"

--- a/detection-rules/open_redirect_mailtrack_korea.yml
+++ b/detection-rules/open_redirect_mailtrack_korea.yml
@@ -22,3 +22,4 @@ tactics_and_techniques:
   - "Evasion"
 detection_methods:
   - "URL analysis"
+id: "73210da5-12ca-5ebf-9135-edb5022ed6cb"


### PR DESCRIPTION
# Description
Detects messages containing links to mailtrack.ksd.or.kr tracking service that redirect to external domains, potentially bypassing security controls through the legitimate Korean mail tracking infrastructure.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/508080dfe8e9ed7f012a033b2a13bf6cae7e4ebc107a5e0034e2b7a688895b64?preview_id=019e9436-1325-7a55-97c8-aac00aa4d348)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e9458-a752-716b-b472-eb0f1c994e6b)
- [multi hunt](https://hunt.limeseed.email/hunts/ea1a76d7-a536-437e-b7e9-043e0a3f875a)