### PR TITLE
refactor rules to use headers.in_reply_to

### DIFF
--- a/detection-rules/attachment_adobe_image_lure.yml
+++ b/detection-rules/attachment_adobe_image_lure.yml
@@ -62,9 +62,7 @@ source: |
     (
       (
         length(headers.references) > 0
-        or not any(headers.hops,
-                   any(.fields, strings.ilike(.name, "In-Reply-To"))
-        )
+        or headers.in_reply_to is null
       )
       and not (
         (

--- a/detection-rules/attachment_adobe_image_lure.yml
+++ b/detection-rules/attachment_adobe_image_lure.yml
@@ -60,10 +60,7 @@ source: |
   )
   and (
     (
-      (
-        length(headers.references) > 0
-        or headers.in_reply_to is null
-      )
+      (length(headers.references) > 0 or headers.in_reply_to is null)
       and not (
         (
           strings.istarts_with(subject.subject, "RE:")
@@ -112,7 +109,6 @@ source: |
     )
   )
   and not profile.by_sender_email().any_messages_benign
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/attachment_callback_phish_with_pdf.yml
+++ b/detection-rules/attachment_callback_phish_with_pdf.yml
@@ -144,9 +144,7 @@ source: |
     (
       (
         length(headers.references) > 0
-        or not any(headers.hops,
-                   any(.fields, strings.ilike(.name, "In-Reply-To"))
-        )
+        or headers.in_reply_to is null
       )
       and not (
         (

--- a/detection-rules/attachment_callback_phish_with_pdf.yml
+++ b/detection-rules/attachment_callback_phish_with_pdf.yml
@@ -72,12 +72,12 @@ source: |
               )
             )
             // check that any _single_ result in the file.explode matches these conditions
-            // a second file.explode is required because the OCR is generated at a different depth within 
+            // a second file.explode is required because the OCR is generated at a different depth within
             // the file.explode results
             and (
               any(file.explode(.),
                   length(.scan.ocr.raw) > 60
-                  // 4 of the following strings are found        
+                  // 4 of the following strings are found
                   and 4 of (
                     // this section is synced with attachment_callback_phish_with_pdf.yml and body_callback_phishing_no_attachment.yml
                     strings.icontains(.scan.ocr.raw, "purchase"),
@@ -142,10 +142,7 @@ source: |
   )
   and (
     (
-      (
-        length(headers.references) > 0
-        or headers.in_reply_to is null
-      )
+      (length(headers.references) > 0 or headers.in_reply_to is null)
       and not (
         (
           strings.istarts_with(subject.subject, "RE:")

--- a/detection-rules/attachment_eml_html_attachment_portal.yml
+++ b/detection-rules/attachment_eml_html_attachment_portal.yml
@@ -21,7 +21,7 @@ source: |
     (length(headers.references) == 0 and headers.in_reply_to is null)
     or (
       not strings.istarts_with(subject.subject, "re:")
-      and not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+      and headers.in_reply_to is null
       and not any(headers.hops, strings.ilike(.signature.headers, "*:reply-to"))
     )
   )

--- a/detection-rules/attachment_fake_attachment_image.yml
+++ b/detection-rules/attachment_fake_attachment_image.yml
@@ -73,7 +73,7 @@ source: |
     )
     and (
       length(headers.references) > 0
-      or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+      or headers.in_reply_to is not null
     )
   )
   // negate highly trusted sender domains unless they fail DMARC authentication

--- a/detection-rules/attachment_fake_attachment_image.yml
+++ b/detection-rules/attachment_fake_attachment_image.yml
@@ -30,8 +30,8 @@ source: |
     or any(ml.logo_detect(file.message_screenshot()).brands,
            .name == "FakeAttachment" and .confidence == "high"
     )
-    
-    // Suspicious table with file size indicators 
+  
+    // Suspicious table with file size indicators
     or regex.contains(body.html.raw,
                       "<table[^>]*>.*?<img[^>]+src=[\"']cid:[^\"']+[\"'][^>]*>.*?\\.(pdf|doc(x)|xls(x)?).*?<font[^>]*>\\s*\\d{1,4}\\.\\d{1,2}\\s*k[bB]"
     )
@@ -71,10 +71,7 @@ source: |
                       '^\[?(EXT|EXTERNAL)\]?[: ]\s*(RE|FWD?|FW|AW|TR|ODG|答复):.*'
       )
     )
-    and (
-      length(headers.references) > 0
-      or headers.in_reply_to is not null
-    )
+    and (length(headers.references) > 0 or headers.in_reply_to is not null)
   )
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (

--- a/detection-rules/attachment_office365_image.yml
+++ b/detection-rules/attachment_office365_image.yml
@@ -84,9 +84,7 @@ source: |
     (
       (
         length(headers.references) > 0
-        or not any(headers.hops,
-                   any(.fields, strings.ilike(.name, "In-Reply-To"))
-        )
+        or headers.in_reply_to is null
       )
       and not (
         (

--- a/detection-rules/attachment_office365_image.yml
+++ b/detection-rules/attachment_office365_image.yml
@@ -82,10 +82,7 @@ source: |
   // negate replies
   and (
     (
-      (
-        length(headers.references) > 0
-        or headers.in_reply_to is null
-      )
+      (length(headers.references) > 0 or headers.in_reply_to is null)
       and not (
         (
           strings.istarts_with(subject.subject, "RE:")

--- a/detection-rules/attachment_vba_macro_auto_exec_unsolicited.yml
+++ b/detection-rules/attachment_vba_macro_auto_exec_unsolicited.yml
@@ -32,7 +32,7 @@ source: |
   // negate replies
   and (
     length(headers.references) == 0
-    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is null
   )
 attack_types:
   - "Malware/Ransomware"

--- a/detection-rules/attachment_vba_macro_auto_exec_unsolicited.yml
+++ b/detection-rules/attachment_vba_macro_auto_exec_unsolicited.yml
@@ -30,10 +30,7 @@ source: |
   )
   
   // negate replies
-  and (
-    length(headers.references) == 0
-    or headers.in_reply_to is null
-  )
+  and (length(headers.references) == 0 or headers.in_reply_to is null)
 attack_types:
   - "Malware/Ransomware"
 tactics_and_techniques:

--- a/detection-rules/bec_fraud_penpal_scam.yml
+++ b/detection-rules/bec_fraud_penpal_scam.yml
@@ -25,7 +25,7 @@ source: |
   // not a reply
   and (
     length(headers.references) == 0
-    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is null
   )
   
   // negate highly trusted sender domains unless they fail DMARC authentication

--- a/detection-rules/bec_fraud_penpal_scam.yml
+++ b/detection-rules/bec_fraud_penpal_scam.yml
@@ -23,10 +23,7 @@ source: |
   )
   
   // not a reply
-  and (
-    length(headers.references) == 0
-    or headers.in_reply_to is null
-  )
+  and (length(headers.references) == 0 or headers.in_reply_to is null)
   
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
@@ -36,7 +33,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:

--- a/detection-rules/body_advance_fee_new_sender.yml
+++ b/detection-rules/body_advance_fee_new_sender.yml
@@ -47,10 +47,7 @@ source: |
       )
       and (
         (
-          (
-            length(headers.references) > 0
-            or headers.in_reply_to is null
-          )
+          (length(headers.references) > 0 or headers.in_reply_to is null)
           and not (
             (
               strings.istarts_with(subject.subject, "RE:")

--- a/detection-rules/body_advance_fee_new_sender.yml
+++ b/detection-rules/body_advance_fee_new_sender.yml
@@ -49,9 +49,7 @@ source: |
         (
           (
             length(headers.references) > 0
-            or not any(headers.hops,
-                       any(.fields, strings.ilike(.name, "In-Reply-To"))
-            )
+            or headers.in_reply_to is null
           )
           and not (
             (

--- a/detection-rules/body_bec_mobile_solicitation.yml
+++ b/detection-rules/body_bec_mobile_solicitation.yml
@@ -38,9 +38,7 @@ source: |
     (
       (
         length(headers.references) > 0
-        or not any(headers.hops,
-                   any(.fields, strings.ilike(.name, "In-Reply-To"))
-        )
+        or headers.in_reply_to is null
       )
       and not (
         (

--- a/detection-rules/body_bec_mobile_solicitation.yml
+++ b/detection-rules/body_bec_mobile_solicitation.yml
@@ -36,10 +36,7 @@ source: |
   )
   and (
     (
-      (
-        length(headers.references) > 0
-        or headers.in_reply_to is null
-      )
+      (length(headers.references) > 0 or headers.in_reply_to is null)
       and not (
         (
           strings.istarts_with(subject.subject, "RE:")
@@ -63,7 +60,6 @@ source: |
     or profile.by_sender().any_messages_malicious_or_spam
   )
   and not profile.by_sender().any_messages_benign
-
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:

--- a/detection-rules/body_bec_mobile_solicitation_reply_thread.yml
+++ b/detection-rules/body_bec_mobile_solicitation_reply_thread.yml
@@ -64,10 +64,7 @@ source: |
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
   // Ensure this is likely a hijacked thread (sender doesn't match thread participants)
-  and (
-    length(headers.references) > 0
-    or headers.in_reply_to is not null
-  )
+  and (length(headers.references) > 0 or headers.in_reply_to is not null)
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:

--- a/detection-rules/body_bec_mobile_solicitation_reply_thread.yml
+++ b/detection-rules/body_bec_mobile_solicitation_reply_thread.yml
@@ -66,7 +66,7 @@ source: |
   // Ensure this is likely a hijacked thread (sender doesn't match thread participants)
   and (
     length(headers.references) > 0
-    or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is not null
   )
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/body_job_scam_freemail_pivot.yml
+++ b/detection-rules/body_job_scam_freemail_pivot.yml
@@ -19,7 +19,7 @@ source: |
     )
     and (
       (length(headers.references) == 0 and headers.in_reply_to is null)
-      or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+      or headers.in_reply_to is null
     )
   )
   and (

--- a/detection-rules/body_microsoft_logo_open_redirect.yml
+++ b/detection-rules/body_microsoft_logo_open_redirect.yml
@@ -50,7 +50,7 @@ source: |
   )
   and not (
     length(headers.references) > 0
-    or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is not null
   )
   and sender.email.domain.root_domain not in $org_domains
   and sender.email.domain.root_domain not in (

--- a/detection-rules/body_microsoft_logo_open_redirect.yml
+++ b/detection-rules/body_microsoft_logo_open_redirect.yml
@@ -48,10 +48,7 @@ source: |
           any(.href_url.rewrite.encoders, strings.icontains(., "open_redirect"))
           and not .href_url.domain.root_domain in $org_domains
   )
-  and not (
-    length(headers.references) > 0
-    or headers.in_reply_to is not null
-  )
+  and not (length(headers.references) > 0 or headers.in_reply_to is not null)
   and sender.email.domain.root_domain not in $org_domains
   and sender.email.domain.root_domain not in (
     "bing.com",
@@ -65,7 +62,6 @@ source: |
     "sharepointonline.com",
     "yammer.com"
   )
-
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:

--- a/detection-rules/brand_impersonation_enbridge.yml
+++ b/detection-rules/brand_impersonation_enbridge.yml
@@ -13,10 +13,7 @@ source: |
           strings.ilike(.display_text, "*pay now*", "*view your bill*")
   )
   // negate replies
-  and (
-    length(headers.references) == 0
-    or headers.in_reply_to is null
-  )
+  and (length(headers.references) == 0 or headers.in_reply_to is null)
   and sender.email.domain.root_domain not in~ (
     'enbridge.com',
     'enbridgegas.com',
@@ -24,7 +21,6 @@ source: |
     'domenergyoheb.com', // Dominion Energy Ohio
     'domenergyuteb.com' // Dominion Energy Utah
   )
-
 attack_types:
   - "BEC/Fraud"
   - "Credential Phishing"

--- a/detection-rules/brand_impersonation_enbridge.yml
+++ b/detection-rules/brand_impersonation_enbridge.yml
@@ -15,7 +15,7 @@ source: |
   // negate replies
   and (
     length(headers.references) == 0
-    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is null
   )
   and sender.email.domain.root_domain not in~ (
     'enbridge.com',

--- a/detection-rules/brand_impersonation_ms_planner.yml
+++ b/detection-rules/brand_impersonation_ms_planner.yml
@@ -63,10 +63,7 @@ source: |
    )
    
    // not a reply
-   and (
-     length(headers.references) == 0
-     or headers.in_reply_to is null
-   )
+   and (length(headers.references) == 0 or headers.in_reply_to is null)
    
    // Planner logo
    // LogoDetect coming soon
@@ -144,7 +141,6 @@ source: |
    and not regex.icontains(body.current_thread.text,
                            '(schedul(e|ing)|set up).{0,20}(call|meeting|demo|zoom|conversation|time|tool|discussion)|book.{0,10}(meeting|demo|call|slot|time)|connect.{0,12}(with me|phone|email)|my.{0,10}(calendar|cal)|reserve.{0,10}s[pl]ot|break the ice|want to know more?|miss your chance|if you no longer wish|if you no longer want|if you wish to opt out|low-code (development|approach|solution|journey|platform)|invite.{0,30}(webinar|presentation)'
    )
-   
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/brand_impersonation_ms_planner.yml
+++ b/detection-rules/brand_impersonation_ms_planner.yml
@@ -65,7 +65,7 @@ source: |
    // not a reply
    and (
      length(headers.references) == 0
-     or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+     or headers.in_reply_to is null
    )
    
    // Planner logo

--- a/detection-rules/brand_impersonation_procore.yml
+++ b/detection-rules/brand_impersonation_procore.yml
@@ -36,7 +36,7 @@ source: |
     )
     and (
       length(headers.references) > 0
-      and any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+      and headers.in_reply_to is not null
     )
   )
   // negate bounce backs

--- a/detection-rules/brand_impersonation_procore.yml
+++ b/detection-rules/brand_impersonation_procore.yml
@@ -34,10 +34,7 @@ source: |
       )
       or strings.istarts_with(subject.subject, "Réponse automatique")
     )
-    and (
-      length(headers.references) > 0
-      and headers.in_reply_to is not null
-    )
+    and (length(headers.references) > 0 and headers.in_reply_to is not null)
   )
   // negate bounce backs
   and not (
@@ -54,7 +51,6 @@ source: |
             )
     )
   )
-
 attack_types:
   - "BEC/Fraud"
   - "Credential Phishing"

--- a/detection-rules/brand_impersonation_robinhood.yml
+++ b/detection-rules/brand_impersonation_robinhood.yml
@@ -69,10 +69,7 @@ source: |
   // negate legitimate replies and forwards
   and (
     (
-      (
-        length(headers.references) > 0
-        or headers.in_reply_to is null
-      )
+      (length(headers.references) > 0 or headers.in_reply_to is null)
       and not (subject.is_reply or subject.is_forward)
     )
     or length(headers.references) == 0
@@ -100,7 +97,6 @@ source: |
     )
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/brand_impersonation_robinhood.yml
+++ b/detection-rules/brand_impersonation_robinhood.yml
@@ -71,9 +71,7 @@ source: |
     (
       (
         length(headers.references) > 0
-        or not any(headers.hops,
-                   any(.fields, strings.ilike(.name, "In-Reply-To"))
-        )
+        or headers.in_reply_to is null
       )
       and not (subject.is_reply or subject.is_forward)
     )

--- a/detection-rules/brand_impersonation_zoom.yml
+++ b/detection-rules/brand_impersonation_zoom.yml
@@ -99,7 +99,7 @@ source: |
     )
     and (
       length(headers.references) > 0
-      or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+      or headers.in_reply_to is not null
     )
   )
   // Not from a legitimate Zoom domain

--- a/detection-rules/brand_impersonation_zoom.yml
+++ b/detection-rules/brand_impersonation_zoom.yml
@@ -76,7 +76,7 @@ source: |
       )
     )
   )
-  // negate auto-generated meeting summaries 
+  // negate auto-generated meeting summaries
   and not (
     strings.icontains(body.current_thread.text, "meeting summary")
     and strings.icontains(body.current_thread.text,
@@ -97,10 +97,7 @@ source: |
                       '^\[?(EXT|EXTERNAL)\]?[: ]\s*(RE|FWD?|FW|AW|TR|ODG|答复):.*'
       )
     )
-    and (
-      length(headers.references) > 0
-      or headers.in_reply_to is not null
-    )
+    and (length(headers.references) > 0 or headers.in_reply_to is not null)
   )
   // Not from a legitimate Zoom domain
   and not (
@@ -113,7 +110,6 @@ source: |
     )
     and headers.auth_summary.dmarc.pass
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/cc_infra_abuse.yml
+++ b/detection-rules/cc_infra_abuse.yml
@@ -98,10 +98,7 @@ source: |
                       '(\[[^\]]+\]\s?){0,3}(re|fwd?|automat.*)\s?:.*'
       )
     )
-    and (
-      length(headers.references) > 0
-      or headers.in_reply_to is not null
-    )
+    and (length(headers.references) > 0 or headers.in_reply_to is not null)
   )
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
@@ -112,7 +109,6 @@ source: |
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
   and profile.by_sender().prevalence in ("new", "outlier", "rare")
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/cc_infra_abuse.yml
+++ b/detection-rules/cc_infra_abuse.yml
@@ -100,7 +100,7 @@ source: |
     )
     and (
       length(headers.references) > 0
-      or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+      or headers.in_reply_to is not null
     )
   )
   // negate highly trusted sender domains unless they fail DMARC authentication

--- a/detection-rules/clickfunnels_infra_abuse.yml
+++ b/detection-rules/clickfunnels_infra_abuse.yml
@@ -95,7 +95,7 @@ source: |
     )
     and (
       length(headers.references) > 0
-      and any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+      and headers.in_reply_to is not null
     )
   )
   // negate highly trusted sender domains unless they fail DMARC authentication

