### PR TITLE
Create rule: new_sender_subdomain_jira.yml

### DIFF
--- a/detection-rules/abuse_jira_new_sender_subdomain.yml
+++ b/detection-rules/abuse_jira_new_sender_subdomain.yml
@@ -94,3 +94,4 @@ detection_methods:
   - "Header analysis"
   - "Sender analysis"
   - "URL analysis"
+id: "9eccfa39-7e7d-519d-92de-f394112c2741"

--- a/detection-rules/abuse_jira_new_sender_subdomain.yml
+++ b/detection-rules/abuse_jira_new_sender_subdomain.yml
@@ -63,22 +63,20 @@ source: |
     (length(headers.references) > 0 or headers.in_reply_to is not null)
     and (
       (
-        (
-          (subject.is_forward or subject.is_reply)
-          // ticket number present
-          or regex.icontains(subject.subject,
-                             '\(?[a-z]{1,8}-\d{1,8}\)?',
-                             'ticket #\d{1,8}'
-          )
+        (subject.is_forward or subject.is_reply)
+        // ticket number present
+        or regex.icontains(subject.subject,
+                           '\(?[a-z]{1,8}-\d{1,8}\)?',
+                           'ticket #\d{1,8}'
         )
-        and (
-          // previous thread exists
-          length(body.previous_threads) >= 1
-          // most service accounts typically do not contain a previous thread
-          or (
-            strings.icontains(body.current_thread.text, "—-—-—-—")
-            or strings.icontains(body.plain.raw, "—-—-—-—")
-          )
+      )
+      and (
+        // previous thread exists
+        length(body.previous_threads) >= 1
+        // most service accounts typically do not contain a previous thread
+        or (
+          strings.icontains(body.current_thread.text, "—-—-—-—")
+          or strings.icontains(body.plain.raw, "—-—-—-—")
         )
       )
     )

--- a/detection-rules/abuse_jira_new_sender_subdomain.yml
+++ b/detection-rules/abuse_jira_new_sender_subdomain.yml
@@ -53,8 +53,8 @@ source: |
     profile.by_sender_email().prevalence == "new"
     and profile.by_sender_email().days_known < 30
     and (
-      not profile.by_sender().solicited
-      or profile.by_sender().any_messages_malicious_or_spam
+      not profile.by_sender_email().solicited
+      or profile.by_sender_email().any_messages_malicious_or_spam
     )
   )
   

--- a/detection-rules/abuse_jira_new_sender_subdomain.yml
+++ b/detection-rules/abuse_jira_new_sender_subdomain.yml
@@ -1,0 +1,96 @@
+name: "Service abuse: Jira notification with suspicious link"
+description: "Detects legitimate, DMARC-authenticated Jira notification emails from Atlassian that contain suspicious links pointing to domains outside the Tranco 1M list, including via URL rewrite parameters. Flags messages from senders with no prior relationship that are not part of an existing thread."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // legitimate & authenticated service desk domain
+  and (
+    sender.email.local_part == "jira"
+    and sender.email.domain.root_domain == "atlassian.net"
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+  
+  // suspicious link is present
+  and (
+    (
+      any(body.links,
+          // ignore not hyperlinks
+          .href_url.scheme == "https"
+          and .parser != "plain"
+          // check tranco 1m
+          and .href_url.domain.root_domain not in $tranco_1m
+      )
+      // check for url rewrites
+      or any(body.links,
+             // ignore not hyperlinks
+             .href_url.scheme == "https"
+             and .parser != "plain"
+             // extract decoded domain
+             and "domain" in keys(.href_url.query_params_decoded)
+             and any(.href_url.query_params_decoded["domain"],
+                     // infra negations
+                     not strings.icontains(., "atlassian.com")
+                     and not strings.icontains(., "atlassian.net")
+                     and not strings.icontains(., "atl-paas.net")
+                     // avatar image service
+                     and not strings.icontains(., "gravatar.com")
+                     // footer links
+                     and not strings.icontains(., "itunes.apple.com")
+                     and not strings.icontains(., "marketplace.microsoft.com")
+                     and not strings.icontains(., "play.google.com")
+                     and not strings.icontains(., "workspace.google.com")
+  
+                     // lastly, check tranco 1m
+                     and . not in $tranco_1m
+             )
+      )
+    )
+  )
+  
+  // sender profile is brand new
+  and (
+    profile.by_sender_email().prevalence == "new"
+    and profile.by_sender_email().days_known < 30
+    and (
+      not profile.by_sender().solicited
+      or profile.by_sender().any_messages_malicious_or_spam
+    )
+  )
+  
+  // negate legitimate replies
+  and not (
+    (length(headers.references) > 0 or headers.in_reply_to is not null)
+    and (
+      (
+        (
+          (subject.is_forward or subject.is_reply)
+          // ticket number present
+          or regex.icontains(subject.subject,
+                             '\(?[a-z]{1,8}-\d{1,8}\)?',
+                             'ticket #\d{1,8}'
+          )
+        )
+        and (
+          // previous thread exists
+          length(body.previous_threads) >= 1
+          // most service accounts typically do not contain a previous thread
+          or (
+            strings.icontains(body.current_thread.text, "—-—-—-—")
+            or strings.icontains(body.plain.raw, "—-—-—-—")
+          )
+        )
+      )
+    )
+  )
+  
+tags:
+  - "Attack surface reduction"
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Header analysis"
+  - "Sender analysis"
+  - "URL analysis"

--- a/detection-rules/link_jira_new_sender_subdomain.yml
+++ b/detection-rules/link_jira_new_sender_subdomain.yml
@@ -1,4 +1,4 @@
-name: "Service abuse: Jira notification with suspicious link"
+name: "Link: Jira notification from new sender subdomain with suspicious link"
 description: "Detects legitimate, DMARC-authenticated Jira notification emails from Atlassian that contain suspicious links pointing to domains outside the Tranco 1M list, including via URL rewrite parameters. Flags messages from senders with no prior relationship that are not part of an existing thread."
 type: "rule"
 severity: "medium"


### PR DESCRIPTION
# Description

Creating a new rule that surfaces JIRA messages from unknown subdomains.

## Logic

- Flags on legitimate Atlassian JIRA senders with valid authentication.
- Checks sender profile for new and unsolicited entity.
- Checks link against Tranco 1M list.
- Decodes mimecast domains & ignores standard expected links.
- Negates legitimate threads, while also accounting for unique reply structures to scope "previous threads".

# Associated samples

[- Sample 1](https://platform.sublime.security/messages/5081d4cffd8c90c6229e599ca9861f439159d28ca4fcb3e333d77301b189259a?preview_id=019f18f7-6db3-79c2-b642-bcf39878460b)

## Associated hunts

[- Hunt 1 (Shared samples) - L90D](https://platform.sublime.security/messages/hunt?huntId=019fc811-509d-77b7-97b1-60849365eb92)
[- Hunt 2 (Multi) - L30D](https://hunt.limeseed.email/hunts/43e3f781-d153-4e17-b7c9-1cf215e9a76f)
