### PR TITLE
Update impersonation_adobe_suspicious_language_link.yml

### DIFF
--- a/detection-rules/impersonation_adobe_suspicious_language_link.yml
+++ b/detection-rules/impersonation_adobe_suspicious_language_link.yml
@@ -12,7 +12,7 @@ source: |
     )
     or length(attachments) == 0
   )
-  and length(body.links) > 0
+  and length(filter(body.links, .href_url.scheme != 'mailto')) > 0
   and (
     any(ml.logo_detect(file.message_screenshot()).brands,
         .name == "Adobe" and .confidence in ("high")


### PR DESCRIPTION
# Description
To prevent FPs exclude mail-to links when checking the length of body.links. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5097de7b1770cd29a77ec8a240a14f3681beddf7d3eb1a5cad8a531b204d01d9?preview_id=019f20f7-fed2-7c9f-b436-effe8e679db3)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [110 Customer regression hunt](https://hunt.limeseed.email/hunts/9ede88ac-d709-45f6-8392-6f8c26e3634b)
- [SWS regression hunt](https://platform.sublime.security/messages/hunt?huntId=019f379a-bbbb-750b-bddd-51a5c5a72d11) - This [sample](https://platform.sublime.security/messages/5053816da8ba2bac745b32ceab4bda8a85e66ea98df8b59410bd50f342a6bd1b?preview_id=019db16c-f8a6-78bf-81df-71264dde0577) has a bug and has been reported to engineering 
