### PR TITLE
Create service_abuse_notion_free_tier_impersonating_vip.yml

### DIFF
--- a/detection-rules/service_abuse_notion_free_tier_impersonating_vip.yml
+++ b/detection-rules/service_abuse_notion_free_tier_impersonating_vip.yml
@@ -1,0 +1,28 @@
+name: "Service abuse: Notion free-tier account impersonating VIP"
+description: "Detects messages sent from Notion's legitimate notification address (notify@mail.notion.so) that pass SPF and DMARC checks, but where the sender's display name matches an internal VIP, and the embedded links resolve to a Notion workspace associated with a free-tier subscription. This pattern indicates abuse of Notion's free tier to craft convincing internal impersonation lures."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and sender.email.email == 'notify@mail.notion.so'
+  and headers.auth_summary.spf.pass
+  and headers.auth_summary.dmarc.pass
+  // from VIP
+  and any($org_vips, strings.icontains(sender.display_name, .display_name))
+  and any(body.current_thread.links,
+          any(ml.link_analysis(.).additional_responses,
+              .json['statsigUser']['custom']['spaceSubscriptionTier'] == 'free'
+          )
+  )
+tags:
+  - "Attack surface reduction"
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: VIP"
+  - "Social engineering"
+detection_methods:
+  - "Sender analysis"
+  - "Header analysis"
+  - "URL analysis"
+  - "Content analysis"

--- a/detection-rules/service_abuse_notion_free_tier_impersonating_vip.yml
+++ b/detection-rules/service_abuse_notion_free_tier_impersonating_vip.yml
@@ -26,3 +26,4 @@ detection_methods:
   - "Header analysis"
   - "URL analysis"
   - "Content analysis"
+id: "966562cb-78b2-5844-a200-d12321df4472"

--- a/detection-rules/service_abuse_notion_free_tier_impersonating_vip.yml
+++ b/detection-rules/service_abuse_notion_free_tier_impersonating_vip.yml
@@ -5,8 +5,6 @@ severity: "medium"
 source: |
   type.inbound
   and sender.email.email == 'notify@mail.notion.so'
-  and headers.auth_summary.spf.pass
-  and headers.auth_summary.dmarc.pass
   // from VIP
   and any($org_vips, strings.icontains(sender.display_name, .display_name))
   and any(body.current_thread.links,


### PR DESCRIPTION
# Description
Detects messages sent from Notion's legitimate notification address (notify@mail.notion.so) that pass SPF and DMARC checks, but where the sender's display name matches an internal VIP, and the embedded links resolve to a Notion workspace associated with a free-tier subscription.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/rules/editor?canonical_id=14df3cf620a645c7dac22800ab3f627cf3f5748d78d70fe50a2d89ebe8edf265&message_id=019f4290-fe8f-70ad-88d5-9a3eb908da3c)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://hunt.limeseed.email/hunts/cfb0cf21-a94c-41df-9c02-d2c203656a0e)
- There is a customer hunt in the ticket. 
