### PR TITLE
Rename beta.DLP: PCI US Credit Card rule to match beta naming convention

### DIFF
--- a/dlp-discovery-rules/beta_dlp_pci_us_credit_card_any.yml
+++ b/dlp-discovery-rules/beta_dlp_pci_us_credit_card_any.yml
@@ -1,4 +1,4 @@
-name: "DLP - PCI: US Credit Card Number (Any Network)"
+name: "beta.DLP: PCI US Credit Card Number (Any Network)"
 description: "Detects messages containing credit card numbers."
 type: "dlp"
 severity: "high"


### PR DESCRIPTION
## What

Updates the `name` field in `dlp-discovery-rules/beta_dlp_pci_us_credit_card_any.yml`:

- **Before:** `DLP - PCI: US Credit Card Number (Any Network)`
- **After:** `beta.DLP: PCI US Credit Card Number (Any Network)`

## Why

This rule was the only `beta_`-prefixed DLP file whose `name` did not carry the `beta.DLP: ` prefix used by the rest of the beta DLP rules (e.g. `beta.DLP: US Social Security Number (SSN)`, `beta.DLP: IBAN Code`). This aligns it with the convention (28 of 31 beta rules use `beta.DLP: <name>`).

No logic changes; `name` field only.