### PR TITLE
Update attachment_pdf_link_sus_lang.yml

### DIFF
--- a/detection-rules/attachment_pdf_link_sus_lang.yml
+++ b/detection-rules/attachment_pdf_link_sus_lang.yml
@@ -11,7 +11,7 @@ source: |
           and any(file.explode(.),
                   .depth == 0
                   // reduce fps by limiting the length to a single link
-                  and length(.scan.url.urls) == 1
+                  and length(distinct(.scan.url.urls, .domain.domain)) == 1
                   and any(filter(.scan.url.urls,
                                  // remove mailto: links
                                  not strings.istarts_with(.url, 'mailto:')
@@ -54,6 +54,17 @@ source: |
                             // a common fp in the .au for a payment system
                             and not strings.icontains(ml.link_analysis(.).final_dom.display_text,
                                                       'View Podium Message'
+                            )
+                          )
+                          // use OCR of the screenshot 
+                          or (
+                            200 <= ml.link_analysis(.).status_code < 300
+                            and length(beta.ocr(ml.link_analysis(.).screenshot).text
+                            ) < 300
+                            and regex.icontains(beta.ocr(ml.link_analysis(.).screenshot
+                                                ).text,
+                                                '\b(?:(?:re)?view|see|read|click\s+(?:here\s+)?to)[\t\x20]*(?:\S+[\t\x20]*){0,3}[\t\x20]*(?:document|message|now|proceed)',
+                                                '\b(?:request|review)\b.{1,5}\b(?:bid|proposal|agreement|portfolio|contract|settlement|invoice)\b'
                             )
                           )
                           // the title contains high confidence indicators


### PR DESCRIPTION
# Description
1. leverage OCR output and use against existing detection logic
2. update to include the count of links to be based on the unique domains of the links

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507f077dba61f6121a3b5c3eb6761d8e53d4ce951bccce0179c13770a6dfafe5?preview_id=019e9930-cf0a-770c-84e6-7825948b5f2d)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Net new Hunt](https://platform.sublime.security/messages/hunt?huntId=019ea89b-7be5-779d-a0cb-dd6dfcc0602d)
- [net New multihunt](https://hunt.limeseed.email/hunts/56927611-c58e-4b06-ad0f-9f9ef3695f6a)