### PR TITLE
Update impersonation_amazon.yml

### DIFF
--- a/detection-rules/impersonation_amazon.yml
+++ b/detection-rules/impersonation_amazon.yml
@@ -25,7 +25,7 @@ source: |
     or regex.icontains(sender.display_name,
                        "prime (?:subscription|notification|support)"
     )
-    or regex.imatch(sender.display_name, "^prime (?:deal|store)$")
+    or regex.imatch(sender.display_name, '^(?:amazon\s)?prime (?:deals?|store)$')
     or strings.ilike(subject.subject, "*prime membership*")
     or (
       strings.ilevenshtein(sender.display_name, 'amazon') <= 1


### PR DESCRIPTION
# Description

Updating current logic to account for a leading `Amazon` before existing `Prime Deals` logic

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5096e0a808f771ffa83f7730bafecd6509f219b869fc74aa60a6e997d8daebb8?preview_id=019f04bf-a9e2-7d08-be0e-4efa3685e21f)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt
](https://platform.sublime.security/messages/hunt?huntId=019f4bbb-b7d3-78a7-93b9-9c06cc12b0d6)