### PR TITLE
ClickFix: Clipboard hijack lure with copy-paste-to-terminal instruction

### DIFF
--- a/detection-rules/link_clickfix_clipboard_hijack_lure.yml
+++ b/detection-rules/link_clickfix_clipboard_hijack_lure.yml
@@ -11,10 +11,10 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-
+  
   // message contains links
   and 0 < length(body.links) < 15
-
+  
   // NLU detects credential theft or malware delivery intent
   and (
     any(ml.nlu_classifier(body.current_thread.text).intents,
@@ -24,10 +24,10 @@ source: |
            .name == "urgency"
     )
   )
-
+  
   // require 2 of the following ClickFix-specific signals
   and 2 of (
-
+  
     // explicit copy-paste-to-terminal instruction
     (
       strings.icontains(body.current_thread.text, "copy")
@@ -36,29 +36,33 @@ source: |
         or strings.icontains(body.current_thread.text, "pasting")
       )
       and any([
-        strings.icontains(body.current_thread.text, "terminal"),
-        strings.icontains(body.current_thread.text, "powershell"),
-        strings.icontains(body.current_thread.text, "command prompt"),
-        strings.icontains(body.current_thread.text, "run dialog"),
-        strings.icontains(body.current_thread.text, "win+r"),
-        strings.icontains(body.current_thread.text, "windows+r"),
-        strings.icontains(body.current_thread.text, "cmd")
-      ], .)
+                strings.icontains(body.current_thread.text, "terminal"),
+                strings.icontains(body.current_thread.text, "powershell"),
+                strings.icontains(body.current_thread.text, "command prompt"),
+                strings.icontains(body.current_thread.text, "run dialog"),
+                strings.icontains(body.current_thread.text, "win+r"),
+                strings.icontains(body.current_thread.text, "windows+r"),
+                strings.icontains(body.current_thread.text, "cmd")
+              ],
+              .
+      )
     ),
-
+  
     // fake CAPTCHA or browser verification framing
     (
       any([
-        strings.icontains(body.current_thread.text, "captcha"),
-        strings.icontains(body.current_thread.text, "verify you are human"),
-        strings.icontains(body.current_thread.text, "human verification"),
-        strings.icontains(body.current_thread.text, "browser check"),
-        strings.icontains(body.current_thread.text, "press windows"),
-        strings.icontains(body.current_thread.text, "press win+r"),
-        strings.icontains(body.current_thread.text, "i am not a robot")
-      ], .)
+            strings.icontains(body.current_thread.text, "captcha"),
+            strings.icontains(body.current_thread.text, "verify you are human"),
+            strings.icontains(body.current_thread.text, "human verification"),
+            strings.icontains(body.current_thread.text, "browser check"),
+            strings.icontains(body.current_thread.text, "press windows"),
+            strings.icontains(body.current_thread.text, "press win+r"),
+            strings.icontains(body.current_thread.text, "i am not a robot")
+          ],
+          .
+      )
     ),
-
+  
     // link resolves to or redirects through a suspicious TLD
     any(body.links,
         .href_url.domain.tld in $suspicious_tlds
@@ -66,12 +70,11 @@ source: |
                .domain.tld in $suspicious_tlds
         )
     ),
-
+  
     // freemail sender — should never send CAPTCHA or terminal instructions
     sender.email.domain.domain in $free_email_providers
-
   )
-
+  
   // negate known security awareness training platforms
   and sender.email.domain.root_domain not in (
     "knowbe4.com",
@@ -79,13 +82,12 @@ source: |
     "cofense.com",
     "terranovasecurity.com"
   )
-
+  
   // negate highly trusted sender domains unless they fail DMARC
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
-
 tags:
   - "Attack surface reduction"
 attack_types:
@@ -105,3 +107,4 @@ references:
   - "https://www.microsoft.com/en-us/security/blog/2026/04/30/email-threat-landscape-q1-2026-trends-and-insights/"
   - "https://yanaivanov.com/writing/clickfix_field_note.html"
 id: ""
+id: "df51b2bb-8f40-51b0-ae6f-ed742cf00109"

