### PR TITLE
Update link_wordress_recipient_email.yml

### DIFF
--- a/detection-rules/link_wordress_recipient_email.yml
+++ b/detection-rules/link_wordress_recipient_email.yml
@@ -26,7 +26,7 @@ source: |
               )
               // not an unsub URL
               and not strings.icontains(.href_url.url, 'unsub')
-              // only a single query_param
+              // less than two query_params
               and length(keys(.href_url.query_params_decoded)) <= 2
             )
           )

--- a/detection-rules/link_wordress_recipient_email.yml
+++ b/detection-rules/link_wordress_recipient_email.yml
@@ -4,17 +4,35 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
+  and recipients.to[0].email.domain.valid
   and any(body.links,
           regex.icontains(.href_url.path,
                           '^\/(?:wp-(?:admin|includes|content|login|json|signup|activate|cron|mail)|xmlrpc\.php)'
           )
-          // base64 encoded
+
           and (
+              // fragments base64 encoded
+
             any(strings.scan_base64(.href_url.fragment),
                 strings.icontains(., recipients.to[0].email.email)
             )
-            // not base64
-            or strings.icontains(.href_url.fragment, recipients.to[0].email.email)
+            // fragments not base64 enbcoded
+            or strings.icontains(.href_url.fragment,
+                                 recipients.to[0].email.email
+            )
+            // query param values are exactly the recipient
+            or (
+              any(flatten(values(.href_url.query_params_decoded)),
+                  . == recipients.to[0].email.email
+                  or any(strings.scan_base64(.),
+                         . == recipients.to[0].email.email
+                  )
+              )
+              // not an unsub URL
+              and not strings.icontains(.href_url.url, 'unsub')
+              // only a single query_param
+              and length(keys(.href_url.query_params_decoded)) <= 2
+            )
           )
   )
 attack_types:

--- a/detection-rules/link_wordress_recipient_email.yml
+++ b/detection-rules/link_wordress_recipient_email.yml
@@ -9,17 +9,13 @@ source: |
           regex.icontains(.href_url.path,
                           '^\/(?:wp-(?:admin|includes|content|login|json|signup|activate|cron|mail)|xmlrpc\.php)'
           )
-
           and (
-              // fragments base64 encoded
-
+            // fragments base64 encoded
             any(strings.scan_base64(.href_url.fragment),
                 strings.icontains(., recipients.to[0].email.email)
             )
             // fragments not base64 enbcoded
-            or strings.icontains(.href_url.fragment,
-                                 recipients.to[0].email.email
-            )
+            or strings.icontains(.href_url.fragment, recipients.to[0].email.email)
             // query param values are exactly the recipient
             or (
               any(flatten(values(.href_url.query_params_decoded)),

--- a/detection-rules/link_wordress_recipient_email.yml
+++ b/detection-rules/link_wordress_recipient_email.yml
@@ -14,7 +14,7 @@ source: |
             any(strings.scan_base64(.href_url.fragment),
                 strings.icontains(., recipients.to[0].email.email)
             )
-            // fragments not base64 enbcoded
+            // fragments not base64 encoded
             or strings.icontains(.href_url.fragment, recipients.to[0].email.email)
             // query param values are exactly the recipient
             or (

--- a/detection-rules/link_wordress_recipient_email.yml
+++ b/detection-rules/link_wordress_recipient_email.yml
@@ -1,5 +1,5 @@
-name: "Link: WordPress admin targeting with recipient identifier in URL fragment"
-description: "Detects messages containing links to WordPress administrative paths (wp-admin, wp-content, wp-includes, etc.) where the URL fragment contains base64-encoded data that includes the recipient's email address, indicating potential targeted compromise attempts."
+name: "Link: WordPress admin targeting with recipient identifier in URL parts"
+description: "Detects messages containing links to WordPress administrative paths (wp-admin, wp-content, wp-includes, etc.) where the URL fragment or query param values contains base64-encoded data that includes the recipient's email address, indicating potential targeted compromise attempts."
 type: "rule"
 severity: "high"
 source: |


### PR DESCRIPTION
# Description

- Expand coverage to include query param values that are exactly the recipient's email (or the base64 encoded version)
- reduce FPs by enforcing a valid recipient domain (no blank recipient values, or "undisclosed")

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50967e5ab368515cc6b37e9c9a0ffd6a421d0fb4fce286c941d72b729f7609f0?preview_id=019f05b4-e6f6-7ea9-94ab-2a29528e9219)
- [Sample 2](https://platform.sublime.security/messages/50733ba0269df491b5f62d261101a9ce26da66a80e62d24e06f12396ac2e54df?preview_id=019e6fd1-4cb3-723a-800f-64aa8e2a87fb)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Net new hunt](https://platform.sublime.security/messages/hunt?huntId=019f05c1-8ca4-7f14-b7ee-2fd57b20edf7)
- [Net new multihunt](https://hunt.limeseed.email/hunts/6e618f5f-077b-4030-8f1e-8bf39dbc9c44)