### PR TITLE
Create impersonation_employee_suspicious_sender.yml

### DIFF
--- a/detection-rules/impersonation_employee_suspicious_sender.yml
+++ b/detection-rules/impersonation_employee_suspicious_sender.yml
@@ -1,0 +1,23 @@
+name: "Impersonation: Employee name in subject with suspicious sender"
+description: "Detects inbound messages where the sender is using a free email provider and their display name matches an known organizational display name. The sender's local part contains common organizational role keywords (mail, office, staff, executive), and the subject line matches the recipient's first name or display name, suggesting a targeted impersonation of an internal employee or executive."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // suspicous local part
+  and strings.contains(sender.email.local_part, 'mail', 'office', 'staff', 'executive')
+  and (mailbox.first_name == subject.base or mailbox.display_name == subject.base)
+  and strings.contains(sender.display_name, " ")
+  and sender.display_name in~ $org_display_names
+  and sender.email.domain.root_domain in $free_email_providers
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Impersonation: Employee"
+  - "Impersonation: VIP"
+  - "Free email provider"
+  - "Social engineering"
+  - "Spoofing"
+detection_methods:
+  - "Sender analysis"
+  - "Content analysis"

--- a/detection-rules/impersonation_employee_suspicious_sender.yml
+++ b/detection-rules/impersonation_employee_suspicious_sender.yml
@@ -4,7 +4,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  // suspicous local part
+  // suspicious local part
   and strings.contains(sender.email.local_part,
                        'mail',
                        'office',

--- a/detection-rules/impersonation_employee_suspicious_sender.yml
+++ b/detection-rules/impersonation_employee_suspicious_sender.yml
@@ -5,7 +5,12 @@ severity: "medium"
 source: |
   type.inbound
   // suspicous local part
-  and strings.contains(sender.email.local_part, 'mail', 'office', 'staff', 'executive')
+  and strings.contains(sender.email.local_part,
+                       'mail',
+                       'office',
+                       'staff',
+                       'executive'
+  )
   and (mailbox.first_name == subject.base or mailbox.display_name == subject.base)
   and strings.contains(sender.display_name, " ")
   and sender.display_name in~ $org_display_names
@@ -21,3 +26,4 @@ tactics_and_techniques:
 detection_methods:
   - "Sender analysis"
   - "Content analysis"
+id: "bb0e78cc-e529-5bcc-b4af-524446e2c2ea"


### PR DESCRIPTION
# Description

Detects inbound messages where the sender is using a free email provider and their display name matches an known organizational display name. The sender's local part contains common organizational role keywords (mail, office, staff, executive), and the subject line matches the recipient's first name or display name.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/508f4a520073b8056b6fef87234ff612cbda88660650def7a9b969e92270bcb6?preview_id=019f1e1e-fe7c-79fb-b296-c455bae463c3)
- [Sample 2](https://platform.sublime.security/messages/5099f36214b725b6f7bcdf1e7bd554d19293145c3fecc778e30cdd30406954f7?preview_id=019f1e1e-24f6-764a-812f-9d9350584af2)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [110 Customer multi-hunt](https://hunt.limeseed.email/hunts/4307b56e-6294-44f3-9267-897daafaf515)

