### PR TITLE
Create service_abuse_adobe_message_from_new_domain.yml

### DIFF
--- a/detection-rules/service_abuse_adobe_message_from_new_domain.yml
+++ b/detection-rules/service_abuse_adobe_message_from_new_domain.yml
@@ -8,10 +8,8 @@ source: |
   and sender.email.email == 'message@adobe.com'
   and headers.auth_summary.dmarc.pass
   // sender has a recently created email domain
-  and any(filter(body.links,
-             .href_url.scheme == 'mailto'
-      ),
-      network.whois(.href_url.domain).days_old < 30
+  and any(filter(body.links, .href_url.scheme == 'mailto'),
+          network.whois(.href_url.domain).days_old < 30
   )
 tags:
   - "Attack surface reduction"
@@ -26,3 +24,4 @@ detection_methods:
   - "Header analysis"
   - "URL analysis"
   - "Whois"
+id: "9f7abbfe-5ecf-5686-a070-c1a465a1af80"

--- a/detection-rules/service_abuse_adobe_message_from_new_domain.yml
+++ b/detection-rules/service_abuse_adobe_message_from_new_domain.yml
@@ -1,12 +1,11 @@
 name: "Service abuse: Adobe message from newly registered domain"
-description: "Detects messages legitimately sent through Adobe's messaging infrastructure (passing DMARC) that contain mailto links pointing to domains registered within the last 30 days."
+description: "Detects messages legitimately sent through Adobe's messaging infrastructure that contain mailto links pointing to domains registered within the last 30 days."
 type: "rule"
 severity: "medium"
 source: |
   type.inbound
   // from Adobe
   and sender.email.email == 'message@adobe.com'
-  and headers.auth_summary.dmarc.pass
   // sender has a recently created email domain
   and any(filter(body.links, .href_url.scheme == 'mailto'),
           network.whois(.href_url.domain).days_old < 30

--- a/detection-rules/service_abuse_adobe_message_from_new_domain.yml
+++ b/detection-rules/service_abuse_adobe_message_from_new_domain.yml
@@ -1,0 +1,28 @@
+name: "Service abuse: Adobe message from newly registered domain"
+description: "Detects messages legitimately sent through Adobe's messaging infrastructure (passing DMARC) that contain mailto links pointing to domains registered within the last 30 days."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // from Adobe
+  and sender.email.email == 'message@adobe.com'
+  and headers.auth_summary.dmarc.pass
+  // sender has a recently created email domain
+  and any(filter(body.links,
+             .href_url.scheme == 'mailto'
+      ),
+      network.whois(.href_url.domain).days_old < 30
+  )
+tags:
+  - "Attack surface reduction"
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+  - "Lookalike domain"
+detection_methods:
+  - "Sender analysis"
+  - "Header analysis"
+  - "URL analysis"
+  - "Whois"


### PR DESCRIPTION
# Description

Detects messages legitimately sent through Adobe's messaging infrastructure (passing DMARC) that contain mailto links pointing to domains registered within the last 30 days.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/509b701ad0e574d0c415ff5509f837aefff12edbf142a3ed6c904aa95098de72)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=019f38d3-d5ef-72f3-a1f6-46f0471946f7)
- [110 Customer hunt](https://hunt.limeseed.email/hunts/b08ee1c0-fabb-4084-907f-f124178bd6b0)
