### PR TITLE
Update abuse_microsoft_subject_stuffing.yml

### DIFF
--- a/detection-rules/abuse_microsoft_subject_stuffing.yml
+++ b/detection-rules/abuse_microsoft_subject_stuffing.yml
@@ -13,7 +13,8 @@ source: |
     // phone number regex
     regex.icontains(strings.replace_confusables(subject.base),
                     '\+?(?:[ilo0-9]{1}.)?\(?[ilo0-9]{3}?\)?.[ilo0-9]{3}.?[ilo0-9]{4}',
-                    '\+?(?:[ilo0-9]{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}[ilo0-9]{3}[\s\.\-⋅]{0,5}[ilo0-9]{4}'
+                    '\+?(?:[ilo0-9]{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}[ilo0-9]{3}[\s\.\-⋅]{0,5}[ilo0-9]{4}',
+                    '\(?[ilo0-9]{3}\)?[^ilo0-9]{0,3}\(?[ilo0-9]{3}\)?.?[ilo0-9]{4}'
     )
     // dollar amounts
     or regex.icontains(subject.base, '(?:USD|\$)\s?\d')


### PR DESCRIPTION
# Description

Adding a regex statement that should tag samples that contain ASCII characters in-between sets of numbers in a phone number

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50a9a59386e81e4d24728534d4ae1121d4fd92734070a65e45519488ea6cba2c?preview_id=019f66c8-0ff8-77ce-865c-2cd83c0cedcb)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019f94ae-7de1-7549-8e62-39553d7fdeaa)