### PR TITLE
tune: expand encrypted PDF password regex to match both passcode and password

### DIFF
--- a/detection-rules/attachment_encrypted_pdf_cred_theft.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft.yml
@@ -23,7 +23,7 @@ source: |
            .name == "cred_theft" and .confidence in ("medium", "high")
     )
     or regex.icontains(body.current_thread.text,
-                       'PDF\s*(?:Access|Preview|Unlock|Decrypt|passcode)',
+                       'PDF\s*(?:Access|Preview|Unlock|Decrypt|pass(?:code|word))',
                        '(Access|Preview|Unlock|Decrypt|Pass)\s*(?:word|code)\s*(?:\S+\s+){0,3}PDF\s*is?\s*:',
                        'This\s+(?:file|document|pdf)\s+is\s+(?:password[-\s]?)\s+protected\.\s*The\s+password\s+is\s*:?',
                        '(?:Access|Preview|Unlock|Decrypt)\s+(?:\S+\s+){0,3}(?:PDF|statement)(?:\S+\s+){0,3}(?:pass(?:word|code)|\s*with\s+\S+)'
@@ -35,7 +35,7 @@ source: |
       )
       and any(body.previous_threads,
               regex.icontains(.text,
-                              'PDF\s*(?:Access|Preview|Unlock|Decrypt|passcode)',
+                              'PDF\s*(?:Access|Preview|Unlock|Decrypt|pass(?:code|word))',
                               '(Access|Preview|Unlock|Decrypt|Pass)\s*(?:word|code)\s*(?:\S+\s+){0,3}PDF\s*is?\s*:',
                               'This\s+(?:file|document|pdf)\s+is\s+(?:password[-\s]?)\s+protected\.\s*The\s+password\s+is\s*:?',
                               '(?:Access|Preview|Unlock|Decrypt)\s+(?:\S+\s+){0,3}(?:PDF|statement)(?:\S+\s+){0,3}(?:pass(?:word|code)|\s*with\s+\S+)'


### PR DESCRIPTION
## Summary
- Updated regex pattern in `attachment_encrypted_pdf_cred_theft` rule to detect both "PDF passcode" and "PDF password" variants
- Changed from literal `passcode` to regex group `pass(?:code|word)` for broader coverage

## Changes
**Before:**
```regex
'PDF\s*(?:Access|Preview|Unlock|Decrypt|passcode)'
```

**After:**
```regex
'PDF\s*(?:Access|Preview|Unlock|Decrypt|pass(?:code|word))'
```

## Validation
✅ Rule syntax validated via `validateRule` MCP tool

## Test plan
- [x] Rule validates successfully
- [ ] Test against sample messages with "PDF password" variants
- [ ] Monitor for FPs after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)