### PR TITLE
Create link_invalid_replyto_with_recipient_details.yml

### DIFF
--- a/detection-rules/link_invalid_replyto_with_recipient_details.yml
+++ b/detection-rules/link_invalid_replyto_with_recipient_details.yml
@@ -1,0 +1,25 @@
+name: "Link: Invalid reply-to with recipient details in subject, body, and encoded link"
+description: "Detects inbound messages with an invalid reply-to address where the recipient's domain SLD appears in the subject, the recipient's local part and domain SLD appear in the body, and the recipient's full email address is base64-encoded within a link fragment."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+    // Invalid reply-to address
+    and any(headers.reply_to, not .email.domain.valid)
+    and strings.icontains(subject.base, recipients.to[0].email.domain.sld)
+    and strings.icontains(body.current_thread.text, recipients.to[0].email.local_part)
+    and strings.icontains(body.current_thread.text, recipients.to[0].email.domain.sld)
+    and any(body.current_thread.links, any(strings.scan_base64(.href_url.fragment), . == recipients.to[0].email.email))
+  
+attack_types:
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Evasion"
+  - "Spoofing"
+detection_methods:
+  - "Header analysis"
+  - "Content analysis"
+  - "URL analysis"
+  - "Sender analysis"

--- a/detection-rules/link_invalid_replyto_with_recipient_details.yml
+++ b/detection-rules/link_invalid_replyto_with_recipient_details.yml
@@ -4,13 +4,20 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-    // Invalid reply-to address
-    and any(headers.reply_to, not .email.domain.valid)
-    and strings.icontains(subject.base, recipients.to[0].email.domain.sld)
-    and strings.icontains(body.current_thread.text, recipients.to[0].email.local_part)
-    and strings.icontains(body.current_thread.text, recipients.to[0].email.domain.sld)
-    and any(body.current_thread.links, any(strings.scan_base64(.href_url.fragment), . == recipients.to[0].email.email))
-  
+  // Invalid reply-to address
+  and any(headers.reply_to, not .email.domain.valid)
+  and strings.icontains(subject.base, recipients.to[0].email.domain.sld)
+  and strings.icontains(body.current_thread.text,
+                        recipients.to[0].email.local_part
+  )
+  and strings.icontains(body.current_thread.text,
+                        recipients.to[0].email.domain.sld
+  )
+  and any(body.current_thread.links,
+          any(strings.scan_base64(.href_url.fragment),
+              . == recipients.to[0].email.email
+          )
+  )
 attack_types:
   - "Credential Phishing"
   - "BEC/Fraud"
@@ -23,3 +30,4 @@ detection_methods:
   - "Content analysis"
   - "URL analysis"
   - "Sender analysis"
+id: "aebbc685-7cbf-56ee-ae32-1a49ddd9dcd6"


### PR DESCRIPTION
# Description
Detects inbound messages with an invalid reply-to address where the recipient's domain SLD appears in the subject, the recipient's local part and domain SLD appear in the body, and the recipient's full email address is base64-encoded within a link fragment.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/508bcb4d29dbfb7b785db1bf1f71c6f1d8603302c53fea824e981d21056f7457)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [20 Customer multi-hunt](https://hunt.limeseed.email/hunts/bdbd1820-996b-4209-9574-e46a8d9c1152)
- [SWS hunt](https://platform.sublime.security/hunts/019ef0e2-2577-78ab-b734-9b95fba9b4b9)
