### PR TITLE
Update impersonation_amazon.yml

### DIFF
--- a/detection-rules/impersonation_amazon.yml
+++ b/detection-rules/impersonation_amazon.yml
@@ -23,7 +23,7 @@ source: |
     or strings.ilevenshtein(sender.display_name, 'amazon marketplace') <= 1
     or strings.ilevenshtein(sender.display_name, 'amazon customer support') <= 1
     or regex.icontains(sender.display_name,
-                       "prime (?:subscription|notification|support|deals)"
+                       "prime (?:subscription|notification|support|deal|store)"
     )
     or strings.ilike(subject.subject, "*prime membership*")
     or (

--- a/detection-rules/impersonation_amazon.yml
+++ b/detection-rules/impersonation_amazon.yml
@@ -23,8 +23,9 @@ source: |
     or strings.ilevenshtein(sender.display_name, 'amazon marketplace') <= 1
     or strings.ilevenshtein(sender.display_name, 'amazon customer support') <= 1
     or regex.icontains(sender.display_name,
-                       "prime (?:subscription|notification|support|deal|store)"
+                       "prime (?:subscription|notification|support)"
     )
+    or regex.icontains(sender.display_name, "^prime (?:deal|store)$")
     or strings.ilike(subject.subject, "*prime membership*")
     or (
       strings.ilevenshtein(sender.display_name, 'amazon') <= 1

--- a/detection-rules/impersonation_amazon.yml
+++ b/detection-rules/impersonation_amazon.yml
@@ -25,7 +25,7 @@ source: |
     or regex.icontains(sender.display_name,
                        "prime (?:subscription|notification|support)"
     )
-    or regex.icontains(sender.display_name, "^prime (?:deal|store)$")
+    or regex.imatch(sender.display_name, "^prime (?:deal|store)$")
     or strings.ilike(subject.subject, "*prime membership*")
     or (
       strings.ilevenshtein(sender.display_name, 'amazon') <= 1

--- a/detection-rules/impersonation_amazon.yml
+++ b/detection-rules/impersonation_amazon.yml
@@ -23,7 +23,7 @@ source: |
     or strings.ilevenshtein(sender.display_name, 'amazon marketplace') <= 1
     or strings.ilevenshtein(sender.display_name, 'amazon customer support') <= 1
     or regex.icontains(sender.display_name,
-                       "prime (subscription|notification|support)"
+                       "prime (?:subscription|notification|support|deals)"
     )
     or strings.ilike(subject.subject, "*prime membership*")
     or (
@@ -34,7 +34,7 @@ source: |
       any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == "cred_theft" and .confidence == "high"
       )
-      and any(beta.ml_topic(body.current_thread.text).topics,
+      and any(ml.nlu_classifier(body.current_thread.text).topics,
               .name in (
                 "Security and Authentication",
                 "Secure Message",


### PR DESCRIPTION
# Description

Minor change to capture samples with the sender display name `Prime Deals` and `Prime Store`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5097b94f22c810d6f71bd708f06396bb237230907a2b25cd64ec7b04004dc3bd?preview_id=019f0a9f-26ac-7a24-a58f-da8edf7cef5c)
- [Sample 2](https://platform.sublime.security/messages/50995e56e1b6ece0c5f3ec0c3a6447feb09689a8f54c597104e29ede28321bfd?preview_id=019f10c5-bc0d-7562-86c8-047478eec375)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019f1fa0-69d5-704b-8ea0-6f860835d744)