### PR TITLE
Create attachment_yara_pdf_blurry_lure_image.yml

### DIFF
--- a/detection-rules/attachment_yara_pdf_blurry_lure_image.yml
+++ b/detection-rules/attachment_yara_pdf_blurry_lure_image.yml
@@ -1,0 +1,23 @@
+name: "Attachment: PDF with blurry lure image"
+description: "Detects PDF attachments containing a blurry image used in credential phishing lures."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(filter(attachments, .file_type == "pdf"),
+          any(file.explode(.),
+              any(.scan.yara.matches,
+                  .name in (
+                    "pdf_lure_image_blurry",
+                  )
+              )
+          )
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "PDF"
+detection_methods:
+  - "File analysis"
+  - "YARA"

--- a/detection-rules/attachment_yara_pdf_blurry_lure_image.yml
+++ b/detection-rules/attachment_yara_pdf_blurry_lure_image.yml
@@ -6,14 +6,9 @@ source: |
   type.inbound
   and any(filter(attachments, .file_type == "pdf"),
           any(file.explode(.),
-              any(.scan.yara.matches,
-                  .name in (
-                    "pdf_lure_image_blurry",
-                  )
-              )
+              any(.scan.yara.matches, .name in ("pdf_lure_image_blurry", ))
           )
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:
@@ -21,3 +16,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "YARA"
+id: "5539a3fd-5821-5fd9-9119-7dd9e42cd739"


### PR DESCRIPTION
# Description
Matches the yara rule for a blurry PDF lure that leads to cred phishing. 

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/506a5a026e597b6d113df9c96541f3a22fd278019fe427648265ef521528db0a?preview_id=019e21bc-ad6b-74e7-b547-549ed638a207)
- [Sample 2](https://platform.sublime.security/messages/507ebbeff6bf9da6eadbbccb496b9679d0c89a7f64ed870f45aa1dc8f4208f01?preview_id=019e936e-778e-7ea2-83e3-a590ebcc799f)

## Associated hunts
I did a multi-hunt with three yara rules I'm working on - this is just one of them. All returned hits were TP. 

- [Hunt 1](https://hunt.limeseed.email/hunts/17bb2861-79e2-4cb2-8b7f-5072f27fa143)
- [Hunt 2](https://platform.sublime.security/messages/hunt?huntId=019e98e7-9cb5-7b71-a9fd-d24911ac3e40)