### PR TITLE
Create attachment_yara_encrypted_pdf_cred_phish.yml

### DIFF
--- a/detection-rules/attachment_yara_encrypted_pdf_cred_phish.yml
+++ b/detection-rules/attachment_yara_encrypted_pdf_cred_phish.yml
@@ -6,14 +6,9 @@ source: |
   type.inbound
   and any(filter(attachments, .file_type == "pdf"),
           any(file.explode(.),
-              any(.scan.yara.matches,
-                  .name in (
-                    "pdf_encrypted_cred_phish_001"
-                  )
-              )
+              any(.scan.yara.matches, .name in ("pdf_encrypted_cred_phish_001"))
           )
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:
@@ -23,3 +18,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "YARA"
+id: "2122a286-4b6c-5f40-a2cd-2ed02c68baca"

--- a/detection-rules/attachment_yara_encrypted_pdf_cred_phish.yml
+++ b/detection-rules/attachment_yara_encrypted_pdf_cred_phish.yml
@@ -1,0 +1,25 @@
+name: "Attachment: Encrypted PDF With Credential Harvesting Indicators"
+description: "Detects encrypted PDF attachments containing patterns and indicators commonly associated with credential harvesting operations, identified through YARA signature analysis."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(filter(attachments, .file_type == "pdf"),
+          any(file.explode(.),
+              any(.scan.yara.matches,
+                  .name in (
+                    "pdf_encrypted_cred_phish_001"
+                  )
+              )
+          )
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Encryption"
+  - "Evasion"
+  - "PDF"
+detection_methods:
+  - "File analysis"
+  - "YARA"


### PR DESCRIPTION
# Description
This is the MQL to accompany an existing yara rule - this is looking at encrypted PDFs with a pretty unique pattern, there's the object hash which is also trending to be very solid... but the yara side of things is pretty good too. The lure they're using is pretty unique and we can match the metadata (WxH) of that even if they encrypt it. 

ESC-15006

# Associated samples


- [Sample 1](https://platform.sublime.security/messages/507a1289dee9ecd1c2e5195f5b7fa219837ad233060ec9af399ca3c3a2e6bf47?preview_id=019e98db-f690-75a9-a837-3b49ac2f3de1)
- [Sample 2](https://platform.sublime.security/messages/507ab3cf7d8a0375c50bfaf05359ec4f9a90a179acae086837006f0d9e435163?preview_id=019e98db-fe80-754b-9457-346cd172e11e)

## Associated hunts
Kinda batched my thoughts with the hunt (three rules testing at once), but still shows impact of the totality. All TPs. 

- [Hunt 1](https://hunt.limeseed.email/hunts/17bb2861-79e2-4cb2-8b7f-5072f27fa143)
