### PR TITLE
Create service_abuse_wufoo_cred_theft.yml

### DIFF
--- a/detection-rules/service_abuse_wufoo_cred_theft.yml
+++ b/detection-rules/service_abuse_wufoo_cred_theft.yml
@@ -1,0 +1,23 @@
+name: "Service abuse: Wufoo credential theft"
+description: "Detects malicious messages sent from Wufoo's legitimate sending address (no-reply@wufoo.com) that are abusing the platform to deliver credential theft content. This rule identifies messages that lack Wufoo's standard display name and structural HTML elements found in legitimate Wufoo emails, while containing a small number of links and content classified as credential theft by NLU analysis."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and sender.email.email == 'no-reply@wufoo.com'
+  and not strings.icontains(sender.display_name, 'Wufoo')
+  // table found in legit wufoo emails
+  and not length(html.xpath(body.html, "//table[@class='readonly']").nodes) == 1
+  and 0 < length(body.links) < 10
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == 'cred_theft' and .confidence != 'low'
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "HTML analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"

--- a/detection-rules/service_abuse_wufoo_cred_theft.yml
+++ b/detection-rules/service_abuse_wufoo_cred_theft.yml
@@ -21,3 +21,4 @@ detection_methods:
   - "HTML analysis"
   - "Natural Language Understanding"
   - "Sender analysis"
+id: "a8d53c37-e26a-53b9-aeba-74486e4504f8"

--- a/detection-rules/service_abuse_wufoo_cred_theft.yml
+++ b/detection-rules/service_abuse_wufoo_cred_theft.yml
@@ -8,7 +8,7 @@ source: |
   and not strings.icontains(sender.display_name, 'Wufoo')
   // table found in legit wufoo emails
   and not length(html.xpath(body.html, "//table[@class='readonly']").nodes) == 1
-  and 0 < length(body.links) < 10
+  and 0 < length(body.links)
   and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name == 'cred_theft' and .confidence != 'low'
   )

--- a/detection-rules/service_abuse_wufoo_cred_theft.yml
+++ b/detection-rules/service_abuse_wufoo_cred_theft.yml
@@ -1,5 +1,5 @@
 name: "Service abuse: Wufoo credential theft"
-description: "Detects malicious messages sent from Wufoo's legitimate sending address (no-reply@wufoo.com) that are abusing the platform to deliver credential theft content. This rule identifies messages that lack Wufoo's standard display name and structural HTML elements found in legitimate Wufoo emails, while containing a small number of links and content classified as credential theft by NLU analysis."
+description: "Detects malicious messages sent from Wufoo's sending address (no-reply@wufoo.com) that are abusing the platform to deliver credential theft content. This rule identifies messages that lack Wufoo's standard display name and structural HTML elements found in legitimate Wufoo emails, while containing links and content classified as credential theft by NLU analysis."
 type: "rule"
 severity: "medium"
 source: |


### PR DESCRIPTION
# Description
Detects malicious messages sent from Wufoo's sending address (no-reply@wufoo.com) that are abusing the platform to deliver credential theft content.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/5094ddedd7acd006c080f7e097b81f4e782f51842136b37f7fa3c97a70e18533?preview_id=019f42f1-85dc-7c81-99bb-3d40ae03f1c3)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [SWS Hunt](https://platform.sublime.security/hunts/019f70e7-88c4-74f3-908a-3581a5d9d9bd)
- [97 customer multi-hunt](https://hunt.limeseed.email/hunts/27cb282a-a46c-4af5-862f-855d681dc41c)

### 8-4-2026 Hunts
- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=019fcd6e-d4c3-744c-8ee9-66bff7eefdf2)
- [97 customer multi-hunt](https://hunt.limeseed.email/hunts/d87862d1-2fe4-4355-b98e-ab0dee0f50d4)

