### PR TITLE
Add daily auto-format MQL rules workflow

### DIFF
--- a/.github/workflows/mql-auto-format.yml
+++ b/.github/workflows/mql-auto-format.yml
@@ -1,0 +1,39 @@
+name: Auto-format MQL rules
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # daily at 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  format:
+    name: Format MQL rules
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out sublime-rules
+      uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: pip install -q requests pyyaml
+
+    - name: Format rules
+      run: python .github/scripts/mql_format.py detection-rules/*.yml insights/**/*.yml
+
+    - name: Open PR if rules changed
+      uses: peter-evans/create-pull-request@v7
+      with:
+        title: 'fmt: Auto-format MQL rules'
+        body: |
+          Automated formatting pass using Sublime's MQL format API.
+
+          This PR was created automatically by the `Auto-format MQL rules` workflow.
+          Review the diffs to confirm the formatter output looks correct before merging.
+        branch: auto/mql-format
+        commit-message: 'fmt: Auto-format MQL rules'
+        labels: chore
+        delete-branch: true


### PR DESCRIPTION
## Description

Adds a daily GitHub Actions workflow that auto-formats all detection rules and insights using Sublime's MQL format API, opening a single rolling PR (`auto/mql-format`) for detection team review when formatting drifts.

## Why

The MQL formatter may evolve over time. Rather than requiring individual PRs to carry a paired sublime-rules formatting PR, a daily chore runs the formatter and surfaces any drift as a single reviewable PR. The PR branch is fixed (`auto/mql-format`) so subsequent runs amend the same PR rather than opening new ones.

## Test plan

- [ ] Trigger workflow manually via `workflow_dispatch` to verify it runs successfully
- [ ] Confirm `peter-evans/create-pull-request` creates/updates the `auto/mql-format` branch correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)