### PR TITLE
Update Fake Photo Share rule

### DIFF
--- a/detection-rules/spam_fake_photo.yml
+++ b/detection-rules/spam_fake_photo.yml
@@ -1,4 +1,4 @@
-name: "Spam: Fake photo share"
+name: "Spam: Photo/image lure"
 description: 'Message contains pretexting language about sharing photos ("found these photos and thought you''d like them", "remember these photos?") and a link with a newly registered domain. Fake threads and plain text bodies have been seen in the wild, indicating active evasion techniques.'
 type: "rule"
 severity: "low"
@@ -66,14 +66,19 @@ source: |
         )
         or (
           length(body.current_thread.text) < 500
-          and strings.ilike(body.current_thread.text,
-                            "*picture*",
-                            "*photo*",
-                            "*image*",
-                            "*sad news*",
-                            "*sad announcement*",
-                            "*sad update*",
-                            "*new pics*"
+          and (
+            strings.ilike(body.current_thread.text,
+                          "*picture*",
+                          "*photo*",
+                          "*image*",
+                          "*sad news*",
+                          "*sad announcement*",
+                          "*sad update*",
+                          "*new pics*"
+            )
+            or regex.icontains(body.current_thread.text,
+                               '\b(photo|pics?|picture)\b'
+            )
           )
         )
       )


### PR DESCRIPTION
# Description
Updated the name of the spam detection rule and modified the conditions for identifying spam messages related to fake photo shares.

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/50865b46967d339ae901c7d22233e40153dfc8df7dfe5b06df12c2a1ee52a257)

## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019edd05-8e8d-7e4f-bdc7-d5b96be232af)
- [Multi-hunt](https://hunt.limeseed.email/hunts/53856218-bc6b-42d5-8b6f-c025c8a6a379)