### PR TITLE
Create service_abuse_postman_cred_theft.yml

### DIFF
--- a/detection-rules/service_abuse_postman_cred_theft.yml
+++ b/detection-rules/service_abuse_postman_cred_theft.yml
@@ -14,7 +14,6 @@ source: |
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:
-  - "Impersonation: Brand"
   - "Social engineering"
   - "Out of band pivot"
 detection_methods:

--- a/detection-rules/service_abuse_postman_cred_theft.yml
+++ b/detection-rules/service_abuse_postman_cred_theft.yml
@@ -21,3 +21,4 @@ detection_methods:
   - "Sender analysis"
   - "Header analysis"
   - "Natural Language Understanding"
+id: "d7177124-8e9f-5916-a3c5-45c22b34ce4f"

--- a/detection-rules/service_abuse_postman_cred_theft.yml
+++ b/detection-rules/service_abuse_postman_cred_theft.yml
@@ -1,0 +1,23 @@
+name: "Service abuse: Postman reply-to mismatch with credential theft intent"
+description: "Detects inbound messages sent from Postman.io where the reply-to address belongs to a different domain than the sender, combined with high or medium confidence credential theft intent detected in the message body. This technique leverages a legitimate service to deliver messages while redirecting replies to an attacker-controlled address."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and sender.email.domain.root_domain == "postman.io"
+  and any(headers.reply_to,
+          .email.domain.root_domain != sender.email.domain.root_domain
+  )
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "cred_theft" and .confidence != "low"
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+  - "Out of band pivot"
+detection_methods:
+  - "Sender analysis"
+  - "Header analysis"
+  - "Natural Language Understanding"


### PR DESCRIPTION
# Description
Detects inbound messages sent from Postman.io where the reply-to address belongs to a different domain than the sender, combined with high or medium confidence credential theft intent detected in the message body.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b2f17283ab48938e8f3cb7a3bcc5761a21ddbe5399bbea2b07e523474ce90c?preview_id=019fa3d9-e69e-7caa-816b-239cf4a55072)


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019fa439-262c-75c6-87c9-6741c79e1098)


