### PR TITLE
Update brand_impersonation_gemini.yml

### DIFF
--- a/detection-rules/brand_impersonation_gemini.yml
+++ b/detection-rules/brand_impersonation_gemini.yml
@@ -6,64 +6,35 @@ source: |
   type.inbound
   and (
     // the address in the footer
-    (
-      regex.icontains(body.current_thread.text,
-                      "600 Third Avenue.{1,2}2nd Floor.{1,2}New York, NY"
-      )
-      and strings.icontains(body.current_thread.text, "Gemini Trust Company")
+    regex.icontains(body.html.display_text,
+                    "600 Third Avenue.{1,2}2nd Floor.{1,2}New York, NY"
     )
-    // logo detect combined with sender display name 
+    or strings.icontains(body.html.display_text, "Gemini Trust Company")
+    // logo detect combined with sender elements
     // need to be more specific here due to other uses of the word "Gemini"
-    or (
-      sender.display_name =~ "Gemini"
-      and any(ml.logo_detect(file.message_screenshot()).brands,
-              .name == "Gemini Trust" and .confidence != "low"
-      )
-    )
-    // copyright footer
-    or strings.icontains(body.current_thread.text,
-                         '© 2025 Gemini Trust Company, LLC'
-    )
-  
+    // or (
+    //   sender.display_name  =~ "Gemini"
+    //   and any(ml.logo_detect(beta.message_screenshot()).brands, .name == "Gemini" and .confidence != "low")
+    // )
     // the social links in the footer
     or (
       length(filter(body.links,
-                    strings.icontains(.href_url.url,
-                                      'https://www.instagram.com/gemini/'
-                    )
-                    or strings.icontains(.href_url.url,
-                                         'https://www.linkedin.com/company/geminitrust/'
-                    )
-                    or strings.icontains(.href_url.url,
-                                         'https://facebook.com/GeminiTrust'
-                    )
-                    or strings.icontains(.href_url.url,
-                                         'https://twitter.com/Gemini'
-                    )
-                    or strings.icontains(.href_url.url,
-                                         'https://support.gemini.com/hc/en-us/requests/new'
-                    )
-                    or strings.icontains(.href_url.url,
-                                         'https://support.gemini.com/hc/en-us/requests/new'
-                    )
+                    .href_url.url == "https://www.instagram.com/gemini/"
+                    or .href_url.url == "https://www.linkedin.com/company/geminitrust/"
+                    or .href_url.url == "https://facebook.com/GeminiTrust"
+                    or .href_url.url == "https://twitter.com/Gemini"
+                    or .href_url.url == "https://support.gemini.com/hc/en-us/requests/new"
              )
       ) >= 4
     )
   )
-  // not forwards/replies
-  and not (
-    length(headers.references) > 0
-    and (subject.is_forward or subject.is_reply)
-    and length(body.previous_threads) >= 1
-  )
+  
   // not from Gemini actual
   and not (
-    sender.email.domain.root_domain in (
-      "gemini.com",
-      "niftygateway.com" // NFT market place owned by Gemini Trust Company
-    )
+    sender.email.domain.root_domain in ("gemini.com")
     and headers.auth_summary.dmarc.pass
   )
+
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/brand_impersonation_gemini.yml
+++ b/detection-rules/brand_impersonation_gemini.yml
@@ -5,17 +5,13 @@ severity: "medium"
 source: |
   type.inbound
   and (
-    // the address in the footer
-    regex.icontains(body.html.display_text,
-                    "600 Third Avenue.{1,2}2nd Floor.{1,2}New York, NY"
+    (
+      // the address in the footer
+      regex.icontains(body.html.display_text,
+                      "600 Third Avenue.{1,2}2nd Floor.{1,2}New York, NY"
+      )
+      and strings.icontains(body.html.display_text, "Gemini Trust Company")
     )
-    or strings.icontains(body.html.display_text, "Gemini Trust Company")
-    // logo detect combined with sender elements
-    // need to be more specific here due to other uses of the word "Gemini"
-    // or (
-    //   sender.display_name  =~ "Gemini"
-    //   and any(ml.logo_detect(beta.message_screenshot()).brands, .name == "Gemini" and .confidence != "low")
-    // )
     // the social links in the footer
     or (
       length(filter(body.links,


### PR DESCRIPTION
# Description
A couple things:
1. We had one of the OR statements in there twice, removing that. 
2. We are using strings.icontains to check the body links, but in testing, we can get away with href_url.url instead. This should help with some perf issues for the rule. 

## Associated samples

- [Sample 1](https://platform.sublime.security/messages/508c2ea2aec45a7ff43f906d940062acf81a4ec2820e3bad43e4aa5320e4cb56?preview_id=019ed1a2-01ae-7935-b32d-b929030a5f54)
- [Sample 2](https://platform.sublime.security/messages/4fd8c31223a48f6d3c6eee15f14311304de49d22152a2cd4d55247fa78b5f16d?preview_id=019b324d-1f1d-754a-9653-34e443a09a55)

## Associated hunts

- [Current Logic](https://platform.sublime.security/messages/hunt?huntId=019f4872-e140-7dfb-b346-1b1fad6c13bd)
- [this PR logic](https://platform.sublime.security/messages/hunt?huntId=019f4881-c79b-705b-87d5-40c132414cab)
- [alternative idea for the fix](https://platform.sublime.security/messages/hunt?huntId=019f4861-b3dd-70a4-b0db-4a9d84a4d8c9)

The difference in these is coming from instances where multiple twitter links are present in the same message. 