--- a/detection-rules/clickfunnels_infra_abuse.yml
+++ b/detection-rules/clickfunnels_infra_abuse.yml
@@ -93,10 +93,7 @@ source: |
       or strings.istarts_with(subject.subject, "FWD:")
       or strings.istarts_with(subject.subject, "Automatic reply:")
     )
-    and (
-      length(headers.references) > 0
-      and headers.in_reply_to is not null
-    )
+    and (length(headers.references) > 0 and headers.in_reply_to is not null)
   )
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (

--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -105,7 +105,7 @@ source: |
   // negate legit replies
   and not (
     length(headers.references) > 0
-    or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is not null
   )
   and not profile.by_sender().any_messages_benign
   

--- a/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
+++ b/detection-rules/credential_phishing_docusign_embedded_image_lure.yml
@@ -85,7 +85,7 @@ source: |
     )
   )
   
-  // links with null display_text that do not go to docusign.* (indicative of hyperlinked image) or the display text contains DOCUMENT 
+  // links with null display_text that do not go to docusign.* (indicative of hyperlinked image) or the display text contains DOCUMENT
   and (
     not profile.by_sender().solicited
     or (
@@ -103,10 +103,7 @@ source: |
   )
   
   // negate legit replies
-  and not (
-    length(headers.references) > 0
-    or headers.in_reply_to is not null
-  )
+  and not (length(headers.references) > 0 or headers.in_reply_to is not null)
   and not profile.by_sender().any_messages_benign
   
   // negate docusign X-Return-Path

--- a/detection-rules/credential_phishing_docusign_html_table_forgery.yml
+++ b/detection-rules/credential_phishing_docusign_html_table_forgery.yml
@@ -78,10 +78,7 @@ source: |
   )
   
   // negate legit replies
