### PR TITLE
Create vip_impersonation_prev_thread_iphone_signoff.yml

### DIFF
--- a/detection-rules/vip_impersonation_prev_thread_iphone_signoff.yml
+++ b/detection-rules/vip_impersonation_prev_thread_iphone_signoff.yml
@@ -15,7 +15,10 @@ source: |
                      )
                      // ends with fake ipad/iphone sign off
                      and (
-                       strings.iends_with(.text, "sent from my iphone.", "sent from my ipad.")
+                       strings.iends_with(.text,
+                                          "sent from my iphone.",
+                                          "sent from my ipad."
+                       )
                      )
               ),
               .sender.email.email
@@ -39,3 +42,4 @@ tactics_and_techniques:
 detection_methods:
   - "Content analysis"
   - "Sender analysis"
+id: "7b3b9dcb-adcf-5335-813b-51f1a42cb4d6"

--- a/detection-rules/vip_impersonation_prev_thread_iphone_signoff.yml
+++ b/detection-rules/vip_impersonation_prev_thread_iphone_signoff.yml
@@ -1,0 +1,41 @@
+name: "VIP impersonation: Invoice fraud with mobile device sign-off"
+description: "Detects inbound messages where a prior thread contains a reply from a known VIP - identifiable by display name or email address and signed off with a 'Sent from my iPhone' or 'Sent from my iPad' footer. However that VIP has been silently dropped from the current message's recipients. This pattern is consistent with fraudulent invoice and payment request lures where an attacker impersonates an internal executive in a thread, then removes them before requesting payment action from the remaining recipients."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(map(filter(body.previous_threads,
+                     // previous thread is authored by a VIP
+                     any($org_vips,
+                         strings.icontains(..sender.display_name, .display_name)
+                         or (
+                           .email != ""
+                           and strings.icontains(..sender.email.email, .email)
+                         )
+                     )
+                     // ends with fake ipad/iphone sign off
+                     and (
+                       strings.iends_with(.text, "sent from my iphone.", "sent from my ipad.")
+                     )
+              ),
+              .sender.email.email
+          ),
+          // VIP is dropped from the current thread recipients
+          // the previous thread sender email is empty, consider it a match
+          . == ""
+          // if it's not empty, check that it's not in the current thread
+          or (
+            not strings.icontains(sender.email.email, .)
+            and not any(flatten([recipients.to, recipients.cc, recipients.bcc]),
+                        strings.icontains(.email.email, ..)
+            )
+          )
+  )
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Impersonation: VIP"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Sender analysis"

--- a/detection-rules/vip_impersonation_prev_thread_iphone_signoff.yml
+++ b/detection-rules/vip_impersonation_prev_thread_iphone_signoff.yml
@@ -5,7 +5,6 @@ severity: "high"
 source: |
   type.inbound
   and any(map(filter(body.previous_threads,
-                     // previous thread is authored by a VIP
                      any($org_vips,
                          strings.icontains(..sender.display_name, .display_name)
                          or (
@@ -13,20 +12,27 @@ source: |
                            and strings.icontains(..sender.email.email, .email)
                          )
                      )
-                     // ends with fake ipad/iphone sign off
                      and (
-                       strings.iends_with(.text,
-                                          "sent from my iphone.",
-                                          "sent from my ipad."
+                       strings.iends_with(.text, "sent from my iphone.")
+                       or strings.iends_with(.text, "sent from my ipad.")
+                     )
+                     and (
+                       any(ml.nlu_classifier(.text, subject=.subject.base).topics,
+                           (
+                             .name == "Financial Communications"
+                             or .name == "Request to View Invoice"
+                           )
+                           and .confidence != "low"
+                       )
+                       or any(ml.nlu_classifier(.text, subject=.subject.base).tags,
+                              (.name == "invoice" or .name == "payment")
+                              and .confidence != "low"
                        )
                      )
               ),
               .sender.email.email
           ),
-          // VIP is dropped from the current thread recipients
-          // the previous thread sender email is empty, consider it a match
           . == ""
-          // if it's not empty, check that it's not in the current thread
           or (
             not strings.icontains(sender.email.email, .)
             and not any(flatten([recipients.to, recipients.cc, recipients.bcc]),


### PR DESCRIPTION
# Description

Add coverage for VIP Impersonation that keys in on a fake mobile device signoff

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50a0ddf065d0959cf439e7f7fe144d6659ac6aec284f349a0fd55099be836896)
- [Sample 2](https://platform.sublime.security/messages/509967022b295d8c10216be2057216bd1bea615d6bf371f4adc5988557cf46f6)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Multihunt](https://hunt.limeseed.email/hunts/9859da43-cd89-4985-8b4f-854d88761be1)
- [Hunt](https://platform.sublime.security/messages/hunt?huntId=019f3d81-afb1-7e81-9764-3fc284bb61c6)
