### PR TITLE
Add detection rule for suspicious copy-paste URLs

### DIFF
--- a/detection-rules/link_sus_domain_copypaste_instructions.yml
+++ b/detection-rules/link_sus_domain_copypaste_instructions.yml
@@ -1,0 +1,39 @@
+name: "Link: Suspicious domain with copy-paste instructions"
+description: "Detects messages instructing recipients to manually copy and paste a URL containing free subdomain hosting domains (pages.dev or web.app) into their browser, while no actual clickable links to those domains are present in the message body. This tactic is used to evade URL scanning by preventing automated link analysis. Supports detection in non-English messages via translation."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and (
+    (
+      strings.icontains(body.current_thread.text, "copy")
+      and strings.icontains(body.current_thread.text, "paste")
+    )
+    or (
+      ml.nlu_classifier(body.current_thread.text).language != 'english'
+      and strings.icontains(beta.ml_translate(body.current_thread.text).text,
+                            'copy'
+      )
+      and strings.icontains(beta.ml_translate(body.current_thread.text).text,
+                            'paste'
+      )
+    )
+  )
+  and (
+    strings.contains(body.current_thread.text, '.pages.dev')
+    or strings.contains(body.current_thread.text, '.web.app')
+  )
+  and not any(body.links,
+              .href_url.domain.root_domain in~ ("web.app", "pages.dev")
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Free subdomain host"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Sender analysis"

--- a/detection-rules/link_sus_domain_copypaste_instructions.yml
+++ b/detection-rules/link_sus_domain_copypaste_instructions.yml
@@ -37,3 +37,4 @@ detection_methods:
   - "Content analysis"
   - "Header analysis"
   - "Sender analysis"
+id: "6dd983b9-7a90-5dbe-b324-a5ed4bfb1f24"


### PR DESCRIPTION
This rule detects messages that instruct users to manually copy and paste URLs from suspicious domains, specifically targeting free subdomain hosting services. It includes support for non-English messages through translation.

# Description

<!-- 
Explain your change and why. For example, "negating legitimate replies," or "adding additional credential theft keywords."

If it's a new rule or insight, explain what the rule is designed to catch/what the insight should fire on.
-->

# Associated samples
- https://platform.sublime.security/messages/508c338769d420b14be9f454668f911eac9788d672be05be8064090e0b235bfb?preview_id=019ef0ab-f379-7f18-93d0-cb9a960e560e

## Associated hunts
- 