### PR TITLE
Add auth check to OpenAI impersonation rule

### DIFF
--- a/detection-rules/impersonation_openai_payment_issues.yml
+++ b/detection-rules/impersonation_openai_payment_issues.yml
@@ -55,7 +55,10 @@ source: |
     strings.icontains(body.current_thread.text, 'active without interruption')
   )
   // not from openai
-  and not sender.email.domain.root_domain == 'openai.com'
+  and not (
+    sender.email.domain.root_domain == 'openai.com'
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
   // negate highly trusted sender domains unless they fail DMARC authentication
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains


### PR DESCRIPTION
# Description

adding auth check to ensure impersonations of `openai.com` are properly flagged.

(haven't observed any in the wild yet, just noticed this while working on an unrelated escalation.)