### PR TITLE
Update: link_romance_suspicious.yml

### DIFF
--- a/detection-rules/link_romance_suspicious.yml
+++ b/detection-rules/link_romance_suspicious.yml
@@ -12,12 +12,8 @@ source: |
     )
     // form submissions can sometimes throw NLU off
     or (
-      strings.icontains(subject.subject,
-                        "form",
-                        "submission",
-                        "submit",
-                        "new message",
-                        "cisco press"
+      regex.icontains(subject.subject,
+                      '(?:\bform\b|submi(?:t|ssion)|new message|cisco press)'
       )
       and headers.mailer is not null
       // common automated form submission systems
@@ -27,7 +23,7 @@ source: |
       // now check for explicit language in the URL path
       and any(body.links,
               regex.icontains(.href_url.path,
-                              '(?:sex|horny|cock|fuck|\bass\b|pussy|dick|tits|cum\b|girlfriend|boyfriend|naked|porn|video|webcam|masturbate|orgasm|breasts|penis|vagina|strip|suck|blowjob|hardcore|nudes?|sexting|cheating|affair|erotic|\blust\b|desire|intimate|explicit|fetish|kinky|seduce|adult\s*(?:\w+\s+){0,2}\s*community|cam shows|local (?:girls?|women|single)|hook.?up|bed partner)'
+                              '(?:sex|horny|cock|fuck|\bass\b|pussy|dick|tits|cum\b|girlfriend|boyfriend|naked|porn|webcam|masturbate|orgasm|breasts|penis|vagina|suck|blowjob|hardcore|nudes?|sexting|erotic|\blust\b|fetish|kinky|seduce|adult\s*(?:\w+\s+){0,2}\s*community|cam shows|local (?:girls?|women|single)|hook.?up|bed partner)'
               )
       )
     )

--- a/detection-rules/link_romance_suspicious.yml
+++ b/detection-rules/link_romance_suspicious.yml
@@ -42,6 +42,7 @@ source: |
     )
     // allow for links that match the sender's domain, if they lead to form submission results
     or (
+      // first check that there actually is a matching link, to avoid creating vacuous truth
       any(body.links,
           .href_url.domain.root_domain == sender.email.domain.root_domain
       )

--- a/detection-rules/link_romance_suspicious.yml
+++ b/detection-rules/link_romance_suspicious.yml
@@ -20,6 +20,8 @@ source: |
               regex.icontains(.href_url.path,
                               '(?:sex|horny|cock|fuck|\bass\b|pussy|dick|tits|cum\b|girlfriend|boyfriend|naked|porn|webcam|masturbate|orgasm|breasts|penis|vagina|suck|blowjob|hardcore|nudes?|sexting|erotic|\blust\b|fetish|kinky|seduce|adult\s*(?:\w+\s+){0,2}\s*community|cam shows|local (?:girls?|women|single)|hook.?up|bed partner)'
               )
+              // negate JWT headers
+              and not regex.contains(.href_url.path, 'eyJ[A-Za-z0-9_-]{10,}')
       )
     )
   )