-  and not (
-    length(headers.references) > 0
-    or headers.in_reply_to is not null
-  )
+  and not (length(headers.references) > 0 or headers.in_reply_to is not null)
   and not profile.by_sender().any_messages_benign
   
   // negate docusign X-Return-Path
@@ -92,7 +89,6 @@ source: |
                       and strings.ends_with(.value, "docusign.net")
               )
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/credential_phishing_docusign_html_table_forgery.yml
+++ b/detection-rules/credential_phishing_docusign_html_table_forgery.yml
@@ -80,7 +80,7 @@ source: |
   // negate legit replies
   and not (
     length(headers.references) > 0
-    or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is not null
   )
   and not profile.by_sender().any_messages_benign
   

--- a/detection-rules/credential_phishing_esign_document_notification.yml
+++ b/detection-rules/credential_phishing_esign_document_notification.yml
@@ -267,7 +267,7 @@ source: |
   // negate replies/fowards containing legitimate docs
   and not (
     length(headers.references) > 0
-    or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is not null
   )
   
   // negate highly trusted sender domains unless they fail DMARC authentication

--- a/detection-rules/credential_phishing_esign_document_notification.yml
+++ b/detection-rules/credential_phishing_esign_document_notification.yml
@@ -265,10 +265,7 @@ source: |
   )
   
   // negate replies/fowards containing legitimate docs
