### PR TITLE
Create service_abuse_ibm_iam_callback.yml

### DIFF
--- a/detection-rules/service_abuse_ibm_iam_callback.yml
+++ b/detection-rules/service_abuse_ibm_iam_callback.yml
@@ -13,7 +13,7 @@ attack_types:
 tactics_and_techniques:
   - "Impersonation: Brand"
   - "Social engineering"
-  - "Spoofing"
+  - "Out of band pivot"
 detection_methods:
   - "Sender analysis"
   - "Content analysis"

--- a/detection-rules/service_abuse_ibm_iam_callback.yml
+++ b/detection-rules/service_abuse_ibm_iam_callback.yml
@@ -18,3 +18,4 @@ detection_methods:
   - "Sender analysis"
   - "Content analysis"
   - "Natural Language Understanding"
+id: "7c4ef255-9063-54a8-99c2-9e20382ef96d"

--- a/detection-rules/service_abuse_ibm_iam_callback.yml
+++ b/detection-rules/service_abuse_ibm_iam_callback.yml
@@ -1,0 +1,20 @@
+name: "Service abuse: IBM IAM account notification with callback scam indicators"
+description: "Detects inbound messages abusing IBM's IAM account notification address that contain callback scam intent patterns identified through natural language analysis."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and sender.email.email == "ibmacct@iam.ibm.com"
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "callback_scam" and .confidence != "low"
+  )
+attack_types:
+  - "Callback Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+  - "Spoofing"
+detection_methods:
+  - "Sender analysis"
+  - "Content analysis"
+  - "Natural Language Understanding"


### PR DESCRIPTION
# Description
Detects inbound messages abusing IBM's IAM account notification address that contain callback scam intent patterns identified through natural language analysis.

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/50887edb3bafedf0aa41c79c70b0a63bf9517f1d8cce0634ee54c211e6b98cf6?preview_id=019ed0bb-d569-79f5-b500-6e0b4013d6ad)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019ed0bc-eb36-7bf0-9d35-0abeb1cf6683)
- [multi hunt](https://hunt.limeseed.email/hunts/4f844612-0325-41c6-a714-4073477a72cc)
