### PR TITLE
Create body_sus_yellow_highlighted_text.yml

### DIFF
--- a/detection-rules/body_sus_yellow_highlighted_text.yml
+++ b/detection-rules/body_sus_yellow_highlighted_text.yml
@@ -1,0 +1,17 @@
+name: "Body: Yellow highlighted text markers"
+description: "Detects messages containing multiple HTML span elements with yellow background highlighting (rgb(255, 241, 0)) and data-markjs attributes, potentially indicating evasion techniques through visual markup manipulation."
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and regex.icount(body.html.raw,
+                   '<span[^>]*data-markjs="true"[^>]*background-color:\s*rgb\(255,\s*241,\s*0\)[^>]*>[^<]'
+  ) >= 2
+attack_types:
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Evasion"
+detection_methods:
+  - "HTML analysis"
+  - "Content analysis"

--- a/detection-rules/body_sus_yellow_highlighted_text.yml
+++ b/detection-rules/body_sus_yellow_highlighted_text.yml
@@ -15,3 +15,4 @@ tactics_and_techniques:
 detection_methods:
   - "HTML analysis"
   - "Content analysis"
+id: "869dd39d-02a5-59f2-8fa9-3922a8fd5467"


### PR DESCRIPTION
# Description
Fun observed patterns where attackers are susceptibly taking screenshots of emails within their inbox but they're using gmail's search feature which highlights the searched word in yellow. They make no extended effort to remediate this big random yellow box around a certain word. I might focus this logic a bit based on how it does in test rules as it's a super wide net right now, elsewise I'll make it an ASR rule maybe... 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50874f589cddf6d3a2f0e0067bae873d561e0fb8dbad242a51f37ea985863540?preview_id=019eb7db-5221-7138-8230-81d29aa885bb)
- [Sample 2](https://platform.sublime.security/messages/507d1f15785a1fc7c3fd63f226982d6396afc37d23be8d677cf5a6a36a4cd0dc?preview_id=019e831d-167b-70b1-ac63-672187cbaf2e)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019ebbbc-2573-7a6c-9d9f-35c45672fce8)
- [Small multi-hunt L24 hours](https://hunt.limeseed.email/hunts/bc9dce4a-61e4-41ab-b7d8-935c8ea710b1)
