### PR TITLE
Update impersonation_google_drive_file_share.yml

### DIFF
--- a/detection-rules/impersonation_google_drive_file_share.yml
+++ b/detection-rules/impersonation_google_drive_file_share.yml
@@ -70,8 +70,15 @@ source: |
                       "*sign*",
                       "*review*"
         )
-        or any(recipients.to,
-               strings.icontains(subject.subject, .email.domain.sld)
+        or (
+          any(recipients.to,
+              strings.icontains(subject.subject, .email.domain.sld)
+              or (
+                (.email.domain.valid == false)
+                and all(recipients.cc, .email.domain.valid == false)
+              )
+          )
+          or length(recipients.to) == 0
         )
         or strings.ilike(subject.subject, "*Docs*", "*Sheets*", "*Slides*")
         or any(body.links,

--- a/detection-rules/impersonation_google_drive_file_share.yml
+++ b/detection-rules/impersonation_google_drive_file_share.yml
@@ -77,6 +77,10 @@ source: |
         or any(body.links,
                strings.icontains(.display_text, "open document")
                or strings.iends_with(.display_text, ".pdf")
+               or (
+                 .display_text =~ "Open"
+                 and network.whois(.href_url.domain).days_old < 365
+               )
         )
         or strings.ilike(sender.display_name, "*Google Drive*")
         or subject.subject is null


### PR DESCRIPTION
# Description

Adding logic to look for `Open` with a link less than 365 days old

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5086aae8043a2109398118cff47a515fbe5769c6f0269b1c1d08efcb9f9ebf56?preview_id=019eb324-7065-79eb-ae8f-2de604d9b75b)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019efaaf-d819-710d-a1d7-e2f57a60a2e6)
- [L7D 92 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/dab78fd3-3f85-4bdc-9f3f-aee3f1b63954)