--- a/detection-rules/link_clickfix_clipboard_hijack_lure.yml
+++ b/detection-rules/link_clickfix_clipboard_hijack_lure.yml
@@ -1,0 +1,123 @@
+name: "ClickFix: Clipboard hijack lure with copy-paste-to-terminal instruction"
+description: |
+  Detects emails delivering ClickFix social engineering lures — messages that
+  instruct the recipient to copy and paste a command into their terminal, Run
+  dialog, or PowerShell, typically combined with a fake CAPTCHA, browser error,
+  or verification prompt. ClickFix attacks use JavaScript to silently replace
+  clipboard contents, causing the user to unknowingly execute a malicious command.
+  Active campaigns in 2026 include TELEPUZ (April 2026+), which uses this
+  technique to deliver a modular MaaS payload via a ClickFix-VIDAR chain.
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+
+  // message contains links
+  and 0 < length(body.links) < 15
+
+  // NLU detects credential theft or malware delivery intent
+  and (
+    any(ml.nlu_classifier(body.current_thread.text).intents,
+        .name in ("cred_theft", "malware") and .confidence in ("medium", "high")
+    )
+    or any(ml.nlu_classifier(body.current_thread.text).entities,
+           .name == "urgency"
+    )
+  )
+
+  // require 2 of the following ClickFix-specific signals
+  and 2 of (
+
+    // explicit copy-paste-to-terminal instruction
+    (
+      strings.icontains(body.current_thread.text, "copy")
+      and (
+        strings.icontains(body.current_thread.text, "paste")
+        or strings.icontains(body.current_thread.text, "pasting")
+      )
+      and any([
+        strings.icontains(body.current_thread.text, "terminal"),
+        strings.icontains(body.current_thread.text, "powershell"),
+        strings.icontains(body.current_thread.text, "command prompt"),
+        strings.icontains(body.current_thread.text, "run dialog"),
+        strings.icontains(body.current_thread.text, "win+r"),
+        strings.icontains(body.current_thread.text, "windows+r"),
+        strings.icontains(body.current_thread.text, "cmd")
+      ], .)
+    ),
+
+    // fake CAPTCHA or browser verification framing
+    (
+      any([
+        strings.icontains(body.current_thread.text, "captcha"),
+        strings.icontains(body.current_thread.text, "verify you are human"),
+        strings.icontains(body.current_thread.text, "human verification"),
+        strings.icontains(body.current_thread.text, "browser check"),
+        strings.icontains(body.current_thread.text, "press windows"),
+        strings.icontains(body.current_thread.text, "press win+r"),
+        strings.icontains(body.current_thread.text, "i am not a robot")
+      ], .)
+    ),
+
+    // link resolves to or redirects through a suspicious TLD
+    any(body.links,
+        .href_url.domain.tld in $suspicious_tlds
+        or any(ml.link_analysis(., mode="aggressive").redirect_history,
+               .domain.tld in $suspicious_tlds
+        )
+    ),
+
+    // freemail sender — should never send CAPTCHA or terminal instructions
+    sender.email.domain.domain in $free_email_providers
+
+  )
+
+  // unsolicited sender
+  and (
+    (
+      profile.by_sender().prevalence in ("new", "outlier")
+      and not profile.by_sender().solicited
+    )
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and not profile.by_sender().any_messages_benign
+    )
+  )
+  and not profile.by_sender().any_messages_benign
+
+  // negate highly trusted sender domains unless they fail DMARC
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not headers.auth_summary.dmarc.pass
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
+
+  // negate known security awareness training platforms
+  and sender.email.domain.root_domain not in (
+    "knowbe4.com",
+    "proofpoint.com",
+    "cofense.com",
+    "terranovasecurity.com"
+  )
+
+tags:
+  - "Attack surface reduction"
+attack_types:
+  - "Malware/Ransomware"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+  - "Scripting"
+detection_methods:
+  - "Content analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"
+  - "URL analysis"
+references:
+  - "https://www.elastic.co/security-labs/telepuz-maas-malware-clickfix"
+  - "https://www.microsoft.com/en-us/security/blog/2026/04/30/email-threat-landscape-q1-2026-trends-and-insights/"
+  - "https://yanaivanov.com/writing/clickfix_field_note.html"
+id: ""

--- a/detection-rules/link_clickfix_clipboard_hijack_lure.yml
+++ b/detection-rules/link_clickfix_clipboard_hijack_lure.yml
@@ -11,23 +11,23 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  
+
   // message contains links
   and 0 < length(body.links) < 15
-  
+
   // NLU detects credential theft or malware delivery intent
   and (
     any(ml.nlu_classifier(body.current_thread.text).intents,
-        .name in ("cred_theft", "malware") and .confidence in ("medium", "high")
+        .name in ("cred_theft") and .confidence in ("medium", "high")
     )
     or any(ml.nlu_classifier(body.current_thread.text).entities,
            .name == "urgency"
     )
   )
