### PR TITLE
Create body_css_clamp_ip_link.yml

### DIFF
--- a/detection-rules/body_css_clamp_ip_link.yml
+++ b/detection-rules/body_css_clamp_ip_link.yml
@@ -5,7 +5,7 @@ severity: "medium"
 source: |
   type.inbound
   and regex.icontains(body.html.raw,
-                      '(?:font-size|line-height):\s*clamp\s*\(\s*(?:-\d+|[0-6](?:px|em|rem|pt)?),'
+                      '(?:font-size|line-height):\s*clamp\s*\(\s*(?:-\d+|0)(?:px|em|rem|pt)?,'
   )
   and any(body.links, .href_url.ip.ip is not null)
 attack_types:

--- a/detection-rules/body_css_clamp_ip_link.yml
+++ b/detection-rules/body_css_clamp_ip_link.yml
@@ -17,3 +17,4 @@ detection_methods:
   - "HTML analysis"
   - "URL analysis"
   - "Content analysis"
+id: "0eaf1193-22e2-5cc2-845c-4f8f26b48ab2"

--- a/detection-rules/body_css_clamp_ip_link.yml
+++ b/detection-rules/body_css_clamp_ip_link.yml
@@ -1,0 +1,19 @@
+name: "Body: CSS clamp() font obfuscation with IP-based links"
+description: "Detects inbound messages using a CSS evasion technique where font-size or line-height properties are set using the clamp() function with very small or negative values — a method used to hide or manipulate rendered text and evade content-based detection. Messages matching this pattern also contain at least one hyperlink resolving directly to an IP address rather than a domain. Observed lures span a wide range of social engineering themes including urgent account alerts, financial offers, storage login codes, service cancellations, and renewal reminders."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and regex.icontains(body.html.raw,
+                      '(?:font-size|line-height):\s*clamp\s*\(\s*(?:-\d+|[0-6](?:px|em|rem|pt)?),'
+  )
+  and any(body.links, .href_url.ip.ip is not null)
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "HTML analysis"
+  - "URL analysis"
+  - "Content analysis"

--- a/detection-rules/body_css_clamp_ip_link.yml
+++ b/detection-rules/body_css_clamp_ip_link.yml
@@ -4,10 +4,21 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and regex.icontains(body.html.raw,
+  and (
+    (
+      regex.icontains(body.html.raw,
                       '(?:font-size|line-height):\s*clamp\s*\(\s*(?:-\d+|0)(?:px|em|rem|pt)?,'
+      )
+      and any(body.links, .href_url.ip.ip is not null)
+    )
+    or any(attachments,
+           (.content_type == "message/rfc822" or .file_extension =~ "eml")
+           and regex.icontains(file.parse_eml(.).body.html.raw,
+                               '(?:font-size|line-height):\s*clamp\s*\(\s*(?:-\d+|0)(?:px|em|rem|pt)?,'
+           )
+           and any(file.parse_eml(.).body.links, .href_url.ip.ip is not null)
+    )
   )
-  and any(body.links, .href_url.ip.ip is not null)
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description

Detects inbound messages using a CSS evasion technique where font-size or line-height properties are set using the clamp() function with very small or negative values — a method used to hide or manipulate rendered text and evade content-based detection. Messages matching this pattern also contain at least one hyperlink resolving directly to an IP address rather than a domain. Observed lures span a wide range of social engineering themes including urgent account alerts, financial offers, storage login codes, service cancellations, and renewal reminders.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50ae91911ae4095bdd55afbea2bf217e2d40e0a1bc6e5888793cdb466d8f6d50?preview_id=019f8bd9-6a85-70a6-969d-b385ed1a5ca5)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=019fa578-90ff-7513-aad8-f1983345ae7a)
- [L30D 50 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/9eec680e-58fd-4992-9524-b77b321f006d)