### PR TITLE
Update link_credential_phishing_secure_message.yml

### DIFF
--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -31,7 +31,7 @@ source: |
       regex.icontains(body.current_thread.text,
                       "secured? (message|directory|document|file)"
       )
-      or regex.icontains(subject.subject,
+      or regex.icontains(subject.base,
                          "secured? (message|directory|document|file)"
       )
       or strings.icontains(body.current_thread.text, "document portal")

--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -62,12 +62,16 @@ source: |
       )
     )
   )
+  // has at least 1 link
   and length(body.links) > 0
+  
+  // negate legitimate message senders
   and (
     sender.email.domain.root_domain not in ("protectedtrust.com")
     and any(body.links,
             .href_url.domain.root_domain != sender.email.domain.root_domain
     )
+    // negate known secure mailers
     and not all(body.links,
                 .href_url.domain.root_domain in (
                   "mimecast.com",
@@ -129,6 +133,7 @@ source: |
       any(headers.hops, any(.fields, .name == 'X-SendInc-Message-Id'))
       and any(headers.domains, .root_domain in ("sendinc.net"))
     )
+    // negating Mimecast sends with MS banner and/or sender's email pulled out as a link
     and not length(filter(body.links,
                           (
                             .display_text is null
@@ -151,12 +156,14 @@ source: |
       profile.by_sender().any_messages_malicious_or_spam
       and not profile.by_sender().any_messages_benign
     )
+    // or the sender is all undisclosed or there are no recipients
     or (
       length(recipients.to) == 0
       or all(recipients.to,
              strings.ilike(.display_name, "undisclosed?recipients")
       )
     )
+    // or the sender exhibits a "self sender" pattern
     or (
       length(recipients.to) == 1
       and any(recipients.to, .email.email == sender.email.email)

--- a/detection-rules/link_credential_phishing_secure_message.yml
+++ b/detection-rules/link_credential_phishing_secure_message.yml
@@ -10,7 +10,6 @@ source: |
       any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == "cred_theft" and .confidence == "high"
       )
-      // add fallback when NLU doesn't pick up cred theft to check for suspicious links
       or any(body.current_thread.links,
              regex.icontains(.display_text, '(?:read|view|open) the message')
              and (
@@ -27,29 +26,30 @@ source: |
            .name == "cred_theft" and .confidence in ("medium", "high")
     )
   )
-  
-  // ----- other suspicious signals here -----
   and (
     (
       regex.icontains(body.current_thread.text,
-                      "secured? (message|directory|document)"
+                      "secured? (message|directory|document|file)"
+      )
+      or regex.icontains(subject.subject,
+                         "secured? (message|directory|document|file)"
       )
       or strings.icontains(body.current_thread.text, "document portal")
       or strings.icontains(body.current_thread.text, "encrypted message")
       or strings.icontains(body.current_thread.text, "protected message")
     )
     or any(body.previous_threads,
-           regex.icontains(.text, "secured? (message|directory|document)")
+           regex.icontains(.text, "secured? (message|directory|document|file)")
            or strings.icontains(.text, "document portal")
            or strings.icontains(.text, "encrypted message")
            or strings.icontains(.text, "protected message")
     )
     or any(body.current_thread.links,
            regex.icontains(ml.link_analysis(.).final_dom.display_text,
-                           'secured? (?:message|directory|document) access'
+                           'secured? (?:message|directory|document|file) access'
            )
            or regex.icontains(ml.link_analysis(.).final_dom.inner_text,
-                              'secured? (?:message|directory|document) access'
+                              'secured? (?:message|directory|document|file) access'
            )
     )
     or (
@@ -62,21 +62,12 @@ source: |
       )
     )
   )
-  // todo: automated display name / human local part
-  // todo: suspicious link (unfurl click trackers)
-  
-  // ----------
-  
-  // has at least 1 link
   and length(body.links) > 0
-  
-  // negate legitimate message senders
   and (
     sender.email.domain.root_domain not in ("protectedtrust.com")
     and any(body.links,
             .href_url.domain.root_domain != sender.email.domain.root_domain
     )
-    // negate known secure mailers
     and not all(body.links,
                 .href_url.domain.root_domain in (
                   "mimecast.com",
@@ -138,7 +129,6 @@ source: |
       any(headers.hops, any(.fields, .name == 'X-SendInc-Message-Id'))
       and any(headers.domains, .root_domain in ("sendinc.net"))
     )
-    // negating Mimecast sends with MS banner and/or sender's email pulled out as a link
     and not length(filter(body.links,
                           (
                             .display_text is null
@@ -161,28 +151,21 @@ source: |
       profile.by_sender().any_messages_malicious_or_spam
       and not profile.by_sender().any_messages_benign
     )
-    // or the sender is all undisclosed or there are no recipients
     or (
       length(recipients.to) == 0
       or all(recipients.to,
              strings.ilike(.display_name, "undisclosed?recipients")
       )
     )
-    // or the sender exhibits a "self sender" pattern
     or (
       length(recipients.to) == 1
       and any(recipients.to, .email.email == sender.email.email)
     )
   )
   and not profile.by_sender().any_messages_benign
-  
-  // negate highly trusted sender domains unless they fail DMARC authentication
-  and (
-    (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and not headers.auth_summary.dmarc.pass
-    )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
 attack_types:
   - "Credential Phishing"


### PR DESCRIPTION
# Description
expanding secure message coverage

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5094abf0f452e58e6d956a692516b5569694a7aafa5af416c3d867f792178810?preview_id=019f4d2e-644b-7bc7-a5ac-41791155bc8d)


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019f7053-e8da-75e4-8af9-8f26e1e60dda) - net new

