### PR TITLE
Update impersonation_ups.yml

### DIFF
--- a/detection-rules/impersonation_ups.yml
+++ b/detection-rules/impersonation_ups.yml
@@ -13,7 +13,6 @@ source: |
   and (
     sender.display_name in~ ("UPS My Choice", "UPS Services", "Ups.com")
     or regex.icontains(sender.display_name, 'ups-\w+')
-    or regex.imatch(sender.display_name, '^ups$')
     or strings.ilike(sender.email.local_part, "*united*parcel*service*")
     or strings.ilike(sender.email.domain.domain, '*united*parcel*service*')
     or strings.icontains(subject.subject, 'UPS delivery')
@@ -23,6 +22,10 @@ source: |
     )
     or strings.icontains(body.html.raw, 'background-color:#351d20')
     or strings.icontains(body.html.raw, 'background-color: #351d20')
+    or (
+      regex.imatch(sender.display_name, '^ups$')
+      and not sender.email.domain.root_domain == "appleid.com"
+    )
   )
   and (
     // Observed in the "footer" of impersation messages

--- a/detection-rules/impersonation_ups.yml
+++ b/detection-rules/impersonation_ups.yml
@@ -23,7 +23,7 @@ source: |
     or strings.icontains(body.html.raw, 'background-color:#351d20')
     or strings.icontains(body.html.raw, 'background-color: #351d20')
     or (
-      regex.imatch(sender.display_name, '^ups$')
+      regex.imatch(sender.display_name, 'ups')
       and not sender.email.domain.root_domain == "appleid.com"
     )
   )

--- a/detection-rules/impersonation_ups.yml
+++ b/detection-rules/impersonation_ups.yml
@@ -13,6 +13,7 @@ source: |
   and (
     sender.display_name in~ ("UPS My Choice", "UPS Services", "Ups.com")
     or regex.icontains(sender.display_name, 'ups-\w+')
+    or regex.imatch(sender.display_name, '^ups$')
     or strings.ilike(sender.email.local_part, "*united*parcel*service*")
     or strings.ilike(sender.email.domain.domain, '*united*parcel*service*')
     or strings.icontains(subject.subject, 'UPS delivery')


### PR DESCRIPTION
# Description

Updating logic to capture samples that have a `sender.display_name` that only contains `UPS`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50a480c16bf6812ac4e93bf91ef40c045bcb657969fa472f62574ff242e50ed1?preview_id=019f5775-915b-71a3-abf6-fcc89a82e392)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019f65dc-bc60-7c4c-a09b-07fd59bde485)