### PR TITLE
Update brand_impersonation_aaa.yml

### DIFF
--- a/detection-rules/brand_impersonation_aaa.yml
+++ b/detection-rules/brand_impersonation_aaa.yml
@@ -4,22 +4,9 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  and (
-    any(ml.nlu_classifier(body.current_thread.text).entities,
-        .name == "org"
-        and .text in~ (
-          'AAA', // American Automobile Assoc.
-          'RAC', // UK Royal Automobile Club
-          'RAA', // Australia Royal Automotive Assoc.
-          'CAA', // Canadian Automobile Assoc.
-          'BCAA', // BC Automobile Assoc.
-          'AMA' // Alberta Motor Assoc.
-        )
-    )
-    or any(ml.nlu_classifier(body.current_thread.text).entities,
-           .name == "sender"
-           and regex.contains(.text, '(?:AAA|RAC|RAA|CAA|BCAA|AMA)')
-    )
+  and any(ml.nlu_classifier(body.current_thread.text).entities,
+          .name in ("org", "sender")
+          and regex.contains(.text, '\b(?:AAA|RAC|RAA|CAA|BCAA|AMA)\b')
   )
   and regex.icontains(body.current_thread.text,
                       '(?:car|vehicle|motor|driver|emergency|road.?side|break.?down|assist|save|discount|complimentary|free\b).{0,10}kit'
@@ -36,7 +23,6 @@ source: |
     )
     or strings.icontains(subject.subject, "quarantine")
   )
-
 
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/brand_impersonation_aaa.yml
+++ b/detection-rules/brand_impersonation_aaa.yml
@@ -13,8 +13,12 @@ source: |
           'RAA', // Australia Royal Automotive Assoc.
           'CAA', // Canadian Automobile Assoc.
           'BCAA', // BC Automobile Assoc.
-          'AMA', // Alberta Motor Assoc.
+          'AMA' // Alberta Motor Assoc.
         )
+    )
+    or any(ml.nlu_classifier(body.current_thread.text).entities,
+           .name == "sender"
+           and regex.contains(.text, '(?:AAA|RAC|RAA|CAA|BCAA|AMA)')
     )
   )
   and regex.icontains(body.current_thread.text,


### PR DESCRIPTION
# Description

Adding to existing `entities` logic by adding `sender` to look for references of `AAA`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50a820df77394506fe582f879f48d126dc22efe54052179b00c6849477911f04?preview_id=019f5e86-f1aa-7dd4-a4fd-7252aed1b60d)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L365D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019f6fe7-8f7e-7572-9c1f-02b78d245b85)