### PR TITLE
Create body_css_clip_path.yml

### DIFF
--- a/detection-rules/body_css_clip_path.yml
+++ b/detection-rules/body_css_clip_path.yml
@@ -1,0 +1,18 @@
+name: "Body: Hidden text via CSS clip-path"
+description: "Detects HTML emails containing a div styled with 'clip-path: inset(100%)', a CSS technique used to visually hide substantial blocks of text (over 150 characters) from the recipient while keeping it present in the underlying HTML. This method is commonly used to evade content-based detection engines by hiding filler or unrelated text within the message body."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(html.xpath(body.html, '//div[contains(@style,"clip-path")]').nodes,
+          regex.icontains(.raw, 'clip-path:\s*inset\(\s*100%')
+          and length(.inner_text) > 150
+  )
+attack_types:
+  - "Spam"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+detection_methods:
+  - "HTML analysis"
+  - "Content analysis"

--- a/detection-rules/body_css_clip_path.yml
+++ b/detection-rules/body_css_clip_path.yml
@@ -1,5 +1,5 @@
 name: "Body: Hidden text via CSS clip-path"
-description: "Detects HTML emails containing a div styled with 'clip-path: inset(100%)', a CSS technique used to visually hide substantial blocks of text (over 150 characters) from the recipient while keeping it present in the underlying HTML. This method is commonly used to evade content-based detection engines by hiding filler or unrelated text within the message body."
+description: "Detects inbound messages containing a div styled with 'clip-path: inset(100%)', a CSS technique used to visually hide substantial blocks of text (over 150 characters) from the recipient while keeping it present in the underlying HTML. This method is commonly used to evade content-based detection engines by hiding filler or unrelated text within the message body."
 type: "rule"
 severity: "medium"
 source: |

--- a/detection-rules/body_css_clip_path.yml
+++ b/detection-rules/body_css_clip_path.yml
@@ -16,3 +16,4 @@ tactics_and_techniques:
 detection_methods:
   - "HTML analysis"
   - "Content analysis"
+id: "ca09550e-7f33-535c-a178-3455faa5143b"

--- a/detection-rules/body_css_clip_path.yml
+++ b/detection-rules/body_css_clip_path.yml
@@ -1,4 +1,4 @@
-name: "Body: Hidden text via CSS clip-path"
+name: "Body: CSS Hidden text via clip-path"
 description: "Detects inbound messages containing a div styled with 'clip-path: inset(100%)', a CSS technique used to visually hide substantial blocks of text (over 150 characters) from the recipient while keeping it present in the underlying HTML. This method is commonly used to evade content-based detection engines by hiding filler or unrelated text within the message body."
 type: "rule"
 severity: "medium"


### PR DESCRIPTION
# Description

Detects inbound messages containing a div styled with 'clip-path: inset(100%)', a CSS technique used to visually hide substantial blocks of text (over 150 characters) from the recipient while keeping it present in the underlying HTML. This method is commonly used to evade content-based detection engines by hiding filler or unrelated text within the message body.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50a00045c8679e444d0fcf8d173bcd87fb6fcc5c9861ec5d063929e362c5c245?preview_id=019fc874-a9ab-7994-acc2-7539e629a9a8)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=019fd263-7ea2-78cd-9170-d29cc01b2ecd)
- [L30D Customer Multi-Hunt](https://hunt.limeseed.email/hunts/a63c7a39-0ef3-4e59-8adc-77d641e9a057)