### PR TITLE
Create link_mixed_href_structure.yml

### DIFF
--- a/detection-rules/link_mixed_href_structure.yml
+++ b/detection-rules/link_mixed_href_structure.yml
@@ -4,30 +4,12 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(distinct(flatten(map(html.xpath(body.html,
-                                             '//body/table/tbody/tr[2]/td/div/table//a'
-                                  ).nodes,
-                                  map(.links, .href_url.url)
-                              )
-                      )
-             )
-  ) == 1
-  and length(distinct(html.xpath(body.html,
-                                 '//body/table/tbody/tr[2]/td/div/table//a'
-                      ).nodes,
-                      .display_text
-             )
-  ) == 2
-  and all(html.xpath(body.html, '//body/table/tbody/tr[2]/td/div/table//a').nodes,
-          .inner_text == .display_text
+  and length(distinct(flatten(map(html.xpath(body.html, '//body/table[contains(@style, "width: 451pt;")]/tbody/tr[2]/td/div/table//a').nodes, map(.links, .href_url.url))))) == 1
+  and length(distinct(html.xpath(body.html, '//body/table[contains(@style, "width: 451pt;")]/tbody/tr[2]/td/div/table//a').nodes, .display_text)) == 2
+  and all(html.xpath(body.html, '//body/table[contains(@style, "width: 451pt;")]/tbody/tr[2]/td/div/table//a').nodes, 
+      .inner_text == .display_text
   )
-  and length(distinct(map(html.xpath(body.html,
-                                     '//body/table/tbody/tr[2]/td/div/table//a'
-                          ).nodes,
-                          strings.icontains(.raw, '<img ')
-                      )
-             )
-  ) == 2
+  and length(distinct(map(html.xpath(body.html, '//body/table[contains(@style, "width: 451pt;")]/tbody/tr[2]/td/div/table//a').nodes, strings.icontains(.raw, '<img ')))) == 2
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/link_mixed_href_structure.yml
+++ b/detection-rules/link_mixed_href_structure.yml
@@ -1,0 +1,21 @@
+name: "Link: Uniform href with mixed text and image anchor structure"
+description: "Detects inbound messages where all anchor elements within a nested table structure share a single unique destination URL, contain exactly two distinct display text values, have matching inner and display text, and include a mix of image and non-image anchor elements. This pattern can be indicative of structured lure content designed to direct recipients to a single malicious destination."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and length(distinct(flatten(map(html.xpath(body.html, '//body/table/tbody/tr[2]/td/div/table//a').nodes, map(.links, .href_url.url))))) == 1
+  and length(distinct(html.xpath(body.html, '//body/table/tbody/tr[2]/td/div/table//a').nodes, .display_text)) == 2
+  and all(html.xpath(body.html, '//body/table/tbody/tr[2]/td/div/table//a').nodes, 
+      .inner_text == .display_text
+  )
+  and length(distinct(map(html.xpath(body.html, '//body/table/tbody/tr[2]/td/div/table//a').nodes, strings.icontains(.raw, '<img ')))) == 2
+
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "HTML analysis"
+  - "URL analysis"

--- a/detection-rules/link_mixed_href_structure.yml
+++ b/detection-rules/link_mixed_href_structure.yml
@@ -4,12 +4,32 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(distinct(flatten(map(html.xpath(body.html, '//body/table[contains(@style, "width: 451pt;")]/tbody/tr[2]/td/div/table//a').nodes, map(.links, .href_url.url))))) == 1
-  and length(distinct(html.xpath(body.html, '//body/table[contains(@style, "width: 451pt;")]/tbody/tr[2]/td/div/table//a').nodes, .display_text)) == 2
-  and all(html.xpath(body.html, '//body/table[contains(@style, "width: 451pt;")]/tbody/tr[2]/td/div/table//a').nodes, 
-      .inner_text == .display_text
+  and length(distinct(flatten(map(html.xpath(body.html,
+                                             '//body/table[contains(@style, "width: 451pt;")]/tbody/tr[2]/td/div/table//a'
+                                  ).nodes,
+                                  map(.links, .href_url.url)
+                              )
+                      )
+             )
+  ) == 1
+  and length(distinct(html.xpath(body.html,
+                                 '//body/table[contains(@style, "width: 451pt;")]/tbody/tr[2]/td/div/table//a'
+                      ).nodes,
+                      .display_text
+             )
+  ) == 2
+  and all(html.xpath(body.html,
+                     '//body/table[contains(@style, "width: 451pt;")]/tbody/tr[2]/td/div/table//a'
+          ).nodes,
+          .inner_text == .display_text
   )
-  and length(distinct(map(html.xpath(body.html, '//body/table[contains(@style, "width: 451pt;")]/tbody/tr[2]/td/div/table//a').nodes, strings.icontains(.raw, '<img ')))) == 2
+  and length(distinct(map(html.xpath(body.html,
+                                     '//body/table[contains(@style, "width: 451pt;")]/tbody/tr[2]/td/div/table//a'
+                          ).nodes,
+                          strings.icontains(.raw, '<img ')
+                      )
+             )
+  ) == 2
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/link_mixed_href_structure.yml
+++ b/detection-rules/link_mixed_href_structure.yml
@@ -4,13 +4,30 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and length(distinct(flatten(map(html.xpath(body.html, '//body/table/tbody/tr[2]/td/div/table//a').nodes, map(.links, .href_url.url))))) == 1
-  and length(distinct(html.xpath(body.html, '//body/table/tbody/tr[2]/td/div/table//a').nodes, .display_text)) == 2
-  and all(html.xpath(body.html, '//body/table/tbody/tr[2]/td/div/table//a').nodes, 
-      .inner_text == .display_text
+  and length(distinct(flatten(map(html.xpath(body.html,
+                                             '//body/table/tbody/tr[2]/td/div/table//a'
+                                  ).nodes,
+                                  map(.links, .href_url.url)
+                              )
+                      )
+             )
+  ) == 1
+  and length(distinct(html.xpath(body.html,
+                                 '//body/table/tbody/tr[2]/td/div/table//a'
+                      ).nodes,
+                      .display_text
+             )
+  ) == 2
+  and all(html.xpath(body.html, '//body/table/tbody/tr[2]/td/div/table//a').nodes,
+          .inner_text == .display_text
   )
-  and length(distinct(map(html.xpath(body.html, '//body/table/tbody/tr[2]/td/div/table//a').nodes, strings.icontains(.raw, '<img ')))) == 2
-
+  and length(distinct(map(html.xpath(body.html,
+                                     '//body/table/tbody/tr[2]/td/div/table//a'
+                          ).nodes,
+                          strings.icontains(.raw, '<img ')
+                      )
+             )
+  ) == 2
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:
@@ -19,3 +36,4 @@ detection_methods:
   - "Content analysis"
   - "HTML analysis"
   - "URL analysis"
+id: "3597dc0f-c8ad-5d89-bb5e-4b523536ec33"

--- a/detection-rules/link_mixed_href_structure.yml
+++ b/detection-rules/link_mixed_href_structure.yml
@@ -4,29 +4,33 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
+  // should have one unique URL
   and length(distinct(flatten(map(html.xpath(body.html,
-                                             '//body/table[contains(@style, "width: 451pt;")]/tbody/tr[2]/td/div/table//a'
+                                             '//body/table/tbody/tr[2]/td/div/table//a'
                                   ).nodes,
                                   map(.links, .href_url.url)
                               )
                       )
              )
   ) == 1
+  // should have two unique display text values
   and length(distinct(html.xpath(body.html,
-                                 '//body/table[contains(@style, "width: 451pt;")]/tbody/tr[2]/td/div/table//a'
+                                 '//body/table/tbody/tr[2]/td/div/table//a'
                       ).nodes,
                       .display_text
              )
   ) == 2
-  and all(html.xpath(body.html,
-                     '//body/table[contains(@style, "width: 451pt;")]/tbody/tr[2]/td/div/table//a'
-          ).nodes,
+  and all(html.xpath(body.html, '//body/table/tbody/tr[2]/td/div/table//a').nodes,
           .inner_text == .display_text
   )
+  // we need one true one false for this check
   and length(distinct(map(html.xpath(body.html,
-                                     '//body/table[contains(@style, "width: 451pt;")]/tbody/tr[2]/td/div/table//a'
+                                     '//body/table/tbody/tr[2]/td/div/table//a'
                           ).nodes,
-                          strings.icontains(.raw, '<img ')
+                          (
+                            strings.icontains(.raw, '<img ')
+                            and strings.icontains(.raw, 'src="cid:')
+                          )
                       )
              )
   ) == 2


### PR DESCRIPTION
# Description
Detects inbound messages where all anchor elements within a nested table structure share a single unique destination URL, contain exactly two distinct display text values, have matching inner and display text, and include a mix of image and non-image anchor elements. This pattern can be indicative of structured lure content designed to direct recipients to a single malicious destination.

This is actually for ESC-17231

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/50a1f9752ed083840025e689b477b4eb5cc4730863d9075b1ab599737ce26344?preview_id=019f3ddd-6569-7c49-ab2b-8d44992d58db)


## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019f6795-767d-7073-802e-c9ccc6d82783)
- [Updated Multi-hunt](https://hunt.limeseed.email/hunts/c89a63fe-4f4e-469d-bb5f-48293239b5cb)
- [Hunt 2 (updated)](https://platform.sublime.security/messages/hunt?huntId=019fc7b0-d82e-75cd-84e6-caa9014cfa50)