-  
+
   // require 2 of the following ClickFix-specific signals
   and 2 of (
-  
+
     // explicit copy-paste-to-terminal instruction
     (
       strings.icontains(body.current_thread.text, "copy")
@@ -36,33 +36,29 @@ source: |
         or strings.icontains(body.current_thread.text, "pasting")
       )
       and any([
-                strings.icontains(body.current_thread.text, "terminal"),
-                strings.icontains(body.current_thread.text, "powershell"),
-                strings.icontains(body.current_thread.text, "command prompt"),
-                strings.icontains(body.current_thread.text, "run dialog"),
-                strings.icontains(body.current_thread.text, "win+r"),
-                strings.icontains(body.current_thread.text, "windows+r"),
-                strings.icontains(body.current_thread.text, "cmd")
-              ],
-              .
-      )
+        strings.icontains(body.current_thread.text, "terminal"),
+        strings.icontains(body.current_thread.text, "powershell"),
+        strings.icontains(body.current_thread.text, "command prompt"),
+        strings.icontains(body.current_thread.text, "run dialog"),
+        strings.icontains(body.current_thread.text, "win+r"),
+        strings.icontains(body.current_thread.text, "windows+r"),
+        strings.icontains(body.current_thread.text, "cmd")
+      ], .)
     ),
-  
+
     // fake CAPTCHA or browser verification framing
     (
       any([
-            strings.icontains(body.current_thread.text, "captcha"),
-            strings.icontains(body.current_thread.text, "verify you are human"),
-            strings.icontains(body.current_thread.text, "human verification"),
-            strings.icontains(body.current_thread.text, "browser check"),
-            strings.icontains(body.current_thread.text, "press windows"),
-            strings.icontains(body.current_thread.text, "press win+r"),
-            strings.icontains(body.current_thread.text, "i am not a robot")
-          ],
-          .
-      )
+        strings.icontains(body.current_thread.text, "captcha"),
+        strings.icontains(body.current_thread.text, "verify you are human"),
+        strings.icontains(body.current_thread.text, "human verification"),
+        strings.icontains(body.current_thread.text, "browser check"),
+        strings.icontains(body.current_thread.text, "press windows"),
+        strings.icontains(body.current_thread.text, "press win+r"),
+        strings.icontains(body.current_thread.text, "i am not a robot")
+      ], .)
     ),
-  
+
     // link resolves to or redirects through a suspicious TLD
     any(body.links,
         .href_url.domain.tld in $suspicious_tlds
@@ -70,33 +66,12 @@ source: |
                .domain.tld in $suspicious_tlds
         )
     ),
-  
+
     // freemail sender — should never send CAPTCHA or terminal instructions
     sender.email.domain.domain in $free_email_providers
+
   )
-  
-  // unsolicited sender
-  and (
-    (
-      profile.by_sender().prevalence in ("new", "outlier")
-      and not profile.by_sender().solicited
-    )
-    or (
-      profile.by_sender().any_messages_malicious_or_spam
-      and not profile.by_sender().any_messages_benign
-    )
-  )
-  and not profile.by_sender().any_messages_benign
-  
-  // negate highly trusted sender domains unless they fail DMARC
-  and (
-    (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and not headers.auth_summary.dmarc.pass
-    )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
-  )
-  
+
   // negate known security awareness training platforms
   and sender.email.domain.root_domain not in (
     "knowbe4.com",
@@ -104,6 +79,13 @@ source: |
     "cofense.com",
     "terranovasecurity.com"
   )
+
+  // negate highly trusted sender domains unless they fail DMARC
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+
 tags:
   - "Attack surface reduction"
 attack_types:
@@ -123,4 +105,3 @@ references:
   - "https://www.microsoft.com/en-us/security/blog/2026/04/30/email-threat-landscape-q1-2026-trends-and-insights/"
   - "https://yanaivanov.com/writing/clickfix_field_note.html"
 id: ""
-id: "df51b2bb-8f40-51b0-ae6f-ed742cf00109"

--- a/detection-rules/link_clickfix_clipboard_hijack_lure.yml
+++ b/detection-rules/link_clickfix_clipboard_hijack_lure.yml
@@ -11,10 +11,10 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-
+  
   // message contains links
   and 0 < length(body.links) < 15
-
+  
   // NLU detects credential theft or malware delivery intent
   and (
     any(ml.nlu_classifier(body.current_thread.text).intents,
@@ -24,10 +24,10 @@ source: |
            .name == "urgency"
     )
   )
