### PR TITLE
Update brand_impersonation_survey.yml

### DIFF
--- a/detection-rules/brand_impersonation_survey.yml
+++ b/detection-rules/brand_impersonation_survey.yml
@@ -16,7 +16,7 @@ source: |
     )
     or length(filter(ml.nlu_classifier(body.current_thread.text).entities,
                      .name == "financial"
-                     and regex.icontains(.text, '\d{2}%\s*discount')
+                     and regex.icontains(.text, '\d{2}%\s*discount$')
               )
     ) >= 2
   )

--- a/detection-rules/brand_impersonation_survey.yml
+++ b/detection-rules/brand_impersonation_survey.yml
@@ -14,6 +14,11 @@ source: |
     or any(ml.nlu_classifier(body.current_thread.text).entities,
            .name == "request" and strings.icontains(.text, 'Claim Your Free Kit')
     )
+    or length(filter(ml.nlu_classifier(body.current_thread.text).entities,
+                     .name == "financial"
+                     and regex.icontains(.text, '\d{2}%\s*discount')
+              )
+    ) >= 2
   )
   and any(ml.nlu_classifier(body.current_thread.text).topics,
           .name == "Advertising and Promotions" and .confidence != "low"


### PR DESCRIPTION
# Description

Adding logic to look for `financial` entities where `.text` contains a two digit number followed by `% discount`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5084e2ee01b2066bd56d7e58c671c4698ea42591debe9bc6b2066513462373c3?preview_id=019ebc43-2f3a-76a2-94d2-9de2adf0c9f2)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019ed576-8094-775c-957d-3d4ecdd8fe9c)