### PR TITLE
Update recon_empty_message_uncommon_sender.yml - b2bh - Adding tracking pixel

### DIFF
--- a/detection-rules/recon_empty_message_uncommon_sender.yml
+++ b/detection-rules/recon_empty_message_uncommon_sender.yml
@@ -3,7 +3,7 @@ description: "Detects incoming messages that are completely empty, containing no
 type: "rule"
 severity: "low"
 source: |
-  type.inbound
+type.inbound
   and subject.base == ""
   and (
     body.plain.raw is null
@@ -14,9 +14,17 @@ source: |
     body.html.raw is null
     or body.html.raw == ""
     or regex.imatch(body.html.raw, '^\s*$')
+    or (
+      // only html tracking pixel
+      regex.icontains(body.html.raw,
+                      '<img[^>]*?width="1(px)?"[^>]*?height="1(px)?"[^>]*?'
+      )
+      and length(body.html.display_text) == 0
+    )
   )
   and length(attachments) == 0
   and profile.by_sender().prevalence != "common"
+  
 tags:
   - "Attack surface reduction"
 attack_types:

--- a/detection-rules/recon_empty_message_uncommon_sender.yml
+++ b/detection-rules/recon_empty_message_uncommon_sender.yml
@@ -3,7 +3,7 @@ description: "Detects incoming messages that are completely empty, containing no
 type: "rule"
 severity: "low"
 source: |
-type.inbound
+  type.inbound
   and subject.base == ""
   and (
     body.plain.raw is null


### PR DESCRIPTION
# Description

Adding logic option for blank display body + tracking pixel.

# Associated samples

[- Sample 1](https://platform.sublime.security/messages/508f386d3d7fdf791f024be89bbb4ddd97897cd06fdee5cef6492dd879a9f323?preview_id=019f4cea-9935-7c1b-9263-18393e530dd4)

## Associated hunts

[- Hunt 1 (Shared Samps) - L90D](https://platform.sublime.security/messages/hunt?huntId=019f4dd2-6d39-7266-8337-3a7ec8411e8a)
[- Hunt 2 (Multi) - L90D](https://hunt.limeseed.email/hunts/d3f74c13-4e26-4edf-a7a8-ffa114c1620a)