### PR TITLE
Refine brand_impersonation_amazon.yml

### DIFF
--- a/detection-rules/brand_impersonation_amazon.yml
+++ b/detection-rules/brand_impersonation_amazon.yml
@@ -27,6 +27,12 @@ source: |
     )
     or strings.ilike(subject.subject, "*prime membership*")
     or (
+      strings.ilike(subject.base, "*prime access*")
+      and regex.icontains(body.current_thread.text,
+                          "prime (membership|subscription|notification|support|video|account)"
+      )
+    )
+    or (
       strings.ilevenshtein(sender.display_name, 'amazon') <= 1
       and sender.email.domain.root_domain in $free_email_providers
     )


### PR DESCRIPTION
# Description
Additional coverage for FN's found in que. Added strings to search for `prime access`.

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/5082583c0814811ec56db956eae10215e73329ed81fcc295a63c00e55ae81d7b?preview_id=019e9eab-2399-74f3-ac76-123db99d4ddf)

## Associated hunts
- [Hunt 1](https://platform.sublime.security/hunts/019ed118-50a5-750b-8100-84acfd7c0ccd)
- [Multi-hunt](https://hunt.limeseed.email/hunts/521b9170-2ba6-4f5f-b722-2780db174f42)