### PR TITLE
Update link_microsoft_low_reputation.yml - Sender negations

### DIFF
--- a/detection-rules/link_microsoft_low_reputation.yml
+++ b/detection-rules/link_microsoft_low_reputation.yml
@@ -385,6 +385,17 @@ source: |
    and subject.subject == strings.replace_confusables(subject.subject)
  )
  
+ // negate legitimate microsoft b2b applications invitations
+ and not (
+   length(body.links) > 0
+   and (
+     sender.email.local_part == "invites"
+     and sender.email.domain.root_domain == "onmicrosoft.com"
+     // infra validated message id
+     and strings.icontains(headers.message_id, "pepf")
+   )
+ )
+ 
  // negate org domains unless they fail DMARC authentication
  and (
    (
@@ -426,6 +437,7 @@ source: |
  and not regex.icontains(body.current_thread.text,
                          '(schedul(e|ing)|set up).{0,20}(call|meeting|demo|zoom|conversation|time|tool|discussion)|book.{0,10}(meeting|demo|call|slot|time)|connect.{0,12}(with me|phone|email)|my.{0,10}(calendar|cal)|reserve.{0,10}s[pl]ot|break the ice|want to know more?|miss your chance|if you no longer wish|if you no longer want|if you wish to opt out|low-code (development|approach|solution|journey|platform)|(?:invite|virtual).{0,30}(webinar|presentation)'
  )
+
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/link_microsoft_low_reputation.yml
+++ b/detection-rules/link_microsoft_low_reputation.yml
@@ -387,13 +387,10 @@ source: |
  
  // negate legitimate microsoft b2b applications invitations
  and not (
-   length(body.links) > 0
-   and (
-     sender.email.local_part == "invites"
-     and sender.email.domain.root_domain == "onmicrosoft.com"
-     // infra validated message id
-     and strings.icontains(headers.message_id, "pepf")
-   )
+   sender.email.local_part == "invites"
+   and sender.email.domain.root_domain == "onmicrosoft.com"
+   // infra validated message id
+   and strings.icontains(headers.message_id, "pepf")
  )
  
  // negate org domains unless they fail DMARC authentication


### PR DESCRIPTION
# Description

Adding another rule into the negation maelstrom for #4990. I thought I had them all but this makes 5.

# Associated samples

[- Sample 1](https://platform.sublime.security/messages/50a2db381eddefa8f5ca99a62ac6f9d740efb451d3f2ac458a3add6f25c4771b?preview_id=019f65e3-ab29-78ad-9f67-b9ff395a8854)

## Associated hunts

[- Hunt 1 (Shared samples) - L180D](https://platform.sublime.security/messages/hunt?huntId=019fc959-e915-770b-b227-02ec7127b1a3)
[- Hunt 2 (Multi) - L30D](https://hunt.limeseed.email/hunts/cd0c1722-ce0c-4be5-a5ec-8093e2b7794e)
[- Hunt 3 - Exclusive](https://platform.sublime.security/messages/hunt?huntId=019fc958-8e58-74be-8c67-a8d4dfdd65e0)