### PR TITLE
Update stripe_invoice_abuse.yml

### DIFF
--- a/detection-rules/stripe_invoice_abuse.yml
+++ b/detection-rules/stripe_invoice_abuse.yml
@@ -41,7 +41,6 @@ source: |
         strings.icontains(body.current_thread.text, "ship your items"),
         strings.icontains(body.current_thread.text, "reach out:"),
         strings.icontains(body.current_thread.text, "pay this invoice"),
-        strings.icontains(body.current_thread.text, "thank you for your order"),
         strings.icontains(body.current_thread.text, "dear"),
         strings.icontains(body.current_thread.text, "need to cancel"),
         strings.icontains(body.current_thread.text, "Яеոеԝаⅼ"),

--- a/detection-rules/stripe_invoice_abuse.yml
+++ b/detection-rules/stripe_invoice_abuse.yml
@@ -7,25 +7,35 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(attachments) == 2
   and sender.email.domain.root_domain == "stripe.com"
   and headers.auth_summary.dmarc.pass
-  and any(attachments,
-          .file_extension == "pdf"
-          and any(file.explode(.),
-                  4 of (
-                    strings.ilike(.scan.ocr.raw, "*Btc Purchase*"),
-                    strings.ilike(.scan.ocr.raw, "*suspicious activity*"),
-                    strings.ilike(.scan.ocr.raw,
-                                  "*get in touch with us straight once*"
-                    ),
-                    strings.ilike(.scan.ocr.raw, "*your phone number*"),
-                    strings.ilike(.scan.ocr.raw, "*due deducted*"),
-                    strings.ilike(.scan.ocr.raw,
-                                  "*merchant security service center*"
-                    ),
-                  )
-          )
+  and (
+    (
+      length(attachments) == 2
+      and any(attachments,
+              .file_extension == "pdf"
+              and any(file.explode(.),
+                      4 of (
+                        strings.ilike(.scan.ocr.raw, "*Btc Purchase*"),
+                        strings.ilike(.scan.ocr.raw, "*suspicious activity*"),
+                        strings.ilike(.scan.ocr.raw,
+                                      "*get in touch with us straight once*"
+                        ),
+                        strings.ilike(.scan.ocr.raw, "*your phone number*"),
+                        strings.ilike(.scan.ocr.raw, "*due deducted*"),
+                        strings.ilike(.scan.ocr.raw,
+                                      "*merchant security service center*"
+                        )
+                      )
+              )
+      )
+    )
+    or (
+      length(attachments) == 1
+      and any(ml.nlu_classifier(body.current_thread.text).intents,
+              .name == "callback_scam" and .confidence == "high"
+      )
+    )
   )
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/stripe_invoice_abuse.yml
+++ b/detection-rules/stripe_invoice_abuse.yml
@@ -31,9 +31,21 @@ source: |
       )
     )
     or (
-      length(attachments) == 1
-      and any(ml.nlu_classifier(body.current_thread.text).intents,
-              .name == "callback_scam" and .confidence == "high"
+      any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "callback_scam" and .confidence == "high"
+      )
+      and 2 of (
+        strings.icontains(body.current_thread.text, "processing your payment"),
+        strings.icontains(body.current_thread.text, "payment has been received"),
+        strings.icontains(body.current_thread.text, "order status update"),
+        strings.icontains(body.current_thread.text, "ship your items"),
+        strings.icontains(body.current_thread.text, "reach out:"),
+        strings.icontains(body.current_thread.text, "pay this invoice"),
+        strings.icontains(body.current_thread.text, "thank you for your order"),
+        strings.icontains(body.current_thread.text, "dear"),
+        strings.icontains(body.current_thread.text, "need to cancel"),
+        strings.icontains(body.current_thread.text, "Яеոеԝаⅼ"),
+        strings.icontains(body.current_thread.text, "order confirmation"),
       )
     )
   )


### PR DESCRIPTION
# Description

Updating logic to capture samples with only one attachment and `callback_scam` intent with `high` confidence

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/509cd26f9e79795ad9e98fcfb1d0b9ec1414bb7a82eeeb52adc1383ce1f02d26?preview_id=019f235f-d783-7a53-854b-8ad97be7e264)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019f60e0-c58a-75ce-8531-68dd79e80829)