### PR TITLE
Create attachment_pdf_self_service_self_sender.yml

### DIFF
--- a/detection-rules/attachment_pdf_self_service_self_sender.yml
+++ b/detection-rules/attachment_pdf_self_service_self_sender.yml
@@ -52,3 +52,4 @@ detection_methods:
   - "Exif analysis"
   - "URL analysis"
   - "Sender analysis"
+id: "9b97f4cf-ab96-5f92-a1ca-90967b94bcb1"

--- a/detection-rules/attachment_pdf_self_service_self_sender.yml
+++ b/detection-rules/attachment_pdf_self_service_self_sender.yml
@@ -39,7 +39,8 @@ source: |
               )
           )
   )
-  
+tags:
+  - "Attack surface reduction"
 attack_types:
   - "BEC/Fraud"
   - "Credential Phishing"

--- a/detection-rules/attachment_pdf_self_service_self_sender.yml
+++ b/detection-rules/attachment_pdf_self_service_self_sender.yml
@@ -1,0 +1,54 @@
+name: "Attachment: PDF with self-service platform links with self sender or blank recipients"
+description: "Detects single-page PDF attachments containing links to self-service content creation platforms, sent to either the sender's own email address or an invalid email domain. This pattern may indicate testing of malicious content or preparation for distribution."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and sum([length(recipients.to), length(recipients.cc)]) == 1
+  and (
+    sender.email.email == recipients.to[0].email.email
+    or recipients.to[0].email.domain.valid == false
+  )
+  and length(attachments) == 1
+  and beta.parse_exif(attachments[0]).page_count == 1
+  and any(filter(attachments, .file_type == "pdf"),
+          any(filter(file.explode(.), .depth == 0),
+              1 <= length(filter(.scan.url.urls,
+                                 // remove mailto: links
+                                 not strings.istarts_with(.url, 'mailto:')
+                                 and not strings.istarts_with(.url, 'email:')
+                                 // remove links found in exiftool output producer/creator
+                                 and not any([
+                                               ..scan.exiftool.producer,
+                                               ..scan.exiftool.creator
+                                             ],
+                                             . is not null
+                                             and strings.icontains(.,
+                                                                   ..domain.domain
+                                             )
+                                 )
+                                 and not .domain.root_domain in ('pdf-tools.com')
+                                 and not .url in (
+                                   'https://gamma.app/?utm_source=made-with-gamma'
+                                 )
+                          )
+              ) <= 3
+              and all(.scan.url.urls,
+                      .domain.root_domain in $self_service_creation_platform_domains
+                      or .domain.domain in $self_service_creation_platform_domains
+              )
+          )
+  )
+  
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "PDF"
+  - "Evasion"
+  - "Free file host"
+detection_methods:
+  - "File analysis"
+  - "Exif analysis"
+  - "URL analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

Add ASR rule covers messages with a single PDF attachment, which contas 1-3 links which all go to self_service_content_creation_platforms and where the message exhibits self sender or empty recipients

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507f077dba61f6121a3b5c3eb6761d8e53d4ce951bccce0179c13770a6dfafe5?preview_id=019e9930-cf0a-770c-84e6-7825948b5f2d)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019ea8db-6fef-7ac9-913f-2b2d40f91b5d)
- [multi-hunt](https://hunt.limeseed.email/hunts/826e7949-4da8-42b2-a82c-a470f60239da)