### PR TITLE
Update spam_onmicrosoft.yml - Sender negation

### DIFF
--- a/detection-rules/spam_onmicrosoft.yml
+++ b/detection-rules/spam_onmicrosoft.yml
@@ -71,7 +71,6 @@ source: |
       // infra validated message id
       and strings.icontains(headers.message_id, "pepf")
     )
-    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
   
   // construct the proper sender domain and check against known recipients

--- a/detection-rules/spam_onmicrosoft.yml
+++ b/detection-rules/spam_onmicrosoft.yml
@@ -71,7 +71,7 @@ source: |
       // infra validated message id
       and strings.icontains(headers.message_id, "pepf")
     )
-    and headers.auth_summary.dmarc.pass
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
   
   // construct the proper sender domain and check against known recipients

--- a/detection-rules/spam_onmicrosoft.yml
+++ b/detection-rules/spam_onmicrosoft.yml
@@ -67,7 +67,6 @@ source: |
     and (
       sender.email.local_part == "invites"
       and sender.email.domain.root_domain == "onmicrosoft.com"
-      and strings.icontains(sender.display_name, "microsoft invitations")
       // infra validated message id
       and strings.icontains(headers.message_id, "pepf")
     )

--- a/detection-rules/spam_onmicrosoft.yml
+++ b/detection-rules/spam_onmicrosoft.yml
@@ -13,6 +13,7 @@ source: |
   )
   and length(recipients.to) < 2
   and length(body.links) > 0
+  
   // bounce-back negations
   and not strings.like(sender.email.local_part,
                        "*postmaster*",
@@ -27,6 +28,7 @@ source: |
               )
               or (.content_type == "text/plain" and .file_extension == "ics")
   )
+  
   // negating legit replies
   and not (
     (
@@ -40,7 +42,8 @@ source: |
     )
     and (length(headers.references) > 0 and headers.in_reply_to is not null)
   )
-  // negating auto-replies
+  
+  // negate auto-replies
   and not (
     any(headers.hops,
         any(.fields, .name =~ "auto-submitted" and .value =~ "auto-generated")
@@ -50,17 +53,34 @@ source: |
         )
     )
   )
+  
   // Microsoft has some legit onmicrosoft domains...
   and not (
     sender.email.domain.domain == "microsoft.onmicrosoft.com"
     and headers.auth_summary.spf.pass
     and all(body.links, .href_url.domain.root_domain == "microsoft.com")
   )
+  
+  // negate legitimate microsoft b2b applications invitations
+  and not (
+    length(body.links) > 0
+    and (
+      sender.email.local_part == "invites"
+      and sender.email.domain.root_domain == "onmicrosoft.com"
+      and strings.icontains(sender.display_name, "microsoft invitations")
+      // infra validated message id
+      and strings.icontains(headers.message_id, "pepf")
+    )
+    and headers.auth_summary.dmarc.pass
+  )
+  
   // construct the proper sender domain and check against known recipients
   and not strings.concat(sender.email.domain.subdomain,
                          ".",
                          sender.email.domain.tld
   ) in $recipient_domains
+  
+  // sender profiles
   and (
     not profile.by_sender().solicited
     or (
@@ -68,7 +88,13 @@ source: |
       and not profile.by_sender().any_messages_benign
     )
   )
-  and not sender.email.domain.domain in $org_domains
+  
+  // negate org domains
+  and not (
+    sender.email.domain.domain in $org_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+
 tags:
  - "Attack surface reduction"
 attack_types:


### PR DESCRIPTION
# Description

- Adding sender negation for legit MSFT b2b invites.
- Adding auth to org_domains
- General readability cleanup


# Associated samples

[- Sample 1](https://platform.sublime.security/messages/50a2db381eddefa8f5ca99a62ac6f9d740efb451d3f2ac458a3add6f25c4771b?preview_id=019f65e3-ab29-78ad-9f67-b9ff395a8854)

## Associated hunts

[- Hunt 1 (Shared samps) - Exclusive - L180D](https://platform.sublime.security/messages/hunt?huntId=019fafb4-b183-7be6-8d2b-e0787f255135)
[- Hunt 2 (Multi) - Exclusive - L30D](https://hunt.limeseed.email/hunts/b6ee503e-796f-4274-8181-e5147b010554)
[- Hunt 3 (Shared samps) - PR Logic - L30D](https://platform.sublime.security/messages/hunt?huntId=019fafb5-d485-7efa-8124-d5b715658441)
[- Hunt 4 (Multi) - PR Logic - L30D](https://hunt.limeseed.email/hunts/437c9f93-2e96-4e3e-94f4-be1e7fe20fa6)