### PR TITLE
Update: impersonation_microsoft.yml - FP - Sender negations

### DIFF
--- a/detection-rules/impersonation_microsoft.yml
+++ b/detection-rules/impersonation_microsoft.yml
@@ -118,9 +118,10 @@ source: |
             )
             or .href_url.domain.tld == "microsoft"
         )
+        and headers.auth_summary.dmarc.pass
       )
   
-      // microsoft b2b applications invitations
+      // microsoft b2b applications invitations - no auth checks
       or (
         sender.email.local_part == "invites"
         and sender.email.domain.root_domain == "onmicrosoft.com"
@@ -129,7 +130,6 @@ source: |
         and strings.icontains(headers.message_id, "pepf")
       )
     )
-    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
   
   // negate highly trusted sender domains unless they fail DMARC authentication

--- a/detection-rules/impersonation_microsoft.yml
+++ b/detection-rules/impersonation_microsoft.yml
@@ -125,7 +125,6 @@ source: |
       or (
         sender.email.local_part == "invites"
         and sender.email.domain.root_domain == "onmicrosoft.com"
-        and strings.icontains(sender.display_name, "microsoft invitations")
         // infra validated message id
         and strings.icontains(headers.message_id, "pepf")
       )

--- a/detection-rules/impersonation_microsoft.yml
+++ b/detection-rules/impersonation_microsoft.yml
@@ -119,7 +119,7 @@ source: |
             or .href_url.domain.tld == "microsoft"
         )
       )
-
+  
       // microsoft b2b applications invitations
       or (
         sender.email.local_part == "invites"
@@ -129,7 +129,7 @@ source: |
         and strings.icontains(headers.message_id, "pepf")
       )
     )
-    and headers.auth_summary.dmarc.pass
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
   
   // negate highly trusted sender domains unless they fail DMARC authentication

--- a/detection-rules/impersonation_microsoft.yml
+++ b/detection-rules/impersonation_microsoft.yml
@@ -108,13 +108,26 @@ source: |
   // negate other legitimate MS notifications
   and not (
     length(body.links) > 0
-    and all(body.links,
+    and (
+      (
+        all(body.links,
             .href_url.domain.root_domain in (
               "aka.ms",
               "microsoftonline.com",
               "microsoft.com"
             )
             or .href_url.domain.tld == "microsoft"
+        )
+      )
+
+      // microsoft b2b applications invitations
+      or (
+        sender.email.local_part == "invites"
+        and sender.email.domain.root_domain == "onmicrosoft.com"
+        and strings.icontains(sender.display_name, "microsoft invitations")
+        // infra validated message id
+        and strings.icontains(headers.message_id, "pepf")
+      )
     )
     and headers.auth_summary.dmarc.pass
   )


### PR DESCRIPTION
# Description
Adds exclusion for legitimate Microsoft B2B application invitations that were previously flagged as brand impersonation. The new logic validates messages using sender local part, domain pattern, display name, and infrastructure-validated message ID to eliminate false positives.

**Net-new coverage:** N/A (FP reduction - 135 messages excluded over 180 days)

# Associated samples

- [Sample 1](https://platform.sublimesecurity.com/messages/50a2db381eddefa8f5ca99a62ac6f9d740efb451d3f2ac458a3add6f25c4771b)

## Associated hunts

- [Hunt 1 (Shared samples) - L180D - Exclusive](https://platform.sublime.security/messages/hunt?huntId=019fa558-6f07-7337-b5c8-38905a4d279b)
- [Hunt 2 (Shared samples) - L180D - Exclusive without rule logic](https://platform.sublime.security/messages/hunt?huntId=019fa55c-0fca-79e5-bda0-2ba8317b5253)
- [Hunt 3 (Multi-hunt) - L30D - Exclusive](https://hunt.limeseed.email/hunts/61dc323a-a239-4015-bd00-2ac712f384c3)