### PR TITLE
Update link_mailto_placeholder.yml - strings.contains short circuit

### DIFF
--- a/detection-rules/link_mailto_placeholder.yml
+++ b/detection-rules/link_mailto_placeholder.yml
@@ -6,6 +6,8 @@ source: |
   type.inbound
   and any(body.links,
           .href_url.scheme == "mailto"
+          and strings.contains(.href_url.url, '{')
+          and strings.contains(.href_url.url, '}')
           and (
             // @{domain} pattern is strong
             regex.icontains(.href_url.url, '@\s*{\s*domain\s*}')


### PR DESCRIPTION
# Description
Short circuit before the regexes by looking for the presence of `{` and `}`, which are very uncommon in emails but required in both regexes. Now that pure string functions don't fold into regex, this should be a super-fast filter.

# Associated samples
n/a

## Associated hunts
n/a - the regexes rely on { and }, so this change is a functional no-op, just an optimization

# Screenshot (insights)
n/a