### PR TITLE
Update fake_thread_suspicious_indicators.yml

### DIFF
--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -84,7 +84,7 @@ source: |
       regex.icontains(subject.subject, '\bre:\s+re:')
       and (
         regex.icontains(subject.base,
-                        '(?:action.{0,10}required|invest(ment|ing)?|enforcement|opportunit|urgent|verif|confirm|suspend|terminat)'
+                        '(?:action.{0,10}required|invest(?:ment|ing)?|enforcement|opportunit|urgent|verif|confirm|suspend|terminat)'
         )
       )
     ),

--- a/detection-rules/fake_thread_suspicious_indicators.yml
+++ b/detection-rules/fake_thread_suspicious_indicators.yml
@@ -78,6 +78,16 @@ source: |
     any(ml.nlu_classifier(body.current_thread.text).intents,
         .name == "cred_theft" and .confidence in~ ("medium", "high")
     ),
+
+    // subject has multiple re: tags and suspicious indicators
+    (
+      regex.icontains(subject.subject, '\bre:\s+re:')
+      and (
+        regex.icontains(subject.base,
+                        '(?:action.{0,10}required|invest(ment|ing)?|enforcement|opportunit|urgent|verif|confirm|suspend|terminat)'
+        )
+      )
+    ),
   
     // commonly abused sender TLD
     strings.ilike(sender.email.domain.tld, "*.jp"),


### PR DESCRIPTION
# Description

FN reported, expanding the coverage of the fake thread with sus indicators to add a new high confidence indicator of suspicious activity. Multiple "re" in the subject alongside suspicious keywords like "urgent" or "action required" 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/508b647a98bed33c95d016da37810ec82fa4476da4edab4af6b2dc254b3f04d2?preview_id=019ecc3a-a9a1-77ff-8308-114ade7f9103)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [net-new diff in shared samples](https://platform.sublime.security/messages/hunt?huntId=019ed08a-a66a-70a0-b380-dfb463bc9b98)
- [net-new diff in multihunt](https://hunt.limeseed.email/hunts/d0853b74-c230-405c-8a85-7d8a1a82a92e)