### PR TITLE
Update and rename abuse_jira_new_sender_subdomain.yml to link_jira_new_sender_subdomain.yml

### DIFF
--- a/detection-rules/link_jira_new_sender_subdomain.yml
+++ b/detection-rules/link_jira_new_sender_subdomain.yml
@@ -1,4 +1,4 @@
-name: "Service abuse: Jira notification with suspicious link"
+name: "Link: Jira notification from new sender subdomain with suspicious link"
 description: "Detects legitimate, DMARC-authenticated Jira notification emails from Atlassian that contain suspicious links pointing to domains outside the Tranco 1M list, including via URL rewrite parameters. Flags messages from senders with no prior relationship that are not part of an existing thread."
 type: "rule"
 severity: "medium"


### PR DESCRIPTION
# Description

Creating a new rule that surfaces JIRA messages from unknown subdomains.

## Logic

- Flags on legitimate Atlassian JIRA senders with valid authentication.
- Checks sender profile for new and unsolicited entity.
- Checks link against Tranco 1M list.
- Decodes mimecast domains & ignores standard expected links.
- Negates legitimate threads, while also accounting for unique reply structures to scope "previous threads".

# Associated samples

[- Sample 1](https://platform.sublime.security/messages/5081d4cffd8c90c6229e599ca9861f439159d28ca4fcb3e333d77301b189259a?preview_id=019f18f7-6db3-79c2-b642-bcf39878460b)

## Associated hunts

[- Hunt 1 (Shared samples) - L90D](https://platform.sublime.security/messages/hunt?huntId=019fcd15-aed0-7d12-825b-8b171bacaece)
[- Hunt 2 (Multi) - L30D](https://hunt.limeseed.email/hunts/800f2ea7-bf82-4368-98ed-079a6ee5f44c)