### PR TITLE
Create link_obfuscation_underscore_dot_substitution.yml

### DIFF
--- a/detection-rules/link_obfuscation_underscore_dot_substitution.yml
+++ b/detection-rules/link_obfuscation_underscore_dot_substitution.yml
@@ -1,0 +1,19 @@
+name: "Link: Obfuscated URL using underscore-dot substitution in display text"
+description: "Detects inbound messages containing links where the display text starts with 'https://' and uses an underscore followed by 'com/' in place of a standard dot-com domain format (e.g., 'example_com/'). This technique is used to obscure the true destination of a URL, bypassing standard URL parsing and security controls, as the malformed URL cannot be resolved by standard URL parsers."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(body.links,
+          strings.starts_with(.display_text, 'https://')
+          and strings.contains(.display_text, '_com/')
+          and strings.parse_url(.display_text).url is null
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "URL analysis"
+  - "Content analysis"

--- a/detection-rules/link_obfuscation_underscore_dot_substitution.yml
+++ b/detection-rules/link_obfuscation_underscore_dot_substitution.yml
@@ -17,3 +17,4 @@ tactics_and_techniques:
 detection_methods:
   - "URL analysis"
   - "Content analysis"
+id: "802edfc6-5031-59bb-831b-16d0772b2b96"

--- a/detection-rules/link_obfuscation_underscore_dot_substitution.yml
+++ b/detection-rules/link_obfuscation_underscore_dot_substitution.yml
@@ -1,5 +1,5 @@
-name: "Link: Obfuscated URL using underscore-dot substitution in display text"
-description: "Detects inbound messages containing links where the display text starts with 'https://' and uses an underscore followed by 'com/' in place of a standard dot-com domain format (e.g., 'example_com/'). This technique is used to obscure the true destination of a URL, bypassing standard URL parsing and security controls, as the malformed URL cannot be resolved by standard URL parsers."
+name: "Link: URL using underscore-dot substitution in display text"
+description: "Detects inbound messages containing links where the display text starts with 'https://' and uses an underscore followed by 'com/' in place of a standard dot-com domain format (e.g., 'example_com/'). This technique is used to bypass display text URL parsing, as the malformed URL cannot be resolved by standard URL parsers."
 type: "rule"
 severity: "medium"
 source: |

--- a/detection-rules/link_obfuscation_underscore_dot_substitution.yml
+++ b/detection-rules/link_obfuscation_underscore_dot_substitution.yml
@@ -8,6 +8,7 @@ source: |
           strings.starts_with(.display_text, 'https://')
           and strings.contains(.display_text, '_com/')
           and strings.parse_url(.display_text).url is null
+          and .href_url.domain.root_domain != 'sharepoint.com'
   )
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/link_obfuscation_underscore_dot_substitution.yml
+++ b/detection-rules/link_obfuscation_underscore_dot_substitution.yml
@@ -7,8 +7,8 @@ source: |
   and any(body.links,
           strings.starts_with(.display_text, 'https://')
           and strings.contains(.display_text, '_com/')
+          and not strings.contains(.display_text, '.com/')
           and strings.parse_url(.display_text).url is null
-          and .href_url.domain.root_domain != 'sharepoint.com'
   )
 attack_types:
   - "Credential Phishing"


### PR DESCRIPTION
# Description
Detects display text that looks like a url but instead of a standard dot-com domain it uses `_com`. Example: https://example_com/

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/508ee5e43e73f3762e2d2ee32020a62fa2adac04f95a0d27c394c3b933567362?preview_id=019f431e-dba5-70e5-9776-bf92f4c5259c)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=019f716c-6ca5-7c41-b15c-0e4211b33d03)
- [97 Customer multi-hunt](https://hunt.limeseed.email/hunts/5099c7fa-ec44-4b55-9f22-ae9bb1afac69)

### 8/5/2026 Hunts
- [SWS Hunts](https://platform.sublime.security/hunts/019fd267-9ac2-76c8-a519-127118d429f6)
- [97 Customer multi-hunt](https://hunt.limeseed.email/hunts/46aa6155-756f-4044-8264-9b1c56a2dfe6)
