### PR TITLE
Create link_format_char_base64_fragment.yml

### DIFF
--- a/detection-rules/link_format_char_base64_fragment.yml
+++ b/detection-rules/link_format_char_base64_fragment.yml
@@ -1,0 +1,20 @@
+name: "Link: Unicode format character obfuscation in display name with base64-encoded URL fragment payload"
+description: "Detects inbound messages where the sender's display name contains Unicode format characters (such as word joiners or invisible separators) interspersed between letters to evade text-based detection. These messages carry links whose URL fragments are unusually long (over 100 characters) and match a base64url-encoded pattern, a technique used to smuggle encoded payloads past URL scanners."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and regex.icontains(sender.display_name, '[a-z]\p{Cf}+[a-z]')
+  and any(body.links,
+          length(.href_url.fragment) > 100
+          and regex.contains(.href_url.fragment, '^[A-Za-z0-9_-]+={0,2}$')
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "URL analysis"
+  - "Sender analysis"
+  - "Content analysis"

--- a/detection-rules/link_format_char_base64_fragment.yml
+++ b/detection-rules/link_format_char_base64_fragment.yml
@@ -1,4 +1,4 @@
-name: "Link: Unicode format character obfuscation in display name with base64-encoded URL fragment payload"
+name: "Link: Unicode character obfuscation in display name with base64-encoded URL fragment"
 description: "Detects inbound messages where the sender's display name contains Unicode format characters (such as word joiners or invisible separators) interspersed between letters to evade text-based detection. These messages carry links whose URL fragments are unusually long (over 100 characters) and match a base64url-encoded pattern, a technique used to smuggle encoded payloads past URL scanners."
 type: "rule"
 severity: "medium"

--- a/detection-rules/link_format_char_base64_fragment.yml
+++ b/detection-rules/link_format_char_base64_fragment.yml
@@ -18,3 +18,4 @@ detection_methods:
   - "URL analysis"
   - "Sender analysis"
   - "Content analysis"
+id: "8619dce9-142e-5b3a-981a-1ac58960b221"


### PR DESCRIPTION
# Description

This rule covers a good amount of FNs. 

Detects inbound messages where the sender's display name contains Unicode format characters (such as word joiners or invisible separators) interspersed between letters to evade text-based detection. These messages carry links whose URL fragments are unusually long (over 100 characters) and match a base64url-encoded pattern, a technique used to smuggle encoded payloads past URL scanners.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b748f8521dd2da23163de366aa8bc2a5334d4e7e9953cc2801da8431a4ff58?preview_id=019fb00d-2808-785d-9c00-d2df106aa1dc)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019fc7b4-a973-7e71-a373-aeded1336dfd)
- [94 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/4d1494b8-5fdc-4662-a61a-2018a84115fc)
