### PR TITLE
Fix invisible character in mql_format.py exclusion entry

### DIFF
--- a/.github/scripts/mql_format.py
+++ b/.github/scripts/mql_format.py
@@ -44,7 +44,7 @@ RETRYABLE_STATUSES = {403, 429, 502, 503, 504}
 # Files to exclude from formatting (e.g., special comment formatting)
 EXCLUDE_FILES = {
     "attachment_cve_2023_38831.yml",
-    "vip_impersonation_fake_thread_vip_missing_email.yml‎"
+    "vip_impersonation_fake_thread_vip_missing_email.yml",
 }
 
 


### PR DESCRIPTION
## Summary
- #4852 added `vip_impersonation_fake_thread_vip_missing_email.yml` to `EXCLUDE_FILES` in `.github/scripts/mql_format.py`, but the string has a trailing invisible U+200E (LEFT-TO-RIGHT MARK) character.
- Because of this, `"vip_impersonation_fake_thread_vip_missing_email.yml" in EXCLUDE_FILES` evaluates to `False` — the intended exclusion never actually took effect.
- Removes the invisible character and adds the missing trailing comma.

## Test plan
- [x] Verified locally that the filename now matches the exclusion set