### PR TITLE
Create service_abuse_outlook_groups_google_sites.yml

### DIFF
--- a/detection-rules/service_abuse_outlook_groups_google_sites.yml
+++ b/detection-rules/service_abuse_outlook_groups_google_sites.yml
@@ -10,7 +10,7 @@ source: |
   )
   and (
     regex.icontains(body.current_thread.text, '\n[a-z0-9]{3}\s*$')
-    or regex.icontains(subject.subject, '\s{2,}[a-z0-9]{3}\s*$')
+    or regex.icontains(subject.base, '\s{2,}[a-z0-9]{3}\s*$')
   )
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/service_abuse_outlook_groups_google_sites.yml
+++ b/detection-rules/service_abuse_outlook_groups_google_sites.yml
@@ -1,0 +1,25 @@
+name: "Service abuse: Outlook Groups with Google Sites link and evasion tag"
+description: "Detects inbound messages sent via Outlook Groups (groups.outlook.com) that contain links to Google Sites, combined with a suspicious short alphanumeric tag appended to either the message body or subject line. This pattern is commonly used to evade detection while redirecting recipients to credential harvesting pages hosted on Google Sites."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and headers.return_path.domain.domain == "groups.outlook.com"
+  and any(body.current_thread.links,
+          .href_url.domain.domain == "sites.google.com"
+  )
+  and (
+    regex.icontains(body.current_thread.text, '\n[a-z0-9]{3}\s*$')
+    or regex.icontains(subject.subject, '\s{2,}[a-z0-9]{3}\s*$')
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Free subdomain host"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "URL analysis"
+  - "Sender analysis"

--- a/detection-rules/service_abuse_outlook_groups_google_sites.yml
+++ b/detection-rules/service_abuse_outlook_groups_google_sites.yml
@@ -23,3 +23,4 @@ detection_methods:
   - "Header analysis"
   - "URL analysis"
   - "Sender analysis"
+id: "c4a6c6bf-2d07-550e-8d67-8d8c6658b1a1"


### PR DESCRIPTION
# Description

Created this PR to build upon PR #4671, looking for the use `groups[.]outlook`, `sites[.]google`, and evasion tags in the body or subject

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/508c1ab56246feb41c10b1adabb13e122d63f9ea2c06611f8f05dfddf6db09d2?preview_id=019ed27a-0591-76b6-82d7-53828ba9eb5b)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=019ed6e1-671a-7805-b9aa-ca339b9b3521)
- [L14D 92 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/bab72d8d-fc4f-409e-b425-3107506bb50f)