### PR TITLE
Create attachment_office_doc_image_link_self_service.yml

### DIFF
--- a/detection-rules/attachment_office_doc_image_link_self_service.yml
+++ b/detection-rules/attachment_office_doc_image_link_self_service.yml
@@ -1,0 +1,48 @@
+name: "Attachment: Office macro file with single image and self-service platform hyperlink"
+description: "Detects inbound Office macro-enabled attachments where the embedded relationship file contains exactly one image and one hyperlink, with the hyperlink pointing to a self-service creation platform domain. This technique is commonly used to lure recipients into clicking a malicious link hosted on a trusted-looking platform while minimizing the complexity of the document to evade detection."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  // office docs
+  and any(filter(attachments, .file_extension in $file_extensions_macros),
+          // explode them
+          any(filter(file.explode(.),
+                     .depth == 1
+                     and .file_extension == "rels"
+                     // single image and hyperlink in relationships
+                     and strings.icount(.scan.strings.raw, 'Relationship Id=') == 2
+                     and strings.icount(.scan.strings.raw, 'relationships/image') == 1
+                     and strings.icount(.scan.strings.raw,
+                                        'relationships/hyperlink'
+                     ) == 1
+              ),
+              // get the full relationship first so we don't have to worry about the ordering of the target value
+              any(regex.iextract(.scan.strings.raw,
+                                 '<Relationship[^\>]+Type=\"[^\"]+relationships/hyperlink[^\>]+\>'
+                  ),
+                  // extract and  the url from the target variable 
+                  strings.parse_url(regex.iextract(.full_match,
+                                                   'Target="(?P<url>[^\"]+)\"'
+                                    )[0].named_groups["url"]
+                  ).domain.domain in $self_service_creation_platform_domains
+                  or strings.parse_url(regex.iextract(.full_match,
+                                                      'Target="(?P<url>[^\"]+)\"'
+                                       )[0].named_groups["url"]
+                  ).domain.root_domain in $self_service_creation_platform_domains
+              )
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Macros"
+  - "Free file host"
+  - "Social engineering"
+  - "Image as content"
+detection_methods:
+  - "Archive analysis"
+  - "File analysis"
+  - "XML analysis"
+  - "URL analysis"
+  - "Macro analysis"

--- a/detection-rules/attachment_office_doc_image_link_self_service.yml
+++ b/detection-rules/attachment_office_doc_image_link_self_service.yml
@@ -46,3 +46,4 @@ detection_methods:
   - "XML analysis"
   - "URL analysis"
   - "Macro analysis"
+id: "6c194d9b-c86d-5bbe-9927-2cd638d60413"


### PR DESCRIPTION
# Description

Add coverage for observed technique of putting an image in an office doc and linking off to a self-service content creation platform. 

Expected low volume telemetry data

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/509bddcb7dca7ca704f0774e9616980aae500ea88689ca31c18ec44c16815555)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/509bddcb7dca7ca704f0774e9616980aae500ea88689ca31c18ec44c16815555)
- [Multihunt](https://hunt.limeseed.email/hunts/28c94178-358a-4672-a60b-0a4227bac55c)