### PR TITLE
Create link_mismatched_free_file_host_with_doc_lure.yml

### DIFF
--- a/detection-rules/link_mismatched_free_file_host_with_doc_lure.yml
+++ b/detection-rules/link_mismatched_free_file_host_with_doc_lure.yml
@@ -55,3 +55,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "URL analysis"
   - "Content analysis"
+id: "19836dcf-cde4-5d9a-903f-c74c1e88e33d"

--- a/detection-rules/link_mismatched_free_file_host_with_doc_lure.yml
+++ b/detection-rules/link_mismatched_free_file_host_with_doc_lure.yml
@@ -1,0 +1,57 @@
+name: "Link: Mismatched free file host links with document lure"
+description: "Detects inbound emails containing mismatched hyperlinks where the displayed URL references a free file hosting service but the actual destination points to another free file host or a suspicious TLD. The rule combines this with NLU classification identifying BEC or credential theft intent, along with body text patterns common to fake document/scan notifications (e.g., 'scanned from', 'shared via', 'for your review') or short, urgency-driven messages. Trusted senders with passing DMARC are excluded to reduce false positives."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(filter(body.current_thread.links, .mismatched),
+          any([.display_url.domain.domain, .display_url.domain.root_domain],
+              . in $free_file_hosts
+          )
+          and (
+            any([.href_url.domain.domain, .href_url.domain.root_domain],
+                . in $free_file_hosts
+            )
+            or .href_url.domain.tld in $suspicious_tlds
+          )
+  )
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name in ("bec", "cred_theft") and .confidence != "low"
+  )
+  and 2 of (
+    regex.icontains(body.current_thread.text,
+                    'scanned from',
+                    'total images',
+                    'attachment format',
+                    'scan information',
+                    'statement/remittance',
+                    'versalink',
+                    'made a file available',
+                    'document from .{0,40}is available',
+                    '(?:uploaded|shared) via',
+                    '(?:report|available) for your review'
+    ),
+    regex.icontains(body.current_thread.text, '={5,}|_{10,}'),
+    length(body.current_thread.text) < 700,
+    regex.icontains(body.current_thread.text,
+                    'kindly review',
+                    'review the attached',
+                    'let us know the next step',
+                    'for your review',
+                    'please review the'
+    )
+  )
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Free file host"
+  - "Social engineering"
+detection_methods:
+  - "Natural Language Understanding"
+  - "URL analysis"
+  - "Content analysis"


### PR DESCRIPTION
# Description

Observed campaign and kind of an interesting pattern I was noticing. Want to just PR this and see how it does in test rules. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b689bcf5d19f3d308fb5e11020fa769b2f641b4554e225750e00d9cad90c46?preview_id=019fa9c8-18a4-7b68-b479-f51dd4d9dcd1)
- [Sample 2](https://platform.sublime.security/messages/50b9394e44566d4aa32be48f68a466ec95be10e27225947aa1ff599a0778af64?preview_id=019fbe82-50e4-7e83-8e2a-7a42349807ff)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019fbef8-1213-7dc3-93b7-7cc85b221386)
- [multihunt](https://hunt.limeseed.email/hunts/117fe41e-5a7e-4f93-abb4-6c68f2043914)