### PR TITLE
Update impersonation_ms_teams_invite.yml

### DIFF
--- a/detection-rules/impersonation_ms_teams_invite.yml
+++ b/detection-rules/impersonation_ms_teams_invite.yml
@@ -43,7 +43,7 @@ source: |
   // no unsubscribe links
   // common in newsletters which link to a webinar style event
   and not any(body.links, strings.icontains(.display_text, "unsub"))
-
+  
   // one of the links contains is a CTA that doesn't link to MS
   and any(body.current_thread.links,
           (
@@ -69,8 +69,7 @@ source: |
           )
           and not (
             .href_url.domain.root_domain == "mimecastprotect.com"
-            and strings.parse_domain(.href_url.query_params_decoded["domain"][0]
-            ).root_domain in (
+            and strings.parse_domain(.href_url.query_params_decoded["domain"][0]).root_domain in (
               "microsoft.com",
               "microsoft.us",
               "microsoft.cn",
@@ -82,13 +81,11 @@ source: |
   )
   // missing the dial by phone element
   and not strings.icontains(body.current_thread.text, 'Dial in by phone')
-
+  
   // any of these suspicious elements from the body
   and (
     // malicious samples leveraged recipient domain branding here
-    not strings.icontains(body.current_thread.text,
-                          'Microsoft Teams Need help?'
-    )
+    not strings.icontains(body.current_thread.text, 'Microsoft Teams Need help?')
     // malicious samples contained unique html elements not present in legit ones
     or strings.icontains(body.html.raw, '<div class="meeting-title">')
     or strings.icontains(body.html.raw, '<div class="meeting-time">')
@@ -96,7 +93,7 @@ source: |
     or strings.icontains(body.html.raw, '<span class="conflict-badge">')
     or strings.icontains(body.html.raw, 'class="join-button"')
   )
-
+  
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (

--- a/detection-rules/impersonation_ms_teams_invite.yml
+++ b/detection-rules/impersonation_ms_teams_invite.yml
@@ -7,7 +7,11 @@ source: |
   and (
     (
       strings.icontains(body.current_thread.text, 'Microsoft Teams')
-      and strings.icontains(body.current_thread.text, 'join the meeting')
+      and strings.icontains(body.current_thread.text,
+                            'join the meeting',
+                            'confirm your attendance',
+                            'confirm attendance'
+      )
       and strings.contains(body.current_thread.text, 'Meeting ID:')
       and strings.contains(body.current_thread.text, 'Passcode:')
     )
@@ -39,13 +43,23 @@ source: |
   // no unsubscribe links
   // common in newsletters which link to a webinar style event
   and not any(body.links, strings.icontains(.display_text, "unsub"))
-  
+
   // one of the links contains is a CTA that doesn't link to MS
   and any(body.current_thread.links,
           (
             .display_text =~ "join the meeting"
             or strings.icontains(.display_text, "join the meeting")
             or strings.icontains(.display_text, "play recording")
+            // is a mismatched domain via .display_url
+            or (
+              .display_url.domain.root_domain in (
+                "microsoft.com",
+                "microsoft.us",
+                "microsoft.cn",
+                "live.com"
+              )
+              and .mismatched
+            )
           )
           and .href_url.domain.root_domain not in (
             "microsoft.com",
@@ -55,7 +69,8 @@ source: |
           )
           and not (
             .href_url.domain.root_domain == "mimecastprotect.com"
-            and strings.parse_domain(.href_url.query_params_decoded["domain"][0]).root_domain in (
+            and strings.parse_domain(.href_url.query_params_decoded["domain"][0]
+            ).root_domain in (
               "microsoft.com",
               "microsoft.us",
               "microsoft.cn",
@@ -67,11 +82,13 @@ source: |
   )
   // missing the dial by phone element
   and not strings.icontains(body.current_thread.text, 'Dial in by phone')
-  
+
   // any of these suspicious elements from the body
   and (
     // malicious samples leveraged recipient domain branding here
-    not strings.icontains(body.current_thread.text, 'Microsoft Teams Need help?')
+    not strings.icontains(body.current_thread.text,
+                          'Microsoft Teams Need help?'
+    )
     // malicious samples contained unique html elements not present in legit ones
     or strings.icontains(body.html.raw, '<div class="meeting-title">')
     or strings.icontains(body.html.raw, '<div class="meeting-time">')
@@ -79,7 +96,7 @@ source: |
     or strings.icontains(body.html.raw, '<span class="conflict-badge">')
     or strings.icontains(body.html.raw, 'class="join-button"')
   )
-  
+
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (

--- a/detection-rules/impersonation_ms_teams_invite.yml
+++ b/detection-rules/impersonation_ms_teams_invite.yml
@@ -43,7 +43,7 @@ source: |
   // no unsubscribe links
   // common in newsletters which link to a webinar style event
   and not any(body.links, strings.icontains(.display_text, "unsub"))
-  
+
   // one of the links contains is a CTA that doesn't link to MS
   and any(body.current_thread.links,
           (
@@ -69,11 +69,15 @@ source: |
           )
           and not (
             .href_url.domain.root_domain == "mimecastprotect.com"
-            and strings.parse_domain(.href_url.query_params_decoded["domain"][0]).root_domain in (
-              "microsoft.com",
-              "microsoft.us",
-              "microsoft.cn",
-              "live.com"
+            and (
+              strings.parse_domain(.href_url.query_params_decoded["domain"][0]).root_domain in (
+                "microsoft.com",
+                "microsoft.us",
+                "microsoft.cn",
+                "live.com"
+              )
+              or strings.parse_domain(.href_url.query_params_decoded["domain"][0]
+              ).root_domain in $bulk_mailer_url_root_domains
             )
           )
           // rewriters often abstract the link
@@ -81,11 +85,13 @@ source: |
   )
   // missing the dial by phone element
   and not strings.icontains(body.current_thread.text, 'Dial in by phone')
-  
+
   // any of these suspicious elements from the body
   and (
     // malicious samples leveraged recipient domain branding here
-    not strings.icontains(body.current_thread.text, 'Microsoft Teams Need help?')
+    not strings.icontains(body.current_thread.text,
+                          'Microsoft Teams Need help?'
+    )
     // malicious samples contained unique html elements not present in legit ones
     or strings.icontains(body.html.raw, '<div class="meeting-title">')
     or strings.icontains(body.html.raw, '<div class="meeting-time">')
@@ -93,7 +99,7 @@ source: |
     or strings.icontains(body.html.raw, '<span class="conflict-badge">')
     or strings.icontains(body.html.raw, 'class="join-button"')
   )
-  
+
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (

--- a/detection-rules/impersonation_ms_teams_invite.yml
+++ b/detection-rules/impersonation_ms_teams_invite.yml
@@ -43,7 +43,7 @@ source: |
   // no unsubscribe links
   // common in newsletters which link to a webinar style event
   and not any(body.links, strings.icontains(.display_text, "unsub"))
-
+  
   // one of the links contains is a CTA that doesn't link to MS
   and any(body.current_thread.links,
           (
@@ -76,8 +76,7 @@ source: |
                 "microsoft.cn",
                 "live.com"
               )
-              or strings.parse_domain(.href_url.query_params_decoded["domain"][0]
-              ).root_domain in $bulk_mailer_url_root_domains
+              or strings.parse_domain(.href_url.query_params_decoded["domain"][0]).root_domain in $bulk_mailer_url_root_domains
             )
           )
           // rewriters often abstract the link
@@ -85,13 +84,11 @@ source: |
   )
   // missing the dial by phone element
   and not strings.icontains(body.current_thread.text, 'Dial in by phone')
-
+  
   // any of these suspicious elements from the body
   and (
     // malicious samples leveraged recipient domain branding here
-    not strings.icontains(body.current_thread.text,
-                          'Microsoft Teams Need help?'
-    )
+    not strings.icontains(body.current_thread.text, 'Microsoft Teams Need help?')
     // malicious samples contained unique html elements not present in legit ones
     or strings.icontains(body.html.raw, '<div class="meeting-title">')
     or strings.icontains(body.html.raw, '<div class="meeting-time">')
@@ -99,7 +96,7 @@ source: |
     or strings.icontains(body.html.raw, '<span class="conflict-badge">')
     or strings.icontains(body.html.raw, 'class="join-button"')
   )
-
+  
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (


### PR DESCRIPTION
# Description

Expand coverage to include mismatched URLs and "confirm your attendance" wording
Expand negation logic to include existing bulk_mailer_url_root_domains into mimecast rewritten urls 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/508b582f99512e3ec62a8a960aa9d2c95852b973e6700d5aa89bc48ff39c7d25?preview_id=019ef0ab-f042-772d-a66b-e902f870adba)
- [Sample 2](https://platform.sublime.security/messages/508b051900cf42020a02491ec8abc5fb036b0b39d6b997ccfa4e133fe88e5d2a?preview_id=019f04de-0614-79c6-b321-103f453991e7)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Net new hunt 1](https://platform.sublime.security/messages/hunt?huntId=019f04f5-fd04-7aa5-a86d-2c457adaa3e5)
- [Multihunt net new](https://hunt.limeseed.email/hunts/5a97eeda-81e3-4808-82ce-e8629cdd3a80)

# Screenshot (insights)
<!-- 
**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
-->
