### PR TITLE
Update service_abuse_calendly_callback.yml

### DIFF
--- a/detection-rules/service_abuse_calendly_callback.yml
+++ b/detection-rules/service_abuse_calendly_callback.yml
@@ -4,7 +4,10 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and sender.email.email == "no-reply@calendly.com"
+  and sender.email.email in (
+    "no-reply@calendly.com",
+    "notifications@calendly.com"
+  )
   and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == "callback_scam" and .confidence != "low"
   )


### PR DESCRIPTION
# Description
add second calendly sender address

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50a7605bf9f980083cfad093a5d7d202463afb9a8da41085544f9aede686e63c?preview_id=019f5c5c-51a2-76a0-ba1e-3ad2aa5848ae)


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019f5caa-99e4-78d4-8018-eb92611ad968) - new matches
- [multi](https://hunt.limeseed.email/hunts/72360dc9-5899-4167-8e64-dcd72a08d169)


