### PR TITLE
Update brand_impersonation_punchbowl.yml

### DIFF
--- a/detection-rules/brand_impersonation_punchbowl.yml
+++ b/detection-rules/brand_impersonation_punchbowl.yml
@@ -15,10 +15,13 @@ source: |
            and strings.icontains(strings.parse_url(.raw).path, '/invitation')
     )
   )
-
   // Phrasing is typically "You're invited"
   and (
     strings.icontains(body.current_thread.text, "you're invited")
+    //
+    // This rule makes use of a beta feature and is subject to change without notice
+    // using the beta feature in custom rules is not suggested until it has been formally released
+    //
     or (
       strings.icontains(beta.ocr(file.message_screenshot()).text,
                         "you're invited"

--- a/detection-rules/brand_impersonation_punchbowl.yml
+++ b/detection-rules/brand_impersonation_punchbowl.yml
@@ -19,6 +19,9 @@ source: |
   // Phrasing is typically "You're invited"
   and (
     strings.icontains(body.current_thread.text, "you're invited")
+    or regex.icontains(body.current_thread.text,
+                       '(?:open|view|see).{0,12}invitation'
+    )
     or any([
              html.xpath(body.html,
                         '//a//img[contains(@src, "btn_open_invitation")]'

--- a/detection-rules/brand_impersonation_punchbowl.yml
+++ b/detection-rules/brand_impersonation_punchbowl.yml
@@ -19,8 +19,13 @@ source: |
   // Phrasing is typically "You're invited"
   and (
     strings.icontains(body.current_thread.text, "you're invited")
-    or regex.icontains(body.current_thread.text,
-                       '(?:open|view|see).{0,12}invitation'
+    or (
+      strings.icontains(beta.ocr(file.message_screenshot()).text,
+                        "you're invited"
+      )
+      and strings.icontains(body.current_thread.text,
+                            "don't want invitations from this host"
+      )
     )
     or any([
              html.xpath(body.html,


### PR DESCRIPTION
# Description

Added logic to utilize `file.messsage_screenshot` to look for `you're invited` in the body of a sample

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5094c0872ed276e18729e55ecb9f2abe791b7d21b1e4a75e52ddc3bac307ae89?preview_id=019eff61-36f1-7e59-bbf0-e72b45eb5924)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=019f03de-c7cc-7c19-90a1-b3df2250cbe8)
- [L14D 92 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/e3fc2c8e-5164-4950-9844-b7603ee439ce)