### PR TITLE
Create open_redirect_gov_to_non_gov.yml

### DIFF
--- a/detection-rules/open_redirect_gov_to_non_gov.yml
+++ b/detection-rules/open_redirect_gov_to_non_gov.yml
@@ -1,0 +1,24 @@
+name: "Open redirect: Government domain used to redirect to non-government URL"
+description: "Detects inbound messages sent to a single recipient containing links hosted on government TLD domains that embed the recipient's email address in the URL and use a redirect parameter pointing to a non-government destination. This technique exploits the trusted reputation of government domains to obscure a malicious redirect target."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and length(recipients.to) == 1
+  and any(body.current_thread.links,
+          strings.contains(.href_url.domain.tld, 'gov')
+          and strings.contains(.href_url.url, recipients.to[0].email.email)
+          and length(.href_url.query_params_decoded['url']) > 0
+          and not any(.href_url.query_params_decoded['url'],
+                      strings.contains(strings.parse_url(.).domain.tld, 'gov')
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Open redirect"
+  - "Social engineering"
+  - "Evasion"
+detection_methods:
+  - "URL analysis"
+  - "Content analysis"

--- a/detection-rules/open_redirect_gov_to_non_gov.yml
+++ b/detection-rules/open_redirect_gov_to_non_gov.yml
@@ -22,3 +22,4 @@ tactics_and_techniques:
 detection_methods:
   - "URL analysis"
   - "Content analysis"
+id: "37add46b-cfbe-5626-83e5-5f4d9ce394a0"


### PR DESCRIPTION
# Description
Detects inbound messages sent to a single recipient containing links hosted on government TLD domains that embed the recipient's email address in the URL and use a redirect parameter pointing to a non-government destination.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/508cb1a8a804c2f1557b91e913a0ed4e4a32dfe6db490a5a88511c2529789522?preview_id=019f4338-b43a-77b3-93a1-914376d790e2)
## Associated hunts


- [98 customer multi-hunt](https://hunt.limeseed.email/hunts/64c8b308-6777-4b1b-8677-d78883f0d695)
- [SWS hunt](https://platform.sublime.security/hunts/019f4c81-f1da-7a0d-bb9d-7203528a25f4)
