### PR TITLE
Add Graymail Remediation automation

### DIFF
--- a/automations/remediate_graymail_messages.yml
+++ b/automations/remediate_graymail_messages.yml
@@ -1,0 +1,8 @@
+name: "Remediate graymail flagged messages"
+description: "Move flagged messages with a Graymail Attack Score to the CATEGORY_PROMOTIONS label (Google Workspace) or the Promotions folder (Microsoft 365)."
+type: "triage_rule"
+triage_flagged_messages: true
+default_actions: ["move_to_graymail"]
+source: |
+  type.inbound
+  and ml.attack_score().verdict == "graymail"


### PR DESCRIPTION
# Description
Adding a Graymail Automation (triage rule) as one of the final steps to support Graymail GA.  To date, we've been creating automations manually in beta tester customer environments. We're now setting up for GA release so we need a system wide automation rule.

On flagged messages, the new rule detects graymail and triggers the "Move to Promotions" action (codename `move_to_graymail`)
