### PR TITLE
Log MQL format retries with latency and response body

### DIFF
--- a/.github/scripts/mql_format.py
+++ b/.github/scripts/mql_format.py
@@ -47,7 +47,7 @@ EXCLUDE_FILES = {
 }
 
 
-def format_source(source: str) -> str:
+def format_source(source: str, label: str = "") -> str:
     """Format MQL source using the Sublime API.
 
     Retries on transient failures (see RETRYABLE_STATUSES and connection-level
@@ -56,10 +56,18 @@ def format_source(source: str) -> str:
     just re-trigger the same edge throttling. 500s are not retried (known
     deterministic API bug) and are raised immediately for graceful per-file
     handling upstream.
+
+    Each retry is logged with the attempt number, the failure, the per-attempt
+    latency, and a slice of the response body. That detail is deliberate: it's
+    what tells us *why* the endpoint is failing - fast 403s with a WAF/access
+    body point at throttling or an IP block, while attempts that crawl toward
+    the 30s timeout point at endpoint overload (where fewer workers might help).
     """
     last_exc: Exception | None = None
+    prefix = f"{label}: " if label else ""
 
     for attempt in range(MAX_RETRIES):
+        start = time.monotonic()
         try:
             resp = requests.post(API_URL, json={
                 "source": source,
@@ -80,18 +88,29 @@ def format_source(source: str) -> str:
             resp.raise_for_status()
             return resp.json()["source"]
         except requests.HTTPError as e:
+            elapsed = time.monotonic() - start
             status = getattr(getattr(e, "response", None), "status_code", None)
             if status not in RETRYABLE_STATUSES:
                 raise
             last_exc = e
+            resp_obj = getattr(e, "response", None)
+            body = " ".join(resp_obj.text[:200].split()) if resp_obj is not None else ""
+            reason = f"HTTP {status} in {elapsed:.1f}s" + (f" - body: {body}" if body else "")
         except requests.RequestException as e:
             # Connection errors, timeouts, etc. - transient, worth retrying.
+            elapsed = time.monotonic() - start
             last_exc = e
+            reason = f"{type(e).__name__} in {elapsed:.1f}s: {e}"
 
         # Don't sleep after the final attempt.
         if attempt < MAX_RETRIES - 1:
             delay = RETRY_BASE_DELAY * (2 ** attempt) + random.uniform(0, 1)
+            print(f"[retry] {prefix}attempt {attempt + 1}/{MAX_RETRIES} failed - "
+                  f"{reason}; retrying in {delay:.1f}s", flush=True)
             time.sleep(delay)
+        else:
+            print(f"[retry] {prefix}attempt {attempt + 1}/{MAX_RETRIES} failed - "
+                  f"{reason}; retries exhausted", flush=True)
 
     # Retry budget exhausted - propagate the last error to the caller. The
     # guard keeps typing/control flow unambiguous; last_exc is only None if the
@@ -165,7 +184,7 @@ def process_file(file_data: dict) -> dict:
     source = file_data["source"]
 
     try:
-        formatted_source = format_source(source)
+        formatted_source = format_source(source, label=path.name)
         changed = normalize(formatted_source) != normalize(source)
         return {
             "path": path,


### PR DESCRIPTION
## What

Adds per-retry logging to `format_source()` in `.github/scripts/mql_format.py` (the **Auto-format MQL** step).

## Why

The retry loop from #4621 is **silent**. In [CI run 27032265885](https://github.com/sublime-security/sublime-rules/actions/runs/27032265885/job/79787951533) the step printed `Processing 1159 files...` and then nothing for **108 seconds**, before failing on a single `403 Forbidden`. That looks like a hang, and gives us no way to tell *why* the endpoint failed.

It also surfaced something important: the retry **did** fire (403 is retryable), but the 403 was **persistent across all 4 attempts** in that window — so retries didn't rescue the run. The ~108s before the first result strongly suggests the attempts were *slow* (near the 30s timeout), not fast 403s. We need data to confirm that.

## How

Each retry now logs: **filename, attempt n/MAX, the failure, per-attempt latency, and a truncated (~200 char) slice of the response body**, via plain `print(flush=True)` (not `::warning::`, since retries can be numerous).

This is deliberately diagnostic — the next failed run will discriminate the root cause:
- **Fast 403s with a WAF / "access denied" body** → throttling or IP block (retries/backoff is the right lever, or the request needs auth)
- **Attempts crawling toward the 30s timeout** → endpoint overload (where reducing `MAX_WORKERS` from 100 would plausibly help)

**Behavior is otherwise unchanged**: 500 still skips without retry, non-retryable statuses still fail fast, and an exhausted retry budget still **fails the job loudly** rather than skipping silently.

## Not included (deliberately)

- **Reducing `MAX_WORKERS`**: plausible root-cause fix, but the current log doesn't yet justify changing CI behavior on a guess. This PR instruments first; we decide after seeing latency data.
- **Treating exhausted-retry 403 as a skip** (like 500): rejected — if the endpoint is systematically 403ing, every file would skip and the job would go green while MQL formatting silently stops. Loud failure is correct.

## Testing

No Python unit-test harness exists for `.github/scripts/`, so validated with an ad-hoc local mock of `requests.post` (sleeps stubbed):

| Scenario | Logged behavior |
|---|---|
| 403 (WAF body), 403, 200 | logs 2 retries w/ body slice + latency, then succeeds |
| persistent 403 | logs all 4 attempts, last = "retries exhausted", raises |
| success first try | logs nothing |
| timeout, 200 | logs exception type + latency, then succeeds |
| 500 | no retry, no log (still skipped upstream) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)