### PR TITLE
fix: replace deprecated $alexa_1m with $tranco_1m in link_cuttly discovery rule

### DIFF
--- a/discovery-rules/link_cuttly.yml
+++ b/discovery-rules/link_cuttly.yml
@@ -7,7 +7,7 @@ authors:
   - twitter: "ajpc500"
 source: |
   type.inbound
-  and not sender.email.domain.root_domain in $alexa_1m
+  and not sender.email.domain.root_domain in $tranco_1m
   and (
     (
         sender.email.domain.root_domain in $free_email_providers


### PR DESCRIPTION
# Replace deprecated $alexa_1m with $tranco_1m in discovery-rules/link_cuttly.yml

---

# Description

Replaces the deprecated `$alexa_1m` list reference with `$tranco_1m` in `discovery-rules/link_cuttly.yml`, completing the Alexa → Tranco migration that open PR #3829 started but did not finish.

This is the last file in the repo still referencing `$alexa_1m`. PR #3829 (Jan 2026) swapped the list in `detection-rules/spam_emoji_cash_lures.yml` and `detection-rules/spoofable_internal_domain_suspicious_signals.yml` but missed this discovery rule.

# Associated samples

N/A — this is a list-name substitution with no behavioral change. The Tranco Top 1M is the repo's canonical replacement for the discontinued Alexa Top 1M.

## Associated hunts

N/A