-
+  
   // require 2 of the following ClickFix-specific signals
   and 2 of (
-
+  
     // explicit copy-paste-to-terminal instruction
     (
       strings.icontains(body.current_thread.text, "copy")
@@ -36,29 +36,33 @@ source: |
         or strings.icontains(body.current_thread.text, "pasting")
       )
       and any([
-        strings.icontains(body.current_thread.text, "terminal"),
-        strings.icontains(body.current_thread.text, "powershell"),
-        strings.icontains(body.current_thread.text, "command prompt"),
-        strings.icontains(body.current_thread.text, "run dialog"),
-        strings.icontains(body.current_thread.text, "win+r"),
-        strings.icontains(body.current_thread.text, "windows+r"),
-        strings.icontains(body.current_thread.text, "cmd")
-      ], .)
+                strings.icontains(body.current_thread.text, "terminal"),
+                strings.icontains(body.current_thread.text, "powershell"),
+                strings.icontains(body.current_thread.text, "command prompt"),
+                strings.icontains(body.current_thread.text, "run dialog"),
+                strings.icontains(body.current_thread.text, "win+r"),
+                strings.icontains(body.current_thread.text, "windows+r"),
+                strings.icontains(body.current_thread.text, "cmd")
+              ],
+              .
+      )
     ),
-
+  
     // fake CAPTCHA or browser verification framing
     (
       any([
-        strings.icontains(body.current_thread.text, "captcha"),
-        strings.icontains(body.current_thread.text, "verify you are human"),
-        strings.icontains(body.current_thread.text, "human verification"),
-        strings.icontains(body.current_thread.text, "browser check"),
-        strings.icontains(body.current_thread.text, "press windows"),
-        strings.icontains(body.current_thread.text, "press win+r"),
-        strings.icontains(body.current_thread.text, "i am not a robot")
-      ], .)
+            strings.icontains(body.current_thread.text, "captcha"),
+            strings.icontains(body.current_thread.text, "verify you are human"),
+            strings.icontains(body.current_thread.text, "human verification"),
+            strings.icontains(body.current_thread.text, "browser check"),
+            strings.icontains(body.current_thread.text, "press windows"),
+            strings.icontains(body.current_thread.text, "press win+r"),
+            strings.icontains(body.current_thread.text, "i am not a robot")
+          ],
+          .
+      )
     ),
-
+  
     // link resolves to or redirects through a suspicious TLD
     any(body.links,
         .href_url.domain.tld in $suspicious_tlds
@@ -66,12 +70,11 @@ source: |
                .domain.tld in $suspicious_tlds
         )
     ),
-
+  
     // freemail sender — should never send CAPTCHA or terminal instructions
     sender.email.domain.domain in $free_email_providers
-
   )
-
+  
   // unsolicited sender
   and (
     (
@@ -84,7 +87,7 @@ source: |
     )
   )
   and not profile.by_sender().any_messages_benign
