### PR TITLE
Create: brand_impersonation_sofi - SoFi financial brand impersonation detection

### DIFF
--- a/detection-rules/brand_impersonation_sofi.yml
+++ b/detection-rules/brand_impersonation_sofi.yml
@@ -1,0 +1,86 @@
+name: "Brand impersonation: SoFi"
+description: "Detects messages impersonating SoFi by analyzing sender display name, domain, body content including specific address references and phone numbers, while excluding legitimate SoFi communications with proper DMARC authentication."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // standard brand template
+  and (
+    (
+      // disclaimer
+      (
+        regex.icontains(body.current_thread.text,
+                        '\bsofi (?:bank|invest|securities|team|tech|wealth)\b'
+        )
+        and regex.icontains(body.current_thread.text,
+                            '©.20[0-9]{2}.(?:sofi|social finance)'
+        )
+        // phone numbers
+        and regex.icontains(body.current_thread.text,
+                            '\(855\)[\s\-\.]456[\s\-\.]7634',
+                            '\(844\)[\s\-\.]908[\s\-\.]7634'
+        )
+      )
+
+      // address
+      or (
+        regex.icontains(body.current_thread.text, '\bsofi\b')
+        and strings.icontains(body.current_thread.text, "2750 E Cottonwood Pkwy")
+        and strings.icontains(body.current_thread.text,
+                              "Salt Lake City, UT 84121"
+        )
+      )
+
+      // observed cred theft ttp
+      or (
+        regex.icontains(sender.display_name, '\bsofi\b')
+        and (
+          strings.icontains(body.current_thread.text,
+                            "trade confirmation",
+                            "self-directed investing account"
+          )
+        )
+      )
+    )
+
+    // negate legitimate replies
+    and not (
+      (length(headers.references) > 0 or headers.in_reply_to is not null)
+      and (subject.is_forward or subject.is_reply)
+      and length(body.previous_threads) >= 1
+    )
+
+    // topic negations
+    and not any(ml.nlu_classifier(body.current_thread.text).topics,
+                .name in ("Newsletters and Digests")
+    )
+
+    // negate sofi & related domains
+    and not (
+      sender.email.domain.root_domain in (
+        "sofi.com", // parent domain
+        "sofi.org", // observed sender domain
+        "samsung.com", // financial partnership
+        "investordelivery.com" // financials delivery platform
+      )
+      and coalesce(headers.auth_summary.dmarc.pass, false)
+    )
+
+    // negate high trust sender root domains unless they fail authentication
+    and not (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and coalesce(headers.auth_summary.dmarc.pass, false)
+    )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Sender analysis"
+  - "Natural Language Understanding"
+  - "URL analysis"
+id: "a1b2c3d4-e5f6-4a5b-8c9d-0e1f2a3b4c5d"

--- a/detection-rules/brand_impersonation_sofi.yml
+++ b/detection-rules/brand_impersonation_sofi.yml
@@ -6,71 +6,65 @@ source: |
   type.inbound
   // standard brand template
   and (
+    // disclaimer
     (
-      // disclaimer
-      (
-        regex.icontains(body.current_thread.text,
-                        '\bsofi (?:bank|invest|securities|team|tech|wealth)\b'
-        )
-        and regex.icontains(body.current_thread.text,
-                            '©.20[0-9]{2}.(?:sofi|social finance)'
-        )
-        // phone numbers
-        and regex.icontains(body.current_thread.text,
-                            '\(855\)[\s\-\.]456[\s\-\.]7634',
-                            '\(844\)[\s\-\.]908[\s\-\.]7634'
-        )
+      regex.icontains(body.current_thread.text,
+                      '\bsofi (?:bank|invest|securities|team|tech|wealth)\b'
       )
-
-      // address
-      or (
-        regex.icontains(body.current_thread.text, '\bsofi\b')
-        and strings.icontains(body.current_thread.text, "2750 E Cottonwood Pkwy")
-        and strings.icontains(body.current_thread.text,
-                              "Salt Lake City, UT 84121"
-        )
+      and regex.icontains(body.current_thread.text,
+                          '©.20[0-9]{2}.(?:sofi|social finance)'
       )
-
-      // observed cred theft ttp
-      or (
-        regex.icontains(sender.display_name, '\bsofi\b')
-        and (
-          strings.icontains(body.current_thread.text,
+      // phone numbers
+      and regex.icontains(body.current_thread.text,
+                          '\(855\)[\s\-\.]456[\s\-\.]7634',
+                          '\(844\)[\s\-\.]908[\s\-\.]7634'
+      )
+    )
+  
+    // address
+    or (
+      regex.icontains(body.current_thread.text, '\bsofi\b')
+      and strings.icontains(body.current_thread.text, "2750 E Cottonwood Pkwy")
+      and strings.icontains(body.current_thread.text, "Salt Lake City, UT 84121")
+    )
+  
+    // observed cred theft ttp
+    or (
+      regex.icontains(sender.display_name, '\bsofi\b')
+      and strings.icontains(body.current_thread.text,
                             "trade confirmation",
                             "self-directed investing account"
-          )
-        )
       )
     )
-
-    // negate legitimate replies
-    and not (
-      (length(headers.references) > 0 or headers.in_reply_to is not null)
-      and (subject.is_forward or subject.is_reply)
-      and length(body.previous_threads) >= 1
+  )
+  
+  // negate legitimate replies
+  and not (
+    (length(headers.references) > 0 or headers.in_reply_to is not null)
+    and (subject.is_forward or subject.is_reply)
+    and length(body.previous_threads) >= 1
+  )
+  
+  // topic negations
+  and not any(ml.nlu_classifier(body.current_thread.text).topics,
+              .name in ("Newsletters and Digests")
+  )
+  
+  // negate sofi & related domains
+  and not (
+    sender.email.domain.root_domain in (
+      "sofi.com", // parent domain
+      "sofi.org", // observed sender domain
+      "samsung.com", // financial partnership
+      "investordelivery.com" // financials delivery platform
     )
-
-    // topic negations
-    and not any(ml.nlu_classifier(body.current_thread.text).topics,
-                .name in ("Newsletters and Digests")
-    )
-
-    // negate sofi & related domains
-    and not (
-      sender.email.domain.root_domain in (
-        "sofi.com", // parent domain
-        "sofi.org", // observed sender domain
-        "samsung.com", // financial partnership
-        "investordelivery.com" // financials delivery platform
-      )
-      and coalesce(headers.auth_summary.dmarc.pass, false)
-    )
-
-    // negate high trust sender root domains unless they fail authentication
-    and not (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and coalesce(headers.auth_summary.dmarc.pass, false)
-    )
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+  
+  // negate high trust sender root domains unless they fail authentication
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
 attack_types:
   - "Credential Phishing"


### PR DESCRIPTION
## Description

New detection rule targeting SoFi financial services brand impersonation. Catches phishing attempts using official company branding, corporate addresses, phone numbers, and observed credential theft tactics (trade confirmation lures).

**Impact:** 14 net new detections

## Changes

### Disclaimer Detection
- Detects SoFi entity names: Bank, Invest, Securities, Team, Tech, Wealth (word boundaries)
- Requires copyright notice: © 20XX SoFi or Social Finance
- Validates official phone numbers: (855) 456-7634, (844) 908-7634
- All three signals required for match

### Address Detection
- Detects "SoFi" brand name with word boundaries
- Combined with corporate address: 2750 E Cottonwood Pkwy
- Plus location: Salt Lake City, UT 84121
- All three components required

### TTP Detection (Observed Credential Theft)
- Sender display name contains "SoFi" (word boundary)
- Combined with credential theft lures:
  - "trade confirmation"
  - "self-directed investing account"

### FP Reduction
- Excludes legitimate SoFi domains with DMARC pass:
  - sofi.com (parent domain)
  - sofi.org (observed sender domain)
  - samsung.com (financial partnership)
  - investordelivery.com (financials delivery platform)
- Excludes $high_trust_sender_root_domains with DMARC pass
- Excludes legitimate email threads (replies with previous threads)
- Excludes newsletter topics

## Associated samples

- [SoFi trade confirmation phishing (koutom.com)](https://platform.sublime.security/messages/50a76bd40e1a65c9dd70423293328cefc48b62f00af6b2b10f24cfe156854b87?preview_id=019f62e4-5563-7470-988a-9093da346b72)

## Associated hunts

- [Shared samples - L90D - PR logic](https://platform.sublime.security/messages/hunt?huntId=019f733f-98d2-7a53-a94c-2a4588a2e52b) - 33 messages (14 net new)
- [Multi-hunt - L90D - PR logic](https://hunt.limeseed.email/hunts/318c8e7a-4cc8-43e0-a319-dbfb32821ca4)