### PR TITLE
Create body_zero_value_css_calc.yml

### DIFF
--- a/detection-rules/body_css_zero_value_calc.yml
+++ b/detection-rules/body_css_zero_value_calc.yml
@@ -1,4 +1,4 @@
-name: "Body: Zero-value CSS calc() obfuscation"
+name: "Body: CSS zero-value calc() obfuscation"
 description: "Detects inbound messages containing HTML where a CSS calc() expression subtracts an identical value and unit from itself (e.g., calc(100px - 100px)), always resolving to zero. This pattern is commonly used to hide or collapse content from view while keeping it present in the underlying HTML, a technique often leveraged to evade text-based detection or conceal malicious content from recipients."
 type: "rule"
 severity: "medium"

--- a/detection-rules/body_zero_value_css_calc.yml
+++ b/detection-rules/body_zero_value_css_calc.yml
@@ -17,3 +17,4 @@ tactics_and_techniques:
   - "Evasion"
 detection_methods:
   - "HTML analysis"
+id: "a9bd4f3f-3c8e-5807-9779-337498fc05e5"

--- a/detection-rules/body_zero_value_css_calc.yml
+++ b/detection-rules/body_zero_value_css_calc.yml
@@ -1,0 +1,19 @@
+name: "Body: Zero-value CSS calc() obfuscation"
+description: "Detects inbound messages containing HTML where a CSS calc() expression subtracts an identical value and unit from itself (e.g., calc(100px - 100px)), always resolving to zero. This pattern is commonly used to hide or collapse content from view while keeping it present in the underlying HTML, a technique often leveraged to evade text-based detection or conceal malicious content from recipients."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(regex.iextract(body.html.raw,
+                         'calc\(\s*(?P<n1>\d+(?:\.\d+)?)(?P<u1>px|vw|vh|em|rem|%)\s*-\s*(?P<n2>\d+(?:\.\d+)?)(?P<u2>px|vw|vh|em|rem|%)\s*\)'
+          ),
+          .named_groups["n1"] == .named_groups["n2"]
+          and .named_groups["u1"] == .named_groups["u2"]
+  )
+attack_types:
+  - "Credential Phishing"
+  - "Spam"
+tactics_and_techniques:
+  - "Evasion"
+detection_methods:
+  - "HTML analysis"


### PR DESCRIPTION
# Description

Found when reviewing results from a PR.

Detects inbound messages containing HTML where a CSS calc() expression subtracts an identical value and unit from itself (e.g., calc(100px - 100px)), always resolving to zero. This pattern is commonly used to hide or collapse content from view while keeping it present in the underlying HTML, a technique often leveraged to evade text-based detection or conceal malicious content from recipients.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50bb436efc58967786ed2c9eb56029b6797c0c6c1731bf4a5c01422c207f7968?preview_id=019fc7cc-9c0d-7b01-b758-fcb4a8abf48a)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=019fd268-c353-7087-a0a3-4830cebbf1dd)
- [L30D Multi-Hunt](https://hunt.limeseed.email/hunts/3527e2c6-e02a-4973-8078-e425d363731a)