### PR TITLE
Create attachment_encrypted_pdf_cred_theft_eml.yml

### DIFF
--- a/detection-rules/attachment_encrypted_pdf_cred_theft_eml.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft_eml.yml
@@ -1,0 +1,101 @@
+name: "Attachment: Encrypted PDF with credential theft language in EML"
+description: "Attached PDF is encrypted, and email body contains credential theft language, wrapped in an attached .eml file. Seen in-the-wild impersonating e-fax services."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(attachments,
+          any(filter(file.parse_eml(.).attachments, .file_type == "pdf"),
+              any(file.explode(.),
+                  any(.scan.exiftool.fields, .key == "Encryption")
+                  or (
+                    .scan.entropy.entropy > 7
+                    and any(.scan.strings.strings,
+                            strings.icontains(., "/Encrypt")
+                    )
+                  )
+              )
+              // Encrypted PDFs do not have child nodes with any data
+              and all(filter(file.explode(.), .depth > 0), .size == 0)
+          )
+          and (
+            any(ml.nlu_classifier(file.parse_eml(.).body.current_thread.text).intents,
+                .name == "cred_theft" and .confidence in ("medium", "high")
+            )
+            or any(ml.nlu_classifier(beta.ocr(file.html_screenshot(file.parse_eml(.
+                                                                   ).body.html
+                                              )
+                                     ).text
+                   ).intents,
+                   .name == "cred_theft" and .confidence in ("medium", "high")
+            )
+            or regex.icontains(file.parse_eml(.).body.current_thread.text,
+                               'PDF\s*(?:Access|Preview|Unlock|Decrypt|passcode)',
+                               '(Access|Preview|Unlock|Decrypt|Pass)\s*(?:word|code)\s*(?:\S+\s+){0,3}PDF\s*is?\s*:',
+                               'This\s+(?:file|document|pdf)\s+is\s+(?:password[-\s]?)\s+protected\.\s*The\s+password\s+is\s*:?',
+                               '(?:Access|Preview|Unlock|Decrypt)\s+(?:\S+\s+){0,3}(?:PDF|statement)(?:\S+\s+){0,3}(?:pass(?:word|code)|\s*with\s+\S+)'
+            )
+            or (
+              (
+                length(file.parse_eml(.).body.current_thread.text) <= 10
+                or (file.parse_eml(.).body.current_thread.text is null)
+              )
+              and any(file.parse_eml(.).body.previous_threads,
+                      regex.icontains(.text,
+                                      'PDF\s*(?:Access|Preview|Unlock|Decrypt|passcode)',
+                                      '(Access|Preview|Unlock|Decrypt|Pass)\s*(?:word|code)\s*(?:\S+\s+){0,3}PDF\s*is?\s*:',
+                                      'This\s+(?:file|document|pdf)\s+is\s+(?:password[-\s]?)\s+protected\.\s*The\s+password\s+is\s*:?',
+                                      '(?:Access|Preview|Unlock|Decrypt)\s+(?:\S+\s+){0,3}(?:PDF|statement)(?:\S+\s+){0,3}(?:pass(?:word|code)|\s*with\s+\S+)'
+                      )
+              )
+            )
+          )
+  )
+  // not forwards/replies
+  and not (
+    (length(headers.references) > 0 or headers.in_reply_to is not null)
+    and (subject.is_forward or subject.is_reply)
+    and length(body.previous_threads) >= 1
+  )
+  and (
+    (
+      profile.by_sender_email().prevalence in ("new", "outlier")
+      and not profile.by_sender_email().solicited
+    )
+    or (
+      profile.by_sender_email().any_messages_malicious_or_spam
+      and not profile.by_sender_email().any_messages_benign
+    )
+    or (
+      length(recipients.to) == 0
+      or all(recipients.to,
+             strings.ilike(.display_name, "undisclosed?recipients")
+      )
+    )
+    or (
+      length(recipients.to) == 1
+      and any(recipients.to, .email.email == sender.email.email)
+    )
+  )
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Encryption"
+  - "Evasion"
+  - "PDF"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Exif analysis"
+  - "File analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"

--- a/detection-rules/attachment_encrypted_pdf_cred_theft_eml.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft_eml.yml
@@ -66,12 +66,13 @@ source: |
       profile.by_sender_email().any_messages_malicious_or_spam
       and not profile.by_sender_email().any_messages_benign
     )
