### PR TITLE
Update attachment_pdf_recip_email_in_link.yml

### DIFF
--- a/detection-rules/attachment_pdf_recip_email_in_link.yml
+++ b/detection-rules/attachment_pdf_recip_email_in_link.yml
@@ -86,8 +86,8 @@ source: |
                             strings.icontains(..url.url, .email.email)
                             // QR code contains the base64 endcoded email
                             or any(strings.scan_base64(..url.url,
-                                                    format="url",
-                                                    ignore_padding=true
+                                                       format="url",
+                                                       ignore_padding=true
                                    ),
                                    strings.icontains(., ..email.email)
                             )

--- a/detection-rules/attachment_pdf_recip_email_in_link.yml
+++ b/detection-rules/attachment_pdf_recip_email_in_link.yml
@@ -74,14 +74,18 @@ source: |
             )
             // or there is a QR code
             or (
-              any(filter(file.explode(.), .depth == 1),
-                  .scan.qr.url.domain.valid
+              //
+              // This rule makes use of a beta feature and is subject to change without notice
+              // using the beta feature in custom rules is not suggested until it has been formally released
+              //
+              any(beta.scan_qr(.).items,
+                  .url.domain.valid
                   and any(recipients.to,
                           // QR code contains the email
                           (
-                            strings.icontains(..scan.qr.url.url, .email.email)
+                            strings.icontains(..url.url, .email.email)
                             // QR code contains the base64 endcoded email
-                            or any(beta.scan_base64(..scan.qr.url.url,
+                            or any(strings.scan_base64(..url.url,
                                                     format="url",
                                                     ignore_padding=true
                                    ),


### PR DESCRIPTION
# Description

Convert the rule to use the beta.scan_qr funciton which supports multipage PDF scanning in order to provide coverage on sample. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507dab89f576216d6769bd0a54a3e497b9a2604ac4122511c15d3bb5a5b97b11?preview_id=019e8e12-95fa-746d-9c4d-79c63ff9fa72)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Net New](https://platform.sublime.security/messages/hunt?huntId=019ead6e-6977-7cbc-af31-debc30766f5d)
- [new New multihunt](https://hunt.limeseed.email/hunts/1a14cde7-b647-465d-96ca-db9d38362442)