### PR TITLE
Create vip_impersonation_prev_thread_space_colon.yml

### DIFF
--- a/detection-rules/vip_impersonation_prev_thread_space_colon.yml
+++ b/detection-rules/vip_impersonation_prev_thread_space_colon.yml
@@ -1,4 +1,4 @@
-name: "VIP Impersonation: Fabricated thread history with fake VIP recipients"
+name: "VIP impersonation: Fabricated thread history with fake VIP recipients"
 description: "Detects inbound messages that contain forged prior thread histories where the fake headers use abnormal spacing around colons - a hallmark of programmatically generated preambles. The fabricated threads reference VIP recipients from the organization who are absent from the live message's actual recipients, suggesting the thread was constructed to manufacture legitimacy. Observed messages impersonate finance or accounts payable workflows, referencing overdue invoices, balance statements, and payment requests targeting real vendors and internal stakeholders."
 type: "rule"
 severity: "high"

--- a/detection-rules/vip_impersonation_prev_thread_space_colon.yml
+++ b/detection-rules/vip_impersonation_prev_thread_space_colon.yml
@@ -61,3 +61,4 @@ detection_methods:
   - "Content analysis"
   - "Header analysis"
   - "Sender analysis"
+id: "b566ef3c-f5c0-5937-a73a-f33b98e02275"

--- a/detection-rules/vip_impersonation_prev_thread_space_colon.yml
+++ b/detection-rules/vip_impersonation_prev_thread_space_colon.yml
@@ -15,7 +15,7 @@ source: |
                  )
           ),
           // the previous thread with the goofy spaces
-          // includes a VIP as a recipeint
+          // includes a VIP as a recipient
           any(map(filter(.recipients.to,
                          // via email
                          .email.email != ""

--- a/detection-rules/vip_impersonation_prev_thread_space_colon.yml
+++ b/detection-rules/vip_impersonation_prev_thread_space_colon.yml
@@ -1,0 +1,63 @@
+name: "VIP Impersonation: Fabricated thread history with fake VIP recipients"
+description: "Detects inbound messages that contain forged prior thread histories where the fake headers use abnormal spacing around colons - a hallmark of programmatically generated preambles. The fabricated threads reference VIP recipients from the organization who are absent from the live message's actual recipients, suggesting the thread was constructed to manufacture legitimacy. Observed messages impersonate finance or accounts payable workflows, referencing overdue invoices, balance statements, and payment requests targeting real vendors and internal stakeholders."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(filter(body.previous_threads,
+                 // single recipient in the previous thread
+                 length(.recipients.to) == 1
+                 and length(.recipients.cc) == 0
+                 // contains spaces around the colons of the "headers"
+                 and strings.count(.preamble, ' : ') >= 2
+                 and regex.icount(.preamble, '(?m)^\s*[a-z]+ +: +\S') == regex.icount(.preamble,
+                                                                                      '(?m)^.'
+                 )
+          ),
+          // the previous thread with the goofy spaces
+          // includes a VIP as a recipeint
+          any(map(filter(.recipients.to,
+                         // via email
+                         .email.email != ""
+                         and any($org_vips,
+                                 strings.icontains(..email.email, .email)
+                                 or strings.icontains(..display_name,
+                                                      .display_name
+                                 )
+                         )
+                  ),
+                  .email.email
+              ),
+              // email is not in the "live" messages
+              not strings.icontains(sender.email.email, .)
+              and not any(recipients.to, strings.icontains(.email.email, ..))
+              and not any(recipients.cc, strings.icontains(.email.email, ..))
+          )
+          or any(map(filter(.recipients.to,
+                            // via display_name
+                            .email.email == ""
+                            and any($org_vips,
+                                    strings.icontains(..display_name,
+                                                      .display_name
+                                    )
+                            )
+                     ),
+                     .display_name
+                 ),
+                 // display name is not in the "live" messages
+                 not any(recipients.to, .display_name == ..)
+                 and not any(recipients.cc, .display_name == ..)
+                 and sender.display_name != .
+          )
+  )
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Impersonation: VIP"
+  - "Social engineering"
+  - "Evasion"
+  - "Spoofing"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

Add coverage for VIP impersonation with suspicious spaces in the previous thread preamble

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50932f36462ecfc6c31460a866968d14ff462ec80bcc149b7aa796b87d6867df?preview_id=019efc67-09cf-7cb7-b67f-6502f5b491eb)
- [Sample 2](https://platform.sublime.security/messages/5095bdd7af9360bb5a6be3bbf4f86eb05b03387d70c6c964aba9d138e44c22c5?preview_id=019eff35-889f-71f6-bf0c-a52d38d73fa5)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->


- [Multihunt](https://hunt.limeseed.email/hunts/6bd42dee-3766-4a5f-92d8-d45fd24eb92b)
- [Hunt](https://platform.sublime.security/messages/hunt?huntId=019f3f71-6279-7859-a35f-b1e8f1fdabe4)
