### PR TITLE
Update spam_fake_photo_share.yml

### DIFF
--- a/detection-rules/spam_fake_photo_share.yml
+++ b/detection-rules/spam_fake_photo_share.yml
@@ -135,9 +135,9 @@ source: |
               and .href_url.domain.root_domain in ("facebook.com", "youtube.com")
             )
             or (
-              // random 5-character subdomain
+              // random 5-6 character subdomain
               regex.icontains(.href_url.domain.domain,
-                              '^[a-z]{5}\.[a-z]{5,}\.[a-z]+'
+                              '^[a-z]{5,6}\.[a-z]{5,}\.[a-z]+'
               )
               // subdomain contains 3+ consecutive consonants
               and regex.icontains(.href_url.domain.domain,


### PR DESCRIPTION
# Description

Broadening regex to allow randomized 5-6 character subdomains

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5095c00ff1704dc3b07ab470b64f4bdc5979deb7ea9f198eedb6eee763ebcf44?preview_id=019efe3b-7673-7809-b310-548d911e2f5c)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019f1f2e-4bd6-7123-9f87-c09081431474)