### PR TITLE
Optimize headers_anonymousfox

### DIFF
--- a/detection-rules/headers_anonymousfox.yml
+++ b/detection-rules/headers_anonymousfox.yml
@@ -8,12 +8,14 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and any(headers.hops,
-          any(.fields,
-              regex.icontains(.name, "X-Authenticated-Sender|X-Sender")
-              and regex.icontains(.value, "(anonymous|smtp)fox-")
-          )
-          or regex.icontains(sender.email.email, "(anonymous|smtp)fox-")
+  and (
+    any(headers.hops,
+        any(.fields,
+            regex.icontains(.name, "^(X-Authenticated-Sender|X-Sender)")
+            and regex.icontains(.value, "(anonymous|smtp)fox-")
+        )
+    )
+    or regex.icontains(sender.email.email, "(anonymous|smtp)fox-")
   )
 attack_types:
   - "BEC/Fraud"


### PR DESCRIPTION
# Description

Sender email doesn't depend on headers loop, so hoist it. Additionally, we expect the header names to begin with `X-` so we can anchor the regexes on header name at line start and speed them up.

# Associated samples
n/a

## Associated hunts
90d hunt shows identical results
- Hunt 1 on old rule: https://platform.sublime.security/hunts/019f37e9-2f1c-7217-b99f-88dc33ea0d29
- Hunt 2 on new rule: https://platform.sublime.security/hunts/019f37e5-0126-7972-891e-b5f6370dd8bb


# Screenshot (insights)
n/a