### PR TITLE
Update brand_impersonation_adobe_sign.yml

### DIFF
--- a/detection-rules/brand_impersonation_adobe_sign.yml
+++ b/detection-rules/brand_impersonation_adobe_sign.yml
@@ -4,19 +4,39 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and length(filter(attachments, .file_type == "pdf")) == 0
   and (
-    regex.icontains(body.html.raw,
-                    'alt="Adobe(?: Acrobat)? Sign"',
-                    "adobe-sign-logo.{0,20}.png",
-                    'alt="Powered by Adobe Acrobat Sign"'
+    (
+      length(filter(attachments, .file_type == "pdf")) == 0
+      and (
+        regex.icontains(body.html.raw,
+                        'alt="Adobe(?: Acrobat)? Sign"',
+                        "adobe-sign-logo.{0,20}.png",
+                        'alt="Powered by Adobe Acrobat Sign"'
+        )
+        or any(html.xpath(body.html, "//img/@src").nodes,
+               strings.parse_url(.raw).domain.root_domain == "adobesign.com"
+               and (
+                 strings.istarts_with(strings.parse_url(.raw).path,
+                                      "/cobrand_logo/"
+                 )
+                 or strings.icontains(strings.parse_url(.raw).path,
+                                      "checkmarkCircle"
+                 )
+               )
+        )
+      )
     )
-    or any(html.xpath(body.html, "//img/@src").nodes,
-           strings.parse_url(.raw).domain.root_domain == "adobesign.com"
-           and (
-             strings.istarts_with(strings.parse_url(.raw).path, "/cobrand_logo/")
-             or strings.icontains(strings.parse_url(.raw).path, "checkmarkCircle")
-           )
+    or (
+      any(attachments,
+          .file_type == "pdf"
+          and any(file.explode(.),
+                  any(.scan.url.urls,
+                      regex.icontains(.url,
+                                      '(?:ad0be.{0,5}s[1i]gn|ad[0o]be.{0,5}s1gn)'
+                      )
+                  )
+          )
+      )
     )
   )
   and not (


### PR DESCRIPTION
# Description

Adding branched logic to look for links within attachments that attempt to obfuscate Adobe Sign

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507646d1f0b86c230464eda30451cb322d38e90c1df0b6f54ca2ba769ed2e682?preview_id=019e846c-a7ef-7b2e-b0c0-bb6e585f549f)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019e99bb-a48d-766d-8833-a16a721fbc29)
- [L7D 50 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/6ad609d0-a97b-4547-be68-f78e2bde6308)