### PR TITLE
Add detection rule for suspicious toll-free numbers

### DIFF
--- a/detection-rules/sus_tollfree_number.yml
+++ b/detection-rules/sus_tollfree_number.yml
@@ -7,6 +7,8 @@ source: |
   and any([body.current_thread.text, subject.subject],
           regex.icontains(., '\b\+?(\d{1}.)?\(?8\d{2}?\)?.555.?0[12]99\b')
   )
+tags:
+ - "Attack surface reduction"
 attack_types:
   - "Spam"
 tactics_and_techniques:

--- a/detection-rules/sus_tollfree_number.yml
+++ b/detection-rules/sus_tollfree_number.yml
@@ -1,0 +1,16 @@
+name: "Spam: Suspicious toll-free phone number"
+description: "Detects messages containing phone numbers 1 800-555-0199 or 1 800-555-0299 in the subject or body, which is reserved for use by the entertainment industry. Commonly used as a placeholder phone number in LLM-generated campaigns."
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and any([body.current_thread.text, subject.subject],
+          regex.icontains(., '\b\+?(\d{1}.)?\(?8\d{2}?\)?.555.?0[12]99\b')
+  )
+attack_types:
+  - "Spam"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+id: "d9766109-6574-5fd8-9c07-d606d3ce82d2"


### PR DESCRIPTION
Detects messages containing the phone number 1 800-555-0199 in the subject or body, which is reserved for use by the entertainment industry. Commonly used as a placeholder phone number in LLM-generated campaigns.

# Associated samples
- https://platform.sublime.security/messages/4ffaa94cc935fe97a0200f15c4bc845944182e0420e2f0a9d3bf08a2445d63d3
- https://platform.sublime.security/messages/4fc2dd72eb2cac000772709f934ef984c7e2df335d96b8f778cf4c44af4449ff
- https://platform.sublime.security/messages/4fc2a075211b115b6b09fd736f9b1f06fd6a41e93bb886e9bdcbf15c711541ab

## Associated hunts
- https://platform.sublime.security/hunts/019bfbc3-af4a-76c1-8a07-e1239ae33492