### PR TITLE
Refine name and description for UPS impersonation rule

### DIFF
--- a/detection-rules/impersonation_ups.yml
+++ b/detection-rules/impersonation_ups.yml
@@ -1,6 +1,6 @@
-name: "Brand impersonation: UPS"
+name: "Brand Impersonation: UPS Delivery"
 description: |
-  Impersonation of United Parcel Service (UPS).
+  Detects messages impersonating UPS (United Parcel Service) through display name, email address patterns, subject content, or HTML styling that mimics UPS branding, while excluding legitimate UPS domains.
 references:
   - "https://www.bleepingcomputer.com/news/security/phishing-campaign-uses-upscom-xss-vuln-to-distribute-malware/"
   - "https://twitter.com/DanielGallagher/status/1429794038463479813"
@@ -12,6 +12,7 @@ source: |
   and sender.email.domain.root_domain not in ("ups.com", "upsemail.com")
   and (
     sender.display_name in~ ("UPS My Choice", "UPS Services")
+    or regex.icontains(sender.display_name, 'UPS-\w+')
     or strings.ilike(sender.email.local_part, "*united*parcel*service*")
     or strings.ilike(sender.email.domain.domain, '*united*parcel*service*')
     or strings.icontains(subject.subject, 'UPS delivery')

--- a/detection-rules/impersonation_ups.yml
+++ b/detection-rules/impersonation_ups.yml
@@ -1,4 +1,4 @@
-name: "Brand Impersonation: UPS Delivery"
+name: "Brand impersonation: UPS"
 description: |
   Detects messages impersonating UPS (United Parcel Service) through display name, email address patterns, subject content, or HTML styling that mimics UPS branding, while excluding legitimate UPS domains.
 references:
@@ -11,8 +11,8 @@ source: |
   type.inbound
   and sender.email.domain.root_domain not in ("ups.com", "upsemail.com")
   and (
-    sender.display_name in~ ("UPS My Choice", "UPS Services")
-    or regex.icontains(sender.display_name, 'UPS-\w+')
+    sender.display_name in~ ("UPS My Choice", "UPS Services", "Ups.com")
+    or regex.icontains(sender.display_name, 'ups-\w+')
     or strings.ilike(sender.email.local_part, "*united*parcel*service*")
     or strings.ilike(sender.email.domain.domain, '*united*parcel*service*')
     or strings.icontains(subject.subject, 'UPS delivery')


### PR DESCRIPTION
# Description
Adding `UPS-\w+` and `UPS.com` sender.display logic to the rule. 

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/5078a039950381b2592cdf85c70567a009a55e72603d3ea8b7e3507b2a073fb5)

## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019eb811-2d6e-7368-9ac5-3beb4eabc555)
- [Multi-hunt](https://hunt.limeseed.email/hunts/574acc44-aea4-4cd0-9468-514eb5b450a1)
