### PR TITLE
Update: attachment_encrypted_pdf_cred_theft.yml - Small regex tweak

### DIFF
--- a/detection-rules/attachment_encrypted_pdf_cred_theft.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft.yml
@@ -23,7 +23,7 @@ source: |
            .name == "cred_theft" and .confidence in ("medium", "high")
     )
     or regex.icontains(body.current_thread.text,
-                       'PDF\s*(?:Access|Preview|Unlock|Decrypt|passcode)',
+                       'PDF\s*(?:Access|Preview|Unlock|Decrypt|pass(?:code|word))',
                        '(Access|Preview|Unlock|Decrypt|Pass)\s*(?:word|code)\s*(?:\S+\s+){0,3}PDF\s*is?\s*:',
                        'This\s+(?:file|document|pdf)\s+is\s+(?:password[-\s]?)\s+protected\.\s*The\s+password\s+is\s*:?',
                        '(?:Access|Preview|Unlock|Decrypt)\s+(?:\S+\s+){0,3}(?:PDF|statement)(?:\S+\s+){0,3}(?:pass(?:word|code)|\s*with\s+\S+)'
@@ -35,7 +35,7 @@ source: |
       )
       and any(body.previous_threads,
               regex.icontains(.text,
-                              'PDF\s*(?:Access|Preview|Unlock|Decrypt|passcode)',
+                              'PDF\s*(?:Access|Preview|Unlock|Decrypt|pass(?:code|word))',
                               '(Access|Preview|Unlock|Decrypt|Pass)\s*(?:word|code)\s*(?:\S+\s+){0,3}PDF\s*is?\s*:',
                               'This\s+(?:file|document|pdf)\s+is\s+(?:password[-\s]?)\s+protected\.\s*The\s+password\s+is\s*:?',
                               '(?:Access|Preview|Unlock|Decrypt)\s+(?:\S+\s+){0,3}(?:PDF|statement)(?:\S+\s+){0,3}(?:pass(?:word|code)|\s*with\s+\S+)'


### PR DESCRIPTION
# Description
- Fixes false negative (ESC-17540) in `attachment_encrypted_pdf_cred_theft` rule
- Updated regex pattern to detect both "PDF passcode" and "PDF password" variants
- Changed `passcode` to regex group `pass(?:code|word)`
- 29 net-new coverage hits

## Changes
**Before:**
```regex
'PDF\s*(?:Access|Preview|Unlock|Decrypt|passcode)'
```

**After:**
```regex
'PDF\s*(?:Access|Preview|Unlock|Decrypt|pass(?:code|word))'
```

# Associated samples

[- Sample 1](https://platform.sublime.security/messages/509952bb77edc01497fc4537db5f29be5a9bc01e8a2d204753ead9c5847942d7?preview_id=019f61ff-a9bc-71ba-9338-db132f29ada8)

## Associated hunts

[- Hunt 1 (Shared samples) - L90D - PR logic](https://platform.sublime.security/messages/hunt?huntId=019f718d-1de0-799f-a2a5-5e795640f4e2)
[- Hunt 2 (Shared samples) - L90D - PR logic vs old logic](https://platform.sublime.security/messages/hunt?huntId=019f711b-a236-7eec-902c-020542ca8ecb)
[- Hunt 3 (Multi-hunt) - L30D - PR logic](https://hunt.limeseed.email/hunts/21382212-71fb-4e90-bc81-1363f673397a)
[- Hunt 4 (Multi-hunt) - L30D - PR logic vs old logic](https://hunt.limeseed.email/hunts/0d855803-2d7c-47d4-b1c5-23e0ed8dd6b9)