### PR TITLE
Update link_credential_cloud_service.yml

### DIFF
--- a/detection-rules/link_credential_cloud_service.yml
+++ b/detection-rules/link_credential_cloud_service.yml
@@ -6,7 +6,9 @@ source: |
   type.inbound
   and (
     any([body.current_thread.text, body.html.inner_text],
-        strings.starts_with(., 'Cloud') or strings.icontains(., "Cloud+ ")
+        strings.starts_with(., 'Cloud')
+        or strings.icontains(., "Cloud+ ")
+        or regex.icontains(., '^\x{FEFF}\s*Cloud')
     )
     // cloud emoji
     or regex.contains(body.current_thread.text, '^\x{2601}')
@@ -16,7 +18,7 @@ source: |
                          '4563 Cloud Way, Server City, CA'
     )
     or any(html.xpath(body.html, '//img/@alt').nodes,
-           regex.icontains(.raw, '^cloud logo')
+           regex.icontains(.raw, '^cloud (?:logo|storage)')
     )
     or regex.icontains(body.current_thread.text, 'cloud id:\s*#\d+')
   )

--- a/detection-rules/link_credential_cloud_service.yml
+++ b/detection-rules/link_credential_cloud_service.yml
@@ -12,7 +12,7 @@ source: |
     )
     // cloud emoji
     or regex.contains(body.current_thread.text, '^\x{2601}')
-    or regex.icontains(body.current_thread.text, '^!\s*Cloud storage')
+    or regex.icontains(body.current_thread.text, '^!\s*cloud storage')
     // address in the body
     or strings.icontains(body.current_thread.text,
                          '4563 Cloud Way, Server City, CA'


### PR DESCRIPTION
# Description

Adding logic to capture samples that lead with a specific unicode character, white space, then `Cloud`, as well as, leading `Cloud Storage` in img alt text

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5089710f45792db7ff3f475b9da692c58acc331a3825584d4d4fb9ee2d97fa11?preview_id=019ef565-b743-7d41-9d2b-eb55e1d7a298)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019f018a-e3c3-74f4-aef2-4802db683ce2)