### PR TITLE
Update link_credential_cloud_service.yml

### DIFF
--- a/detection-rules/link_credential_cloud_service.yml
+++ b/detection-rules/link_credential_cloud_service.yml
@@ -15,6 +15,10 @@ source: |
     or strings.icontains(body.current_thread.text,
                          '4563 Cloud Way, Server City, CA'
     )
+    or any(html.xpath(body.html, '//img/@alt').nodes,
+           regex.icontains(.raw, '^cloud logo')
+    )
+    or regex.icontains(body.current_thread.text, 'cloud id:\s*#\d+')
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == 'cred_theft' and .confidence == 'high'


### PR DESCRIPTION
# Description

Adding logic to look for generic `Cloud Logo` in alt text or `cloud id: #` followed by a random series of numbers

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5079e303d36516fd15f182f7f997f903bfc4d1c5a2088a3dc0148642df17e7b7?preview_id=019e94d4-cef8-79a1-a1ab-cd338b9f8b9b)
- [Sample 2](https://platform.sublime.security/messages/508cfec2f6042117130602b412c9278ccdcabdbc376126524a885216a24109f9?preview_id=019ece5f-54fb-773f-b61a-e4a111d68930)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019edb31-c076-7dbb-9a3f-37c2500906c0)