### PR TITLE
Update link_credential_phishing_voicemail_language.yml

### DIFF
--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -63,7 +63,7 @@ source: |
                        'Listen to V[o0][il1]ceMa[il1][li1]',
                        'New v[o0][il1]cema[il1][li1] from',
                        'v[o0][il1]ce note',
-                       '(?:sends?|sent|new|received)\s+a?\s*v[\W_]?[o0][\W_]?[il1]?[\W_]?ce[\W_]{0,2}m+[\W_]?(?:s+[\W_]?g+|ss?age)'
+                       '\bv[\W_][o0][\W_]?[il1]?ce[\W_]{0,2}m[\W_]?ss?g\b'
     )
     // pull out two regexes that could benefit from negations
     or (

--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -63,7 +63,7 @@ source: |
                        'Listen to V[o0][il1]ceMa[il1][li1]',
                        'New v[o0][il1]cema[il1][li1] from',
                        'v[o0][il1]ce note',
-                       '(?:sends?|sent|new|received)\s+a?\s*v[\W_]{0,2}[o0][\W_]{0,2}[il1]?[\W_]{0,2}ce[\W_]{0,3}(?:m+[\W_]?s+[\W_]?g+|m+[\W_]?ss?age)'
+                       '(?:sends?|sent|new|received)\s+a?\s*v[\W_]?[o0][\W_]?[il1]?[\W_]?ce[\W_]{0,2}m+[\W_]?(?:s+[\W_]?g+|ss?age)'
     )
     // pull out two regexes that could benefit from negations
     or (

--- a/detection-rules/link_credential_phishing_voicemail_language.yml
+++ b/detection-rules/link_credential_phishing_voicemail_language.yml
@@ -20,7 +20,7 @@ source: |
     any([subject.subject, sender.display_name],
         regex.icontains(.,
                         // split phrases that occur within 3 words between or only punctuation between them
-                        '(?:v[nm](\b|[[:punct:]])?|\bv[o0][il1]ce(?:mail|message)?|audi[o0]|incoming|missed(?:\sa\s)?|left( a)?|wireless)(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:mail|message|msg|recording|received|notif|support|ca[li1][li1]\d*\b|ca[il1][il1](?:er)?|log|transcript(?:ion)?)\b',
+                        '(?:v[nm](\b|[[:punct:]])?|\bv[o0][il1]ce(?:mail|message)?|audi[o0]|incoming|missed(?:\sa\s)?|left( a)?|wireless)(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:mail|message|msg|recording|received|notif|support|ca[li1][li1]\d*\b|ca[il1][il1](?:er)?|log(?:ger)?|transcript(?:ion)?)\b',
                         // regex specific to v-mail, v_msg, v,mail, etc
                         // list of "secondary" words synced with regex above this one
                         'v[[:punct:]](?:mail|message|msg|recording|received|notif|support|ca[li1][li1]\d*\b|ca[il1][il1](?:er)?|log|transcript(?:ion)?\b)',
@@ -44,7 +44,7 @@ source: |
                         // "X new voice..." patterns
                         '\d+\s+new.*v[o0][il1]ce(?:mail|message|m[\*]+)?',
                         // sent-message patterns
-                        '(?:sent|new|incoming)[\s\-]+message.*(v[o0][il1]ce|<.*@.*>)',
+                        '(?:sent|new|incoming)[\s\-]+message.*(v[o0][il1]ce|<.*@.*>)'
         )
     )
     // body.current_thread.text inspection should be very specific to avoid FP
@@ -62,14 +62,15 @@ source: |
                        '\bv[o0][il1]cema[il1][li1] transcript\b',
                        'Listen to V[o0][il1]ceMa[il1][li1]',
                        'New v[o0][il1]cema[il1][li1] from',
-                       'v[o0][il1]ce note'
+                       'v[o0][il1]ce note',
+                       '(?:sends?|sent|new|received)\s+a?\s*v[\W_]{0,2}[o0][\W_]{0,2}[il1]?[\W_]{0,2}ce[\W_]{0,3}(?:m+[\W_]?s+[\W_]?g+|m+[\W_]?ss?age)'
     )
     // pull out two regexes that could benefit from negations
     or (
       regex.icontains(body.current_thread.text,
                       // body.current_thread.text,
                       '(?:you|we) (?:have |received )+(?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:\b|\s+)v[o0][il1]ce\s?(?:ma[il1][li1]|aud[il1][o0]|message|notification)',
-                      'left you a (?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:v[o0][il1]ce(?:ma[il1][li1])?|aud[il1][o0])(?: message|notification)?',
+                      'left you a (?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:v[o0][il1]ce(?:ma[il1][li1])?|aud[il1][o0])(?: message|notification)?'
       )
       and not regex.icontains(body.current_thread.text,
                               '(?:I(?:\sjust)?|just(?: called you at (?:\d+[[:punct:]])+) and)? left you a (?:\w+(\s\w+)?|[[:punct:]]+|\s+){0,3}(?:v[o0][il1]ce(?:mail)?|audio)(?: message)?'


### PR DESCRIPTION
# Description

Updating regex statements for `body.current_thread.text` and `subject.subject`/`sender.display_name` to capture additional samples

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5096ec576ea2bd0d402f6acfeacf84e2965da5dd3e1ca3beb5bdba7c9c4d01a5?preview_id=019f13e4-947d-7b9f-805a-a7bbdc67d14b)
- [Sample 2](https://platform.sublime.security/messages/50994a2b6d41efb1ac644d47f24b2dab5a63b247b41611ee57d22f67251d6acb?preview_id=019f137b-31e3-741b-81c4-cb4050162dcc)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New](https://platform.sublime.security/messages/hunt?huntId=019f37df-12a2-7df1-9523-ac6ecfa29355)