### PR TITLE
Update: attachment_encrypted_pdf_cred_theft

### DIFF
--- a/detection-rules/attachment_encrypted_pdf_cred_theft.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft.yml
@@ -26,7 +26,8 @@ source: |
                        'PDF\s*(?:Access|Preview|Unlock|Decrypt|passcode)',
                        '(Access|Preview|Unlock|Decrypt|Pass)\s*(?:word|code)\s*(?:\S+\s+){0,3}PDF\s*is?\s*:',
                        'This\s+(?:file|document|pdf)\s+is\s+(?:password[-\s]?)\s+protected\.\s*The\s+password\s+is\s*:?',
-                       '(?:Access|Preview|Unlock|Decrypt)\s+(?:\S+\s+){0,3}(?:PDF|statement)(?:\S+\s+){0,3}(?:pass(?:word|code)|\s*with\s+\S+)'
+                       '(?:Access|Preview|Unlock|Decrypt)\s+(?:\S+\s+){0,3}(?:PDF|statement)(?:\S+\s+){0,3}(?:pass(?:word|code)|\s*with\s+\S+)',
+                       'Please\s+(?:find|see)\s+(?:the\s+)?attached\s+(?:file|document|PDF)(?:\s+\S+){0,8}\s+(?:file\s+)?(?:passcode|password|access\s+code)\s+is\s*[:;\-]?'
     )
     or (
       (

--- a/detection-rules/attachment_encrypted_pdf_cred_theft.yml
+++ b/detection-rules/attachment_encrypted_pdf_cred_theft.yml
@@ -27,7 +27,7 @@ source: |
                        '(Access|Preview|Unlock|Decrypt|Pass)\s*(?:word|code)\s*(?:\S+\s+){0,3}PDF\s*is?\s*:',
                        'This\s+(?:file|document|pdf)\s+is\s+(?:password[-\s]?)\s+protected\.\s*The\s+password\s+is\s*:?',
                        '(?:Access|Preview|Unlock|Decrypt)\s+(?:\S+\s+){0,3}(?:PDF|statement)(?:\S+\s+){0,3}(?:pass(?:word|code)|\s*with\s+\S+)',
-                       'Please\s+(?:find|see)\s+(?:the\s+)?attached\s+(?:file|document|PDF)(?:\s+\S+){0,8}\s+(?:file\s+)?(?:passcode|password|access\s+code)\s+is\s*[:;\-]?'
+                       'The\s+(?:file|document|pdf|attachment)\s+(?:pass(?:code|word)|access\s*code)\s+is\s*'
     )
     or (
       (
@@ -39,7 +39,8 @@ source: |
                               'PDF\s*(?:Access|Preview|Unlock|Decrypt|passcode)',
                               '(Access|Preview|Unlock|Decrypt|Pass)\s*(?:word|code)\s*(?:\S+\s+){0,3}PDF\s*is?\s*:',
                               'This\s+(?:file|document|pdf)\s+is\s+(?:password[-\s]?)\s+protected\.\s*The\s+password\s+is\s*:?',
-                              '(?:Access|Preview|Unlock|Decrypt)\s+(?:\S+\s+){0,3}(?:PDF|statement)(?:\S+\s+){0,3}(?:pass(?:word|code)|\s*with\s+\S+)'
+                              '(?:Access|Preview|Unlock|Decrypt)\s+(?:\S+\s+){0,3}(?:PDF|statement)(?:\S+\s+){0,3}(?:pass(?:word|code)|\s*with\s+\S+)',
+                              'The\s+(?:file|document|pdf|attachment)\s+(?:pass(?:code|word)|access\s*code)\s+is\s*'
               )
       )
     )


### PR DESCRIPTION
# Description

adding additional regex condition to account for `please see attached` patterns

# Associated samples
- https://platform.sublime.security/messages/50a9b619594b432bcced8a6a5dc98c2f61457a5f90e52f7711767288d328bb16
- https://platform.sublime.security/messages/50ab09d5387c9ee5c6819c81d7f39ec64b6aecbded41be1f02bbc88c97ad34f8

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=019f8ac1-e5f4-7c81-a605-d3033e2ae86b
