### PR TITLE
Create attachment_pdf_obj_hash_w9.yml

### DIFF
--- a/detection-rules/attachment_pdf_obj_hash_w9.yml
+++ b/detection-rules/attachment_pdf_obj_hash_w9.yml
@@ -1,0 +1,19 @@
+name: "Attachment: PDF Object Hash associated with a fake invoice and a W-9"
+description: "Matching PDF Object Hash associated with a fake invoice followed by a W-9."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(filter(attachments, .file_type == "pdf"),
+          any(file.explode(.),
+              .scan.pdf_obj_hash.object_hash == "cc08b7eae4b6f5f4e897dd0998b90e21"
+          )
+  )
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "PDF"
+  - "Evasion"
+detection_methods:
+  - "File analysis"
+  - "Threat Intelligence"

--- a/detection-rules/attachment_pdf_obj_hash_w9.yml
+++ b/detection-rules/attachment_pdf_obj_hash_w9.yml
@@ -17,3 +17,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "Threat Intelligence"
+id: "44e6f204-1792-532d-9db5-983e25a8cda0"


### PR DESCRIPTION
# Description
Matching PDF Object Hash associated with a fake invoice followed by a W-9.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/507d204c54f71fd545cd4cc24c0e6d8ef9b028678eb0e37c2e8110ed44d22141?preview_id=019eff35-878b-7f1f-b744-20a073cc53be)
- [Sample 2](https://platform.sublime.security/messages/507d541d993b33559ab74715c335165f6d00bd4d156bde8f23d5cb08cf942215?preview_id=019eff30-dba3-70e8-ba8a-d8e15bb11582)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [110 Customer multihunt](https://hunt.limeseed.email/hunts/1e1740f0-241f-4943-a3eb-3547cc5aecaf)
- [SWS Hunt](https://platform.sublime.security/hunts/019f1e5d-d65e-7a54-883f-a59b4207e975)