+  or (
+    length(recipients.to) == 0
     or (
-      length(recipients.to) == 0
-      or all(recipients.to,
-             strings.ilike(.display_name, "undisclosed?recipients")
-      )
+      all(recipients.to, .email.domain.valid == false)
+      and all(recipients.cc, .email.domain.valid == false)
     )
+  )
     or (
       length(recipients.to) == 1
       and any(recipients.to, .email.email == sender.email.email)

--- a/detection-rules/attachment_encrypted_pdf_cred_theft_eml.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft_eml.yml
@@ -99,3 +99,4 @@ detection_methods:
   - "File analysis"
   - "Natural Language Understanding"
   - "Sender analysis"
+id: "f4a5fb9e-ecda-57a8-bc3c-851d64b8d06d"

--- a/detection-rules/attachment_encrypted_pdf_cred_theft_eml.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft_eml.yml
@@ -78,12 +78,9 @@ source: |
     )
   )
   // negate highly trusted sender domains unless they fail DMARC authentication
-  and (
-    (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and not headers.auth_summary.dmarc.pass
-    )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
 
 attack_types:

--- a/detection-rules/attachment_encrypted_pdf_cred_theft_eml.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft_eml.yml
@@ -31,7 +31,7 @@ source: |
             )
             or regex.icontains(file.parse_eml(.).body.current_thread.text,
                                'PDF\s*(?:Access|Preview|Unlock|Decrypt|passcode)',
-                               '(Access|Preview|Unlock|Decrypt|Pass)\s*(?:word|code)\s*(?:\S+\s+){0,3}PDF\s*is?\s*:',
+                               '(?:Access|Preview|Unlock|Decrypt|Pass)\s*(?:word|code)\s*(?:\S+\s+){0,3}PDF\s*is?\s*:',
                                'This\s+(?:file|document|pdf)\s+is\s+(?:password[-\s]?)\s+protected\.\s*The\s+password\s+is\s*:?',
                                '(?:Access|Preview|Unlock|Decrypt)\s+(?:\S+\s+){0,3}(?:PDF|statement)(?:\S+\s+){0,3}(?:pass(?:word|code)|\s*with\s+\S+)'
             )

--- a/detection-rules/attachment_encrypted_pdf_cred_theft_eml.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft_eml.yml
@@ -43,7 +43,7 @@ source: |
               and any(file.parse_eml(.).body.previous_threads,
                       regex.icontains(.text,
                                       'PDF\s*(?:Access|Preview|Unlock|Decrypt|passcode)',
-                                      '(Access|Preview|Unlock|Decrypt|Pass)\s*(?:word|code)\s*(?:\S+\s+){0,3}PDF\s*is?\s*:',
+                                      '(?:Access|Preview|Unlock|Decrypt|Pass)\s*(?:word|code)\s*(?:\S+\s+){0,3}PDF\s*is?\s*:',
                                       'This\s+(?:file|document|pdf)\s+is\s+(?:password[-\s]?)\s+protected\.\s*The\s+password\s+is\s*:?',
                                       '(?:Access|Preview|Unlock|Decrypt)\s+(?:\S+\s+){0,3}(?:PDF|statement)(?:\S+\s+){0,3}(?:pass(?:word|code)|\s*with\s+\S+)'
                       )

--- a/detection-rules/attachment_encrypted_pdf_cred_theft_eml.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft_eml.yml
@@ -66,13 +66,13 @@ source: |
       profile.by_sender_email().any_messages_malicious_or_spam
       and not profile.by_sender_email().any_messages_benign
     )
-  or (
-    length(recipients.to) == 0
     or (
-      all(recipients.to, .email.domain.valid == false)
-      and all(recipients.cc, .email.domain.valid == false)
+      length(recipients.to) == 0
+      or (
+        all(recipients.to, .email.domain.valid == false)
+        and all(recipients.cc, .email.domain.valid == false)
+      )
     )
-  )
     or (
       length(recipients.to) == 1
       and any(recipients.to, .email.email == sender.email.email)
@@ -83,7 +83,6 @@ source: |
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description
Matching the logic of [this rule](https://github.com/sublime-security/sublime-rules/blob/main/detection-rules/attachment_encrypted_pdf_cred_theft.yml) but in cases where instead of an attached pdf, we have an attached .eml which then has an attached pdf. 

# Associated samples


- [Sample 1](https://platform.sublime.security/messages/50a116ab716382135f309b4d2927d68f07698c5208c8bbf9b3d5c8f88face695?preview_id=019f434a-2a9f-7b37-932d-80c9a931d04a)


## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019f438c-47f4-7bf6-ac51-3aed85cd9adc)
