### PR TITLE
Update attachment_pdf_sus_string_single_url.yml

### DIFF
--- a/detection-rules/attachment_pdf_sus_string_single_url.yml
+++ b/detection-rules/attachment_pdf_sus_string_single_url.yml
@@ -74,7 +74,7 @@ source: |
                            )
                     ) == 1
                     or 
-                    // there is one one domain
+                    // there is only one unique domain
                     (
                       length(distinct(filter(.scan.url.urls,
                                              // remove mailto: links

--- a/detection-rules/attachment_pdf_sus_string_single_url.yml
+++ b/detection-rules/attachment_pdf_sus_string_single_url.yml
@@ -67,9 +67,7 @@ source: |
                                                                     ..domain.domain
                                               )
                                   )
-                                  and not .domain.root_domain in (
-                                    'pdf-tools.com'
-                                  )
+                                  and not .domain.root_domain in ('pdf-tools.com')
                                   and not .url in (
                                     'https://gamma.app/?utm_source=made-with-gamma'
                                   )

--- a/detection-rules/attachment_pdf_sus_string_single_url.yml
+++ b/detection-rules/attachment_pdf_sus_string_single_url.yml
@@ -14,7 +14,7 @@ source: |
                   any(.scan.strings.strings,
                       regex.icontains(.,
                                       // action!
-                                      '^\s*(?:view documents?|view pdf|view presentation|preview new docusign|Download Secure PDF|VIEW DOCUMENT HERE|ACCESS DOCUMENT|REVIEW NEW SECURE DOCUMENT|OPEN SECURE VIEWER|DOWNLOAD RFP DOCUMENT|View Dashboard here|ACCESS SECURE DOCUMENTS|VIEW PROPOSAL DOCUMENTS|ACCESS / VIEW PROPOSAL DOCUMENT|Review & Sign Document|Open PDF|Access Document\(s\)|(?:P?RE)?VIEW SHARED DOCUMENT|New Secured Document|ACCESS SECURE RFP PORTAL|Please Review and Sign|Review and Validate|SECURE DOCUMENT|Open Document|View Details|Q!_Compensation/Salary Amendments\.pptx|PREVIEW DOCUMENT HERE|Download Tax Details Below:|Review and Sign Document|Review Document|Open Encrypted|OPEN DOCUMENT HERE|Click to read message|CLICK HERE TO VIEW DOCUMENTS)\s*$',
+                                      '^\s*(?:view documents?|view pdf|view presentation|preview new docusign|Download Secure PDF|VIEW DOCUMENT HERE|ACCESS DOCUMENT|REVIEW NEW SECURE DOCUMENT|OPEN SECURE VIEWER|DOWNLOAD RFP DOCUMENT|View Dashboard here|ACCESS SECURE DOCUMENTS|VIEW PROPOSAL DOCUMENTS|ACCESS / VIEW PROPOSAL DOCUMENT|Review & Sign Document|Open PDF|Access Document\(s\)|(?:P?RE)?VIEW SHARED DOCUMENT|New Secured Document|ACCESS SECURE RFP PORTAL|Please Review and Sign|Review and Validate|SECURE DOCUMENT|Open Document|View Details|Q!_Compensation/Salary Amendments\.pptx|PREVIEW DOCUMENT HERE|Download Tax Details Below:|Review and Sign Document|Review Document|Open Encrypted|OPEN DOCUMENT HERE|Click to read message|CLICK HERE TO VIEW DOCUMENTS|VIEW FULL DOCUMENT HERE)\s*$',
                                       // "secure fax"
                                       'View Secure Fax',
                                       // more fake errors
@@ -52,28 +52,93 @@ source: |
           )
           and any(file.explode(.),
                   .depth == 0
-                  and length(filter(.scan.url.urls,
-                                    // remove mailto: links
-                                    not strings.istarts_with(.url, 'mailto:')
-                                    and not strings.istarts_with(.url, 'email:')
-                                    // remove links found in exiftool output producer/creator
-                                    and not any([
-                                                  ..scan.exiftool.producer,
-                                                  ..scan.exiftool.creator
-                                                ],
-                                                . is not null
-                                                and strings.icontains(.,
-                                                                      ..domain.domain
-                                                )
-                                    )
-                                    and not .domain.root_domain in (
-                                      'pdf-tools.com'
-                                    )
-                                    and not .url in (
-                                      'https://gamma.app/?utm_source=made-with-gamma'
-                                    )
+                  and (
+                    length(filter(.scan.url.urls,
+                                  // remove mailto: links
+                                  not strings.istarts_with(.url, 'mailto:')
+                                  and not strings.istarts_with(.url, 'email:')
+                                  // remove links found in exiftool output producer/creator
+                                  and not any([
+                                                ..scan.exiftool.producer,
+                                                ..scan.exiftool.creator
+                                              ],
+                                              . is not null
+                                              and strings.icontains(.,
+                                                                    ..domain.domain
+                                              )
+                                  )
+                                  and not .domain.root_domain in (
+                                    'pdf-tools.com'
+                                  )
+                                  and not .url in (
+                                    'https://gamma.app/?utm_source=made-with-gamma'
+                                  )
+                           )
+                    ) == 1
+                    or 
+                    // there is one one domain
+                    (
+                      length(distinct(filter(.scan.url.urls,
+                                             // remove mailto: links
+                                             not strings.istarts_with(.url,
+                                                                      'mailto:'
+                                             )
+                                             and not strings.istarts_with(.url,
+                                                                          'email:'
+                                             )
+                                             // remove links found in exiftool output producer/creator
+                                             and not any([
+                                                           ..scan.exiftool.producer,
+                                                           ..scan.exiftool.creator
+                                                         ],
+                                                         . is not null
+                                                         and strings.icontains(.,
+                                                                               ..domain.domain
+                                                         )
+                                             )
+                                             and not .domain.root_domain in (
+                                               'pdf-tools.com'
+                                             )
+                                             and not .url in (
+                                               'https://gamma.app/?utm_source=made-with-gamma'
+                                             )
+                                      ),
+                                      .domain.domain
                              )
-                  ) == 1
+                      ) == 1
+                      // all of them are in self_service
+                      and all(distinct(filter(.scan.url.urls,
+                                              // remove mailto: links
+                                              not strings.istarts_with(.url,
+                                                                       'mailto:'
+                                              )
+                                              and not strings.istarts_with(.url,
+                                                                           'email:'
+                                              )
+                                              // remove links found in exiftool output producer/creator
+                                              and not any([
+                                                            ..scan.exiftool.producer,
+                                                            ..scan.exiftool.creator
+                                                          ],
+                                                          . is not null
+                                                          and strings.icontains(.,
+                                                                                ..domain.domain
+                                                          )
+                                              )
+                                              and not .domain.root_domain in (
+                                                'pdf-tools.com'
+                                              )
+                                              and not .url in (
+                                                'https://gamma.app/?utm_source=made-with-gamma'
+                                              )
+                                       ),
+                                       .domain.domain
+                              ),
+                              .domain.domain in $self_service_creation_platform_domains
+                              or .domain.root_domain in $self_service_creation_platform_domains
+                      )
+                    )
+                  )
           )
   )
 attack_types:


### PR DESCRIPTION
# Description

Allow rule to match when there are more than 1 link, but all links are self_service_content_creation_platform domains
# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507f077dba61f6121a3b5c3eb6761d8e53d4ce951bccce0179c13770a6dfafe5?preview_id=019e9930-cf0a-770c-84e6-7825948b5f2d)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Net new Hunt](https://platform.sublime.security/messages/hunt?huntId=019ea89b-7be5-779d-a0cb-dd6dfcc0602d)
- [net new multi-hunt](https://hunt.limeseed.email/hunts/033319eb-dda0-4966-aa26-b424bf0577ed)