### PR TITLE
logic fix in attachment_credential_phishing_secure_message

### DIFF
--- a/detection-rules/attachment_credential_phishing_secure_message.yml
+++ b/detection-rules/attachment_credential_phishing_secure_message.yml
@@ -49,8 +49,11 @@ source: |
               .root_domain in ("zixport.com", "zixcorp.com", "zixmail.net")
       )
     )
-    and not all(body.links,
-                .href_url.domain.root_domain in ("mimecast.com", "cisco.com")
+    and (
+      length(body.links) == 0
+      or not all(body.links,
+                 .href_url.domain.root_domain in ("mimecast.com", "cisco.com")
+      )
     )
   )
   and (


### PR DESCRIPTION
# Description
when body.links is an empty, mql returns true so `not all()` evaluates to false.  this means that the rule never fires for messages without body links.

# Associated samples

## Associated hunts


# Screenshot (insights)
