### PR TITLE
Create link_credential_cloud_support.yml

### DIFF
--- a/detection-rules/link_credential_cloud_support.yml
+++ b/detection-rules/link_credential_cloud_support.yml
@@ -5,7 +5,12 @@ severity: "medium"
 source: |
   type.inbound
   and sender.email.local_part == 'support'
-  and 1 < length(body.current_thread.links) <= 5
+  and 1 < length(filter(body.current_thread.links,
+                        not regex.icontains(.href_url.url,
+                                            '\.(pdf|doc|docx|csv|xls|xlsx|ppt|pptx)'
+                        )
+                 )
+  ) <= 5
   and all(body.current_thread.links,
           .href_url.domain.root_domain in $free_file_hosts
           or .href_url.domain.domain in $free_file_hosts
@@ -15,6 +20,11 @@ source: |
   )
   and any(ml.nlu_classifier(body.current_thread.text).topics,
           .name == 'File Sharing and Cloud Services' and .confidence != 'low'
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/link_credential_cloud_support.yml
+++ b/detection-rules/link_credential_cloud_support.yml
@@ -25,6 +25,4 @@ detection_methods:
   - "Sender analysis"
   - "URL analysis"
   - "Natural Language Understanding"
-  - "Header analysis"
-  - "Natural Language Understanding"
 id: "816ad5de-e97c-5d8d-93bf-d0ed100d5607"

--- a/detection-rules/link_credential_cloud_support.yml
+++ b/detection-rules/link_credential_cloud_support.yml
@@ -1,0 +1,26 @@
+name: "Link: Free file host links from suspicious support sender with credential theft language"
+description: "Detects inbound messages from senders using the local part 'support' that contain a small number of links pointing exclusively to free file hosting services. The message fails SPF authentication, and NLU signals indicate credential theft intent related to file sharing or cloud services."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+    and sender.email.local_part == 'support'
+    and 1 < length(body.current_thread.links) < 4
+    and all(body.current_thread.links,
+            .href_url.domain.root_domain in $free_file_hosts
+            or .href_url.domain.domain in $free_file_hosts
+    ) 
+    and coalesce(headers.auth_summary.spf.pass, false) == false
+    and any(ml.nlu_classifier(body.current_thread.text).intents, .name == 'cred_theft' and .confidence != 'low')
+    and any(ml.nlu_classifier(body.current_thread.text).topics, .name == 'File Sharing and Cloud Services' and .confidence != 'low')
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Free file host"
+  - "Social engineering"
+detection_methods:
+  - "Sender analysis"
+  - "URL analysis"
+  - "Natural Language Understanding"
+  - "Header analysis"
+  - "Natural Language Understanding"

--- a/detection-rules/link_credential_cloud_support.yml
+++ b/detection-rules/link_credential_cloud_support.yml
@@ -10,7 +10,6 @@ source: |
           .href_url.domain.root_domain in $free_file_hosts
           or .href_url.domain.domain in $free_file_hosts
   )
-  and coalesce(headers.auth_summary.spf.pass, false) == false
   and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == 'cred_theft' and .confidence != 'low'
   )

--- a/detection-rules/link_credential_cloud_support.yml
+++ b/detection-rules/link_credential_cloud_support.yml
@@ -4,15 +4,19 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-    and sender.email.local_part == 'support'
-    and 1 < length(body.current_thread.links) < 4
-    and all(body.current_thread.links,
-            .href_url.domain.root_domain in $free_file_hosts
-            or .href_url.domain.domain in $free_file_hosts
-    ) 
-    and coalesce(headers.auth_summary.spf.pass, false) == false
-    and any(ml.nlu_classifier(body.current_thread.text).intents, .name == 'cred_theft' and .confidence != 'low')
-    and any(ml.nlu_classifier(body.current_thread.text).topics, .name == 'File Sharing and Cloud Services' and .confidence != 'low')
+  and sender.email.local_part == 'support'
+  and 1 < length(body.current_thread.links) < 4
+  and all(body.current_thread.links,
+          .href_url.domain.root_domain in $free_file_hosts
+          or .href_url.domain.domain in $free_file_hosts
+  )
+  and coalesce(headers.auth_summary.spf.pass, false) == false
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == 'cred_theft' and .confidence != 'low'
+  )
+  and any(ml.nlu_classifier(body.current_thread.text).topics,
+          .name == 'File Sharing and Cloud Services' and .confidence != 'low'
+  )
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:
@@ -24,3 +28,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Header analysis"
   - "Natural Language Understanding"
+id: "816ad5de-e97c-5d8d-93bf-d0ed100d5607"

--- a/detection-rules/link_credential_cloud_support.yml
+++ b/detection-rules/link_credential_cloud_support.yml
@@ -1,5 +1,5 @@
 name: "Link: Free file host links from suspicious support sender with credential theft language"
-description: "Detects inbound messages from senders using the local part 'support' that contain a small number of links pointing exclusively to free file hosting services. The message fails SPF authentication, and NLU signals indicate credential theft intent related to file sharing or cloud services."
+description: "Detects inbound messages from senders using the local part 'support' that contain a small number of links pointing exclusively to free file hosting services. The message contains NLU signals indicate credential theft intent related to file sharing or cloud services."
 type: "rule"
 severity: "medium"
 source: |

--- a/detection-rules/link_credential_cloud_support.yml
+++ b/detection-rules/link_credential_cloud_support.yml
@@ -5,7 +5,7 @@ severity: "medium"
 source: |
   type.inbound
   and sender.email.local_part == 'support'
-  and 1 < length(body.current_thread.links) < 4
+  and 1 < length(body.current_thread.links) <= 5
   and all(body.current_thread.links,
           .href_url.domain.root_domain in $free_file_hosts
           or .href_url.domain.domain in $free_file_hosts


### PR DESCRIPTION
# Description
This is a new rule created for FNs for fake cloud support renewals.  
Sender local part is `support`.  All links are to free file host(usually google cloud storage or s3).  SPF fails. Cred_theft  intent and File Sharing and Cloud Services topic. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/509315168f8508297accfcd5165e6eb87502e964ece94dd460b98b5449ff2134?preview_id=019ef47d-8354-7ea3-b77c-289ed156f8f5)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [110 customer multi-hunt ](https://hunt.limeseed.email/hunts/4db0ce34-c3fd-4815-a2c4-9121c52a0a29)
- [SWS hunt](https://platform.sublime.security/messages/hunt?huntId=019ef582-ab46-7d78-86b7-5e0fee856702)
