### PR TITLE
Create open_redirect_pointing_to_new_domain.yml

### DIFF
--- a/detection-rules/open_redirect_pointing_to_new_domain.yml
+++ b/detection-rules/open_redirect_pointing_to_new_domain.yml
@@ -9,7 +9,7 @@ source: |
           strings.contains(.href_url.url, recipients.to[0].email.email)
           and length(.href_url.query_params_decoded['url']) > 0
           and any(.href_url.query_params_decoded['url'],
-                      network.whois(strings.parse_url(.).domain).days_old < 100
+                  network.whois(strings.parse_url(.).domain).days_old < 100
           )
   )
 attack_types:
@@ -20,3 +20,4 @@ tactics_and_techniques:
 detection_methods:
   - "URL analysis"
   - "Whois"
+id: "861400d2-930a-5484-afa6-3dfa850dfec2"

--- a/detection-rules/open_redirect_pointing_to_new_domain.yml
+++ b/detection-rules/open_redirect_pointing_to_new_domain.yml
@@ -1,0 +1,22 @@
+name: "Open redirect: Recipient address embedded in redirect URL pointing to newly registered domain"
+description: "Detects inbound messages sent to a single recipient where the body contains a link that embeds the recipient's email address in a URL query parameter, and the resolved destination domain was registered less than 100 days ago. This pattern is consistent with personalized redirect links designed to evade detection while directing targets to newly established infrastructure."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and length(recipients.to) == 1
+  and any(body.current_thread.links,
+          strings.contains(.href_url.url, recipients.to[0].email.email)
+          and length(.href_url.query_params_decoded['url']) > 0
+          and any(.href_url.query_params_decoded['url'],
+                      network.whois(strings.parse_url(.).domain).days_old < 100
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Open redirect"
+  - "Social engineering"
+detection_methods:
+  - "URL analysis"
+  - "Whois"

--- a/detection-rules/open_redirect_pointing_to_new_domain.yml
+++ b/detection-rules/open_redirect_pointing_to_new_domain.yml
@@ -9,7 +9,10 @@ source: |
           strings.contains(.href_url.url, recipients.to[0].email.email)
           and length(.href_url.query_params_decoded['url']) > 0
           and any(.href_url.query_params_decoded['url'],
-                  network.whois(strings.parse_url(.).domain).days_old < 100
+                  strings.contains(strings.parse_url(.).url,
+                                   recipients.to[0].email.email
+                  )
+                  and network.whois(strings.parse_url(.).domain).days_old < 100
           )
   )
 attack_types:


### PR DESCRIPTION
# Description

Detects inbound messages sent to a single recipient where the body contains a link that embeds the recipient's email address in a URL query parameter, and the resolved destination domain was registered less than 100 days ago.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/508c4eddd639d1863a9d9fc6b900b9cee249bfc2ec838d16a84bfcb593e84abf?preview_id=019f4330-da4d-7e5f-995b-4af57e48f2b0)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [SWS Hunt](https://platform.sublime.security/hunts/019f47d1-78e3-766b-b0b0-b4c631fefc99)
- [98 customer multi-hunt](https://hunt.limeseed.email/hunts/3f77cb4c-c169-40a8-b2f6-8ebe14b9be58)

