### PR TITLE
Create link_concatenated_display_text_pdf_reference.yml

### DIFF
--- a/detection-rules/link_concatenated_display_text_pdf_reference.yml
+++ b/detection-rules/link_concatenated_display_text_pdf_reference.yml
@@ -4,10 +4,13 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and strings.contains(body.current_thread.text, strings.concat(body.current_thread.links[0].display_text, body.current_thread.links[1].display_text))
+  and strings.contains(body.current_thread.text,
+                       strings.concat(body.current_thread.links[0].display_text,
+                                      body.current_thread.links[1].display_text
+                       )
+  )
   and body.current_thread.links[0].href_url.url == body.current_thread.links[1].href_url.url
   and strings.icontains(body.current_thread.links[1].display_text, 'pdf')
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:
@@ -16,3 +19,4 @@ tactics_and_techniques:
 detection_methods:
   - "Content analysis"
   - "URL analysis"
+id: "4cb86869-bb02-5903-bb7b-3cc2f88eb207"

--- a/detection-rules/link_concatenated_display_text_pdf_reference.yml
+++ b/detection-rules/link_concatenated_display_text_pdf_reference.yml
@@ -1,0 +1,18 @@
+name: "Link: Concatenated display text concealing duplicate URLs with PDF reference"
+description: "Detects messages where two identical links are displayed as a single continuous text string, with the second link containing 'PDF' in its display text. This technique can be used to obscure the true nature of links by making them appear as legitimate document references."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and strings.contains(body.current_thread.text, strings.concat(body.current_thread.links[0].display_text, body.current_thread.links[1].display_text))
+  and body.current_thread.links[0].href_url.url == body.current_thread.links[1].href_url.url
+  and strings.icontains(body.current_thread.links[1].display_text, 'pdf')
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description
Detects messages where two identical links are displayed as a single continuous text string, with the second link containing 'PDF' in its display text.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507ea08883dfcb5f60ac00310f57b7173143b742feacb42b9f2f43f112d593da?preview_id=019e89b3-0a58-7809-b0d6-37232adb5e6d)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=019ea8b5-9136-73bc-967b-057f38cc2131)
- [40 customer multi-hunt](https://hunt.limeseed.email/hunts/9ad43f64-d7b2-4c58-9049-6930a29e1a8e)
- [17 customer multi-hunt](https://hunt.limeseed.email/hunts/f345401e-996c-4b5e-a86b-16e9dc180821)
- [1 customer hunt](https://hunt.limeseed.email/hunts/91b780cc-3430-4e95-8e89-7db22fa3afdc)
