### PR TITLE
fix: exclude public contact mailboxes from BEC new-sender rule

### DIFF
--- a/detection-rules/body_business_email_compromise_new_sender.yml
+++ b/detection-rules/body_business_email_compromise_new_sender.yml
@@ -45,6 +45,9 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
+  
+  // negate public contact mailboxes
+  and sender.email.email not in $public_contact_mailboxes
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:


### PR DESCRIPTION
## Summary
Adds a negation for `$public_contact_mailboxes` to `body_business_email_compromise_new_sender`. Public contact mailboxes (info@, support@, hello@, etc.) are high-volume inbound recipients from new/unknown senders by design — excluding them reduces FP noise on this rule.

## Test plan
- [ ] Verify rule still fires on a genuine BEC payload from a new-sender domain
- [ ] Confirm `$public_contact_mailboxes` list is populated in target tenants before enabling

Made with [Cursor](https://cursor.com)