### PR TITLE
Create link_javascript_obfuscation_redirect.yml

### DIFF
--- a/detection-rules/link_javascript_obfuscation_redirect.yml
+++ b/detection-rules/link_javascript_obfuscation_redirect.yml
@@ -1,0 +1,49 @@
+name: "Link: JavaScript redirect with hash-based obfuscation"
+description: "Detects inbound messages sent to self, invalid recipients, or undisclosed recipients containing links that, upon analysis, include a JavaScript setTimeout redirect using location.hash to obscure the final destination. This technique delays redirection and appends URL fragments to evade static link inspection."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+    // self sender or invaild recipent domain or local parts match
+    (
+      length(recipients.to) == 1
+      and (
+        sender.email.email == recipients.to[0].email.email
+        or recipients.to[0].email.domain.valid == false
+        or sender.email.local_part == recipients.to[0].email.local_part
+      )
+    )
+    // no recipients defined
+    or (
+      (
+        length(recipients.to) == 0
+        or all(recipients.to, .display_name == "Undisclosed recipients")
+      )
+      and length(recipients.cc) == 0
+      and length(recipients.bcc) == 0
+    )
+  )
+  and 0 < length(body.links) < 10
+  and any(body.current_thread.links,
+          any(html.xpath(ml.link_analysis(., mode="aggressive").final_dom,
+                         "//script"
+              ).nodes,
+              strings.starts_with(.raw,
+                                  '<script>setTimeout(function(){window.location="'
+              )
+              and strings.ends_with(.raw, '"+location.hash},3000)</script>')
+          )
+  )
+  
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Scripting"
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "URL analysis"
+  - "Javascript analysis"
+  - "HTML analysis"
+  - "Sender analysis"

--- a/detection-rules/link_javascript_obfuscation_redirect.yml
+++ b/detection-rules/link_javascript_obfuscation_redirect.yml
@@ -47,3 +47,4 @@ detection_methods:
   - "Javascript analysis"
   - "HTML analysis"
   - "Sender analysis"
+id: "05c8c2d1-6018-5a3e-9e20-be1b41796e62"

--- a/detection-rules/link_javascript_obfuscation_redirect.yml
+++ b/detection-rules/link_javascript_obfuscation_redirect.yml
@@ -24,7 +24,7 @@ source: |
       and length(recipients.bcc) == 0
     )
   )
-  and 0 < length(body.links) < 10
+  and 0 < length(body.current_thread.links) < 10
   and any(body.current_thread.links,
           any(html.xpath(ml.link_analysis(., mode="aggressive").final_dom,
                          "//script"

--- a/detection-rules/link_javascript_obfuscation_redirect.yml
+++ b/detection-rules/link_javascript_obfuscation_redirect.yml
@@ -32,7 +32,7 @@ source: |
               strings.starts_with(.raw,
                                   '<script>setTimeout(function(){window.location="'
               )
-              and strings.ends_with(.raw, '"+location.hash},3000)</script>')
+              and strings.iends_with(.raw, '"+location.hash},3000)</script>')
           )
   )
   

--- a/detection-rules/link_javascript_obfuscation_redirect.yml
+++ b/detection-rules/link_javascript_obfuscation_redirect.yml
@@ -30,12 +30,11 @@ source: |
                          "//script"
               ).nodes,
               strings.istarts_with(.raw,
-                                  '<script>setTimeout(function(){window.location="'
+                                   '<script>setTimeout(function(){window.location="'
               )
               and strings.iends_with(.raw, '"+location.hash},3000)</script>')
           )
   )
-  
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/link_javascript_obfuscation_redirect.yml
+++ b/detection-rules/link_javascript_obfuscation_redirect.yml
@@ -18,7 +18,7 @@ source: |
     or (
       (
         length(recipients.to) == 0
-        or all(recipients.to, .display_name == "Undisclosed recipients")
+        or all(recipients.to, .email.domain.valid == false)
       )
       and length(recipients.cc) == 0
       and length(recipients.bcc) == 0

--- a/detection-rules/link_javascript_obfuscation_redirect.yml
+++ b/detection-rules/link_javascript_obfuscation_redirect.yml
@@ -29,7 +29,7 @@ source: |
           any(html.xpath(ml.link_analysis(., mode="aggressive").final_dom,
                          "//script"
               ).nodes,
-              strings.starts_with(.raw,
+              strings.istarts_with(.raw,
                                   '<script>setTimeout(function(){window.location="'
               )
               and strings.iends_with(.raw, '"+location.hash},3000)</script>')

--- a/detection-rules/link_javascript_timeout_redirect.yml
+++ b/detection-rules/link_javascript_timeout_redirect.yml
@@ -1,5 +1,5 @@
-name: "Link: JavaScript redirect with hash-based obfuscation"
-description: "Detects inbound messages sent to self, invalid recipients, or undisclosed recipients containing links that, upon analysis, include a JavaScript setTimeout redirect using location.hash to obscure the final destination. This technique delays redirection and appends URL fragments to evade static link inspection."
+name: "Link: Suspicious recipient with timeout redirect"
+description: "Detects inbound messages sent to self, invalid recipients, or undisclosed recipients containing links that, upon analysis, include a JavaScript setTimeout redirect. This technique delays redirection and appends URL fragments to evade static link inspection."
 type: "rule"
 severity: "medium"
 source: |


### PR DESCRIPTION
# Description
Detects inbound messages sent to self, invalid recipients, or undisclosed recipients containing links that, upon analysis, include a JavaScript setTimeout redirect using location.hash to obscure the final destination.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/509486be52c48d7f1a6c71aea776748f6b8e4eeae5ee912177b297c63711863b?preview_id=019f42f4-4133-76bb-9383-6c00ba725a3c)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [97 customer multi-hunt](https://hunt.limeseed.email/hunts/93dc92c5-b625-4f87-92ad-b93b3b5a4e9f)
- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=019f6262-22ad-7e14-9bf8-73378bfc7c8b)
