### PR TITLE
Limit phishing_blue_button_links to anchors that actually have a link

### DIFF
--- a/detection-rules/phishing_blue_button_file_sharing.yml
+++ b/detection-rules/phishing_blue_button_file_sharing.yml
@@ -18,8 +18,7 @@ source: |
     )
   )
   and any(html.xpath(body.html, '//a[@href]').nodes,
-          // hrefs like "#" (JS-driven buttons, etc.), tel:, mailto:, cid:, etc. never produce a
-          // .links entry at all; skip those before doing any regex work
+          // has an actual link somewhere else
           length(.links) > 0
           // ignore links going to microsoft
           and not any(.links,

--- a/detection-rules/phishing_blue_button_file_sharing.yml
+++ b/detection-rules/phishing_blue_button_file_sharing.yml
@@ -17,16 +17,10 @@ source: |
       )
     )
   )
-  and any(filter(html.xpath(body.html, '//a[@href]').nodes,
-                 // blue button background, background-color and observed colors
-                 regex.icontains(.raw,
-                                 '(?:background(?:-color)?)\s*[:\s]\s*#(?:0078d4|3a78d1)'
-                 )
-          ),
-          (
-            // it's styled as a button
-            regex.icontains(.raw, 'padding')
-          )
+  and any(html.xpath(body.html, '//a[@href]').nodes,
+          // hrefs like "#" (JS-driven buttons, etc.), tel:, mailto:, cid:, etc. never produce a
+          // .links entry at all; skip those before doing any regex work
+          length(.links) > 0
           // ignore links going to microsoft
           and not any(.links,
                       (
@@ -54,6 +48,12 @@ source: |
                         )
                       )
           )
+          // blue button background, background-color and observed colors
+          and regex.icontains(.raw,
+                               '(?:background(?:-color)?)\s*[:\s]\s*#(?:0078d4|3a78d1)'
+          )
+          // it's styled as a button
+          and regex.icontains(.raw, 'padding')
   )
   and any(ml.nlu_classifier(body.current_thread.text).intents, .name != "benign")
   // negate attachments that contain the known microsoft content type

--- a/detection-rules/phishing_blue_button_file_sharing.yml
+++ b/detection-rules/phishing_blue_button_file_sharing.yml
@@ -49,7 +49,7 @@ source: |
           )
           // blue button background, background-color and observed colors
           and regex.icontains(.raw,
-                               '(?:background(?:-color)?)\s*[:\s]\s*#(?:0078d4|3a78d1)'
+                              '(?:background(?:-color)?)\s*[:\s]\s*#(?:0078d4|3a78d1)'
           )
           // it's styled as a button
           and regex.icontains(.raw, 'padding')
@@ -64,7 +64,6 @@ source: |
     sender.email.domain.root_domain == "microsoft.com"
     and headers.auth_summary.dmarc.pass
   )
-  
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description

If the anchor's href is to something like "#", there's no point in evaluating its style. Move the faster filters first.

# Associated samples
n/a

## Associated hunts
https://platform.sublime.security/hunts/019f3cd1-39e4-7254-bd45-22d6bae942ec
Found 7 message groups:
* One had `href="#"` and was still flagged by a medium severity rule
* All others had `href=""` surrounding no text, and were still flagged by multiple high severity rules

# Screenshot (insights)
n/a