### PR TITLE
Enhance brand impersonation detection for Punchbowl

### DIFF
--- a/detection-rules/brand_impersonation_punchbowl.yml
+++ b/detection-rules/brand_impersonation_punchbowl.yml
@@ -12,7 +12,10 @@ source: |
     // image sourced from punchbowl
     or any(html.xpath(body.html, '//img/@src').nodes,
            strings.parse_url(.raw).domain.domain == "static.punchbowl.com"
-           and strings.icontains(strings.parse_url(.raw).path, '/invitation')
+           and strings.icontains(strings.parse_url(.raw).path,
+                                 '/invitation',
+                                 '/invite'
+           )
     )
   )
   // Phrasing is typically "You're invited"
@@ -23,12 +26,15 @@ source: |
     // using the beta feature in custom rules is not suggested until it has been formally released
     //
     or (
-      strings.icontains(beta.ocr(file.message_screenshot()).text,
-                        "you're invited",
-                        "open me",
-                        "manage invitation"
+      regex.icontains(beta.ocr(file.message_screenshot()).text,
+                      "you're invited",
+                      "open me",
+                      "manage invitation"
       )
-      and regex.icontains(body.current_thread.text, 'don.t want .{1,40}\?')
+      and regex.icontains(body.current_thread.text,
+                          'don.t want .{1,40}\?',
+                          '(?:view|open|click|access).{1,10}(?:computer|(?:lap|desk)top)' // instruction to open link on a computer
+      )
     )
     or any([
              html.xpath(body.html,


### PR DESCRIPTION
# Description

broadening scope of check for embedded punchbowl assets to include `/invite` (should cover presence of "open invite" buttons and similar)

adding regex condition to flag instructions to access the link from a computer

# Associated samples
- https://platform.sublime.security/messages/509b77af8f5ff5eaef9bb085413afae5ce6243f6babf833b1b5229bdb0a7afb7
- https://platform.sublime.security/messages/50b15714cbf48f3bdcf3de7ca9603701c5540f4f566a74cb4b659a2455352c65

## Associated hunts
- https://platform.sublime.security/hunts/019fa483-19d2-7461-87fa-2c3f0cbed72d
- https://hunt.limeseed.email/hunts/52416c11-0683-42ef-98d7-aa778003b883