### PR TITLE
Create vip_impersonation_fake_thread_vip_missing_email.yml

### DIFF
--- a/detection-rules/vip_impersonation_fake_thread_vip_missing_email.yml
+++ b/detection-rules/vip_impersonation_fake_thread_vip_missing_email.yml
@@ -57,3 +57,4 @@ detection_methods:
   - "Header analysis"
   - "Content analysis"
   - "Sender analysis"
+id: "44a68195-1d0d-5a9f-b984-994784f73eee"

--- a/detection-rules/vip_impersonation_fake_thread_vip_missing_email.yml
+++ b/detection-rules/vip_impersonation_fake_thread_vip_missing_email.yml
@@ -11,7 +11,7 @@ source: |
       any(ml.nlu_classifier(body.previous_threads[length(body.previous_threads)-1].text, subject=body.previous_threads[length(body.previous_threads)-1].subject.base).tags, .name in ("invoice", "payment") and .confidence != "low")
       or any(ml.nlu_classifier(body.previous_threads[length(body.previous_threads)-1].text, subject=body.previous_threads[length(body.previous_threads)-1].subject.base).topics, .name in ("Request to View Invoice", "Payment Information") and .confidence != "low")
   )
-  // second to oldest thread is invoice/payment realated
+  // second to oldest thread is invoice/payment related
   and (
       any(ml.nlu_classifier(body.previous_threads[length(body.previous_threads)-2].text, subject=body.previous_threads[length(body.previous_threads)-2].subject.base).tags, .name in ("invoice", "payment") and .confidence != "low")
       or any(ml.nlu_classifier(body.previous_threads[length(body.previous_threads)-2].text, subject=body.previous_threads[length(body.previous_threads)-2].subject.base).topics, .name in ("Request to View Invoice", "Payment Information") and .confidence != "low")

--- a/detection-rules/vip_impersonation_fake_thread_vip_missing_email.yml
+++ b/detection-rules/vip_impersonation_fake_thread_vip_missing_email.yml
@@ -26,7 +26,7 @@ source: |
     or body.previous_threads[length(body.previous_threads) - 2].sender.email.email == ""
     or body.previous_threads[length(body.previous_threads) - 2].recipients.to[0].email.email == ""
   )
-  // an org vip sent/receieved messages
+  // an org vip sent/received messages
   and any($org_vips,
     ( body.previous_threads[length(body.previous_threads) - 1].recipients.to[0].display_name == .display_name
       and body.previous_threads[length(body.previous_threads) - 2].sender.display_name == .display_name )

--- a/detection-rules/vip_impersonation_fake_thread_vip_missing_email.yml
+++ b/detection-rules/vip_impersonation_fake_thread_vip_missing_email.yml
@@ -1,0 +1,59 @@
+name: "VIP impersonation: Fake thread with VIPs missing email metadata"
+description: "Detects inbound messages that weaponize fabricated invoice or payment thread histories to impersonate or involve organizational VIPs. The rule identifies conversations where the two oldest visible threads discuss invoices, payments, or executive engagements, but contain incomplete sender or recipient email addresses — a hallmark of stitched-together or forged thread context. The targeted VIP appears in the fabricated thread history but is conspicuously absent from the current message's recipients, suggesting the VIP's name is being leveraged to establish false legitimacy while routing the live message away from their oversight. Matched messages span executive search retainer invoices, past-due account notices, wire transfer instructions, and advisory billing lures targeting named executives at known organizations."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  // we need at least two threads
+  and length(body.previous_threads) > 1 
+  // oldest thread is invoice/payment related
+  and (
+      any(ml.nlu_classifier(body.previous_threads[length(body.previous_threads)-1].text, subject=body.previous_threads[length(body.previous_threads)-1].subject.base).tags, .name in ("invoice", "payment") and .confidence != "low")
+      or any(ml.nlu_classifier(body.previous_threads[length(body.previous_threads)-1].text, subject=body.previous_threads[length(body.previous_threads)-1].subject.base).topics, .name in ("Request to View Invoice", "Payment Information") and .confidence != "low")
+  )
+  // second to oldest thread is invoice/payment realated
+  and (
+      any(ml.nlu_classifier(body.previous_threads[length(body.previous_threads)-2].text, subject=body.previous_threads[length(body.previous_threads)-2].subject.base).tags, .name in ("invoice", "payment") and .confidence != "low")
+      or any(ml.nlu_classifier(body.previous_threads[length(body.previous_threads)-2].text, subject=body.previous_threads[length(body.previous_threads)-2].subject.base).topics, .name in ("Request to View Invoice", "Payment Information") and .confidence != "low")
+  )
+  // each of the two oldest threads have 1 or less recipients (sometimes the "to" header is missing)
+  and length(body.previous_threads[length(body.previous_threads) - 1].recipients.to) <= 1
+  and length(body.previous_threads[length(body.previous_threads) - 2].recipients.to) <= 1
+  // at least one party in the two oldest threads is missing an email
+  and (
+    body.previous_threads[length(body.previous_threads) - 1].sender.email.email == ""
+    or body.previous_threads[length(body.previous_threads) - 1].recipients.to[0].email.email == ""
+    or body.previous_threads[length(body.previous_threads) - 2].sender.email.email == ""
+    or body.previous_threads[length(body.previous_threads) - 2].recipients.to[0].email.email == ""
+  )
+  // an org vip sent/receieved messages
+  and any($org_vips,
+    ( body.previous_threads[length(body.previous_threads) - 1].recipients.to[0].display_name == .display_name
+      and body.previous_threads[length(body.previous_threads) - 2].sender.display_name == .display_name )
+    or ( body.previous_threads[length(body.previous_threads) - 1].sender.display_name == .display_name
+      and body.previous_threads[length(body.previous_threads) - 2].recipients.to[0].display_name == .display_name )
+  )
+  // the VIP is no longer in the current message
+  and not any(flatten([recipients.to, recipients.cc, recipients.bcc]),
+              any($org_vips,
+                  .email != ""
+                  and strings.icontains(..email.email, .email)
+                  and (
+                    ( body.previous_threads[length(body.previous_threads) - 1].recipients.to[0].display_name == .display_name
+                      and body.previous_threads[length(body.previous_threads) - 2].sender.display_name == .display_name )
+                    or ( body.previous_threads[length(body.previous_threads) - 1].sender.display_name == .display_name
+                      and body.previous_threads[length(body.previous_threads) - 2].recipients.to[0].display_name == .display_name )
+                  )))
+  // not from authorized senders on the org's domain
+  and not (sender.email.domain.domain in $org_domains and coalesce(headers.auth_summary.dmarc.pass, false))
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Impersonation: VIP"
+  - "Social engineering"
+  - "Spoofing"
+detection_methods:
+  - "Natural Language Understanding"
+  - "Header analysis"
+  - "Content analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

Add coverage for observed tehcnique where the email address is missing from previous thread sender/recipient and only populates display names

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50a27590cd5cbca37c4529b6870f9211d78ccca2309d7701041f289442b39f95?preview_id=019f43f5-140e-76ea-b1f7-43c2950879e6)
- [Sample 2](https://platform.sublime.security/messages/50a2e2d2e47f54135c2f8c74fa3a296d73b2f6620b0eec5f7fc8376943c593d0?preview_id=019f43f5-1773-7815-9368-7acbbd008568)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Multihunt 1](https://hunt.limeseed.email/hunts/6b11f2db-4767-4236-bb89-bbab27d5b20f)
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019f47a7-ebc0-709b-abf7-0362f352a8b4)
