### PR TITLE
Update callback_phishing_microsoft_comment.yml

### DIFF
--- a/detection-rules/callback_phishing_microsoft_comment.yml
+++ b/detection-rules/callback_phishing_microsoft_comment.yml
@@ -37,12 +37,14 @@ source: |
         strings.ilike(body.current_thread.text, '*renew*'),
         strings.ilike(body.current_thread.text, '*refund*')
       )
+      or regex.count(body.current_thread.text, '[^\x00-\x7F]') > 20
     )
     // phone number regex
     and any([body.current_thread.text, subject.subject],
             regex.icontains(.,
                             '\+?([ilo0-9]{1}.)?\(?[ilo0-9]{3}?\)?.[ilo0-9]{3}.?[ilo0-9]{4}',
-                            '\+?([ilo0-9]{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}[ilo0-9]{3}[\s\.\-⋅]{0,5}[ilo0-9]{4}'
+                            '\+?([ilo0-9]{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}[ilo0-9]{3}[\s\.\-⋅]{0,5}[ilo0-9]{4}',
+                            '\(?[ilo0-9]{3}\)?[^ilo0-9]{0,3}\(?[ilo0-9]{3}\)?.?[ilo0-9]{4}'
             )
     )
   )


### PR DESCRIPTION
# Description

Adding `regex.count` logic to tag samples that are heavy with non-ASCII characters and additional phone number regex logic

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50a9a59386e81e4d24728534d4ae1121d4fd92734070a65e45519488ea6cba2c?preview_id=019f66c8-0ff8-77ce-865c-2cd83c0cedcb)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019f94af-c61c-7f28-815d-81f5004d6d83)