### PR TITLE
Create sender_display_name_spoofing_alert_email.yml

### DIFF
--- a/detection-rules/sender_display_name_spoofing_alert_email.yml
+++ b/detection-rules/sender_display_name_spoofing_alert_email.yml
@@ -1,0 +1,17 @@
+name: "Spoofed 'alert' display name with mismatched sender address"
+description: "Detects inbound messages where the sender's display name is formatted as an email address with the local part 'alert', but the actual sender address does not match the email parsed from the display name. This technique is used to mislead recipients into believing the message originates from a legitimate alert notification system."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and strings.parse_email(sender.display_name).local_part == 'alert'
+  and sender.email.email != strings.parse_email(sender.display_name).email
+attack_types:
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Spoofing"
+  - "Social engineering"
+  - "Impersonation: Brand"
+detection_methods:
+  - "Sender analysis"

--- a/detection-rules/sender_display_name_spoofing_alert_email.yml
+++ b/detection-rules/sender_display_name_spoofing_alert_email.yml
@@ -15,3 +15,4 @@ tactics_and_techniques:
   - "Impersonation: Brand"
 detection_methods:
   - "Sender analysis"
+id: "a134013b-b364-52b1-8e30-8107760bc14f"


### PR DESCRIPTION
# Description
Detects inbound messages where the sender's display name is formatted as an email address with the local part 'alert', but the actual sender address does not match the email parsed from the display name.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/509c2863836129f9214487e2038e51be1604d3db10af6d1ea1a5e679686c17c4?preview_id=019f42d8-72ec-7185-a94c-9a72a51ace31)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=019f4811-da6a-761d-bc57-544886d13ffa)
- [98 customer multi-hunt](https://hunt.limeseed.email/hunts/be2a2022-fe54-4289-accf-0a4de8cc21a4)


