### PR TITLE
Create recon_real_estate_inquiry_empty_body.yml

### DIFF
--- a/detection-rules/recon_real_estate_inquiry_empty_body.yml
+++ b/detection-rules/recon_real_estate_inquiry_empty_body.yml
@@ -30,3 +30,4 @@ tactics_and_techniques:
 detection_methods:
   - "Content analysis"
   - "Sender analysis"
+id: "1f477050-7558-5fdc-859c-9c8ca9bddae5"

--- a/detection-rules/recon_real_estate_inquiry_empty_body.yml
+++ b/detection-rules/recon_real_estate_inquiry_empty_body.yml
@@ -1,0 +1,32 @@
+name: "Reconnaissance: Fake real estate inquiry with empty body"
+description: "Detects inbound messages with no body content — neither plain text nor HTML — but an unusually long subject line containing real estate inquiry language. The subject lines impersonate prospective home buyers asking about specific property listings or seeking a trusted local real estate agent, often mentioning relocation. These messages are designed to establish contact with real estate professionals as a precursor to fraud."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+    body.plain.raw is null
+    or body.plain.raw == ""
+    or regex.imatch(body.plain.raw, '^\s*$')
+  )
+  and (
+    body.html.raw is null
+    or body.html.raw == ""
+    or regex.imatch(body.html.raw, '^\s*$')
+  )
+  and length(subject.base) > 150
+  and (
+    strings.icontains(subject.base, 'purchase a home')
+    or regex.icontains(subject.base,
+                       'the listing (?:on|at)',
+                       '(?:interested in|regarding) (?:this|the) property',
+                       '(?:will be|are) relocating'
+    )
+  )
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

Detects inbound messages with no body content — neither plain text nor HTML — but an unusually long subject line containing real estate inquiry language. The subject lines impersonate prospective home buyers asking about specific property listings or seeking a trusted local real estate agent, often mentioning relocation. These messages are designed to establish contact with real estate professionals as a precursor to fraud.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5091b25f69d1c2062b83a22149f7079473b6b1178dd07532efbd2ff31ae1d902?preview_id=019f243d-b63a-7eba-aa25-93d80eab1d5a)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=019f3c43-bb10-7e7d-8d62-70db83cded72)
- [L30D 92 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/ae5adc62-e901-48f1-be55-b1febf9b6bdc)
