### PR TITLE
excludes false positives from outlign.co

### DIFF
--- a/detection-rules/brand_impersonation_ms_planner.yml
+++ b/detection-rules/brand_impersonation_ms_planner.yml
@@ -51,7 +51,8 @@ source: |
                "msftauthimages.net",
                "mimecastprotect.com",
                "office.com",
-               "microsoftproject.com"
+               "microsoftproject.com",
+               "outlign.co"
              )
              or any(body.links, .href_url.domain.domain in $free_file_hosts)
            )


### PR DESCRIPTION
Outlign sends messages that probably match on task assigned messages from Outlign.

# Description

<!-- 
Outlign uses language that causes this rule to fire, incorrectly so. This change adds outlign.co as a potential false positive.
-->

# Associated samples
<!-- 
I tested a new hunt with this exclusion and it worked in my testing.
-->



