### PR TITLE
Update impersonation_sharepoint_body_credential_theft.yml

### DIFF
--- a/detection-rules/impersonation_sharepoint_body_credential_theft.yml
+++ b/detection-rules/impersonation_sharepoint_body_credential_theft.yml
@@ -131,7 +131,7 @@ source: |
                    strings.icontains(subject.subject, .display_text)
                    or .display_text == "Open"
             ),
-            .href_url.domain.root_domain in ("sharepoint.com", "1drv.ms"")
+            .href_url.domain.root_domain in ("sharepoint.com", "1drv.ms")
             or (
               .href_url.domain.tld == "ms"
               // Microsoft does not own the .ms TLD, this checks to ensure it is one of their domains

--- a/detection-rules/impersonation_sharepoint_body_credential_theft.yml
+++ b/detection-rules/impersonation_sharepoint_body_credential_theft.yml
@@ -131,7 +131,7 @@ source: |
                    strings.icontains(subject.subject, .display_text)
                    or .display_text == "Open"
             ),
-            .href_url.domain.root_domain in ("sharepoint.com")
+            .href_url.domain.root_domain in ("sharepoint.com", "1drv.ms"")
             or (
               .href_url.domain.tld == "ms"
               // Microsoft does not own the .ms TLD, this checks to ensure it is one of their domains


### PR DESCRIPTION
# Description
adding OneDrive to the body links check to negate legitimate Microsoft shares. this is already coupled with the message ID format verifying it is SP/OD

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b01ef18c340f6becebef15095212d37c0bed7115712002f66079c364928dcc?preview_id=019f8a91-2c35-7ba0-8ccf-1ce8bff30faa)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019fc954-f682-7093-b6c5-9fae8d502267) - messages that will be negated