-
+  
   // negate highly trusted sender domains unless they fail DMARC
   and (
     (
@@ -93,7 +96,7 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
+  
   // negate known security awareness training platforms
   and sender.email.domain.root_domain not in (
     "knowbe4.com",
@@ -101,7 +104,6 @@ source: |
     "cofense.com",
     "terranovasecurity.com"
   )
-
 tags:
   - "Attack surface reduction"
 attack_types:
@@ -121,3 +123,4 @@ references:
   - "https://www.microsoft.com/en-us/security/blog/2026/04/30/email-threat-landscape-q1-2026-trends-and-insights/"
   - "https://yanaivanov.com/writing/clickfix_field_note.html"
 id: ""
+id: "df51b2bb-8f40-51b0-ae6f-ed742cf00109"

--- a/detection-rules/link_clickfix_clipboard_hijack_lure.yml
+++ b/detection-rules/link_clickfix_clipboard_hijack_lure.yml
@@ -21,20 +21,44 @@ source: |
   )
   
   // REQUIRED: email must contain explicit copy-paste-to-terminal instruction
-  // this is the core ClickFix signal — the attacker has to tell the victim what to do
-  and strings.icontains(body.current_thread.text, "copy")
+  // or keystroke-only variant (e.g. press Windows+R, Ctrl+V, Enter) — UAT-11795/ClickFix
   and (
-    strings.icontains(body.current_thread.text, "paste")
-    or strings.icontains(body.current_thread.text, "pasting")
-  )
-  and strings.icontains(body.current_thread.text,
-                        "terminal",
-                        "powershell",
-                        "command prompt",
-                        "run dialog",
-                        "win+r",
-                        "windows+r",
-                        "cmd"
+    (
+      strings.icontains(body.current_thread.text, "copy")
+      and (
+        strings.icontains(body.current_thread.text, "paste")
+        or strings.icontains(body.current_thread.text, "pasting")
+      )
+      and strings.icontains(body.current_thread.text,
+                            "terminal",
+                            "powershell",
+                            "command prompt",
+                            "run dialog",
+                            "win+r",
+                            "windows+r",
+                            "cmd",
+                            "mshta"
+      )
+    )
+    or (
+      // keystroke-only variant — no copy/paste language, just key instructions
+      strings.icontains(body.current_thread.text,
+                        "ctrl+v",
+                        "ctrl-v",
+                        "press windows+r",
+                        "press win+r"
+      )
+      and strings.icontains(body.current_thread.text,
+                            "terminal",
+                            "powershell",
+                            "command prompt",
+                            "run dialog",
+                            "win+r",
+                            "windows+r",
+                            "cmd",
+                            "mshta"
+      )
+    )
   )
   
   // require 1 additional supporting signal

--- a/detection-rules/link_clickfix_clipboard_hijack_lure.yml
+++ b/detection-rules/link_clickfix_clipboard_hijack_lure.yml
@@ -29,34 +29,17 @@ source: |
         strings.icontains(body.current_thread.text, "paste")
         or strings.icontains(body.current_thread.text, "pasting")
       )
