### PR TITLE
Update link_romance_suspicious.yml

### DIFF
--- a/detection-rules/link_romance_suspicious.yml
+++ b/detection-rules/link_romance_suspicious.yml
@@ -12,6 +12,7 @@ source: |
   and 1 of (
     any(body.links, network.whois(.href_url.domain).days_old < 30),
     any(body.links, .href_url.domain.root_domain in $url_shorteners),
+    any(body.links, .href_url.domain.domain in $free_subdomain_hosts),
     any(body.links, .href_url.domain.tld in ('ru', 'app', 'digital', 'click')),
     any(headers.reply_to, network.whois(.email.domain).days_old < 30)
   )


### PR DESCRIPTION
# Description

Adding logic to account for `sites[.]google` links and other free subdomain hosts

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5085830c37d7ff183a380102ddb21a5c9f501715a40163fcf9beef5e13a692bf?preview_id=019eacbe-4b53-779f-9dcb-a830a46c70e3)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019ed5f4-7d67-7e62-abf8-8ed6baad260b)