### PR TITLE
Create headers_unregistered_domain_via_zeptomail.yml

### DIFF
--- a/detection-rules/headers_unregistered_domain_via_zeptomail.yml
+++ b/detection-rules/headers_unregistered_domain_via_zeptomail.yml
@@ -4,9 +4,13 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and any(headers.hops, any(.fields, .name == 'X-Report-Abuse' and strings.contains(.value, 'zeptomail.in')))
-  and network.whois(sender.email.domain).found == false 
-  
+  and any(headers.hops,
+          any(.fields,
+              .name == 'X-Report-Abuse'
+              and strings.contains(.value, 'zeptomail.in')
+          )
+  )
+  and network.whois(sender.email.domain).found == false
 attack_types:
   - "BEC/Fraud"
   - "Credential Phishing"
@@ -18,3 +22,4 @@ detection_methods:
   - "Header analysis"
   - "Whois"
   - "Sender analysis"
+id: "8cf73c40-84c9-540f-a93e-477e3b2a4db9"

--- a/detection-rules/headers_unregistered_domain_via_zeptomail.yml
+++ b/detection-rules/headers_unregistered_domain_via_zeptomail.yml
@@ -1,0 +1,20 @@
+name: "Headers: Unregistered domain sending via ZeptoMail relay"
+description: "Detects inbound messages routed through ZeptoMail's infrastructure where the sender's domain has no resolvable WHOIS record. This combination of an unregistered domain and a transactional mail relay is a strong indicator of suspicious or fraudulent activity."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(headers.hops, any(.fields, .name == 'X-Report-Abuse' and strings.contains(.value, 'zeptomail.in')))
+  and network.whois(sender.email.domain).found == false 
+  
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+  - "Spam"
+tactics_and_techniques:
+  - "Spoofing"
+  - "Evasion"
+detection_methods:
+  - "Header analysis"
+  - "Whois"
+  - "Sender analysis"


### PR DESCRIPTION
# Description
Detects inbound messages routed through ZeptoMail's infrastructure where the sender's domain has no resolvable WHOIS record.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/508cb1a8a804c2f1557b91e913a0ed4e4a32dfe6db490a5a88511c2529789522?preview_id=019f4338-b43a-77b3-93a1-914376d790e2)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [98 customer mult-hunt](https://hunt.limeseed.email/hunts/a583d471-ad93-48ba-8319-ad7ce437a926)
- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=019f476e-fb84-769b-abe9-dd4e2561ea6e)

