### PR TITLE
Create attachment_pdf_localhost_ip.yml

### DIFF
--- a/detection-rules/attachment_pdf_localhost_ip.yml
+++ b/detection-rules/attachment_pdf_localhost_ip.yml
@@ -1,0 +1,26 @@
+name: "Attachment: PDF with localhost IP in EXIF title metadata"
+description: "Detects inbound PDF attachments where the EXIF title metadata starts with '127.0.0.1', sent either to a self-addressed recipient or an invalid recipient domain. This technique may indicate automated or malicious document generation tools embedding localhost references in file metadata."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // self sender or invaild recipent domain
+    and length(recipients.to) == 1
+    and (
+      sender.email.email == recipients.to[0].email.email
+      or recipients.to[0].email.domain.valid == false
+    )
+  and any(filter(attachments, .file_type == "pdf"),
+          strings.starts_with(beta.parse_exif(.).title, "127.0.0.1")
+  )
+  
+attack_types:
+  - "Credential Phishing"
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "PDF"
+  - "Evasion"
+detection_methods:
+  - "Exif analysis"
+  - "File analysis"
+  - "Sender analysis"

--- a/detection-rules/attachment_pdf_localhost_ip.yml
+++ b/detection-rules/attachment_pdf_localhost_ip.yml
@@ -5,15 +5,14 @@ severity: "medium"
 source: |
   type.inbound
   // self sender or invaild recipent domain
-    and length(recipients.to) == 1
-    and (
-      sender.email.email == recipients.to[0].email.email
-      or recipients.to[0].email.domain.valid == false
-    )
+  and length(recipients.to) == 1
+  and (
+    sender.email.email == recipients.to[0].email.email
+    or recipients.to[0].email.domain.valid == false
+  )
   and any(filter(attachments, .file_type == "pdf"),
           strings.starts_with(beta.parse_exif(.).title, "127.0.0.1")
   )
-  
 attack_types:
   - "Credential Phishing"
   - "Malware/Ransomware"
@@ -24,3 +23,4 @@ detection_methods:
   - "Exif analysis"
   - "File analysis"
   - "Sender analysis"
+id: "2649b4b9-5228-5b26-af5c-5b4e3b4a9926"


### PR DESCRIPTION
# Description
Detects inbound PDF attachments where the EXIF title metadata starts with '127.0.0.1', sent either to a self-addressed recipient or an invalid recipient domain.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5080fd0612941c774dcaa783a775738dfb61a5e7b3fb63f13b8707747e4aafa7)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [22 customer multi-hunt](https://hunt.limeseed.email/hunts/aa7c6c27-0676-4b25-bd1f-962685ead88f)
- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=019efa7a-ee64-7a41-9c49-0a9674fcae51)
- [110 customer multi-hunt](https://hunt.limeseed.email/hunts/143317d6-5b21-4024-95a1-f36073c33217)