### PR TITLE
Two more rule optimizations to help affected env

### DIFF
--- a/detection-rules/brand_impersonation_godaddy.yml
+++ b/detection-rules/brand_impersonation_godaddy.yml
@@ -5,10 +5,9 @@ severity: "medium"
 source: |
   type.inbound
   and (
-    regex.icontains(sender.display_name, 'godaddy')
-    or strings.ilike(sender.display_name, "*godaddy*")
+    strings.icontains(sender.display_name, 'godaddy')
     or strings.ilevenshtein(sender.display_name, 'godaddy') <= 1
-    or strings.ilike(sender.email.domain.domain, '*godaddy*')
+    or strings.icontains(sender.email.domain.domain, 'godaddy')
   )
   and not (
     sender.email.domain.root_domain in (

--- a/detection-rules/malformed_url_prefix.yml
+++ b/detection-rules/malformed_url_prefix.yml
@@ -6,7 +6,7 @@ references:
 type: "rule"
 severity: "high"
 source: |
-  any(body.links, regex.icontains(.href_url.url, ':/\\'))
+  any(body.links, strings.icontains(.href_url.url, ':/\'))
   or (
     regex.icontains(body.plain.raw, 'https?:\\\\[^\\s]+')
     and (


### PR DESCRIPTION
# Description
This is not a panacea for our issues, but these are still good changes to make regardless.

* brand_impersonation_godaddy.yml - `regex.icontains(foo)` and `strings.ilike(*foo*)` are semantically equivalent, so there's no point in checking both. They're also both inferior to just `strings.icontains(foo)`
* malformed_url_prefix.yml - `regex.icontains` normally collapses raw strings into a simple `strings.icontains` check automatically, but it can't for this one (TL;DR because of the escaped backslash `\\`).

These new versions are logically identical (the second one we literally do on the backend for most things already), so I have not done any hunts.

# Associated samples
n/a
## Associated hunts
n/a
# Screenshot (insights)
n/a