### PR TITLE
Create service_abuse_adobe_newly_observed_email_domain.yml

### DIFF
--- a/detection-rules/service_abuse_adobe_newly_observed_email_domain.yml
+++ b/detection-rules/service_abuse_adobe_newly_observed_email_domain.yml
@@ -20,7 +20,7 @@ source: |
           .href_url.domain.domain not in $sender_domains
           and .href_url.domain.domain not in $recipient_domains
   )
-  // there is a link to an adobe hosted content
+  // there is a single link to an adobe hosted content
   and length(distinct(filter(body.links,
                              .href_url.domain.root_domain == "adobe.com"
                              and strings.istarts_with(.href_url.path, '/id/urn:')

--- a/detection-rules/service_abuse_adobe_newly_observed_email_domain.yml
+++ b/detection-rules/service_abuse_adobe_newly_observed_email_domain.yml
@@ -1,0 +1,42 @@
+name: "Service abuse: Adobe share containing newly observed email address domain"
+description: "Detects legitimate Adobe notification emails that contain a genuine Adobe-hosted document link alongside a mailto link with an external email address that is not the recipient, not part of the organization's domains, not associated with Adobe, and has never been observed in prior inbound or outbound mail. This pattern indicates abuse of Adobe's trusted email infrastructure to redirect victims into contacting an attacker-controlled address outside the normal mail flow."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  // from Adobe
+  and sender.email.email == 'message@adobe.com'
+  // the email address in the body
+  and any(filter(body.links,
+                 .href_url.scheme == 'mailto'
+                 // is not the recipient
+                 and .href_url.url !~ recipients.to[0].email.email
+                 // not in org domains
+                 and .href_url.domain.domain not in $org_domains
+                 // and not adobe 
+                 and .href_url.domain.root_domain != "adobe.com"
+          ),
+          // and has not been observed inbound/outbound in the environment
+          .href_url.domain.domain not in $sender_domains
+          and .href_url.domain.domain not in $recipient_domains
+  )
+  // there is a link link to an adobe hosted content
+  and length(distinct(filter(body.links,
+                             .href_url.domain.root_domain == "adobe.com"
+                             and strings.istarts_with(.href_url.path,
+                                                      '/id/urn:'
+                             )
+                      ),
+                      .href_url.url
+             )
+  ) == 1
+attack_types:
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Out of band pivot"
+  - "Social engineering"
+detection_methods:
+  - "URL analysis"
+  - "Sender analysis"
+  - "Content analysis"

--- a/detection-rules/service_abuse_adobe_newly_observed_email_domain.yml
+++ b/detection-rules/service_abuse_adobe_newly_observed_email_domain.yml
@@ -20,7 +20,7 @@ source: |
           .href_url.domain.domain not in $sender_domains
           and .href_url.domain.domain not in $recipient_domains
   )
-  // there is a link link to an adobe hosted content
+  // there is a link to an adobe hosted content
   and length(distinct(filter(body.links,
                              .href_url.domain.root_domain == "adobe.com"
                              and strings.istarts_with(.href_url.path, '/id/urn:')

--- a/detection-rules/service_abuse_adobe_newly_observed_email_domain.yml
+++ b/detection-rules/service_abuse_adobe_newly_observed_email_domain.yml
@@ -13,7 +13,7 @@ source: |
                  and .href_url.url !~ recipients.to[0].email.email
                  // not in org domains
                  and .href_url.domain.domain not in $org_domains
-                 // and not adobe 
+                 // and not adobe
                  and .href_url.domain.root_domain != "adobe.com"
           ),
           // and has not been observed inbound/outbound in the environment
@@ -23,9 +23,7 @@ source: |
   // there is a link link to an adobe hosted content
   and length(distinct(filter(body.links,
                              .href_url.domain.root_domain == "adobe.com"
-                             and strings.istarts_with(.href_url.path,
-                                                      '/id/urn:'
-                             )
+                             and strings.istarts_with(.href_url.path, '/id/urn:')
                       ),
                       .href_url.url
              )
@@ -40,3 +38,4 @@ detection_methods:
   - "URL analysis"
   - "Sender analysis"
   - "Content analysis"
+id: "35605b1f-f640-53ae-8dfb-59ecba1d0e09"


### PR DESCRIPTION
# Description

Created new rule for observed pattern of domains that have never been seen before sending adobe shares.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b544cef77a8d763ee859876393765c3cfce1ece61e8b10d3616637952db359?preview_id=019fb2aa-977a-72f4-9142-433fba68a1fb)


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019fb9fd-4183-748c-a327-266ad655eb8a)
- [Multihunt](https://hunt.limeseed.email/hunts/071e9e5b-94ad-49a8-89ff-bbb8ab05726b)