--- a/detection-rules/link_romance_suspicious.yml
+++ b/detection-rules/link_romance_suspicious.yml
@@ -43,7 +43,7 @@ source: |
   ) < 3
   and (
     all(body.links,
-    .parser == "hyperlink"
+        .parser == "hyperlink"
         and .href_url.domain.root_domain != sender.email.domain.root_domain
     )
     // allow for a single plain link that matches the sender's domain

--- a/detection-rules/link_romance_suspicious.yml
+++ b/detection-rules/link_romance_suspicious.yml
@@ -15,11 +15,6 @@ source: |
       regex.icontains(subject.subject,
                       '(?:\bform\b|submi(?:t|ssion)|new message|cisco press)'
       )
-      and headers.mailer is not null
-      // common automated form submission systems
-      and regex.icontains(headers.mailer,
-                          'phpmailer|wpmail|wp mail smtp|easywpsmtp|post.smtp|drupal|typo3|codeigniter|nette|activecampaign|symfony|laravel|zend|cakephp|yii|enginemailer|msgsend|sailthru|sympa'
-      )
       // check for explicit language in the URL path
       and any(body.links,
               regex.icontains(.href_url.path,
@@ -43,15 +38,16 @@ source: |
   ) < 3
   and (
     all(body.links,
-        .parser == "hyperlink"
-        and .href_url.domain.root_domain != sender.email.domain.root_domain
+        .href_url.domain.root_domain != sender.email.domain.root_domain
     )
-    // allow for a single plain link that matches the sender's domain
-    or length(filter(body.links,
-                     .parser == "plain"
-                     and .href_url.domain.root_domain == sender.email.domain.root_domain
-              )
-    ) == 1
+    // allow for links that match the sender's domain, if they lead to form submission results
+    or (
+      all(filter(body.links,
+                 .href_url.domain.root_domain == sender.email.domain.root_domain
+          ),
+          strings.icontains(.href_url.path, "submission", "submit")
+      )
+    )
   )
 attack_types:
   - "Spam"

--- a/detection-rules/link_romance_suspicious.yml
+++ b/detection-rules/link_romance_suspicious.yml
@@ -42,10 +42,13 @@ source: |
     )
     // allow for links that match the sender's domain, if they lead to form submission results
     or (
-      all(filter(body.links,
-                 .href_url.domain.root_domain == sender.email.domain.root_domain
-          ),
-          strings.icontains(.href_url.path, "submission", "submit")
+      any(body.links,
+          .href_url.domain.root_domain == sender.email.domain.root_domain
+      )
+      and all(filter(body.links,
+                     .href_url.domain.root_domain == sender.email.domain.root_domain
+              ),
+              strings.icontains(.href_url.path, "submission", "submit")
       )
     )
   )

--- a/detection-rules/link_romance_suspicious.yml
+++ b/detection-rules/link_romance_suspicious.yml
@@ -20,7 +20,7 @@ source: |
       and regex.icontains(headers.mailer,
                           'phpmailer|wpmail|wp mail smtp|easywpsmtp|post.smtp|drupal|typo3|codeigniter|nette|activecampaign|symfony|laravel|zend|cakephp|yii|enginemailer|msgsend|sailthru|sympa'
       )
-      // now check for explicit language in the URL path
+      // check for explicit language in the URL path
       and any(body.links,
               regex.icontains(.href_url.path,
                               '(?:sex|horny|cock|fuck|\bass\b|pussy|dick|tits|cum\b|girlfriend|boyfriend|naked|porn|webcam|masturbate|orgasm|breasts|penis|vagina|suck|blowjob|hardcore|nudes?|sexting|erotic|\blust\b|fetish|kinky|seduce|adult\s*(?:\w+\s+){0,2}\s*community|cam shows|local (?:girls?|women|single)|hook.?up|bed partner)'
@@ -42,19 +42,17 @@ source: |
                  )
   ) < 3
   and (
-    all(filter(body.links, .parser != "plain"),
-        .href_url.domain.root_domain != sender.email.domain.root_domain
+    all(body.links,
+    .parser == "hyperlink"
+        and .href_url.domain.root_domain != sender.email.domain.root_domain
     )
-    // negate if every clickable link is authenticated Klaviyo tracking
-    and not (
-      all(filter(body.links, .parser != "plain"),
-          .href_url.domain.root_domain in ("klclick.com", "klclick1.com")
-      )
-      // ensure message passes auth
-      and coalesce(headers.auth_summary.dmarc.pass, false)
-    )
+    // allow for a single plain link that matches the sender's domain
+    or length(filter(body.links,
+                     .parser == "plain"
+                     and .href_url.domain.root_domain == sender.email.domain.root_domain
+              )
+    ) == 1
   )
-
 attack_types:
   - "Spam"
 tactics_and_techniques:

--- a/detection-rules/link_romance_suspicious.yml
+++ b/detection-rules/link_romance_suspicious.yml
@@ -5,22 +5,47 @@ severity: "low"
 source: |
   type.inbound
   and length(body.previous_threads) == 0
-  and any(ml.nlu_classifier(body.current_thread.text).topics,
-          .name in ("Romance", "Sexually Explicit Messages")
-          and .confidence == "high"
+  and (
+    any(ml.nlu_classifier(body.current_thread.text).topics,
+        .name in ("Romance", "Sexually Explicit Messages")
+        and .confidence == "high"
+    )
+    // form submissions can sometimes throw NLU off
+    or (
+      strings.icontains(subject.subject,
+                        "form",
+                        "submission",
+                        "submit",
+                        "new message",
+                        "cisco press"
+      )
+      and headers.mailer is not null
+      // common automated form submission systems
+      and regex.icontains(headers.mailer,
+                          'phpmailer|wpmail|wp mail smtp|easywpsmtp|post.smtp|drupal|typo3|codeigniter|nette|activecampaign|symfony|laravel|zend|cakephp|yii|enginemailer|msgsend|sailthru|sympa'
+      )
+      // now check for explicit language in the URL path
+      and any(body.links,
+              regex.icontains(.href_url.path,
+                              '(?:sex|horny|cock|fuck|\bass\b|pussy|dick|tits|cum\b|girlfriend|boyfriend|naked|porn|video|webcam|masturbate|orgasm|breasts|penis|vagina|strip|suck|blowjob|hardcore|nudes?|sexting|cheating|affair|erotic|\blust\b|desire|intimate|explicit|fetish|kinky|seduce|adult\s*(?:\w+\s+){0,2}\s*community|cam shows|local (?:girls?|women|single)|hook.?up|bed partner)'
+              )
+      )
+    )
   )
   and 1 of (
     any(body.links, network.whois(.href_url.domain).days_old < 30),
     any(body.links, .href_url.domain.root_domain in $url_shorteners),
     any(body.links, .href_url.domain.domain in $free_subdomain_hosts),
     any(body.links, .href_url.domain.tld in ('ru', 'app', 'digital', 'click')),
-    any(headers.reply_to, network.whois(.email.domain).days_old < 30)
+    any(headers.reply_to, network.whois(.email.domain).days_old < 30),
+    // link leads to telegram hosting infra
+    any(body.links, .href_url.domain.root_domain in ("telegra.ph", "graph.org"))
   )
   and 0 < length(distinct(body.links,
                           .href_url.domain.root_domain not in ("aka.ms")
                  )
   ) < 3
-  and all(body.links,
+  and all(filter(body.links, .parser != "plain"),
           .href_url.domain.root_domain != sender.email.domain.root_domain
   )
 

--- a/detection-rules/link_romance_suspicious.yml
+++ b/detection-rules/link_romance_suspicious.yml
@@ -41,8 +41,18 @@ source: |
                           .href_url.domain.root_domain not in ("aka.ms")
                  )
   ) < 3
-  and all(filter(body.links, .parser != "plain"),
-          .href_url.domain.root_domain != sender.email.domain.root_domain
+  and (
+    all(filter(body.links, .parser != "plain"),
+        .href_url.domain.root_domain != sender.email.domain.root_domain
+    )
+    // negate if every clickable link is authenticated Klaviyo tracking
+    and not (
+      all(filter(body.links, .parser != "plain"),
+          .href_url.domain.root_domain in ("klclick.com", "klclick1.com")
+      )
+      // ensure message passes auth
+      and coalesce(headers.auth_summary.dmarc.pass, false)
+    )
   )
 
 attack_types:

--- a/detection-rules/link_romance_suspicious.yml
+++ b/detection-rules/link_romance_suspicious.yml
@@ -20,7 +20,7 @@ source: |
               regex.icontains(.href_url.path,
                               '(?:sex|horny|cock|fuck|\bass\b|pussy|dick|tits|cum\b|girlfriend|boyfriend|naked|porn|webcam|masturbate|orgasm|breasts|penis|vagina|suck|blowjob|hardcore|nudes?|sexting|erotic|\blust\b|fetish|kinky|seduce|adult\s*(?:\w+\s+){0,2}\s*community|cam shows|local (?:girls?|women|single)|hook.?up|bed partner)'
               )
-              // negate JWT headers
+              // negate base64-encoded JWT object headers
               and not regex.contains(.href_url.path, 'eyJ[A-Za-z0-9_-]{10,}')
       )
     )


### PR DESCRIPTION
# Description

adding logic to bypass NLU if the message is an automated form submission and has suspicious link terminology

adding telegraph file hosts (`telegra.ph`, `graph.org`) to suspicious link destination list

filtering condition that requires all links to not lead to the sender's domain to allow form submission results

# Associated samples
- https://platform.sublime.security/messages/50b57deaf9b41f5c9f19fb01bd3140fdc2858caced3d34523af49263d4a16530
- https://platform.sublime.security/messages/50987045d6507bbda986cc8104046cb917a83faf951c00269a9677ece58a34e1
- https://platform.sublime.security/messages/50afbe46c7efb110dede62bcb6dd783697b76645866f4b9e283b1f4169bd8d4c