### PR TITLE
Create link_storage_google_indexphp.yml

### DIFF
--- a/detection-rules/link_storage_google_indexphp.yml
+++ b/detection-rules/link_storage_google_indexphp.yml
@@ -5,13 +5,12 @@ severity: "high"
 source: |
   type.inbound
   and any(body.links,
-          .href_url.domain.domain == "storage.googleapis.com"          
+          .href_url.domain.domain == "storage.googleapis.com"
           and (
             strings.iends_with(.href_url.path, 'index.php')
             or regex.icontains(.href_url.fragment, '^\/?index.php')
           )
-          
-  ) 
+  )
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:
@@ -20,3 +19,4 @@ tactics_and_techniques:
   - "Open redirect"
 detection_methods:
   - "URL analysis"
+id: "d0ecb49a-6251-51b2-850e-b3503dd3d02f"

--- a/detection-rules/link_storage_google_indexphp.yml
+++ b/detection-rules/link_storage_google_indexphp.yml
@@ -1,0 +1,22 @@
+name: "Link: Google Cloud Storage link with index.php in URL""
+description: "Detects inbound messages containing links hosted on storage.googleapis.com that point to an index.php path, either in the URL path or fragment. Attackers abuse Google Cloud Storage to host malicious content, leveraging the trusted domain to bypass security filters."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(body.links,
+          and .href_url.domain.domain == "storage.googleapis.com"          
+          (
+            strings.iends_with(.href_url.path, 'index.php')
+            or regex.icontains(.href_url.fragment, '^\/?index.php')
+          )
+          
+  ) 
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Free file host"
+  - "Open redirect"
+detection_methods:
+  - "URL analysis"

--- a/detection-rules/link_storage_google_indexphp.yml
+++ b/detection-rules/link_storage_google_indexphp.yml
@@ -5,8 +5,8 @@ severity: "high"
 source: |
   type.inbound
   and any(body.links,
-          and .href_url.domain.domain == "storage.googleapis.com"          
-          (
+          .href_url.domain.domain == "storage.googleapis.com"          
+          and (
             strings.iends_with(.href_url.path, 'index.php')
             or regex.icontains(.href_url.fragment, '^\/?index.php')
           )

--- a/detection-rules/link_storage_google_indexphp.yml
+++ b/detection-rules/link_storage_google_indexphp.yml
@@ -1,4 +1,4 @@
-name: "Link: Google Cloud Storage link with index.php in URL""
+name: "Link: Google Cloud Storage link with index.php in URL"
 description: "Detects inbound messages containing links hosted on storage.googleapis.com that point to an index.php path, either in the URL path or fragment. Attackers abuse Google Cloud Storage to host malicious content, leveraging the trusted domain to bypass security filters."
 type: "rule"
 severity: "high"


### PR DESCRIPTION
# Description

Add new rule to cover url format within storage.googleapis.com.  Samples not observed in multihunt - seems to be targetting non-corporate accounts

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/505e7f01fd7f8526f9e601ef9d4753935161881c53b5bb407cb7094dd0169dcc?preview_id=019f0037-5678-7312-8083-6ac4f686b8ab)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019f1674-a1e6-7df6-9149-7eeb3b465203)
- [Multihunt - no results](https://hunt.limeseed.email/hunts/57902467-b9c4-42aa-8fef-b53e82d47ac5)

