### PR TITLE
Create attachment_ics_teams_impersonation.yml

### DIFF
--- a/detection-rules/attachment_ics_teams_impersonation.yml
+++ b/detection-rules/attachment_ics_teams_impersonation.yml
@@ -54,8 +54,7 @@ source: |
                               .href_url.domain.root_domain in (
                                 "microsoft.com",
                                 "microsoftsupport.com",
-                                "office.com",
-                                "mimecastprotect.com"
+                                "office.com"
                               )
                   )
           )

--- a/detection-rules/attachment_ics_teams_impersonation.yml
+++ b/detection-rules/attachment_ics_teams_impersonation.yml
@@ -1,0 +1,47 @@
+name: "Attachment: Fake Microsoft Teams meeting invite via ICS attachment"
+description: "Detects inbound messages containing ICS calendar attachments that reference Microsoft Teams meetings but contain links pointing to non-Microsoft domains. The rule specifically filters out legitimate Microsoft-generated calendar files by checking the product ID, then inspects event details for Teams-related references in the location or description fields while flagging any links that do not resolve to known Microsoft domains."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(attachments,
+          (
+            .file_type == "ics"
+            or .file_extension == "ics"
+            or .content_type in ("application/ics", "text/calendar")
+          )
+          //
+          // This rule makes use of a beta feature and is subject to change without notice
+          // using the beta feature in custom rules is not suggested until it has been formally released
+          //
+          and not strings.icontains(beta.file.parse_ics(.).product_id,
+                                    "microsoft"
+          )
+          and any(beta.file.parse_ics(.).events,
+                  (
+                    regex.icontains(.location, '(?:microsoft\s)?teams$')
+                    or strings.icontains(.description,
+                                         "microsoft teams",
+                                         "teams meeting",
+                                         "join microsoft teams",
+                                         "join teams meeting"
+                    )
+                  )
+                  and not any(.links,
+                              .href_url.domain.root_domain in (
+                                "microsoft.com",
+                                "microsoftsupport.com",
+                                "office.com"
+                              )
+                  )
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "File analysis"
+  - "Content analysis"
+  - "URL analysis"

--- a/detection-rules/attachment_ics_teams_impersonation.yml
+++ b/detection-rules/attachment_ics_teams_impersonation.yml
@@ -45,3 +45,4 @@ detection_methods:
   - "File analysis"
   - "Content analysis"
   - "URL analysis"
+id: "f05efcd4-bb26-56d7-80ed-7c16b4e2d1d2"

--- a/detection-rules/attachment_ics_teams_impersonation.yml
+++ b/detection-rules/attachment_ics_teams_impersonation.yml
@@ -15,23 +15,47 @@ source: |
           // using the beta feature in custom rules is not suggested until it has been formally released
           //
           and not strings.icontains(beta.file.parse_ics(.).product_id,
-                                    "microsoft"
+                                    "microsoft",
+                                    "google"
           )
           and any(beta.file.parse_ics(.).events,
                   (
-                    regex.icontains(.location, '(?:microsoft\s)?teams$')
-                    or strings.icontains(.description,
-                                         "microsoft teams",
-                                         "teams meeting",
-                                         "join microsoft teams",
-                                         "join teams meeting"
+                    (
+                      regex.imatch(.location, 'teams meeting')
+                      or (
+                        strings.icontains(.description,
+                                          "teams meeting",
+                                          "join microsoft teams",
+                                          "join teams meeting",
+                        )
+                        and strings.icontains(.description,
+                                              "join on your computer",
+                                              "confirmed invitation",
+                                              "account review"
+                        )
+                      )
+                    )
+                    or (
+                      regex.imatch(.location, 'teams')
+                      and strings.icontains(.description,
+                                            "microsoft teams",
+                                            "secure access"
+                      )
+                    )
+                    or (
+                      regex.imatch(.location, 'microsoft teams')
+                      and strings.icontains(.description,
+                                            "meeting id:",
+                                            "attached document"
+                      )
                     )
                   )
                   and not any(.links,
                               .href_url.domain.root_domain in (
                                 "microsoft.com",
                                 "microsoftsupport.com",
-                                "office.com"
+                                "office.com",
+                                "mimecastprotect.com"
                               )
                   )
           )


### PR DESCRIPTION
# Description

Detects inbound messages containing ICS calendar attachments that reference Microsoft Teams meetings but contain links pointing to non-Microsoft domains. The rule specifically filters out legitimate Microsoft-generated calendar files by checking the product ID, then inspects event details for Teams-related references in the location or description fields while flagging any links that do not resolve to known Microsoft domains.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/508fbf69446418ec38a05115b93235786c2cdbf14be4013ec42be9300b3c6401?preview_id=019f4d2e-60bd-756f-8a00-46bd12b80318)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019f71b4-7021-7aba-b0da-b096f9c27727)