### PR TITLE
Create body_bec_invoice_new_sender.yml

### DIFF
--- a/detection-rules/body_bec_invoice_new_sender.yml
+++ b/detection-rules/body_bec_invoice_new_sender.yml
@@ -1,0 +1,53 @@
+name: "BEC: Financial fraud from newly registered sender domain"
+description: "Detects inbound messages from domains registered less than 30 days ago that exhibit business email compromise intent with high-confidence financial or payment topics. The message must also contain explicit banking details such as account and routing numbers, invoice references, or payment urgency language, and must either fail DMARC on a trusted domain or originate from an untrusted domain."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and network.whois(sender.email.domain).days_old < 30
+  and any(ml.nlu_classifier(body.current_thread.text).intents, .name == "bec")
+  and (
+    any(ml.nlu_classifier(body.current_thread.text).topics,
+        .name == "Financial Communications" and .confidence == "high"
+    )
+    or any(ml.nlu_classifier(body.current_thread.text).topics,
+           .name == "Payment Information" and .confidence == "high"
+    )
+  )
+  and (
+    (
+      regex.icontains(body.current_thread.text,
+                      'account\s*(?:number|num|no\.?)\s*:?\s*\d{5,}'
+      )
+      and regex.icontains(body.current_thread.text,
+                          '(?:wire\s*)?routing\s*(?:number|num|no\.?)\s*:?\s*\d{5,}'
+      )
+    )
+    or regex.icontains(body.current_thread.text,
+                       'invoice\s*(?:#|number|num|no\.?)\s*:?\s*[A-Z0-9-]{3,}',
+                       'per\s+\w+.{0,5}s\s+request'
+    )
+    or strings.icontains(body.current_thread.text,
+                         'due upon receipt',
+                         'confirm receipt of invoice',
+                         'see attached invoice'
+    )
+  )
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Spoofing"
+detection_methods:
+  - "Natural Language Understanding"
+  - "Whois"
+  - "Content analysis"
+  - "Sender analysis"
+  - "Header analysis"

--- a/detection-rules/body_bec_invoice_new_sender.yml
+++ b/detection-rules/body_bec_invoice_new_sender.yml
@@ -31,12 +31,10 @@ source: |
                          'see attached invoice'
     )
   )
-  and (
-    (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and not headers.auth_summary.dmarc.pass
-    )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/body_bec_invoice_new_sender.yml
+++ b/detection-rules/body_bec_invoice_new_sender.yml
@@ -51,3 +51,4 @@ detection_methods:
   - "Content analysis"
   - "Sender analysis"
   - "Header analysis"
+id: "4be9b165-975f-5587-b780-9441d1b30782"

--- a/detection-rules/body_bec_invoice_new_sender.yml
+++ b/detection-rules/body_bec_invoice_new_sender.yml
@@ -8,10 +8,8 @@ source: |
   and any(ml.nlu_classifier(body.current_thread.text).intents, .name == "bec")
   and (
     any(ml.nlu_classifier(body.current_thread.text).topics,
-        .name == "Financial Communications" and .confidence == "high"
-    )
-    or any(ml.nlu_classifier(body.current_thread.text).topics,
-           .name == "Payment Information" and .confidence == "high"
+        .name in ("Financial Communications", "Payment Information")
+        and .confidence == "high"
     )
   )
   and (


### PR DESCRIPTION
# Description

Detects inbound messages from domains registered less than 30 days ago that exhibit business email compromise intent with high-confidence financial or payment topics. The message must also contain explicit banking details such as account and routing numbers, invoice references, or payment urgency language, and must either fail DMARC on a trusted domain or originate from an untrusted domain

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50934309163d5ca40f3a9e1cd9aa5c61fbee3384a1abf809b0d00cd31efd554e?preview_id=019ef68f-de81-7acf-9f93-5f7a8efbfafa)
- [Sample 2](https://platform.sublime.security/messages/5093651c499f33b6c9e0eeadda8cd57037dc56b3422000b1abcf02cf04aea313?preview_id=019ef68f-ada4-72e1-adb0-29aedf89266d)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=019efad6-bb48-7f14-8647-d90371c47e81)
- [L7D 92 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/16c4f19b-948b-4c5c-8c5d-23289377bb71)