### PR TITLE
Update link_office365_suspicious_app_authorization.yml

### DIFF
--- a/detection-rules/link_office365_suspicious_app_authorization.yml
+++ b/detection-rules/link_office365_suspicious_app_authorization.yml
@@ -11,21 +11,23 @@ source: |
   type.inbound
   and (
     // links in email body
-    any(body.links,
-        .href_url.domain.domain == 'login.microsoftonline.com'
-        and (
-          strings.ilike(.href_url.query_params,
-                        '*offline_access*',
-                        '*.readwrite*',
-                        '*.read*',
-                        '*ctx=*',
-                        '*prompt=none*'
-          )
-          or (
-            strings.icontains(.href_url.path, '/common/reprocess')
-            and strings.icontains(.href_url.query_params, 'ctx=')
-            and strings.icontains(.href_url.query_params, 'sessionId=')
-          )
+    any([body.links, body.current_thread.links],
+        any(.,
+            .href_url.domain.domain == 'login.microsoftonline.com'
+            and (
+              strings.ilike(.href_url.query_params,
+                            '*offline_access*',
+                            '*.readwrite*',
+                            '*.read*',
+                            '*ctx=*',
+                            '*prompt=none*'
+              )
+              or (
+                strings.icontains(.href_url.path, '/common/reprocess')
+                and strings.icontains(.href_url.query_params, 'ctx=')
+                and strings.icontains(.href_url.query_params, 'sessionId=')
+              )
+            )
         )
     )
     // links in PDF, HTML, DOCX and PPTX attachments


### PR DESCRIPTION
# Description
noticed while IOC hunting, this sample's URL was missing from body.links. turns out Go's HTML parser short-circuits on malformed inputs (two stacked <!DOCTYPE html> docs in one part) under CVE-2025-47911 to prevent a DoS.
body.current_thread.links still finds the link, so checking both in the rule closes the gap. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/508bc12bdd20ec0624dd7368466daed4f4f4badbc4c267b0b164568e4dd2d1b1?preview_id=019ecf33-06f5-7222-a335-c259aa1935af)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019ed11b-37cc-7641-a90c-c65e4930ef42)
- [multi hunt](https://hunt.limeseed.email/hunts/e188545c-94a4-4a28-896a-4baf029421d6)


