### PR TITLE
Create link_self_sender_ip_check.yml

### DIFF
--- a/detection-rules/link_self_sender_ip_check.yml
+++ b/detection-rules/link_self_sender_ip_check.yml
@@ -10,8 +10,9 @@ source: |
     and recipients.to[0].email.email == sender.email.email
   )
   and any(body.current_thread.links,
-          any(ml.link_analysis(.).unique_urls_accessed,
-              .url == 'https://ipinfo.io/json'
+          .href_url.domain.root_domain != sender.email.domain.root_domain
+          and any(ml.link_analysis(.).unique_urls_accessed,
+                  .url == 'https://ipinfo.io/json'
           )
   )
 attack_types:

--- a/detection-rules/link_self_sender_ip_check.yml
+++ b/detection-rules/link_self_sender_ip_check.yml
@@ -1,5 +1,5 @@
-name: "Link: Self-sender with IP geolocation check"
-description: "Detects messages where the sender and recipient are the same address and the email contains a link that accesses ipinfo.io to gather IP geolocation information on the user."
+name: "Link: Self-sender with IP geolocation check and suspicious link behavior"
+description: "Detects messages where the sender and recipient are the same address that access IP geolocation services (ipinfo.io) and exhibit suspicious behavior, such as randomization scripting or confirmed credential harvesting indicators."
 type: "rule"
 severity: "medium"
 source: |
@@ -13,6 +13,16 @@ source: |
           .href_url.domain.root_domain != sender.email.domain.root_domain
           and any(ml.link_analysis(.).unique_urls_accessed,
                   .url == 'https://ipinfo.io/json'
+          )
+          and (
+            strings.icontains(ml.link_analysis(.).final_dom.raw,
+                              'Math.floor',
+                              'Math.random'
+            )
+            or (
+              ml.link_analysis(.).credphish.disposition == "phishing"
+              and ml.link_analysis(.).credphish.confidence in ("medium", "high")
+            )
           )
   )
 attack_types:

--- a/detection-rules/link_self_sender_ip_check.yml
+++ b/detection-rules/link_self_sender_ip_check.yml
@@ -9,22 +9,15 @@ source: |
     length(recipients.to) == 1
     and recipients.to[0].email.email == sender.email.email
   )
-  and any(body.current_thread.links,
-          .href_url.domain.root_domain != sender.email.domain.root_domain
-          and any(ml.link_analysis(.).unique_urls_accessed,
-                  .url == 'https://ipinfo.io/json'
-          )
-          and (
-            strings.icontains(ml.link_analysis(.).final_dom.raw,
-                              'Math.floor',
-                              'Math.random'
-            )
-            or (
-              ml.link_analysis(.).credphish.disposition == "phishing"
-              and ml.link_analysis(.).credphish.confidence in ("medium", "high")
-            )
+  and 0 < length(body.current_thread.links) < 10
+  and any(filter(body.current_thread.links,
+                 .href_url.domain.root_domain != sender.email.domain.root_domain
+          ),
+          any(ml.link_analysis(.).unique_urls_accessed,
+              .url == 'https://ipinfo.io/json'
           )
   )
+  and not headers.return_path.domain.root_domain == "salesforce.com"
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/link_self_sender_ip_check.yml
+++ b/detection-rules/link_self_sender_ip_check.yml
@@ -9,8 +9,11 @@ source: |
     length(recipients.to) == 1
     and recipients.to[0].email.email == sender.email.email
   )
-  and any(body.current_thread.links, any(ml.link_analysis(.).unique_urls_accessed, .url == 'https://ipinfo.io/json'))
-
+  and any(body.current_thread.links,
+          any(ml.link_analysis(.).unique_urls_accessed,
+              .url == 'https://ipinfo.io/json'
+          )
+  )
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:
@@ -19,3 +22,4 @@ tactics_and_techniques:
 detection_methods:
   - "Sender analysis"
   - "URL analysis"
+id: "fa708c3c-c40f-5b0d-b9c4-e9512fb32629"

--- a/detection-rules/link_self_sender_ip_check.yml
+++ b/detection-rules/link_self_sender_ip_check.yml
@@ -1,0 +1,21 @@
+name: "Link: Self-sender with IP geolocation check"
+description: "Detects messages where the sender and recipient are the same address and the email contains a link that accesses ipinfo.io to gather IP geolocation information on the user."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // self sender
+  and (
+    length(recipients.to) == 1
+    and recipients.to[0].email.email == sender.email.email
+  )
+  and any(body.current_thread.links, any(ml.link_analysis(.).unique_urls_accessed, .url == 'https://ipinfo.io/json'))
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "Sender analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description
Detects messages where the sender and recipient are the same address and the email contains a link that accesses ipinfo.io

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50862f6ccafff27a0303b0683f6fb80e074735982914811847c85408dd85ac19)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=019f0455-9fe1-76ab-ad19-a42ca77a6b87)
- [10 customer multi-hunt](https://hunt.limeseed.email/hunts/dcfad40d-28a9-4530-a596-7ab935b59fcf)
- [17 customer multi-hunt](https://hunt.limeseed.email/hunts/5407cce0-ca9c-4049-a32f-b94767e5c154)
- [60 customer multi-hunt](https://hunt.limeseed.email/hunts/eb229718-80b9-4086-b261-b2a6dc4925cd)
