### PR TITLE
[DRAFT] Optimize phishing_blue_button_file_sharing

### DIFF
--- a/detection-rules/phishing_blue_button_file_sharing.yml
+++ b/detection-rules/phishing_blue_button_file_sharing.yml
@@ -11,9 +11,9 @@ source: |
     or headers.in_reply_to is null
   )
   and any(html.xpath(body.html,
-                      // blue button background or background-color and observed colors, plus padding for button styling
-                      '//a[@href][contains(translate(@style,"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz"),"background") and (contains(translate(@style,"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz"),"0078d4") or contains(translate(@style,"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz"),"3a78d1")) and contains(translate(@style,"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz"),"padding")]'
-                     ).nodes,
+                     // blue button background or background-color and observed colors, plus padding for button styling
+                     '//a[@href][contains(translate(@style,"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz"),"background") and (contains(translate(@style,"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz"),"0078d4") or contains(translate(@style,"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz"),"3a78d1")) and contains(translate(@style,"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz"),"padding")]'
+          ).nodes,
           // ignore links going to microsoft
           not any(.links,
                   (
@@ -52,7 +52,6 @@ source: |
     sender.email.domain.root_domain == "microsoft.com"
     and headers.auth_summary.dmarc.pass
   )
-  
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/phishing_blue_button_file_sharing.yml
+++ b/detection-rules/phishing_blue_button_file_sharing.yml
@@ -5,17 +5,10 @@ severity: "low"
 source: |
   type.inbound
   and (
-    // no previous threads
+    // no previous threads, or no thread references at all
     length(body.previous_threads) == 0
-    // or is a fake thread
-    or (
-      (length(headers.references) == 0 or headers.in_reply_to is null)
-      and (
-        subject.is_reply
-        or subject.is_forward
-        or length(body.previous_threads) > 0
-      )
-    )
+    or length(headers.references) == 0
+    or headers.in_reply_to is null
   )
   and any(html.xpath(body.html,
                       // match the anchor's own inline style for blue-button background-color and

--- a/detection-rules/phishing_blue_button_file_sharing.yml
+++ b/detection-rules/phishing_blue_button_file_sharing.yml
@@ -17,42 +17,38 @@ source: |
       )
     )
   )
-  and any(filter(html.xpath(body.html, '//a[@href]').nodes,
-                 // blue button background, background-color and observed colors
-                 regex.icontains(.raw,
-                                 '(?:background(?:-color)?)\s*[:\s]\s*#(?:0078d4|3a78d1)'
-                 )
-          ),
-          (
-            // it's styled as a button
-            regex.icontains(.raw, 'padding')
-          )
+  and any(html.xpath(body.html,
+                      // match the anchor's own inline style for blue-button background-color and
+                      // padding; avoids scanning descendant markup, which can be arbitrarily
+                      // large per anchor and dominates cost on content-heavy messages
+                      '//a[@href][contains(translate(@style,"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz"),"background") and (contains(translate(@style,"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz"),"0078d4") or contains(translate(@style,"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz"),"3a78d1")) and contains(translate(@style,"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz"),"padding")]'
+                     ).nodes,
           // ignore links going to microsoft
-          and not any(.links,
-                      (
-                        .href_url.domain.sld in (
-                          "microsoft",
-                          "azure",
-                          "outlook.office365",
-                          "office365"
-                        )
-                      )
-                      or .href_url.domain.domain in $tenant_domains
-                      or (
-                        .href_url.domain.root_domain in (
-                          "mimecast.com",
-                          "mimecastprotect.com"
-                        )
-                        and any(.href_url.query_params_decoded['domain'],
-                                strings.parse_domain(.).domain in (
-                                  "microsoft.com",
-                                  "azure.com",
-                                  "outlook.office365.com",
-                                  "office365.com"
-                                )
-                                or strings.parse_domain(.).domain in $tenant_domains
-                        )
-                      )
+          not any(.links,
+                  (
+                    .href_url.domain.sld in (
+                      "microsoft",
+                      "azure",
+                      "outlook.office365",
+                      "office365"
+                    )
+                  )
+                  or .href_url.domain.domain in $tenant_domains
+                  or (
+                    .href_url.domain.root_domain in (
+                      "mimecast.com",
+                      "mimecastprotect.com"
+                    )
+                    and any(.href_url.query_params_decoded['domain'],
+                            strings.parse_domain(.).domain in (
+                              "microsoft.com",
+                              "azure.com",
+                              "outlook.office365.com",
+                              "office365.com"
+                            )
+                            or strings.parse_domain(.).domain in $tenant_domains
+                    )
+                  )
           )
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents, .name != "benign")

--- a/detection-rules/phishing_blue_button_file_sharing.yml
+++ b/detection-rules/phishing_blue_button_file_sharing.yml
@@ -11,9 +11,7 @@ source: |
     or headers.in_reply_to is null
   )
   and any(html.xpath(body.html,
-                      // match the anchor's own inline style for blue-button background-color and
-                      // padding; avoids scanning descendant markup, which can be arbitrarily
-                      // large per anchor and dominates cost on content-heavy messages
+                      // blue button background or background-color and observed colors, plus padding for button styling
                       '//a[@href][contains(translate(@style,"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz"),"background") and (contains(translate(@style,"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz"),"0078d4") or contains(translate(@style,"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz"),"3a78d1")) and contains(translate(@style,"ABCDEFGHIJKLMNOPQRSTUVWXYZ","abcdefghijklmnopqrstuvwxyz"),"padding")]'
                      ).nodes,
           // ignore links going to microsoft


### PR DESCRIPTION
# Description

Old version ran xpath to grab every anchor, then regexed all html found within that anchor (including display text and subtags) to get styling info. That's a lot more content than we need, so have the xpath do the filter itself on just the anchor's style tag (much simpler, no regex involved)

# Associated samples
n/a

## Associated hunts
Same results on 14d hunt with 889 matched groups
- Hunt 1 on old rule: https://platform.sublime.security/hunts/019f37f4-e3df-70de-ab02-a7b69b44fe0a
- Hunt 2 on new rule: https://platform.sublime.security/hunts/019f37f5-1cc5-7d39-9000-8e1ba2b80847

# Screenshot (insights)
n/a