### PR TITLE
Create phishing_personalized_doc_signing_request.yml

### DIFF
--- a/detection-rules/phishing_personalized_doc_signing_request.yml
+++ b/detection-rules/phishing_personalized_doc_signing_request.yml
@@ -11,19 +11,15 @@ source: |
     strings.icontains(body.current_thread.text, 'docusign', 'document'),
     // greeting uses recipient's email local_part
     any(recipients.to,
-        (
-          (
-            strings.icontains(body.current_thread.text,
-                              strings.concat("You're receiving this on behalf of ",
-                                             .email.domain.sld
-                              )
-            )
-            or strings.icontains(body.current_thread.text,
-                                 strings.concat("Invitation to sign document for ",
-                                                .email.domain.sld
-                                 )
-            )
-          )
+        strings.icontains(body.current_thread.text,
+                          strings.concat("You're receiving this on behalf of ",
+                                         .email.domain.sld
+                          )
+        )
+        or strings.icontains(body.current_thread.text,
+                             strings.concat("Invitation to sign document for ",
+                                            .email.domain.sld
+                             )
         )
     ),
     // templated html artifact

--- a/detection-rules/phishing_personalized_doc_signing_request.yml
+++ b/detection-rules/phishing_personalized_doc_signing_request.yml
@@ -1,0 +1,43 @@
+name: "Credential phishing: Personalized document signing request"
+description: "Detects messages with a single recipient and personalized document signing requests. The rule identifies messages referencing DocuSign or document-related language, combined with domain-specific greeting patterns or known malicious HTML artifacts associated with fraudulent signing invitations from entities such as STAR Capital or Agito AS."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // personalized document form ensures recipients should always be 1
+  and length(recipients.to) == 1
+  and 2 of (
+    // document/sign language
+    strings.icontains(body.current_thread.text, 'docusign', 'document'),
+    // greeting uses recipient's email local_part
+    any(recipients.to,
+        (
+          (
+            strings.icontains(body.current_thread.text,
+                              strings.concat("You're receiving this on behalf of ",
+                                             .email.domain.sld
+                              )
+            )
+            or strings.icontains(body.current_thread.text,
+                                 strings.concat("Invitation to sign document for ",
+                                                .email.domain.sld
+                                 )
+            )
+          )
+        )
+    ),
+    // templated html artifact
+    strings.contains(body.html.raw,
+                     'STAR Capital invites you to exchange',
+                     'Reminder: Invitation to sign document for Agito AS'
+    )
+  )
+attack_types:
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "HTML analysis"

--- a/detection-rules/phishing_personalized_doc_signing_request.yml
+++ b/detection-rules/phishing_personalized_doc_signing_request.yml
@@ -41,3 +41,4 @@ tactics_and_techniques:
 detection_methods:
   - "Content analysis"
   - "HTML analysis"
+id: "367978c7-f850-571f-8b8f-7076ff6a9aca"


### PR DESCRIPTION
# Description

Detects messages with a single recipient and personalized document signing requests. The rule identifies messages referencing DocuSign or document-related language, combined with domain-specific greeting patterns or known malicious HTML artifacts associated with fraudulent signing invitations from entities such as STAR Capital or Agito AS.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b367274f6345a9e0270159934f6b85fc10b00e3bf652be134529bf2fbc4436?preview_id=019f9a65-2e41-76ef-a0bd-257951daba88)
- [Sample 2](https://platform.sublime.security/messages/50b1a15ed1bbf6cdd4ffaeb83bc519b501ae7a75039be2bdcd623081c29b1441?preview_id=019f99e5-100c-7adc-9797-20caaa162a9f)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019f9a7d-3cca-751a-9c20-7ecafc6fa64d)
