### PR TITLE
Update brand_impersonation_squarespace.yml

### DIFF
--- a/detection-rules/brand_impersonation_squarespace.yml
+++ b/detection-rules/brand_impersonation_squarespace.yml
@@ -5,7 +5,9 @@ severity: "medium"
 source: |
   type.inbound
   and (
-    strings.icontains(sender.display_name, "squarespace")
+    strings.icontains(strings.replace_confusables(sender.display_name),
+                      "squarespace"
+    )
     or strings.ilevenshtein(sender.display_name, "squarespace") < 2
     or regex.icontains(sender.display_name,
                        's\x{206E}+q\x{206E}+u\x{206E}+a\x{206E}+r\x{206E}+e\x{206E}+s\x{206E}+p\x{206E}+a\x{206E}+c\x{206E}+e'


### PR DESCRIPTION
# Description

Updating `sender.display_name` logic to use `strings.replace_confusables` to tag the sender display name `𝗦𝗤𝗨𝗔𝗥𝗘𝗦𝗣𝗔𝗖𝗘`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50a74391c02b696618ac052e0989f67e240a39b5a2ac99feb08d4f3ca7f8ac51?preview_id=019f5b6b-e406-750d-aec9-2a2758e6c2e1)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019f662b-b3e8-732d-8205-1421b76a5593)