-      and strings.icontains(body.current_thread.text,
-                            "terminal",
-                            "powershell",
-                            "command prompt",
-                            "run dialog",
-                            "win+r",
-                            "windows+r",
-                            "cmd",
-                            "mshta"
+      and regex.icontains(body.current_thread.text,
+                          '(?:terminal|powershell|command prompt|run dialog|win(?:dows)?\s*\+\s*r|\bcmd\b|mshta)'
       )
     )
     or (
       // keystroke-only variant — no copy/paste language, just key instructions
-      strings.icontains(body.current_thread.text,
-                        "ctrl+v",
-                        "ctrl-v",
-                        "press windows+r",
-                        "press win+r"
+      regex.icontains(body.current_thread.text,
+                      '(?:ctrl\s*[+-]\s*v|press win(?:dows)?\s*\+\s*r)'
       )
-      and strings.icontains(body.current_thread.text,
-                            "terminal",
-                            "powershell",
-                            "command prompt",
-                            "run dialog",
-                            "win+r",
-                            "windows+r",
-                            "cmd",
-                            "mshta"
+      and regex.icontains(body.current_thread.text,
+                          '(?:terminal|powershell|command prompt|run dialog|win(?:dows)?\s*\+r|\bcmd\b|mshta)'
       )
     )
   )
@@ -65,14 +48,8 @@ source: |
   and 1 of (
   
     // fake CAPTCHA or browser verification framing
-    strings.icontains(body.current_thread.text,
-                      "captcha",
-                      "verify you are human",
-                      "human verification",
-                      "browser check",
-                      "press windows",
-                      "press win+r",
-                      "i am not a robot"
+    regex.icontains(body.current_thread.text,
+                    '(?:captcha|verify you are human|human verification|browser check|press windows|press win\s*\+\s*r|i am not a robot)'
     ),
   
     // link resolves to or redirects through a suspicious TLD
@@ -89,7 +66,11 @@ source: |
   
   // negate highly trusted sender domains unless they fail DMARC
   and not (
-    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      // and org_domains
+      or sender.email.domain.domain in $org_domains
+    )
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
 tags:

--- a/detection-rules/link_clickfix_clipboard_hijack_lure.yml
+++ b/detection-rules/link_clickfix_clipboard_hijack_lure.yml
@@ -11,10 +11,10 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-
+  
   // message contains links
   and 0 < length(body.links) < 15
-
+  
   // NLU detects credential theft or malware delivery intent
   and (
     any(ml.nlu_classifier(body.current_thread.text).intents,
@@ -24,10 +24,10 @@ source: |
            .name == "urgency"
     )
   )
-
+  
   // require 2 of the following ClickFix-specific signals
   and 2 of (
-
+  
     // explicit copy-paste-to-terminal instruction
     (
       strings.icontains(body.current_thread.text, "copy")
@@ -35,14 +35,30 @@ source: |
         strings.icontains(body.current_thread.text, "paste")
         or strings.icontains(body.current_thread.text, "pasting")
       )
-      and strings.icontains(body.current_thread.text, "terminal", "powershell", "command prompt", "run dialog", "win+r", "windows+r", "cmd")
+      and strings.icontains(body.current_thread.text,
+                            "terminal",
+                            "powershell",
+                            "command prompt",
+                            "run dialog",
+                            "win+r",
+                            "windows+r",
+                            "cmd"
+      )
     ),
-
+  
     // fake CAPTCHA or browser verification framing
     (
-      strings.icontains(body.current_thread.text, "captcha", "verify you are human", "human verification", "browser check", "press windows", "press win+r", "i am not a robot")
+      strings.icontains(body.current_thread.text,
+                        "captcha",
+                        "verify you are human",
+                        "human verification",
+                        "browser check",
+                        "press windows",
+                        "press win+r",
+                        "i am not a robot"
+      )
     ),
-
+  
     // link resolves to or redirects through a suspicious TLD
     any(body.links,
         .href_url.domain.tld in $suspicious_tlds
@@ -50,12 +66,11 @@ source: |
                .domain.tld in $suspicious_tlds
         )
     ),
-
+  
     // freemail sender — should never send CAPTCHA or terminal instructions
     sender.email.domain.domain in $free_email_providers
-
   )
-
+  
   // negate known security awareness training platforms
   and sender.email.domain.root_domain not in (
     "knowbe4.com",
@@ -63,13 +78,12 @@ source: |
     "cofense.com",
     "terranovasecurity.com"
   )
-
+  
   // negate highly trusted sender domains unless they fail DMARC
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
-
 tags:
   - "Attack surface reduction"
 attack_types:
@@ -88,3 +102,4 @@ references:
   - "https://www.elastic.co/security-labs/telepuz-maas-malware-clickfix"
   - "https://www.microsoft.com/en-us/security/blog/2026/04/30/email-threat-landscape-q1-2026-trends-and-insights/"
   - "https://yanaivanov.com/writing/clickfix_field_note.html"
+id: "df51b2bb-8f40-51b0-ae6f-ed742cf00109"

--- a/detection-rules/link_clickfix_clipboard_hijack_lure.yml
+++ b/detection-rules/link_clickfix_clipboard_hijack_lure.yml
@@ -11,54 +11,46 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  
+
   // message contains links
   and 0 < length(body.links) < 15
-  
-  // NLU detects credential theft or malware delivery intent
-  and (
-    any(ml.nlu_classifier(body.current_thread.text).intents,
-        .name in ("cred_theft") and .confidence in ("medium", "high")
-    )
-    or any(ml.nlu_classifier(body.current_thread.text).entities,
-           .name == "urgency"
-    )
+
+  // NLU detects credential theft intent
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name in ("cred_theft") and .confidence in ("medium", "high")
   )
-  
-  // require 2 of the following ClickFix-specific signals
-  and 2 of (
-  
-    // explicit copy-paste-to-terminal instruction
-    (
-      strings.icontains(body.current_thread.text, "copy")
-      and (
-        strings.icontains(body.current_thread.text, "paste")
-        or strings.icontains(body.current_thread.text, "pasting")
-      )
-      and strings.icontains(body.current_thread.text,
-                            "terminal",
-                            "powershell",
-                            "command prompt",
-                            "run dialog",
-                            "win+r",
-                            "windows+r",
-                            "cmd"
-      )
-    ),
-  
+
+  // REQUIRED: email must contain explicit copy-paste-to-terminal instruction
+  // this is the core ClickFix signal — the attacker has to tell the victim what to do
+  and strings.icontains(body.current_thread.text, "copy")
+  and (
+    strings.icontains(body.current_thread.text, "paste")
+    or strings.icontains(body.current_thread.text, "pasting")
+  )
+  and strings.icontains(body.current_thread.text,
+                        "terminal",
+                        "powershell",
+                        "command prompt",
+                        "run dialog",
+                        "win+r",
+                        "windows+r",
+                        "cmd"
+  )
+
+  // require 1 additional supporting signal
+  and 1 of (
+
     // fake CAPTCHA or browser verification framing
-    (
-      strings.icontains(body.current_thread.text,
-                        "captcha",
-                        "verify you are human",
-                        "human verification",
-                        "browser check",
-                        "press windows",
-                        "press win+r",
-                        "i am not a robot"
-      )
+    strings.icontains(body.current_thread.text,
+                      "captcha",
+                      "verify you are human",
+                      "human verification",
+                      "browser check",
+                      "press windows",
+                      "press win+r",
+                      "i am not a robot"
     ),
-  
+
     // link resolves to or redirects through a suspicious TLD
     any(body.links,
         .href_url.domain.tld in $suspicious_tlds
@@ -66,11 +58,12 @@ source: |
                .domain.tld in $suspicious_tlds
         )
     ),
-  
-    // freemail sender — should never send CAPTCHA or terminal instructions
+
+    // freemail sender — should never send terminal instructions
     sender.email.domain.domain in $free_email_providers
+
   )
-  
+
   // negate known security awareness training platforms
   and sender.email.domain.root_domain not in (
     "knowbe4.com",
@@ -78,12 +71,13 @@ source: |
     "cofense.com",
     "terranovasecurity.com"
   )
-  
+
   // negate highly trusted sender domains unless they fail DMARC
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
+
 tags:
   - "Attack surface reduction"
 attack_types:
@@ -102,4 +96,3 @@ references:
   - "https://www.elastic.co/security-labs/telepuz-maas-malware-clickfix"
   - "https://www.microsoft.com/en-us/security/blog/2026/04/30/email-threat-landscape-q1-2026-trends-and-insights/"
   - "https://yanaivanov.com/writing/clickfix_field_note.html"
-id: "df51b2bb-8f40-51b0-ae6f-ed742cf00109"

--- a/detection-rules/link_clickfix_clipboard_hijack_lure.yml
+++ b/detection-rules/link_clickfix_clipboard_hijack_lure.yml
@@ -63,7 +63,6 @@ source: |
     sender.email.domain.domain in $free_email_providers
   )
   
-  
   // negate highly trusted sender domains unless they fail DMARC
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains

--- a/detection-rules/link_clickfix_clipboard_hijack_lure.yml
+++ b/detection-rules/link_clickfix_clipboard_hijack_lure.yml
@@ -11,15 +11,15 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-
+  
   // message contains links
   and 0 < length(body.links) < 15
-
+  
   // NLU detects credential theft intent
   and any(ml.nlu_classifier(body.current_thread.text).intents,
           .name in ("cred_theft") and .confidence in ("medium", "high")
   )
-
+  
   // REQUIRED: email must contain explicit copy-paste-to-terminal instruction
   // this is the core ClickFix signal — the attacker has to tell the victim what to do
   and strings.icontains(body.current_thread.text, "copy")
@@ -36,10 +36,10 @@ source: |
                         "windows+r",
                         "cmd"
   )
