### PR TITLE
Update brand_impersonation_pfpt_secure_message.yml

### DIFF
--- a/detection-rules/brand_impersonation_pfpt_secure_message.yml
+++ b/detection-rules/brand_impersonation_pfpt_secure_message.yml
@@ -37,7 +37,7 @@ source: |
   and (
     // contains a link
     length(body.current_thread.links) >= 1
-    // or an attachment (legt attachments negated in stanza below)
+    // or an attachment (legit attachments negated in stanza below)
     or length(attachments) > 0
   )
   

--- a/detection-rules/brand_impersonation_pfpt_secure_message.yml
+++ b/detection-rules/brand_impersonation_pfpt_secure_message.yml
@@ -25,7 +25,7 @@ source: |
           and strings.icontains(.raw, 'Proofpoint')
       )
     )
-    // no links but has attaachments which impersonante proofpoint
+    // no links but has attachments which impersonate proofpoint
     or any(attachments,
            strings.icontains(file.parse_text(.).text, '<h1>Proofpoint |')
            or any(html.xpath(file.parse_html(.), '//title').nodes,

--- a/detection-rules/brand_impersonation_pfpt_secure_message.yml
+++ b/detection-rules/brand_impersonation_pfpt_secure_message.yml
@@ -12,8 +12,30 @@ source: |
     or regex.icontains(body.current_thread.text,
                        ('Copyright © 2009-202\d Proofpoint, Inc.')
     )
+    or strings.icontains(body.html.raw, '<h1>Proofpoint |')
+    // body.html contains a suspicious title impersonating proofpoint
+    or (
+      any(html.xpath(body.html, '//title').nodes,
+          strings.icontains(.raw, "secure access")
+          and strings.icontains(.raw, 'Proofpoint')
+      )
+    )
+    // no links but has attaachments which impersonante proofpoint
+    or any(attachments,
+           strings.icontains(file.parse_text(.).text, '<h1>Proofpoint |')
+           or any(html.xpath(file.parse_html(.), '//title').nodes,
+                  strings.icontains(.raw, "secure access")
+                  and strings.icontains(.raw, 'Proofpoint')
+           )
+    )
   )
-  and length(body.current_thread.links) >= 1
+  and (
+    // contains a link
+    length(body.current_thread.links) >= 1
+    // or an attachment (legt attachments negated in stanza below)
+    or length(attachments) > 0
+  )
+  
   // pfpt secure share uri
   and not (
     any(body.links,

--- a/detection-rules/brand_impersonation_pfpt_secure_message.yml
+++ b/detection-rules/brand_impersonation_pfpt_secure_message.yml
@@ -11,7 +11,7 @@ source: |
                        "Secured by Proofpoint Encryption,"
       )
       and not strings.iends_with(body.current_thread.text,
-                                 "\nSecured by Proofpoint Encryption, Copyright © 2009-2016 Proofpoint, Inc. All rights reserved."
+                                 "Secured by Proofpoint Encryption, Copyright © 2009-2016 Proofpoint, Inc. All rights reserved."
       )
     )
     or regex.icontains(body.current_thread.text,

--- a/detection-rules/brand_impersonation_pfpt_secure_message.yml
+++ b/detection-rules/brand_impersonation_pfpt_secure_message.yml
@@ -6,8 +6,13 @@ source: |
   type.inbound
   and (
     // matching proofpoint secure messaging
-    strings.contains(body.current_thread.text,
-                     "Secured by Proofpoint Encryption,"
+    (
+      strings.contains(body.current_thread.text,
+                       "Secured by Proofpoint Encryption,"
+      )
+      and not strings.iends_with(body.current_thread.text,
+                                 "\nSecured by Proofpoint Encryption, Copyright © 2009-2016 Proofpoint, Inc. All rights reserved."
+      )
     )
     or regex.icontains(body.current_thread.text,
                        ('Copyright © 2009-202\d Proofpoint, Inc.')


### PR DESCRIPTION
# Description

Add coverage for another form of pfpt impersonation

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/508842512b189ed953a139f5e01011dba8b1929c251670d4011e756acced9428?preview_id=019ebe07-b6df-7778-b1b8-d8d8aed28acb)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L365 Net new hunt](https://platform.sublime.security/messages/hunt?huntId=019f0059-377f-745e-815c-9dfc619bec0c)
- [Net new multihunt](https://hunt.limeseed.email/hunts/75b520ae-2bcb-49ee-9748-b93730a693bb)