### PR TITLE
Update recon_short_generic_greeting.yml

### DIFF
--- a/detection-rules/recon_short_generic_greeting.yml
+++ b/detection-rules/recon_short_generic_greeting.yml
@@ -23,7 +23,10 @@ source: |
       recipients.to[0].email.domain.root_domain
     )
     or (
-      any(recipients.to, strings.ilike(.display_name, "undisclosed?recipients"))
+      (
+        all(recipients.to, .email.domain.valid == false)
+        and all(recipients.cc, .email.domain.valid == false)
+      )
       or length(recipients.to) == 0
     )
   )

--- a/detection-rules/recon_short_generic_greeting.yml
+++ b/detection-rules/recon_short_generic_greeting.yml
@@ -18,8 +18,14 @@ source: |
   )
   // external freemail sender
   and sender.email.domain.root_domain in $free_email_providers
-  and sender.email.domain.root_domain not in (
-    recipients.to[0].email.domain.root_domain
+  and (
+    sender.email.domain.root_domain not in (
+      recipients.to[0].email.domain.root_domain
+    )
+    or (
+      any(recipients.to, strings.ilike(.display_name, "undisclosed?recipients"))
+      or length(recipients.to) == 0
+    )
   )
   and (
     length(recipients.cc) == 0


### PR DESCRIPTION
# Description

Added logic to look for empty recipients or `undisclosed recipients`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5086372465759629142614b44d3cd57b44cdc0865b583f15c5908220a84a6cfd?preview_id=019eb1b8-b637-7b11-987b-495f3de245fe)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019ed5b1-e255-7cf4-a4a0-5ca191f5682c)