-  and not (
-    length(headers.references) > 0
-    or headers.in_reply_to is not null
-  )
+  and not (length(headers.references) > 0 or headers.in_reply_to is not null)
   
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (

--- a/detection-rules/credential_phishing_suspicious_subject_nlu_financial_urgent.yml
+++ b/detection-rules/credential_phishing_suspicious_subject_nlu_financial_urgent.yml
@@ -263,7 +263,7 @@ source: |
   // not a reply
   and (
     not strings.istarts_with(subject.subject, "re:")
-    and not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    and headers.in_reply_to is null
   )
   
   // the message is unsolicited and no false positives

--- a/detection-rules/francais_business_email_compromise_new_sender.yml
+++ b/detection-rules/francais_business_email_compromise_new_sender.yml
@@ -28,7 +28,7 @@ source: |
     )
     and (
       length(headers.references) > 0
-      or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+      or headers.in_reply_to is not null
     )
   )
   and (

--- a/detection-rules/francais_business_email_compromise_new_sender.yml
+++ b/detection-rules/francais_business_email_compromise_new_sender.yml
@@ -26,10 +26,7 @@ source: |
                       '(\[[^\]]+\]\s?){0,3}(re|fwd?|automat.*)\s?:.*'
       )
     )
-    and (
-      length(headers.references) > 0
-      or headers.in_reply_to is not null
-    )
+    and (length(headers.references) > 0 or headers.in_reply_to is not null)
   )
   and (
     not profile.by_sender().solicited
@@ -47,7 +44,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:

--- a/detection-rules/headers_freemail_replyto_returnpath_mismatch.yml
+++ b/detection-rules/headers_freemail_replyto_returnpath_mismatch.yml
@@ -44,7 +44,7 @@ source: |
   // negate legit replies
   and not (
     length(headers.references) > 0
-    or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is not null
   )
   
   // legitimate quickbooks from known sender

--- a/detection-rules/headers_freemail_replyto_returnpath_mismatch.yml
+++ b/detection-rules/headers_freemail_replyto_returnpath_mismatch.yml
@@ -42,10 +42,7 @@ source: |
   )
   
   // negate legit replies
