### PR TITLE
Optimize xpath usage in phishing_blue_button_file_sharing.yml

### DIFF
--- a/detection-rules/phishing_blue_button_file_sharing.yml
+++ b/detection-rules/phishing_blue_button_file_sharing.yml
@@ -17,7 +17,11 @@ source: |
       )
     )
   )
-  and any(filter(html.xpath(body.html, '//a[@href]').nodes,
+  and any(filter(html.xpath(body.html,
+                            // require some styling anywhere in the anchor before running the
+                            // (comparatively expensive) regex checks below
+                            '//a[@href][@style or .//@style]'
+                 ).nodes,
                  // blue button background, background-color and observed colors
                  regex.icontains(.raw,
                                  '(?:background(?:-color)?)\s*[:\s]\s*#(?:0078d4|3a78d1)'


### PR DESCRIPTION
# Description
If an anchor or its subnodes doesn't have styling, there's no point in running a style-matching regex over its contents. xpath can do this filtering much faster than regex based on the actual attributes of the nodes, with the added bonus that it doesn't have to materialize a navigator for non-matching nodes.

Unlike previous attempts (#4804 and #4817), this one should also be logic neutral, since the regex can (and should) only really match the contents of a style attribute anyway.

# Associated samples
n/a

## Associated hunts
90d hunt: https://platform.sublime.security/hunts/019f4282-89e2-797b-8292-87f0572b0331
2 results, both the same campaign, actor put style element text in the anchor but didn't actually put them in a `style=` attribute, so the new xpath filter doesn't grab them. However, given that browsers also don't render those style elements without the actual attribute, I think that makes the rule match the actual output better. Even without this low severity rule, 4 other medium severity rules still match.

# Screenshot (insights)
n/a