### PR TITLE
Create attachment_pdf_yara_fake_invoice_image_font.yml

### DIFF
--- a/detection-rules/attachment_pdf_yara_fake_invoice_image_font.yml
+++ b/detection-rules/attachment_pdf_yara_fake_invoice_image_font.yml
@@ -1,0 +1,24 @@
+name: "Attachment: PDF with fake invoice using suspicious font sizing"
+description: "PDF attachment contains a fake invoice with suspicious font size patterns and unique image sizes, typically used in fraudulent billing schemes."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(filter(attachments, .file_type == "pdf"), 
+      any(file.explode(.),
+          any(.scan.yara.matches,
+              .name == "pdf_fake_invoice_image_font_sizes"
+          )
+      )
+  ) 
+
+attack_types:
+  - "BEC/Fraud"
+  - "Callback Phishing"
+tactics_and_techniques:
+  - "PDF"
+  - "Social engineering"
+detection_methods:
+  - "File analysis"
+  - "YARA"
+  - "Content analysis"

--- a/detection-rules/attachment_pdf_yara_fake_invoice_image_font.yml
+++ b/detection-rules/attachment_pdf_yara_fake_invoice_image_font.yml
@@ -4,14 +4,13 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and any(filter(attachments, .file_type == "pdf"), 
-      any(file.explode(.),
-          any(.scan.yara.matches,
-              .name == "pdf_fake_invoice_image_font_sizes"
+  and any(filter(attachments, .file_type == "pdf"),
+          any(file.explode(.),
+              any(.scan.yara.matches,
+                  .name == "pdf_fake_invoice_image_font_sizes"
+              )
           )
-      )
-  ) 
-
+  )
 attack_types:
   - "BEC/Fraud"
   - "Callback Phishing"
@@ -22,3 +21,4 @@ detection_methods:
   - "File analysis"
   - "YARA"
   - "Content analysis"
+id: "d7721177-8a36-56ef-9e1e-8a54c6a0409b"


### PR DESCRIPTION
# Description
This is the matching MQL rule for the existing yara rule. We're trying to match PDFs with unique font/glyph sizes and a unique image size included in the document. 

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/507f5fd02facc9631c08225daabad546bedb578890fae610e24751dc787b93fa?preview_id=019e938d-b493-7bce-ad1d-817fdb933413)

## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019eac45-89ec-71b6-a90c-db9c8729d2c1)
- [Multi-hunt (in-progress)](https://hunt.limeseed.email/hunts/1d477d5f-8894-4b90-b392-5babd906db98)
