### PR TITLE
Create body_invisible_unicode_obfuscated_phone.yml

### DIFF
--- a/detection-rules/body_invisible_unicode_obfuscated_phone.yml
+++ b/detection-rules/body_invisible_unicode_obfuscated_phone.yml
@@ -5,11 +5,11 @@ severity: "medium"
 source: |
   type.inbound
   and length(body.links) == 0
-  and regex.contains(body.html.raw, 
-      '(\x{2065}|\x{200E}|\x{200F}|\x{2066}|\x{2067}|\x{2068}|\x{2069}|\x{200B}|\x{200C}|\x{200D}|\x{FEFF}){3}'
+  and regex.contains(body.html.raw,
+                     '(\x{2065}|\x{200E}|\x{200F}|\x{2066}|\x{2067}|\x{2068}|\x{2069}|\x{200B}|\x{200C}|\x{200D}|\x{FEFF}){3}'
   )
   and regex.contains(body.html.raw,
-      '\d[\x{200E}\x{200F}\x{200B}\x{200C}\x{200D}\x{2065}\x{FEFF}\x{2011}]{1,6}\d'
+                     '\d[\x{200E}\x{200F}\x{200B}\x{200C}\x{200D}\x{2065}\x{FEFF}\x{2011}]{1,6}\d'
   )
 attack_types:
   - "BEC/Fraud"
@@ -21,3 +21,4 @@ tactics_and_techniques:
 detection_methods:
   - "HTML analysis"
   - "Content analysis"
+id: "6b951465-0566-58e4-b29e-d0bc998adca0"

--- a/detection-rules/body_invisible_unicode_obfuscated_phone.yml
+++ b/detection-rules/body_invisible_unicode_obfuscated_phone.yml
@@ -1,0 +1,23 @@
+name: "Body: Invisible Unicode with obfuscated phone number"
+description: "Detects inbound messages with no links that contain clusters of invisible Unicode control characters (including bidirectional marks, zero-width characters, and BOM) in the raw HTML body, as well as digits separated by these invisible characters. This pattern is indicative of content obfuscation to evade text-based detection."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and length(body.links) == 0
+  and regex.contains(body.html.raw, 
+      '(\x{2065}|\x{200E}|\x{200F}|\x{2066}|\x{2067}|\x{2068}|\x{2069}|\x{200B}|\x{200C}|\x{200D}|\x{FEFF}){3}'
+  )
+  and regex.contains(body.html.raw,
+      '\d[\x{200E}\x{200F}\x{200B}\x{200C}\x{200D}\x{2065}\x{FEFF}\x{2011}]{1,6}\d'
+  )
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+  - "Spam"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "HTML analysis"
+  - "Content analysis"

--- a/detection-rules/body_invisible_unicode_obfuscated_phone.yml
+++ b/detection-rules/body_invisible_unicode_obfuscated_phone.yml
@@ -4,12 +4,14 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(body.links) == 0
-  and regex.contains(body.html.raw,
-                     '(\x{2065}|\x{200E}|\x{200F}|\x{2066}|\x{2067}|\x{2068}|\x{2069}|\x{200B}|\x{200C}|\x{200D}|\x{FEFF}){3}'
+  and regex.contains(body.html.raw, 
+      '(\x{2065}|\x{200E}|\x{200F}|\x{2066}|\x{2067}|\x{2068}|\x{2069}|\x{200B}|\x{200C}|\x{200D}|\x{FEFF}){3}'
   )
   and regex.contains(body.html.raw,
-                     '\d[\x{200E}\x{200F}\x{200B}\x{200C}\x{200D}\x{2065}\x{FEFF}\x{2011}]{1,6}\d'
+      '\d[\x{200E}\x{200F}\x{200B}\x{200C}\x{200D}\x{2065}\x{FEFF}]{1,6}\d'
+  )
+  and regex.icontains(body.html.raw, 
+      's.{0,6}t.{0,6}u.{0,6}d.{0,6}e.{0,6}n.{0,6}t.{0,10}l.{0,6}o.{0,6}a.{0,6}n'
   )
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/body_invisible_unicode_obfuscated_phone.yml
+++ b/detection-rules/body_invisible_unicode_obfuscated_phone.yml
@@ -4,14 +4,14 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and regex.contains(body.html.raw, 
-      '(\x{2065}|\x{200E}|\x{200F}|\x{2066}|\x{2067}|\x{2068}|\x{2069}|\x{200B}|\x{200C}|\x{200D}|\x{FEFF}){3}'
+  and regex.contains(body.html.raw,
+                     '(\x{2065}|\x{200E}|\x{200F}|\x{2066}|\x{2067}|\x{2068}|\x{2069}|\x{200B}|\x{200C}|\x{200D}|\x{FEFF}){3}'
   )
   and regex.contains(body.html.raw,
-      '\d[\x{200E}\x{200F}\x{200B}\x{200C}\x{200D}\x{2065}\x{FEFF}]{1,6}\d'
+                     '\d[\x{200E}\x{200F}\x{200B}\x{200C}\x{200D}\x{2065}\x{FEFF}]{1,6}\d'
   )
-  and regex.icontains(body.html.raw, 
-      's.{0,6}t.{0,6}u.{0,6}d.{0,6}e.{0,6}n.{0,6}t.{0,10}l.{0,6}o.{0,6}a.{0,6}n'
+  and regex.icontains(body.html.raw,
+                      's.{0,6}t.{0,6}u.{0,6}d.{0,6}e.{0,6}n.{0,6}t.{0,10}l.{0,6}o.{0,6}a.{0,6}n'
   )
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/body_invisible_unicode_student_loan_callback.yml
+++ b/detection-rules/body_invisible_unicode_student_loan_callback.yml
@@ -1,5 +1,5 @@
-name: "Body: Invisible Unicode with obfuscated phone number"
-description: "Detects inbound messages with no links that contain clusters of invisible Unicode control characters (including bidirectional marks, zero-width characters, and BOM) in the raw HTML body, as well as digits separated by these invisible characters. This pattern is indicative of content obfuscation to evade text-based detection."
+name: "Body: Invisible Unicode obfuscation student loan callback phishing"
+description: "Detects messages containing clusters of Unicode zero-width and invisible characters (such as LRM, RLM, zero-width space, BOM, and directional isolates) interspersed within digit sequences and body content matching 'student loan' patterns. This technique is used to obscure text from security filters while remaining visually coherent to recipients."
 type: "rule"
 severity: "medium"
 source: |


### PR DESCRIPTION
# Description

New campaign observed from Mode report. 

Detects inbound messages with no links that contain clusters of invisible Unicode control characters (including bidirectional marks, zero-width characters, and BOM) in the raw HTML body, as well as digits separated by these invisible characters. This pattern is indicative of content obfuscation to evade text-based detection.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5094f7829a57350345066621099f863374499284627e3806964f8850aedff213?preview_id=019efb46-3a0d-7489-a502-61177cc9d848)
- [Sample 2](https://platform.sublime.security/messages/5094a9477c1b17e3a7d48754bb8756259d202ad57ef0cfbc8d86bf6a6e28cc40?preview_id=019efb46-3fed-76b4-b164-a88260eff11e)
- [Sampel 3](https://platform.sublime.security/messages/5094e47ab8ba87684ccd64f69c1804a063ae5af26a6d4e533846c5cdb5bafe61?preview_id=019efb46-3aca-7284-a37f-be094f26c448)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=019eff96-c5ad-7214-b4ce-e7b389bf8871)
- [L7D 92 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/a8974f7e-0737-4dfc-a813-faa767500b20)