### PR TITLE
Update impersonation_paypal.yml

### DIFF
--- a/detection-rules/impersonation_paypal.yml
+++ b/detection-rules/impersonation_paypal.yml
@@ -17,7 +17,7 @@ source: |
     or strings.icontains(body.current_thread.text, "paypal account services")
     or regex.icontains(body.current_thread.text, 'secure[-\._]?pay[-\._]?pal')
     or regex.icontains(body.current_thread.text,
-                       '(?:paypa[i1]\b|paypa[|!]|p@y\.?p@l)'
+                       '(?:pay[-\._\s]*pa[i1]\b|paypa[|!]|p@y\.?p@l)'
     )
     or any(attachments,
            (.file_type in $file_types_images or .file_type == "pdf")
@@ -42,7 +42,10 @@ source: |
                                      "*transaction*",
                                      "*bitcoin*",
                                      "*dear customer*",
-                                     "*suspicious activity*"
+                                     "*suspicious activity*",
+                                     "*contact support*",
+                                     "*helpdesk*",
+                                     "*authorize*payment*"
                    )
            )
     )
@@ -54,7 +57,10 @@ source: |
                         "*transaction*",
                         "*bitcoin*",
                         "*dear customer*",
-                        "*suspicious activity*"
+                        "*suspicious activity*",
+                        "*contact support*",
+                        "*helpdesk*",
+                        "*authorize*payment*"
       )
     )
   )

--- a/detection-rules/impersonation_paypal.yml
+++ b/detection-rules/impersonation_paypal.yml
@@ -44,8 +44,7 @@ source: |
                                      "*dear customer*",
                                      "*suspicious activity*",
                                      "*contact support*",
-                                     "*helpdesk*",
-                                     "*authorize*payment*"
+                                     "*helpdesk*"
                    )
            )
     )
@@ -59,8 +58,7 @@ source: |
                         "*dear customer*",
                         "*suspicious activity*",
                         "*contact support*",
-                        "*helpdesk*",
-                        "*authorize*payment*"
+                        "*helpdesk*"
       )
     )
   )


### PR DESCRIPTION
# Description

Updating regex statement to capture more attempts to obfuscate the keyword `PayPal`, as well as adding additional keywords to existing `ilike` logic

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50a83797a09a7466fd34b1e12a62719eda5da82d4c3bce41985e69389638ed03?preview_id=019f60b9-95db-7202-b589-bee013e3a898)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019f700d-46a5-7250-b2d9-a802f13987b4)