### PR TITLE
Create attachment_yara_pdf_eCheckRun_lure.yml

### DIFF
--- a/detection-rules/attachment_yara_pdf_eCheckRun_lure.yml
+++ b/detection-rules/attachment_yara_pdf_eCheckRun_lure.yml
@@ -1,5 +1,5 @@
 name: "Attachment: PDF with eCheckRun lures"
-description: "Detects PDF attachments containing artifacts from a couple eCheckRun lures we've observed. "
+description: "Detects PDF attachments matching yara rules looking for attachments containing artifacts from related to fake financial/invoice themes, including eCheckRun lures. These are commonly used to trick users into believe they have received legitmate electronic payment messages."
 type: "rule"
 severity: "medium"
 source: |

--- a/detection-rules/attachment_yara_pdf_eCheckRun_lure.yml
+++ b/detection-rules/attachment_yara_pdf_eCheckRun_lure.yml
@@ -1,0 +1,23 @@
+name: "Attachment: PDF with eCheckRun lures"
+description: "Detects PDF attachments containing artifacts from a couple eCheckRun lures we've observed. "
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(filter(attachments, .file_type == "pdf"),
+          any(file.explode(.),
+              any(.scan.yara.matches,
+                  .name in (
+                    "pdf_eCheckLure_format",
+                  )
+              )
+          )
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "PDF"
+detection_methods:
+  - "File analysis"
+  - "YARA"

--- a/detection-rules/attachment_yara_pdf_eCheckRun_lure.yml
+++ b/detection-rules/attachment_yara_pdf_eCheckRun_lure.yml
@@ -6,14 +6,9 @@ source: |
   type.inbound
   and any(filter(attachments, .file_type == "pdf"),
           any(file.explode(.),
-              any(.scan.yara.matches,
-                  .name in (
-                    "pdf_eCheckLure_format",
-                  )
-              )
+              any(.scan.yara.matches, .name in ("pdf_eCheckLure_format", ))
           )
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:
@@ -21,3 +16,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "YARA"
+id: "577991e1-b7c4-5f35-a2ca-239424062e7d"


### PR DESCRIPTION
# Description
We're catching these ones based on some of the link rect boxes and some text artifacts. Matches two different eCheckRun lures we've found ITW. 

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/5078f4779ec5ba5a51111a48f30510ba28c70bdace644fc8cbf12ab8bc1c09e1?preview_id=019e6ae6-02dd-7ae7-bac0-9f42f1e27e84)
- [Sample 2](https://platform.sublime.security/messages/507893077557e496b4be78b7d6143603bfde4b8a0af19a1964270ed37600daea?preview_id=019e6a38-fdd7-7b87-9dcc-7f6373dca0bf)

## Associated hunts
Multi-hunt was run with three different yara rules - but the telemetry was all TP.
- [Multi-hunt](https://hunt.limeseed.email/hunts/17bb2861-79e2-4cb2-8b7f-5072f27fa143) 
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e9902-1bde-7026-bde4-0c9ad381ac61)
- [90d shared samples](https://platform.sublime.security/messages/hunt?huntId=019e9948-cbcb-7145-bded-6679fc0a9822)
