### PR TITLE
Create link_svg_rcpt_address.yml

### DIFF
--- a/detection-rules/link_svg_rcpt_address.yml
+++ b/detection-rules/link_svg_rcpt_address.yml
@@ -1,0 +1,31 @@
+name: "Link: SVG with embedded recipient data"
+description: "Detects SVG links that contain the recipient's email address either in plain text or base64 encoded format within the URL, indicating potential tracking or targeting mechanisms."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(body.links,
+          strings.iends_with(.href_url.path, '.svg')
+          and any(recipients.to,
+                  .email.domain.valid
+                  // contained in the url
+                  and (
+                    strings.icontains(..href_url.url, .email.email)
+                    // or contains the base64 endcoded email
+                    or any(strings.scan_base64(..href_url.url,
+                                               format="url",
+                                               ignore_padding=true
+                           ),
+                           strings.icontains(., ..email.email)
+                    )
+                  )
+          )
+  )
+  
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+detection_methods:
+  - "URL analysis"
+  - "Content analysis"

--- a/detection-rules/link_svg_rcpt_address.yml
+++ b/detection-rules/link_svg_rcpt_address.yml
@@ -29,3 +29,4 @@ tactics_and_techniques:
 detection_methods:
   - "URL analysis"
   - "Content analysis"
+id: "a67ff913-f8cf-58af-a159-7ae20f6c063d"


### PR DESCRIPTION
# Description

Add coverage for observed pattern of linking to svgs (which can have javascript) that includes the recipient email address in the url. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50874f589cddf6d3a2f0e0067bae873d561e0fb8dbad242a51f37ea985863540?preview_id=019eb7db-5221-7138-8230-81d29aa885bb)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Multihunt](https://hunt.limeseed.email/hunts/9b7b1610-2b73-429c-a246-18c17e3af066)
- [hunt L365](https://platform.sublime.security/messages/hunt?huntId=019eb852-99bd-7df0-b941-5690561b7c95)
