### PR TITLE
Create link_storage_google_lis.yml

### DIFF
--- a/detection-rules/link_storage_google_lis.yml
+++ b/detection-rules/link_storage_google_lis.yml
@@ -1,0 +1,22 @@
+name: "link: Google Cloud Storage with short-path link delivery"
+description: "Detects inbound messages containing links to Google Cloud Storage (storage.googleapis.com) where the URL path ends in 'ls' or 'lis', matching a pattern used to host redirector or landing pages. Observed across multilingual spam and unsolicited promotional messages — including fake parcel delivery notifications impersonating FedEx and T&T, as well as product advertisement lures — sent from a variety of compromised or unrelated sender domains. The consistent use of this specific GCS path pattern suggests a shared delivery infrastructure across multiple senders."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+    and any(body.links,
+            .href_url.domain.domain == "storage.googleapis.com"
+            // path ends with lis or ls
+            and regex.icontains(.href_url.path, '^/[^\/]+/li?s$')
+    )
+attack_types:
+  - "Spam"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Free file host"
+  - "Evasion"
+  - "Social engineering"
+  - "Impersonation: Brand"
+detection_methods:
+  - "URL analysis"
+  - "Content analysis"

--- a/detection-rules/link_storage_google_lis.yml
+++ b/detection-rules/link_storage_google_lis.yml
@@ -4,11 +4,11 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-    and any(body.links,
-            .href_url.domain.domain == "storage.googleapis.com"
-            // path ends with lis or ls
-            and regex.icontains(.href_url.path, '^/[^\/]+/li?s$')
-    )
+  and any(body.links,
+          .href_url.domain.domain == "storage.googleapis.com"
+          // path ends with lis or ls
+          and regex.icontains(.href_url.path, '^/[^\/]+/li?s$')
+  )
 attack_types:
   - "Spam"
   - "Credential Phishing"
@@ -20,3 +20,4 @@ tactics_and_techniques:
 detection_methods:
   - "URL analysis"
   - "Content analysis"
+id: "88a473bb-b8a1-59b7-ac54-24ec84424ac2"


### PR DESCRIPTION
# Description

Add ocverage for observed URL pattern being used long term to delivery a variety of malicious mesages

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50954bdc2a6f569ff3bc3d2dbd486dbf15c211b17e230f66b5f7a1d49b483b9b?preview_id=019f01a0-7834-74c4-9857-e67ade5c8131)
- [Sample 2](https://platform.sublime.security/messages/508aadfebd41aa1c66eefebc145e331fe3e7280a080dbb7565cd90491ee0b50c?preview_id=019efa22-3471-7a0e-8c6a-970d3e78e552)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019f16a3-f21b-77d4-a6f0-5e05cd335a9b)
- [Multihunt](https://hunt.limeseed.email/hunts/b2d703b3-ad6c-4ca3-b276-9b57dd5f5814)
