### PR TITLE
Create link_fake_forward_suspicious_url.yml

### DIFF
--- a/detection-rules/link_fake_forward_suspicious_url.yml
+++ b/detection-rules/link_fake_forward_suspicious_url.yml
@@ -1,0 +1,28 @@
+name: "Link: Fake forwarded message with suspicious URL in plain text"
+description: "Detects inbound plain text messages (no HTML body) with no prior thread history that contain a URL and are structured as a forwarded message. The rule checks for a 'Begin forwarded message' preamble, either standalone or followed by a From field matching the sender's display name, suggesting the message may be disguising its origin or delivering malicious links via forwarded message formatting."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and body.html.raw is null
+  and length(body.previous_threads) == 0
+  and regex.contains(body.current_thread.text, 'https?://')
+  and (
+    regex.imatch(body.current_thread.preamble, '^begin forwarded message:\s*')
+    or (
+      regex.imatch(body.current_thread.preamble,
+                   '^begin forwarded message:\s*from:\s*[^<@\n]+\s*'
+      )
+      and strings.icontains(body.current_thread.preamble, sender.display_name)
+    )
+  )
+attack_types:
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Evasion"
+detection_methods:
+  - "Content analysis"
+  - "Sender analysis"
+  - "URL analysis"

--- a/detection-rules/link_fake_forward_suspicious_url.yml
+++ b/detection-rules/link_fake_forward_suspicious_url.yml
@@ -8,10 +8,10 @@ source: |
   and length(body.previous_threads) == 0
   and regex.contains(body.current_thread.text, 'https?://')
   and (
-    regex.imatch(body.current_thread.preamble, '^begin forwarded message:\s*')
+    regex.imatch(body.current_thread.preamble, 'begin forwarded message:\s*')
     or (
       regex.imatch(body.current_thread.preamble,
-                   '^begin forwarded message:\s*from:\s*[^<@\n]+\s*'
+                   'begin forwarded message:\s*from:\s*[^<@\n]+\s*'
       )
       and strings.icontains(body.current_thread.preamble, sender.display_name)
     )

--- a/detection-rules/link_fake_forward_suspicious_url.yml
+++ b/detection-rules/link_fake_forward_suspicious_url.yml
@@ -26,3 +26,4 @@ detection_methods:
   - "Content analysis"
   - "Sender analysis"
   - "URL analysis"
+id: "f325deee-62a4-5595-9d47-9729330b3245"


### PR DESCRIPTION
# Description

This PR meant to build upon the rule [Spam: Fake photo share](https://github.com/sublime-security/sublime-rules/blob/main/detection-rules/spam_fake_photo_share.yml)

Detects inbound plain text messages (no HTML body) with no prior thread history that contain a URL and are structured as a forwarded message. The rule checks for a 'Begin forwarded message' preamble, either standalone or followed by a From field matching the sender's display name, suggesting the message may be disguising its origin or delivering malicious links via forwarded message formatting.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50a48fb10d9b055b8634f8b51eb8c58273b3b262248c526c5a1b8fb2a8cb8d03?preview_id=019f6106-02b0-79ef-a673-123efbf39761)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=019f6bef-5288-7eff-904d-eb87d1ed6ae0)
- [L30D 65 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/0746856c-d767-4000-9c76-61fe5bdc8a2c)