### PR TITLE
Add detection rule for OpenAI ChatGPT Ads impersonation

### DIFF
--- a/detection-rules/brand_impersonation_openai_chatgptads.yml
+++ b/detection-rules/brand_impersonation_openai_chatgptads.yml
@@ -1,0 +1,49 @@
+name: "Brand Impersonation: OpenAI with ChatGPT Ads lure"
+description: "Detects messages impersonating OpenAI or ChatGPT, that contain specific references to ChatGPT Ads. Observed harvesting advertisting account credentials."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and (
+    // sender or subject contains openai or chatgpt
+    regex.icontains(sender.display_name, '\bchat\s*gpt\b')
+    or regex.icontains(sender.display_name, '\bopen\s*a[li]\b')
+    or regex.icontains(subject.subject, '\bchat\s*gpt\b')
+    or regex.icontains(subject.subject, '\bopen\s*a[li]\b')
+    or regex.icontains(body.current_thread.text,
+                       '(?:regarding\s*your\s*Open\s*A[lI]\s*account|Open\s*A[lI]\s*\.\s*All\s*rights\s*reserved|the\s*open\s*ai\s*team)'
+    )
+    // display name references OpenAI CEO Sam Altman
+    or strings.icontains(sender.display_name, "Sam Altman")
+  )
+  and 2 of (
+    regex.icontains(body.current_thread.text, 'ChatGPT.{0,15}Ads'),
+    strings.icontains(body.current_thread.text, "ad account"),
+    strings.icontains(body.current_thread.text, "connect account"),
+    strings.icontains(body.current_thread.text, "ad campaign"),
+    strings.icontains(body.current_thread.text, "invitation"),
+    // OpenAI mailing address
+    regex.icontains(body.current_thread.text,
+                    '3180 18(?:th)? St(?:reet)?,? San Francisco,? (?:CA|California)'
+    )
+  )
+  // suspicious sender domain
+  and (
+    regex.icontains(sender.email.domain.domain, '(?:open.?ai|chat.?gpt)')
+    or network.whois(sender.email.domain).days_old < 365
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Sender analysis"
+  - "Whois"
+  - "Content analysis"

--- a/detection-rules/brand_impersonation_openai_chatgptads.yml
+++ b/detection-rules/brand_impersonation_openai_chatgptads.yml
@@ -47,3 +47,4 @@ detection_methods:
   - "Sender analysis"
   - "Whois"
   - "Content analysis"
+id: "96f5864c-3fd8-5797-aa5b-2f9bc91eced6"

--- a/detection-rules/brand_impersonation_openai_chatgptads.yml
+++ b/detection-rules/brand_impersonation_openai_chatgptads.yml
@@ -17,7 +17,7 @@ source: |
     or strings.icontains(sender.display_name, "Sam Altman")
     // OpenAI mailing address
     or regex.icontains(body.current_thread.text,
-                    '3180 18(?:th)? St(?:reet)?,? San Francisco,? (?:CA|California)'
+                       '3180 18(?:th)? St(?:reet)?,? San Francisco,? (?:CA|California)'
     )
   )
   and 2 of (
@@ -37,7 +37,6 @@ source: |
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/brand_impersonation_openai_chatgptads.yml
+++ b/detection-rules/brand_impersonation_openai_chatgptads.yml
@@ -15,6 +15,10 @@ source: |
     )
     // display name references OpenAI CEO Sam Altman
     or strings.icontains(sender.display_name, "Sam Altman")
+    // OpenAI mailing address
+    or regex.icontains(body.current_thread.text,
+                    '3180 18(?:th)? St(?:reet)?,? San Francisco,? (?:CA|California)'
+    )
   )
   and 2 of (
     regex.icontains(body.current_thread.text, 'ChatGPT.{0,15}Ads'),
@@ -22,10 +26,6 @@ source: |
     strings.icontains(body.current_thread.text, "connect account"),
     strings.icontains(body.current_thread.text, "ad campaign"),
     strings.icontains(body.current_thread.text, "invitation"),
-    // OpenAI mailing address
-    regex.icontains(body.current_thread.text,
-                    '3180 18(?:th)? St(?:reet)?,? San Francisco,? (?:CA|California)'
-    )
   )
   // suspicious sender domain
   and (


### PR DESCRIPTION
# Description

This rule detects messages impersonating OpenAI or ChatGPT, specifically targeting references to ChatGPT Ads and potential credential harvesting attempts.

# Associated samples
- https://platform.sublime.security/messages/5092fc8c1f591ea8e4316de5265edd880dbc6745b5464958091bbe0813fa33ff
- https://platform.sublime.security/messages/508d5a4bba56ddf07d9457d37e8b0ab93892ea668ac3e09cd5716e1192e9c492?preview_id=019ed627-e781-7cf6-bfb4-4970a625d871

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=019ef0b7-ad2b-7542-8138-8c09d5e6454f