### PR TITLE
Create brand_impersonation_autodesk.yml

### DIFF
--- a/detection-rules/brand_impersonation_autodesk.yml
+++ b/detection-rules/brand_impersonation_autodesk.yml
@@ -1,0 +1,44 @@
+name: "Brand impersonation: Autodesk"
+description: "Detects messages impersonating Autodesk by identifying key indicators such as Autodesk branding, corporate address details, trademark language, and copyright notices, while ensuring the sender is not from a legitimate Autodesk domain with valid DMARC authentication."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+    (
+      any(ml.nlu_classifier(body.current_thread.text).entities,
+          .name == "org" and strings.icontains(.text, 'Autodesk')
+      )
+      and any(ml.nlu_classifier(body.current_thread.text).intents,
+              .name == "cred_theft" and .confidence == "high"
+      )
+    )
+    or 2 of (
+      strings.icontains(body.current_thread.text, "Autodesk, Inc."),
+      strings.icontains(body.current_thread.text, "One Market, Ste. 400"),
+      strings.icontains(body.current_thread.text, "San Francisco, CA 94105")
+    )
+    or regex.icontains(body.current_thread.text,
+                       '©\s*(?:20[0-9]{2}\s*)?Autodesk,?\s*Inc\.'
+    )
+    or strings.icontains(body.current_thread.text,
+                         'Autodesk and the Autodesk logo are registered trademarks'
+    )
+  )
+  and not (
+    sender.email.domain.root_domain in (
+      "autodesk.com",
+      "autodeskcommunications.com"
+    )
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+  
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Natural Language Understanding"
+  - "Content analysis"
+  - "Sender analysis"

--- a/detection-rules/brand_impersonation_autodesk.yml
+++ b/detection-rules/brand_impersonation_autodesk.yml
@@ -7,7 +7,7 @@ source: |
   and (
     (
       any(ml.nlu_classifier(body.current_thread.text).entities,
-          .name == "org" and strings.icontains(.text, 'Autodesk')
+          .name == "sender" and strings.icontains(.text, 'Autodesk')
       )
       and any(ml.nlu_classifier(body.current_thread.text).intents,
               .name == "cred_theft" and .confidence == "high"

--- a/detection-rules/brand_impersonation_autodesk.yml
+++ b/detection-rules/brand_impersonation_autodesk.yml
@@ -42,3 +42,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Content analysis"
   - "Sender analysis"
+id: "53edde6d-3954-5c93-af10-b34736dd537f"


### PR DESCRIPTION
# Description
Detects messages impersonating Autodesk by identifying key indicators such as Autodesk branding, corporate address details, trademark language, and copyright notices, while ensuring the sender is not from a legitimate Autodesk domain with valid DMARC authentication.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/509b9117c9dfdb3c70ce03a2bae2697d0043c602d631845240366445d4084504?preview_id=019f39d9-f017-7ed7-b6f5-c7af3f4ce533)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019f3dc5-b426-7e84-9fb3-ecced0c5b025)


