### PR TITLE
Update credential_phishing_esign_document_notification.yml

### DIFF
--- a/detection-rules/credential_phishing_esign_document_notification.yml
+++ b/detection-rules/credential_phishing_esign_document_notification.yml
@@ -167,7 +167,8 @@ source: |
                         'REVIEW.*DOCUMENT',
                         'Open Document',
                         'Sign Now',
-                        'complete tasks?'
+                        'complete tasks?',
+                        'go to documents'
         )
         // check that the display_text is all lowercase
         or (

--- a/detection-rules/credential_phishing_esign_document_notification.yml
+++ b/detection-rules/credential_phishing_esign_document_notification.yml
@@ -167,8 +167,7 @@ source: |
                         'REVIEW.*DOCUMENT',
                         'Open Document',
                         'Sign Now',
-                        'complete tasks?',
-                        'go to documents'
+                        'complete tasks?'
         )
         // check that the display_text is all lowercase
         or (
@@ -190,6 +189,14 @@ source: |
   
         // the display text is _exactly_
         or .display_text in~ ("Open")
+  
+        // the display text is "go to documents" with the local part of recipient email in body
+        or (
+          strings.icontains(.display_text, "go to documents")
+          and any(recipients.to,
+                  strings.contains(body.current_thread.text, .email.local_part)
+          )
+        )
   
         // URL fragment containing recipient's address
         or .href_url.fragment in map(recipients.to, .email.email)


### PR DESCRIPTION
# Description

Adding `go to documents` as a string in `.display_text` logic

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b688e8b170ce664c6845e419be135ac7c0c439d5441d4f5c8026f3ea2c52f1?preview_id=019fa95f-c1ec-7e66-a25b-8c318b354dff)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019fc77b-a07c-7469-832b-25a0d4d92aed)