### PR TITLE
Update service_abuse_apple_callback.yml

### DIFF
--- a/detection-rules/service_abuse_apple_callback.yml
+++ b/detection-rules/service_abuse_apple_callback.yml
@@ -28,8 +28,12 @@ source: |
             // we have to account for NLU not catching it as callback_scam
             // this catches more than one digit followed by all capital letters
             // 599 USD, we use the unicode category Lu for capital letters from a bunch of languges
-            or regex.contains(beta.ml_translate(.named_groups["first_line"]).text,
-                              '\d{2,} \p{Lu}{2,5} '
+            or (
+              any(regex.extract(beta.ml_translate(.named_groups["first_line"]).text,
+                                '(\d{2,} \p{Lu}{2,5} )'
+                  ),
+                  not regex.icontains(.full_match, '[AP]M\s+$')
+              )
             )
             // commonly observed phrase "if not you call"
             or strings.icontains(.named_groups["first_line"], "If not you call")


### PR DESCRIPTION
# Description

Fix FPs because apple changed their template to cause the first line to contain details which matched our regex.  Update regex to no longer match on AM\PM formatted times. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507d6ab0ef7e17859d5a7043f30251ef23241bfbf067e430dc3dd2d1c4b5aed7?preview_id=019eb3ad-fd87-7cfc-af03-a7dc88aecc1d)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Messages that will no longer match](https://platform.sublime.security/messages/hunt?huntId=019eb3b5-416f-72ec-8b2c-d2c87d807ad2)
