### PR TITLE
Update impersonation_quickbooks.yml

### DIFF
--- a/detection-rules/impersonation_quickbooks.yml
+++ b/detection-rules/impersonation_quickbooks.yml
@@ -44,8 +44,8 @@ source: |
                          'QuickBooks and Intuit are trademarks of Intuit Inc.'
     )
     or strings.icontains(body.current_thread.text, "QuickBooks Cloud Services")
-    or strings.icontains(body.current_thread.text,
-                         "Secured by QuickBooks Payments"
+    or regex.icontains(body.current_thread.text,
+                       '(?:Secured by )?QuickBooks Payments'
     )
     or strings.icontains(body.current_thread.text, "QuickBooks Support Center")
     // phone number and update language

--- a/detection-rules/impersonation_quickbooks.yml
+++ b/detection-rules/impersonation_quickbooks.yml
@@ -78,11 +78,23 @@ source: |
       )
     )
     or any(body.links,
-           regex.icontains(.display_url.url, '(?:quickbooks|intuit)')
-           and .mismatched
-           and not .href_url.domain.root_domain in (
-             "mimecast.com",
-             "mimecastprotect.com"
+           (
+             regex.icontains(.display_url.url, '(?:quickbooks|intuit)')
+             and .mismatched
+             and not .href_url.domain.root_domain in (
+               "mimecast.com",
+               "mimecastprotect.com"
+             )
+           )
+           or (
+             regex.icontains(.href_url.path, '(?:quickbooks|intuit)')
+             and not strings.icontains(.href_url.domain.root_domain,
+                                       "quickbooks",
+                                       "intuit"
+             )
+             and not any(ml.nlu_classifier(body.current_thread.text).topics,
+                         .name == "Advertising and Promotions"
+             )
            )
     )
   )


### PR DESCRIPTION
# Description

Added logic to look for links that contain `quickbooks` or `intuit` in the `path`, but the root domain does not, while negating `Advertising and Promotions` topics.

Also added additional keywords to capture additional FNs

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50803533ecf59186e63a2dbd739d134ccfbf3b04e198b6b4366bed605ec84f5d?preview_id=019eb2e4-d1aa-789f-8330-f5d4308afe97)
- [Sample 2](https://platform.sublime.security/messages/507b1779b49e8f309cd9a6b957c17ffbc55731b9f68a40be5b30774ef90b879e?preview_id=019eb2e4-c296-7226-aaed-435d783ca738)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019ed604-62f5-7acf-999e-4b1a2f5e2083)