### PR TITLE
Retry transient API failures in Auto-format MQL step

### DIFF
--- a/.github/scripts/mql_format.py
+++ b/.github/scripts/mql_format.py
@@ -75,11 +75,8 @@ def format_source(source: str) -> str:
                 error.response = resp
                 raise error
 
-            if resp.status_code in RETRYABLE_STATUSES:
-                error = requests.HTTPError(f"{resp.status_code} Server Error")
-                error.response = resp
-                raise error
-
+            # Let requests build the HTTPError (accurate reason phrase + URL).
+            # The handler below decides whether the status is retryable.
             resp.raise_for_status()
             return resp.json()["source"]
         except requests.HTTPError as e:
@@ -96,8 +93,14 @@ def format_source(source: str) -> str:
             delay = RETRY_BASE_DELAY * (2 ** attempt) + random.uniform(0, 1)
             time.sleep(delay)
 
-    # Retry budget exhausted - propagate the last error to the caller.
-    raise last_exc
+    # Retry budget exhausted - propagate the last error to the caller. The
+    # guard keeps typing/control flow unambiguous; last_exc is only None if the
+    # loop never ran (e.g. a misconfigured MAX_RETRIES <= 0).
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError(
+        f"format_source made no attempts (MAX_RETRIES={MAX_RETRIES})"
+    )
 
 
 def extract_source(content: str) -> str | None:

--- a/.github/scripts/mql_format.py
+++ b/.github/scripts/mql_format.py
@@ -12,6 +12,8 @@ Usage:
 
 import sys
 import re
+import time
+import random
 import argparse
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -31,6 +33,14 @@ except ImportError:
 API_URL = "https://play.sublime.security/v1/rules/format"
 MAX_WORKERS = 100
 
+# Retry config for transient API failures (e.g. intermittent 403s from the
+# edge/WAF under the high-concurrency fan-out, rate limiting, gateway errors).
+MAX_RETRIES = 4
+RETRY_BASE_DELAY = 1.0  # seconds; exponential backoff with jitter
+# Transient statuses worth retrying. 500 is intentionally excluded: it's a
+# deterministic API bug with empty comment lines, so retrying never helps.
+RETRYABLE_STATUSES = {403, 429, 502, 503, 504}
+
 # Files to exclude from formatting (e.g., special comment formatting)
 EXCLUDE_FILES = {
     "attachment_cve_2023_38831.yml",
@@ -38,22 +48,56 @@ EXCLUDE_FILES = {
 
 
 def format_source(source: str) -> str:
-    """Format MQL source using the Sublime API."""
-    resp = requests.post(API_URL, json={
-        "source": source,
-        "max_line_width": 80,
-        "indent": 2,
-        "prefer_multi_line_root": True,
-    }, timeout=30)
+    """Format MQL source using the Sublime API.
 
-    # Handle 500 errors gracefully - this is a known API bug with empty comment lines
-    if resp.status_code == 500:
-        error = requests.HTTPError("500 Server Error")
-        error.response = resp
-        raise error
+    Retries on transient failures (see RETRYABLE_STATUSES and connection-level
+    errors) with exponential backoff plus jitter. The jitter matters because up
+    to MAX_WORKERS requests fan out concurrently, so a synchronized retry would
+    just re-trigger the same edge throttling. 500s are not retried (known
+    deterministic API bug) and are raised immediately for graceful per-file
+    handling upstream.
+    """
+    last_exc: Exception | None = None
 
-    resp.raise_for_status()
-    return resp.json()["source"]
+    for attempt in range(MAX_RETRIES):
+        try:
+            resp = requests.post(API_URL, json={
+                "source": source,
+                "max_line_width": 80,
+                "indent": 2,
+                "prefer_multi_line_root": True,
+            }, timeout=30)
+
+            # Handle 500 errors gracefully - this is a known API bug with empty
+            # comment lines. Not retryable, so surface it immediately.
+            if resp.status_code == 500:
+                error = requests.HTTPError("500 Server Error")
+                error.response = resp
+                raise error
+
+            if resp.status_code in RETRYABLE_STATUSES:
+                error = requests.HTTPError(f"{resp.status_code} Server Error")
+                error.response = resp
+                raise error
+
+            resp.raise_for_status()
+            return resp.json()["source"]
+        except requests.HTTPError as e:
+            status = getattr(getattr(e, "response", None), "status_code", None)
+            if status not in RETRYABLE_STATUSES:
+                raise
+            last_exc = e
+        except requests.RequestException as e:
+            # Connection errors, timeouts, etc. - transient, worth retrying.
+            last_exc = e
+
+        # Don't sleep after the final attempt.
+        if attempt < MAX_RETRIES - 1:
+            delay = RETRY_BASE_DELAY * (2 ** attempt) + random.uniform(0, 1)
+            time.sleep(delay)
+
+    # Retry budget exhausted - propagate the last error to the caller.
+    raise last_exc
 
 
 def extract_source(content: str) -> str | None:


### PR DESCRIPTION
## What

Adds bounded retry-with-backoff to `format_source()` in `.github/scripts/mql_format.py`, the script run by the **Auto-format MQL** step in `rule-validate.yml`.

## Why

The Auto-format MQL CI step has been hitting **intermittent 403s** from the `play.sublime.security/v1/rules/format` endpoint — most likely edge/WAF throttling triggered by the 100-worker `ThreadPoolExecutor` fan-out. `format_source()` previously made a single POST with no retries, so one transient 403 failed the entire job.

## How

Wrapped the POST in a retry loop:

- **Up to 4 attempts**, exponential backoff (`1·2^n` s) plus up to 1s random **jitter**. The jitter is deliberate — with up to 100 concurrent workers, a synchronized backoff would just re-trip the same throttle.
- **Retries on** `403`, `429`, `502`, `503`, `504`, and connection-level errors (timeouts/dropped connections). `resp.raise_for_status()` builds the `HTTPError`; the handler decides retryability from the status code.
- **`500` stays non-retryable** — it's the documented deterministic empty-comment-line API bug, so it still flows to the graceful per-file "skipped" warning.
- **Non-retryable 4xx** (e.g. 404) still fail fast.
- An **exhausted retry budget propagates the last error** (guarded against `None`), so the job still fails loudly rather than silently succeeding.

### Worst-case timing

Sleeps only happen between attempts (not after the last), so 3 backoff sleeps totaling ~7–10s of added latency on a flaky file. Files run in parallel, so this doesn't stack across the run.

## Testing

There is no Python unit-test harness for `.github/scripts/` (no pytest config or `test_*.py`; the workflow "tests" are rule tests), so this was validated with an **ad-hoc local mock** of `requests.post` (real sleeps stubbed) — not committed test files. Results:

| Scenario | Result |
|---|---|
| 403, 403, 200 | succeeds after 3 calls |
| persistent 403 | raises after 4 calls (budget) |
| 500 | raises immediately, 1 call (no retry) |
| 404 | raises immediately, 1 call (no retry) |
| 429, 200 | succeeds after 2 calls |
| connection error, 200 | succeeds after 2 calls |

🤖 Generated with [Claude Code](https://claude.com/claude-code)