### PR TITLE
Update brand_impersonation_siriusxm.yml

### DIFF
--- a/detection-rules/brand_impersonation_siriusxm.yml
+++ b/detection-rules/brand_impersonation_siriusxm.yml
@@ -8,7 +8,12 @@ source: |
     regex.icontains(sender.display_name, 'sirius[._-]?xm')
     or strings.ilevenshtein(sender.display_name, 'siriusxm') <= 1
     or strings.ilike(sender.email.domain.domain, '*siriusxm*')
-    or strings.istarts_with(body.current_thread.text, 'sirius xm')
+    or (
+      strings.istarts_with(body.current_thread.text, 'sirius xm')
+      and regex.contains(body.current_thread.text,
+                         '[\x{1F600}-\x{1F64F}]|[\x{1F300}-\x{1F5FF}]|[\x{1F680}-\x{1F6FF}]|[\x{1F1E0}-\x{1F1FF}]|[\x{2600}-\x{26FF}]|[\x{2700}-\x{27BF}]'
+      )
+    )
   )
   and (
     sender.email.domain.root_domain not in (

--- a/detection-rules/brand_impersonation_siriusxm.yml
+++ b/detection-rules/brand_impersonation_siriusxm.yml
@@ -5,7 +5,7 @@ severity: "medium"
 source: |
   type.inbound
   and (
-    regex.icontains(sender.display_name, 'sirius[\s._-]?xm')
+    regex.icontains(sender.display_name, 'sirius[._-]?xm')
     or strings.ilevenshtein(sender.display_name, 'siriusxm') <= 1
     or strings.ilike(sender.email.domain.domain, '*siriusxm*')
     or strings.istarts_with(body.current_thread.text, 'sirius xm', 'siriusxm')
@@ -26,10 +26,17 @@ source: |
         'engagement360.net', // SiriusXM survey vendor
         'sciquest.com' // SiriusXM Procurement
       )
-      and not headers.auth_summary.dmarc.pass
+      and not coalesce(headers.auth_summary.dmarc.pass, false)
     )
   )
   and not profile.by_sender().solicited
+  and (
+    (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and not coalesce(headers.auth_summary.dmarc.pass, false)
+    )
+    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  )
 attack_types:
   - "Callback Phishing"
   - "Credential Phishing"

--- a/detection-rules/brand_impersonation_siriusxm.yml
+++ b/detection-rules/brand_impersonation_siriusxm.yml
@@ -5,9 +5,10 @@ severity: "medium"
 source: |
   type.inbound
   and (
-    strings.ilike(sender.display_name, '*siriusxm*')
+    regex.icontains(sender.display_name, 'sirius[\s._-]?xm')
     or strings.ilevenshtein(sender.display_name, 'siriusxm') <= 1
     or strings.ilike(sender.email.domain.domain, '*siriusxm*')
+    or strings.istarts_with(body.current_thread.text, 'sirius xm', 'siriusxm')
   )
   and (
     sender.email.domain.root_domain not in (

--- a/detection-rules/brand_impersonation_siriusxm.yml
+++ b/detection-rules/brand_impersonation_siriusxm.yml
@@ -31,7 +31,7 @@ source: |
         'engagement360.net', // SiriusXM survey vendor
         'sciquest.com' // SiriusXM Procurement
       )
-      and not coalesce(headers.auth_summary.dmarc.pass, false)
+      and not headers.auth_summary.dmarc.pass
     )
   )
   and not profile.by_sender().solicited

--- a/detection-rules/brand_impersonation_siriusxm.yml
+++ b/detection-rules/brand_impersonation_siriusxm.yml
@@ -8,7 +8,7 @@ source: |
     regex.icontains(sender.display_name, 'sirius[._-]?xm')
     or strings.ilevenshtein(sender.display_name, 'siriusxm') <= 1
     or strings.ilike(sender.email.domain.domain, '*siriusxm*')
-    or strings.istarts_with(body.current_thread.text, 'sirius xm', 'siriusxm')
+    or strings.istarts_with(body.current_thread.text, 'sirius xm')
   )
   and (
     sender.email.domain.root_domain not in (

--- a/detection-rules/brand_impersonation_siriusxm.yml
+++ b/detection-rules/brand_impersonation_siriusxm.yml
@@ -30,12 +30,10 @@ source: |
     )
   )
   and not profile.by_sender().solicited
-  and (
-    (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and not coalesce(headers.auth_summary.dmarc.pass, false)
-    )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
 attack_types:
   - "Callback Phishing"


### PR DESCRIPTION
# Description

Updating logic to tag samples that start with a variation of `Sirius XM`. Also updating `sender.display_name` logic to utilize regex to tag display names that have `Sirius XM` with different types of connecting characters

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b8cdd4fd00a0c4dcb04053e46479f0db12e763817a71b38db7fcd5361bba95?preview_id=019fb3f8-de4e-707d-8834-24ce10924016)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019fccd0-700f-7624-aef3-06e7e8bc31a5)