### PR TITLE
Update: credential_phishing_corporate_services_impersonation_with_suspicious_link - Improve display text regex

### DIFF
--- a/detection-rules/credential_phishing_corporate_services_impersonation_with_suspicious_link.yml
+++ b/detection-rules/credential_phishing_corporate_services_impersonation_with_suspicious_link.yml
@@ -14,7 +14,7 @@ source: |
                           )
                  )
   ) <= 8
-  
+
   // HR language found in subject
   and (
     (
@@ -28,7 +28,7 @@ source: |
                           '20\d{2}\b(?:\w+(?:\s\w+)?|[[:punct:]]+|\s+){0,5}(benefits?(?:$|.?(?:statement|enrollment))|handbook|comp\b|compensation|salary|bonus|\bpay(?:roll)?\b)'
       )
     )
-  
+
     // or HR language found in sender
     or (
       regex.icontains(sender.display_name,
@@ -42,14 +42,14 @@ source: |
       )
       and not strings.icontains(sender.display_name, "get it")
     )
-  
+
     // or assessment report language found in body
     or (
       regex.icontains(body.current_thread.text,
                       '20\d{2}(?:[[:punct:]](?:20)?\d{2})? (?:\w+ )?assessment report'
       )
     )
-  
+
     // or HR department language found in body via NLU
     or any(ml.nlu_classifier(body.current_thread.text).entities,
            .name in ("org", "sender")
@@ -60,18 +60,18 @@ source: |
            )
     )
   )
-  
+
   // suspicious display_text
   and (
     any(body.links,
         regex.icontains(.display_text,
-                        '(?:verify|view|click|download|goto|keep|Vιew|release|access|open|allow|deny|new).{0,10}(?:request|handbook|here|report|attachment|current|download|fax|file|document|message|same|doc|access|polic(?:y|ie))s?'
+                        '(?:access|account|allow|click|deny|download|goto|keep|new|open|release|verify|view|Vιew).{0,10}(?:access|attachment|change|current|doc|document|download|fax|file|handbook|here|message|polic(?:y|ie)|report|request|same)s?'
         )
         and not strings.ilike(.display_text, "*unsub*")
         and not strings.ilike(.display_text, "*privacy?policy*")
         and not strings.ilike(.href_url.url, "*privacy?policy*")
         and not strings.ilike(.display_text, "*REGISTER*")
-  
+
         // from a low reputation link
         and (
           not .href_url.domain.root_domain in $org_domains
@@ -84,7 +84,7 @@ source: |
               or .href_url.domain.domain in $url_shorteners
               or .href_url.domain.domain in $social_landing_hosts
             )
-            or 
+            or
             // or mass mailer link, masks the actual URL
             .href_url.domain.root_domain in (
               "hubspotlinks.com",
@@ -132,7 +132,7 @@ source: |
       )
     )
   )
-  
+
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (


### PR DESCRIPTION
## Description

Updated suspicious link display_text regex pattern to improve detection coverage for corporate services impersonation phishing.

**Impact:** 109 net new detections

## Changes

### Display Text Pattern Update
- Alphabetized action keywords for readability
- Added "account" and "change" to action keywords
- Before: `(?:verify|view|click|download|goto|keep|Vιew|release|access|open|allow|deny|new)`
- After: `(?:access|account|allow|click|deny|download|goto|keep|new|open|release|verify|view|Vιew)`

## Associated samples

- [Sample 1](https://platform.sublime.security/messages/50a9e9ab8034bb66a4ef36cc3e47eda227af61b8571272ff49fdffb0fe0471f1?preview_id=019f67c5-2a33-73a7-b3ea-318f5b0b484d)

## Associated hunts

- [Comparative - Shared L90D](https://platform.sublime.security/messages/hunt?huntId=019f7570-624c-7d7f-bbd6-07fe9acf5b71)
- [PR Logic - Shared L90D](https://platform.sublime.security/messages/hunt?huntId=019f7570-4e9e-7b9b-9652-ceb3a63534f3)
- [Comparative - Multi L30D](https://hunt.limeseed.email/hunts/e201f99b-25f0-4718-af72-682d84034ef8)
- [PR Logic - Multi L30D](https://hunt.limeseed.email/hunts/d9b3fe30-72b8-41ce-8ef3-92bfe98724f8)

## Note

See "Moved to Promotions" action - relevant to these detections.