### PR TITLE
Update impersonation_microsoft_credential_theft.yml - Sender Negations

### DIFF
--- a/detection-rules/impersonation_microsoft_credential_theft.yml
+++ b/detection-rules/impersonation_microsoft_credential_theft.yml
@@ -86,6 +86,21 @@ source: |
       )
     )
   )
+  
+  // negate legitimate microsoft b2b applications invitations
+  and not (
+    length(body.links) > 0
+    and (
+      sender.email.local_part == "invites"
+      and sender.email.domain.root_domain == "onmicrosoft.com"
+      and strings.icontains(sender.display_name, "microsoft invitations")
+      // infra validated message id
+      and strings.icontains(headers.message_id, "pepf")
+    )
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+  
+  // sender profiles
   and (
     not profile.by_sender().solicited
     or (
@@ -132,7 +147,7 @@ source: |
             )
     )
   )
-
+  
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (

--- a/detection-rules/impersonation_microsoft_credential_theft.yml
+++ b/detection-rules/impersonation_microsoft_credential_theft.yml
@@ -52,12 +52,14 @@ source: |
     and headers.return_path.email == "noreply@planner.office365.com"
     and headers.auth_summary.dmarc.details.from.root_domain == "office365.com"
   )
+  
   // Microsoft has some legit onmicrosoft domains...
   and not (
     sender.email.domain.domain == "microsoft.onmicrosoft.com"
     and headers.auth_summary.spf.pass
     and all(body.links, .href_url.domain.root_domain == "microsoft.com")
   )
+  
   // message is not from sharepoint actual (additional check in case DMARC check above fails to bail out)
   and not (
     (
@@ -97,7 +99,6 @@ source: |
       // infra validated message id
       and strings.icontains(headers.message_id, "pepf")
     )
-    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
   
   // sender profiles

--- a/detection-rules/impersonation_microsoft_credential_theft.yml
+++ b/detection-rules/impersonation_microsoft_credential_theft.yml
@@ -95,7 +95,6 @@ source: |
     and (
       sender.email.local_part == "invites"
       and sender.email.domain.root_domain == "onmicrosoft.com"
-      and strings.icontains(sender.display_name, "microsoft invitations")
       // infra validated message id
       and strings.icontains(headers.message_id, "pepf")
     )


### PR DESCRIPTION
# Description

- Adding sender negation for legitimate B2B invites

# Associated samples

[- Sample 1](https://platform.sublime.security/messages/50a2db381eddefa8f5ca99a62ac6f9d740efb451d3f2ac458a3add6f25c4771b?preview_id=019f65e3-ab29-78ad-9f67-b9ff395a8854)

## Associated hunts

[- Hunt 1 (Shared samps) - Exclusive - L180D](https://platform.sublime.security/messages/hunt?huntId=019fafdd-5ee8-7659-a023-8b09f47849c0)
[- Hunt 2 (Multi) - Exclusive - L30D](https://hunt.limeseed.email/hunts/46dda704-08ef-4aa1-8201-8def05b20bb0)
[- Hunt 3 (Shared samps) - PR Logic - L30D](https://platform.sublime.security/messages/hunt?huntId=019fafdd-2672-7317-854e-902c991e36ef)
[- Hunt 4 (Multi) - PR Logic - L30D](https://hunt.limeseed.email/hunts/29522adf-94f6-48eb-9e75-2deb85876d51)