### PR TITLE
Create service_abuse_zoom_clips_unregistered_reply_to_domain.yml

### DIFF
--- a/detection-rules/service_abuse_zoom_clips_unregistered_reply_to_domain.yml
+++ b/detection-rules/service_abuse_zoom_clips_unregistered_reply_to_domain.yml
@@ -21,3 +21,4 @@ detection_methods:
   - "Sender analysis"
   - "Header analysis"
   - "Whois"
+id: "a00900fd-1b91-568e-ab9b-bd33873af253"

--- a/detection-rules/service_abuse_zoom_clips_unregistered_reply_to_domain.yml
+++ b/detection-rules/service_abuse_zoom_clips_unregistered_reply_to_domain.yml
@@ -1,0 +1,23 @@
+name: "Service abuse: Zoom Clips with unregistered reply-to domain"
+description: "Detects messages sent through legitimate Zoom infrastructure sharing a clip, where the reply-to domain has no registered WHOIS record."
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  // Legitimate zoom sending infrastructure
+  and sender.email.email == "no-reply@zoom.us"
+  // sharing a clip
+  and strings.starts_with(subject.base, 'Clips')
+  // reply-to domain is not registered
+  and (network.whois(headers.reply_to[0].email.domain).found == false)
+tags:
+  - "Attack surface reduction"
+attack_types:
+  - "Spam"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Evasion"
+detection_methods:
+  - "Sender analysis"
+  - "Header analysis"
+  - "Whois"

--- a/detection-rules/service_abuse_zoom_newly_reply_to_domain.yml
+++ b/detection-rules/service_abuse_zoom_newly_reply_to_domain.yml
@@ -7,7 +7,10 @@ source: |
   // Legitimate zoom sending infrastructure
   and sender.email.email == "no-reply@zoom.us"
   // newly registered reply-to domain
-  and network.whois(headers.reply_to[0].email.domain).days_old < 45
+  and (
+    network.whois(headers.reply_to[0].email.domain).days_old < 45
+    or network.whois(headers.reply_to[0].email.domain).found == false
+  )
 tags:
   - "Attack surface reduction"
 attack_types:

--- a/detection-rules/service_abuse_zoom_newly_reply_to_domain.yml
+++ b/detection-rules/service_abuse_zoom_newly_reply_to_domain.yml
@@ -7,10 +7,7 @@ source: |
   // Legitimate zoom sending infrastructure
   and sender.email.email == "no-reply@zoom.us"
   // newly registered reply-to domain
-  and (
-    network.whois(headers.reply_to[0].email.domain).days_old < 45
-    or network.whois(headers.reply_to[0].email.domain).found == false
-  )
+  and network.whois(headers.reply_to[0].email.domain).days_old < 45
 tags:
   - "Attack surface reduction"
 attack_types:


### PR DESCRIPTION
# Description
Detects messages sent through legitimate Zoom infrastructure sharing a clip, where the reply-to domain has no registered WHOIS record.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50963a06c0631c9f86ded70f96f055a5d366c7983f66bbd31f7dc941d5fb6d1c?preview_id=019f223f-570c-75bc-8939-b1ce5aad164c)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [98 Customer multi-hunt](https://hunt.limeseed.email/hunts/853f6bf2-aec3-465c-ac2a-dedb5f23f23a)
- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=019f4ce8-1cd9-7cb2-a713-13a6753205f6)

### Hunts from July 14 2026
- [97 customer multi-hunt (3d)](https://hunt.limeseed.email/hunts/2ecdb504-9731-44aa-ae82-654506ee123f)