-  and not (
-    length(headers.references) > 0
-    or headers.in_reply_to is not null
-  )
+  and not (length(headers.references) > 0 or headers.in_reply_to is not null)
   
   // legitimate quickbooks from known sender
   and not (
@@ -58,7 +55,6 @@ source: |
       "common"
     )
   )
-
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:

--- a/detection-rules/hr_impersonation_docusign_comment.yml
+++ b/detection-rules/hr_impersonation_docusign_comment.yml
@@ -58,10 +58,7 @@ source: |
   and not (all(headers.reply_to, .email.domain.root_domain in $org_domains))
   
   // Negate replies
-  and (
-    length(headers.references) == 0
-    or headers.in_reply_to is null
-  )
+  and (length(headers.references) == 0 or headers.in_reply_to is null)
 attack_types:
   - "BEC/Fraud"
   - "Credential Phishing"

--- a/detection-rules/hr_impersonation_docusign_comment.yml
+++ b/detection-rules/hr_impersonation_docusign_comment.yml
@@ -60,7 +60,7 @@ source: |
   // Negate replies
   and (
     length(headers.references) == 0
-    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is null
   )
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/impersonation_adobe_suspicious_language_link.yml
+++ b/detection-rules/impersonation_adobe_suspicious_language_link.yml
@@ -85,9 +85,7 @@ source: |
     (
       (
         length(headers.references) > 0
-        or not any(headers.hops,
-                   any(.fields, strings.ilike(.name, "In-Reply-To"))
-        )
+        or headers.in_reply_to is null
       )
       and not (
         (

--- a/detection-rules/impersonation_adobe_suspicious_language_link.yml
+++ b/detection-rules/impersonation_adobe_suspicious_language_link.yml
@@ -83,10 +83,7 @@ source: |
   // Negate replies & forwards
   and (
     (
-      (
-        length(headers.references) > 0
-        or headers.in_reply_to is null
-      )
+      (length(headers.references) > 0 or headers.in_reply_to is null)
       and not (
         (
           strings.istarts_with(subject.subject, "RE:")
@@ -151,7 +148,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/impersonation_benefits_enrollment.yml
+++ b/detection-rules/impersonation_benefits_enrollment.yml
@@ -76,7 +76,7 @@ source: |
   // negate replies
   and (
     length(headers.references) == 0
-    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is null
   )
   
   // Negate common marketing mailers

--- a/detection-rules/impersonation_benefits_enrollment.yml
+++ b/detection-rules/impersonation_benefits_enrollment.yml
@@ -74,10 +74,7 @@ source: |
     )
   )
   // negate replies
-  and (
-    length(headers.references) == 0
-    or headers.in_reply_to is null
-  )
+  and (length(headers.references) == 0 or headers.in_reply_to is null)
   
   // Negate common marketing mailers
   and not regex.icontains(sender.display_name,

--- a/detection-rules/impersonation_capitalone.yml
+++ b/detection-rules/impersonation_capitalone.yml
@@ -212,7 +212,7 @@ source: |
     )
     and (
       length(headers.references) > 0
-      and any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+      and headers.in_reply_to is not null
     )
   )
   // negate bounce backs

--- a/detection-rules/impersonation_capitalone.yml
+++ b/detection-rules/impersonation_capitalone.yml
@@ -210,10 +210,7 @@ source: |
       )
       or strings.istarts_with(subject.subject, "Réponse automatique")
     )
-    and (
-      length(headers.references) > 0
-      and headers.in_reply_to is not null
-    )
+    and (length(headers.references) > 0 and headers.in_reply_to is not null)
   )
   // negate bounce backs
   and not (

--- a/detection-rules/impersonation_dhl.yml
+++ b/detection-rules/impersonation_dhl.yml
@@ -68,10 +68,7 @@ source: |
   )
   and (
     (
-      (
-        length(headers.references) > 0
-        or headers.in_reply_to is null
-      )
+      (length(headers.references) > 0 or headers.in_reply_to is null)
       and not (
         (
           strings.istarts_with(subject.subject, "RE:")
@@ -140,7 +137,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/impersonation_dhl.yml
+++ b/detection-rules/impersonation_dhl.yml
@@ -70,9 +70,7 @@ source: |
     (
       (
         length(headers.references) > 0
-        or not any(headers.hops,
-                   any(.fields, strings.ilike(.name, "In-Reply-To"))
-        )
+        or headers.in_reply_to is null
       )
       and not (
         (

--- a/detection-rules/impersonation_google_groups_suspicious.yml
+++ b/detection-rules/impersonation_google_groups_suspicious.yml
@@ -47,9 +47,7 @@ source: |
       (subject.is_forward or subject.is_reply)
       and (
         (length(headers.references) == 0 and headers.in_reply_to is null)
-        or not any(headers.hops,
-                   any(.fields, strings.ilike(.name, "In-Reply-To"))
-        )
+        or headers.in_reply_to is null
       )
     ),
   

--- a/detection-rules/impersonation_human_resources.yml
+++ b/detection-rules/impersonation_human_resources.yml
@@ -30,7 +30,7 @@ source: |
   // negate replies
   and (
     length(headers.references) == 0
-    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is null
   )
   // Negate common marketing mailers
   and not (

--- a/detection-rules/impersonation_human_resources.yml
+++ b/detection-rules/impersonation_human_resources.yml
@@ -28,10 +28,7 @@ source: |
   )
   
   // negate replies
-  and (
-    length(headers.references) == 0
-    or headers.in_reply_to is null
-  )
+  and (length(headers.references) == 0 or headers.in_reply_to is null)
   // Negate common marketing mailers
   and not (
     sender.display_name is not null

--- a/detection-rules/impersonation_okta.yml
+++ b/detection-rules/impersonation_okta.yml
@@ -11,7 +11,7 @@ source: |
   )
   and not (
     length(headers.references) > 0
-    or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is not null
   )
   and not (
     sender.email.domain.root_domain in~ (

--- a/detection-rules/impersonation_okta.yml
+++ b/detection-rules/impersonation_okta.yml
@@ -9,10 +9,7 @@ source: |
     or strings.ilike(sender.email.domain.domain, '*Okta*')
     or strings.ilike(subject.subject, '*Okta*')
   )
-  and not (
-    length(headers.references) > 0
-    or headers.in_reply_to is not null
-  )
+  and not (length(headers.references) > 0 or headers.in_reply_to is not null)
   and not (
     sender.email.domain.root_domain in~ (
       'oktacdn.com',
@@ -47,7 +44,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/link_credential_phishing.yml
+++ b/detection-rules/link_credential_phishing.yml
@@ -44,7 +44,7 @@ source: |
     )
     and (
       length(headers.references) > 0
-      or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+      or headers.in_reply_to is not null
     )
   )
   // negate highly trusted sender domains unless they fail DMARC authentication

--- a/detection-rules/link_credential_phishing.yml
+++ b/detection-rules/link_credential_phishing.yml
@@ -42,10 +42,7 @@ source: |
       // out of office auto-reply
       or strings.istarts_with(subject.subject, "Automatic reply:")
     )
-    and (
-      length(headers.references) > 0
-      or headers.in_reply_to is not null
-    )
+    and (length(headers.references) > 0 or headers.in_reply_to is not null)
   )
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
@@ -67,8 +64,6 @@ source: |
   // if the "References" is in the body of the message, it's probably a bounce
   and not any(headers.references, strings.contains(body.html.display_text, .))
   and not profile.by_sender().any_messages_benign
-
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -484,9 +484,7 @@ source: |
     (
       (
         length(headers.references) > 0
-        or not any(headers.hops,
-                   any(.fields, strings.ilike(.name, "In-Reply-To"))
-        )
+        or headers.in_reply_to is null
       )
       and not (
         (

--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -482,10 +482,7 @@ source: |
   // negate replies
   and (
     (
-      (
-        length(headers.references) > 0
-        or headers.in_reply_to is null
-      )
+      (length(headers.references) > 0 or headers.in_reply_to is null)
       and not (
         (
           strings.istarts_with(subject.subject, "RE:")

--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -616,10 +616,7 @@ source: |
       // the NLU model will handle these better natively soon
       or strings.istarts_with(subject.subject, "Automatic reply:")
     )
-    and (
-      length(headers.references) > 0
-      or headers.in_reply_to is not null
-    )
+    and (length(headers.references) > 0 or headers.in_reply_to is not null)
   )
   // bounce-back negations
   and not any(attachments,

--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -618,7 +618,7 @@ source: |
     )
     and (
       length(headers.references) > 0
-      or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+      or headers.in_reply_to is not null
     )
   )
   // bounce-back negations

--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -16,7 +16,7 @@ source: |
                .scan.entropy.entropy > 7 and length(.scan.ocr.raw) < 20
            )
     )
-    // or there are duplicate pdfs in name 
+    // or there are duplicate pdfs in name
     or (
       length(filter(attachments, .file_type == "pdf")) > length(distinct(filter(attachments,
                                                                                 .file_type == "pdf"
@@ -48,7 +48,7 @@ source: |
     )
   )
   
-  // body contains expire, expiration, loose, lose 
+  // body contains expire, expiration, loose, lose
   and (
     regex.icontains(body.current_thread.text,
                     '(expir(e(d|s)?|ation|s)?|\blo(o)?se\b|(?:offices?|microsoft).365|re.{0,3}confirm)|due for update'
@@ -189,10 +189,7 @@ source: |
   )
   
   // not a reply
-  and (
-    length(headers.references) == 0
-    or headers.in_reply_to is null
-  )
+  and (length(headers.references) == 0 or headers.in_reply_to is null)
   
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (

--- a/detection-rules/link_fake_password_expiration.yml
+++ b/detection-rules/link_fake_password_expiration.yml
@@ -191,7 +191,7 @@ source: |
   // not a reply
   and (
     length(headers.references) == 0
-    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is null
   )
   
   // negate highly trusted sender domains unless they fail DMARC authentication

--- a/detection-rules/link_fake_thread_nlu_financial_request.yml
+++ b/detection-rules/link_fake_thread_nlu_financial_request.yml
@@ -12,7 +12,7 @@ source: |
   // Check for the Presence of References or In-Reply-To properties
   and (
     (length(headers.references) == 0 and headers.in_reply_to is null)
-    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is null
   )
   
   // sender's domain is not in body, and body has > 0 links

--- a/detection-rules/link_fake_zoom_invite.yml
+++ b/detection-rules/link_fake_zoom_invite.yml
@@ -68,7 +68,7 @@ source: |
     or subject.is_forward
     and (
       length(headers.references) > 0
-      or any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+      or headers.in_reply_to is not null
     )
   )
   // Not from a legitimate Zoom domain

--- a/detection-rules/link_fake_zoom_invite.yml
+++ b/detection-rules/link_fake_zoom_invite.yml
@@ -56,7 +56,7 @@ source: |
     )
   )
   
-  // negate auto-generated meeting summaries 
+  // negate auto-generated meeting summaries
   and not (
     strings.icontains(body.current_thread.text, "meeting summary")
     and strings.icontains(body.current_thread.text,
@@ -66,10 +66,7 @@ source: |
   and not (
     subject.is_reply
     or subject.is_forward
-    and (
-      length(headers.references) > 0
-      or headers.in_reply_to is not null
-    )
+    and (length(headers.references) > 0 or headers.in_reply_to is not null)
   )
   // Not from a legitimate Zoom domain
   and not (
@@ -82,7 +79,6 @@ source: |
     )
     and headers.auth_summary.dmarc.pass
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/link_google_open_redirect_with_suspicious_indicators.yml
+++ b/detection-rules/link_google_open_redirect_with_suspicious_indicators.yml
@@ -25,7 +25,7 @@ source: |
   // not a reply
   and (
     length(headers.references) == 0
-    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is null
   )
   // With a Google Redirect
   and any(body.links,

--- a/detection-rules/link_google_open_redirect_with_suspicious_indicators.yml
+++ b/detection-rules/link_google_open_redirect_with_suspicious_indicators.yml
@@ -23,10 +23,7 @@ source: |
     and headers.auth_summary.dmarc.pass
   )
   // not a reply
-  and (
-    length(headers.references) == 0
-    or headers.in_reply_to is null
-  )
+  and (length(headers.references) == 0 or headers.in_reply_to is null)
   // With a Google Redirect
   and any(body.links,
           (

--- a/detection-rules/link_microsoft_low_reputation.yml
+++ b/detection-rules/link_microsoft_low_reputation.yml
@@ -5,7 +5,7 @@ severity: "medium"
 source: |
  type.inbound
  and 0 < length(body.links) < 50
- // suspicious link 
+ // suspicious link
  and any(body.links,
          (
            .href_url.domain.tld == "ru"
@@ -72,10 +72,7 @@ source: |
  )
  
  // not a reply
- and (
-   length(headers.references) == 0
-   or headers.in_reply_to is null
- )
+ and (length(headers.references) == 0 or headers.in_reply_to is null)
  
  // Microsoft logo
  and (

--- a/detection-rules/link_microsoft_low_reputation.yml
+++ b/detection-rules/link_microsoft_low_reputation.yml
@@ -74,7 +74,7 @@ source: |
  // not a reply
  and (
    length(headers.references) == 0
-   or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+   or headers.in_reply_to is null
  )
  
  // Microsoft logo

--- a/detection-rules/spam_blackbaud_infrastructure_abuse.yml
+++ b/detection-rules/spam_blackbaud_infrastructure_abuse.yml
@@ -10,7 +10,7 @@ source: |
   and regex.imatch(subject.subject, 'RE\s?:.*')
   and (
     length(headers.references) == 0
-    or not any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+    or headers.in_reply_to is null
   )
   and any(body.links, .display_text is null)
 attack_types:

--- a/detection-rules/spam_blackbaud_infrastructure_abuse.yml
+++ b/detection-rules/spam_blackbaud_infrastructure_abuse.yml
@@ -8,10 +8,7 @@ source: |
   and any(headers.hops, any(.fields, strings.ilike(.name, "x-campaignid")))
   and any(headers.domains, strings.contains(.domain, "blackbaud.com"))
   and regex.imatch(subject.subject, 'RE\s?:.*')
-  and (
-    length(headers.references) == 0
-    or headers.in_reply_to is null
-  )
+  and (length(headers.references) == 0 or headers.in_reply_to is null)
   and any(body.links, .display_text is null)
 attack_types:
   - "Spam"

--- a/detection-rules/spam_fake_photo_share.yml
+++ b/detection-rules/spam_fake_photo_share.yml
@@ -149,10 +149,7 @@ source: |
   )
   and (
     (
-      (
-        length(headers.references) > 0
-        or headers.in_reply_to is null
-      )
+      (length(headers.references) > 0 or headers.in_reply_to is null)
       and not (
         (
           strings.istarts_with(subject.subject, "RE:")

--- a/detection-rules/spam_fake_photo_share.yml
+++ b/detection-rules/spam_fake_photo_share.yml
@@ -151,9 +151,7 @@ source: |
     (
       (
         length(headers.references) > 0
-        or not any(headers.hops,
-                   any(.fields, strings.ilike(.name, "In-Reply-To"))
-        )
+        or headers.in_reply_to is null
       )
       and not (
         (

--- a/detection-rules/spam_onmicrosoft.yml
+++ b/detection-rules/spam_onmicrosoft.yml
@@ -40,7 +40,7 @@ source: |
     )
     and (
       length(headers.references) > 0
-      and any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))
+      and headers.in_reply_to is not null
     )
   )
   // negating auto-replies

--- a/detection-rules/spam_onmicrosoft.yml
+++ b/detection-rules/spam_onmicrosoft.yml
@@ -38,10 +38,7 @@ source: |
       )
       or strings.istarts_with(subject.subject, "Réponse automatique")
     )
-    and (
-      length(headers.references) > 0
-      and headers.in_reply_to is not null
-    )
+    and (length(headers.references) > 0 and headers.in_reply_to is not null)
   )
   // negating auto-replies
   and not (

--- a/detection-rules/spam_single_recipient_duplicated_in_cc.yml
+++ b/detection-rules/spam_single_recipient_duplicated_in_cc.yml
@@ -87,9 +87,7 @@ source: |
       regex.imatch(subject.subject, '(\[[^\]]+\]\s?){0,3}(re|fwd?)\s?:.*')
       and (
         (length(headers.references) == 0 and headers.in_reply_to is null)
-        or not any(headers.hops,
-                   any(.fields, strings.ilike(.name, "In-Reply-To"))
-        )
+        or headers.in_reply_to is null
       )
     )
   )

--- a/detection-rules/vip_impersonation_charity.yml
+++ b/detection-rules/vip_impersonation_charity.yml
@@ -25,9 +25,7 @@ source: |
       (subject.is_forward or subject.is_reply)
       and (
         (length(headers.references) == 0 and headers.in_reply_to is null)
-        or not any(headers.hops,
-                   any(.fields, strings.ilike(.name, "In-Reply-To"))
-        )
+        or headers.in_reply_to is null
       )
     )
     // fake thread, but no indication in the subject line


### PR DESCRIPTION

# Description
As part of looking at rules logic that attempts to determine if a message is a reply, i noticed many rules used an outdated pattern 
This PR replaces the  use of `any(headers.hops, any(.fields, strings.ilike(.name, "In-Reply-To")))` with `headers.in_reply_to`
