### PR TITLE
Add detection rule for suspicious ICS attachments

### DIFF
--- a/detection-rules/attachment_ics_sus_application_id.yml
+++ b/detection-rules/attachment_ics_sus_application_id.yml
@@ -26,3 +26,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "Content analysis"
+id: "35566008-d9be-5e48-bd42-b8920c946110"

--- a/detection-rules/attachment_ics_sus_application_id.yml
+++ b/detection-rules/attachment_ics_sus_application_id.yml
@@ -1,0 +1,28 @@
+name: "Attachment: ICS calendar file with suspicious application identifier"
+description: "Flags messages containing ICS calendar file attachments whose parsed PRODID field contains a suspicious non-standard application identifier."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(attachments,
+          (
+            .file_type == "ics"
+            or (
+              .file_extension == "ics"
+              or .content_type in ("application/ics", "text/calendar")
+            )
+          )
+          //
+          // This rule makes use of a beta feature and is subject to change without notice
+          // using the beta feature in custom rules is not suggested until it has been formally released
+          //
+          and strings.icontains(beta.file.parse_ics(.).product_id, "-//My App")
+  )
+attack_types:
+  - "ICS Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Evasion"
+detection_methods:
+  - "File analysis"
+  - "Content analysis"


### PR DESCRIPTION
# Description

This rule flags messages with ICS calendar file attachments that contain a suspicious non-standard application identifier in the PRODID field.

# Associated samples
- https://platform.sublime.security/messages/509d8ad3d3b66579ce29040545b70ecaae6954e5fe22ed4ada80270355969543
- https://platform.sublime.security/messages/508b491741ef93384312771b1ac58ab772b5e387c62807489610f98cb554a07e
- https://platform.sublime.security/messages/508ec4ba17cc46372723c3327b8e27548d3dc315ca4995ea3283ed75372bc382

## Associated hunts
- https://hunt.limeseed.email/hunts/c11db639-6636-4f5f-8596-8fc3f75fe275https://hunt.limeseed.email/hunts/c11db639-6636-4f5f-8596-8fc3f75fe275