-
+  
   // require 1 additional supporting signal
   and 1 of (
-
+  
     // fake CAPTCHA or browser verification framing
     strings.icontains(body.current_thread.text,
                       "captcha",
@@ -50,7 +50,7 @@ source: |
                       "press win+r",
                       "i am not a robot"
     ),
-
+  
     // link resolves to or redirects through a suspicious TLD
     any(body.links,
         .href_url.domain.tld in $suspicious_tlds
@@ -58,12 +58,11 @@ source: |
                .domain.tld in $suspicious_tlds
         )
     ),
-
+  
     // freemail sender — should never send terminal instructions
     sender.email.domain.domain in $free_email_providers
-
   )
-
+  
   // negate known security awareness training platforms
   and sender.email.domain.root_domain not in (
     "knowbe4.com",
@@ -71,13 +70,12 @@ source: |
     "cofense.com",
     "terranovasecurity.com"
   )
-
+  
   // negate highly trusted sender domains unless they fail DMARC
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
-
 tags:
   - "Attack surface reduction"
 attack_types:
@@ -96,3 +94,4 @@ references:
   - "https://www.elastic.co/security-labs/telepuz-maas-malware-clickfix"
   - "https://www.microsoft.com/en-us/security/blog/2026/04/30/email-threat-landscape-q1-2026-trends-and-insights/"
   - "https://yanaivanov.com/writing/clickfix_field_note.html"
+id: "df51b2bb-8f40-51b0-ae6f-ed742cf00109"

--- a/detection-rules/link_clickfix_clipboard_hijack_lure.yml
+++ b/detection-rules/link_clickfix_clipboard_hijack_lure.yml
@@ -11,10 +11,10 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  
+
   // message contains links
   and 0 < length(body.links) < 15
-  
+
   // NLU detects credential theft or malware delivery intent
   and (
     any(ml.nlu_classifier(body.current_thread.text).intents,
@@ -24,10 +24,10 @@ source: |
            .name == "urgency"
     )
   )
