### PR TITLE
Update impersonation_microsoft.yml

### DIFF
--- a/detection-rules/impersonation_microsoft.yml
+++ b/detection-rules/impersonation_microsoft.yml
@@ -121,12 +121,9 @@ source: |
   )
   
   // negate highly trusted sender domains unless they fail DMARC authentication
-  and (
-    (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and not coalesce(headers.auth_summary.dmarc.pass, false)
-    )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
   // not a newsletter or advertisement
   and not (

--- a/detection-rules/impersonation_microsoft.yml
+++ b/detection-rules/impersonation_microsoft.yml
@@ -27,7 +27,8 @@ source: |
       and strings.ilike(body.current_thread.text, "*microsoft*")
     )
     or regex.icontains(body.current_thread.text,
-                       ".*reach you.{0,20}Microsoft Teams"
+                       ".*reach you.{0,20}Microsoft Teams",
+                       "microsoft account\n2fa"
     )
     or strings.icontains(body.current_thread.text, "microsoft account team")
     or strings.ilike(sender.display_name, '*new activity in Teams*')
@@ -123,7 +124,7 @@ source: |
   and (
     (
       sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and not headers.auth_summary.dmarc.pass
+      and not coalesce(headers.auth_summary.dmarc.pass, false)
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )


### PR DESCRIPTION
# Description

Updating regex logic to tag samples with `microsoft account\n2fa` and also added `coalesce` to high trust root domain, authentication, logic

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b5a45c931e52a67adedb89a45be58601c3c8ac5deb2d3de6859c2df42ee456?preview_id=019faa5b-edee-7ace-91f0-2a3fcc86dd55)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019fc94f-c5ce-72d2-8a5f-1ab066787d7e)