### PR TITLE
Hoist NLU classifier call out of body.links loop in link_mailto_placeholder

### DIFF
--- a/detection-rules/link_mailto_placeholder.yml
+++ b/detection-rules/link_mailto_placeholder.yml
@@ -5,14 +5,13 @@ severity: "medium"
 source: |
   type.inbound
   and (
-    // @{domain} pattern is strong on its own
+    // @{domain} pattern is strong
     any(body.links,
         .href_url.scheme == "mailto"
         and regex.icontains(.href_url.url, '@\s*{\s*domain\s*}')
     )
     // combine {RECIPIENT_EMAIL} and {SENDER EMAIL} with NLU to remove a bunch of
-    // benign use cases. NLU doesn't depend on the link, so it's hoisted out of the
-    // any(body.links, ...) loop to avoid re-evaluating it per link.
+    // benign use cases
     or (
       any(body.links,
           .href_url.scheme == "mailto"

--- a/detection-rules/link_mailto_placeholder.yml
+++ b/detection-rules/link_mailto_placeholder.yml
@@ -4,22 +4,26 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and any(body.links,
+  and (
+    // @{domain} pattern is strong on its own
+    any(body.links,
+        .href_url.scheme == "mailto"
+        and regex.icontains(.href_url.url, '@\s*{\s*domain\s*}')
+    )
+    // combine {RECIPIENT_EMAIL} and {SENDER EMAIL} with NLU to remove a bunch of
+    // benign use cases. NLU doesn't depend on the link, so it's hoisted out of the
+    // any(body.links, ...) loop to avoid re-evaluating it per link.
+    or (
+      any(body.links,
           .href_url.scheme == "mailto"
-          and (
-            // @{domain} pattern is strong
-            regex.icontains(.href_url.url, '@\s*{\s*domain\s*}')
-            // combine {RECIPIENT_EMAIL} and {SENDER EMAIL} with NLU to remove a bunch of
-            // benign use cases
-            or (
-              regex.icontains(.href_url.url,
+          and regex.icontains(.href_url.url,
                               '{\s*(?:RECIPIENT|SENDER)[_\s]?EMAIL\s*}'
-              )
-              and any(ml.nlu_classifier(body.current_thread.text).intents,
-                      .name in ("cred_theft", "bec") and .confidence == "high"
-              )
-            )
           )
+      )
+      and any(ml.nlu_classifier(body.current_thread.text).intents,
+              .name in ("cred_theft", "bec") and .confidence == "high"
+      )
+    )
   )
 attack_types:
   - "Credential Phishing"


### PR DESCRIPTION
# Description

The classifier check on `body.current_thread.text` doesn't depend on link content, so nesting it inside `any(body.links, ...)` means the call site is reached once per qualifying link instead of once overall, and even though it's cached, it's not free. Hoisting the loop-independent check out of the loop saves that. Note that this requires splitting into two `any`s, since it was previously `any(P or (Q and C)`, so now it's `any(P) or (any(Q) and C)` (the scheme check is duplicated in both loops but is significantly cheaper than the cached nlu call).


# Associated samples
n/a - this is a no-op optimization

## Associated hunts
n/a

# Screenshot (insights)
n/a