### PR TITLE
Create attachment_pdf_single_page_s3_link.yml

### DIFF
--- a/detection-rules/attachment_pdf_single_page_s3_link.yml
+++ b/detection-rules/attachment_pdf_single_page_s3_link.yml
@@ -28,3 +28,4 @@ detection_methods:
   - "File analysis"
   - "Exif analysis"
   - "URL analysis"
+id: "86b16409-a40b-5dd8-8589-05fdcf115f89"

--- a/detection-rules/attachment_pdf_single_page_s3_link.yml
+++ b/detection-rules/attachment_pdf_single_page_s3_link.yml
@@ -1,0 +1,30 @@
+name: "Attachment: Single-page PDF with S3-hosted HTML link"
+description: "Detects inbound messages containing a single-page PDF attachment that includes exactly one URL, which links directly to an HTML file hosted on an Amazon S3 bucket. This technique is commonly used to redirect recipients to credential harvesting pages while leveraging trusted cloud infrastructure to evade detection."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(attachments,
+          .file_type == "pdf"
+          // a single page pdf
+          and beta.parse_exif(.).page_count == 1
+          and any(file.explode(.),
+                  length(.scan.pdf.urls) == 1
+                  and any(.scan.pdf.urls,
+                          strings.contains(.path, '.html')
+                          and // links directly to a S3 bucket
+                          .domain.root_domain == "amazonaws.com"
+                          and strings.icontains(.domain.subdomain, "s3")
+                  )
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "PDF"
+  - "Free file host"
+  - "Evasion"
+detection_methods:
+  - "File analysis"
+  - "Exif analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description
Detects inbound messages containing a single-page PDF attachment that includes exactly one URL, which links directly to an HTML file hosted on an Amazon S3 bucket.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/509c2863836129f9214487e2038e51be1604d3db10af6d1ea1a5e679686c17c4?preview_id=019f42d8-72ec-7185-a94c-9a72a51ace31)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [SWS Hunt](https://platform.sublime.security/hunts/019f4818-0ce5-7437-9d84-b5bc20e2a1d9)
- [97 customer multi-hunt](https://hunt.limeseed.email/hunts/e63881e7-e009-49f1-9fc4-9fd2399596dd)

