### PR TITLE
Update generic_zip.yar

### DIFF
--- a/yara/generic_zip.yar
+++ b/yara/generic_zip.yar
@@ -2,7 +2,8 @@ rule zipline_delivery_telekom {
 	meta:
 		author      = "kyle eaton"
 		date        = "2026-06-18"
-		description = "https://github.security.telekom.com/2026/06/ZipLine-linked-spearphishing-campaign.html"
+		ref = "https://github.security.telekom.com/2026/06/ZipLine-linked-spearphishing-campaign.html"
+		description = "zip file with one double extension (docx.lnk) and two docx lures per the ref campaign"
 	strings:
 		$pklfh = { 50 4b 03 04 }
 		$ext   = ".docx.lnk"
@@ -14,5 +15,28 @@ rule zipline_delivery_telekom {
 		) and
 		for 2 i in (1..100): (
 			($docx in ((@pklfh[i] + 30 + uint16(@pklfh[i] + 26) - !docx)..(@pklfh[i] + 30 + uint16(@pklfh[i] + 26))))
+		)
+}
+
+rule zip_smuggler_default {
+	meta:
+		author      = "kyle eaton"
+		ref      = "https://github.com/Octoberfest7/zip_smuggling"
+		date        = "2026-06-22"
+		description = "zip file with the default 'egghunt' value 0x55555555 after the file bytes of a PKLFH. s/o @ffforward"
+	strings:
+		$pklfh = { 50 4b 03 04 }
+		$ext   = ".lnk"
+	condition:
+		uint16be(0) == 0x504b
+		and for any i in (1..100): (
+			// extra field == 0
+			uint16(@pklfh[i] + 28) == 0x00
+			// UUUU after the file data
+			and uint32be(@pklfh[i] + 30 + uint16(@pklfh[i] + 26) + uint32(@pklfh[i] + 18)) == 0x55555555
+		)
+		// need at least one LNK file 
+		and for any i in (1..100): (
+			($ext in ((@pklfh[i] + 30 + uint16(@pklfh[i] + 26) - !ext)..(@pklfh[i] + 30 + uint16(@pklfh[i] + 26))))
 		)
 }


### PR DESCRIPTION
##Description
Two changes:
- with the older zipline_delivery rule I'm updating the metadata.
- new rule zip_smuggler_default - this is looking at the default zip smuggler (project) files that it creates with data embedded into the "extra data" space of the file but no extra data length set.