### PR TITLE
Create service_abuse_zohodesk_job_scam.yml

### DIFF
--- a/detection-rules/service_abuse_zohodesk_job_scam.yml
+++ b/detection-rules/service_abuse_zohodesk_job_scam.yml
@@ -20,3 +20,4 @@ detection_methods:
   - "Header analysis"
   - "Sender analysis"
   - "Natural Language Understanding"
+id: "af2ab304-7f1e-5284-936d-f04ae91370f7"

--- a/detection-rules/service_abuse_zohodesk_job_scam.yml
+++ b/detection-rules/service_abuse_zohodesk_job_scam.yml
@@ -8,7 +8,7 @@ source: |
   and any(headers.reply_to, .email.domain.root_domain != "zohodesk.com")
   and (
     any(ml.nlu_classifier(body.current_thread.text).intents,
-        .name == "job_scam" and .confidence == "high"
+        .name == "job_scam" and .confidence != "low"
     )
     // nlu fallback where we don't get job scam
     or strings.icontains(body.current_thread.text, "talent acquisition")

--- a/detection-rules/service_abuse_zohodesk_job_scam.yml
+++ b/detection-rules/service_abuse_zohodesk_job_scam.yml
@@ -6,8 +6,12 @@ source: |
   type.inbound
   and sender.email.domain.root_domain == "zohodesk.com"
   and any(headers.reply_to, .email.domain.root_domain != "zohodesk.com")
-  and any(ml.nlu_classifier(body.current_thread.text).intents,
-          .name == "job_scam" and .confidence != "low"
+  and (
+    any(ml.nlu_classifier(body.current_thread.text).intents,
+        .name == "job_scam" and .confidence == "high"
+    )
+    // nlu fallback where we don't get job scam
+    or strings.icontains(body.current_thread.text, "talent acquisition")
   )
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/service_abuse_zohodesk_job_scam.yml
+++ b/detection-rules/service_abuse_zohodesk_job_scam.yml
@@ -1,0 +1,22 @@
+name: "Service abuse: Zohodesk reply-to mismatch with job scam indicators"
+description: "Detects inbound messages sent from Zohodesk infrastructure where the reply-to address points to a domain outside of Zohodesk, combined with natural language signals indicating job scam content. This technique abuses legitimate Zohodesk services to add credibility while redirecting responses to an external actor-controlled address."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and sender.email.domain.root_domain == "zohodesk.com"
+  and any(headers.reply_to, .email.domain.root_domain != "zohodesk.com")
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "job_scam" and .confidence != "low"
+  )
+attack_types:
+  - "BEC/Fraud"
+  - "Spam"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Out of band pivot"
+  - "Spoofing"
+detection_methods:
+  - "Header analysis"
+  - "Sender analysis"
+  - "Natural Language Understanding"


### PR DESCRIPTION
# Description
Detects inbound messages sent from Zohodesk infrastructure where the reply-to address points to a domain outside of Zohodesk, combined with natural language signals indicating job scam content.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b09d8dfbf12bb505e6adfa44f6c8e053e75a80714922258552ae6bd7226ef8?preview_id=019f8b03-002b-7355-afce-747ff919c952)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019f8b1b-97eb-7b4d-b229-e1e0efa7410e)
- [very large multi](https://hunt.limeseed.email/hunts/268b4ce3-14b5-4deb-9f8f-381f68df2f76)