-  
+
   // require 2 of the following ClickFix-specific signals
   and 2 of (
-  
+
     // explicit copy-paste-to-terminal instruction
     (
       strings.icontains(body.current_thread.text, "copy")
@@ -35,34 +35,14 @@ source: |
         strings.icontains(body.current_thread.text, "paste")
         or strings.icontains(body.current_thread.text, "pasting")
       )
-      and any([
-                strings.icontains(body.current_thread.text, "terminal"),
-                strings.icontains(body.current_thread.text, "powershell"),
-                strings.icontains(body.current_thread.text, "command prompt"),
-                strings.icontains(body.current_thread.text, "run dialog"),
-                strings.icontains(body.current_thread.text, "win+r"),
-                strings.icontains(body.current_thread.text, "windows+r"),
-                strings.icontains(body.current_thread.text, "cmd")
-              ],
-              .
-      )
+      and strings.icontains(body.current_thread.text, "terminal", "powershell", "command prompt", "run dialog", "win+r", "windows+r", "cmd")
     ),
-  
+
     // fake CAPTCHA or browser verification framing
     (
-      any([
-            strings.icontains(body.current_thread.text, "captcha"),
-            strings.icontains(body.current_thread.text, "verify you are human"),
-            strings.icontains(body.current_thread.text, "human verification"),
-            strings.icontains(body.current_thread.text, "browser check"),
-            strings.icontains(body.current_thread.text, "press windows"),
-            strings.icontains(body.current_thread.text, "press win+r"),
-            strings.icontains(body.current_thread.text, "i am not a robot")
-          ],
-          .
-      )
+      strings.icontains(body.current_thread.text, "captcha", "verify you are human", "human verification", "browser check", "press windows", "press win+r", "i am not a robot")
     ),
-  
+
     // link resolves to or redirects through a suspicious TLD
     any(body.links,
         .href_url.domain.tld in $suspicious_tlds
@@ -70,11 +50,12 @@ source: |
                .domain.tld in $suspicious_tlds
         )
     ),
-  
+
     // freemail sender — should never send CAPTCHA or terminal instructions
     sender.email.domain.domain in $free_email_providers
+
   )
-  
+
   // negate known security awareness training platforms
   and sender.email.domain.root_domain not in (
     "knowbe4.com",
@@ -82,12 +63,13 @@ source: |
     "cofense.com",
     "terranovasecurity.com"
   )
-  
+
   // negate highly trusted sender domains unless they fail DMARC
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
+
 tags:
   - "Attack surface reduction"
 attack_types:
@@ -106,5 +88,3 @@ references:
   - "https://www.elastic.co/security-labs/telepuz-maas-malware-clickfix"
   - "https://www.microsoft.com/en-us/security/blog/2026/04/30/email-threat-landscape-q1-2026-trends-and-insights/"
   - "https://yanaivanov.com/writing/clickfix_field_note.html"
-id: ""
-id: "df51b2bb-8f40-51b0-ae6f-ed742cf00109"

--- a/detection-rules/link_clickfix_clipboard_hijack_lure.yml
+++ b/detection-rules/link_clickfix_clipboard_hijack_lure.yml
@@ -63,13 +63,6 @@ source: |
     sender.email.domain.domain in $free_email_providers
   )
   
-  // negate known security awareness training platforms
-  and sender.email.domain.root_domain not in (
-    "knowbe4.com",
-    "proofpoint.com",
-    "cofense.com",
-    "terranovasecurity.com"
-  )
   
   // negate highly trusted sender domains unless they fail DMARC
   and not (


### PR DESCRIPTION
# Description
Detects emails delivering ClickFix social engineering lures — messages that instruct the recipient to copy and paste a command into their terminal or Run dialog, combined with links to suspicious TLDs associated with ClickFix staging infrastructure.

Coverage gap versus existing rules:
- link_credential_phishing_copy_paste_instructions requires all links to be URL shorteners and is self-sender only — ClickFix emails link to staging domains from external senders
- self_sender_french_copypaste_instructions is French-only and self-sender only
- attachment_powershell_content catches PowerShell as an attachment, not body-level copy-paste-to-terminal instructions

Active campaign reference: TELEPUZ (April 2026+), documented by Elastic Security Labs July 16, 2026.

# Associated samples
- https://yanaivanov.com/writing/clickfix_field_note.html
- https://gist.github.com/yana-ivanov/7dcd7bdb7c321f3b42117e6104603ee7