### PR TITLE
Update impersonation_paypal.yml

### DIFF
--- a/detection-rules/impersonation_paypal.yml
+++ b/detection-rules/impersonation_paypal.yml
@@ -19,6 +19,13 @@ source: |
     or regex.icontains(body.current_thread.text,
                        '(?:pay[-\._\s]*pa[i1]\b|paypa[|!]|p@y\.?p@l)'
     )
+    or (
+      strings.istarts_with(body.current_thread.text, 'paypal')
+      and regex.icontains(body.current_thread.text,
+                          '\+?([ilo0-9]{1}.)?\(?[ilo0-9]{3}?\)?.[ilo0-9]{3}.?[ilo0-9]{4}',
+                          '\+?([ilo0-9]{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}[ilo0-9]{3}[\s\.\-⋅]{0,5}[ilo0-9]{4}'
+      )
+    )
     or any(attachments,
            (.file_type in $file_types_images or .file_type == "pdf")
            and any(ml.logo_detect(.).brands, .name == "PayPal")

--- a/detection-rules/impersonation_paypal.yml
+++ b/detection-rules/impersonation_paypal.yml
@@ -21,9 +21,9 @@ source: |
     )
     or (
       strings.istarts_with(body.current_thread.text, 'paypal')
-      and regex.icontains(body.current_thread.text,
-                          '\+?([ilo0-9]{1}.)?\(?[ilo0-9]{3}?\)?.[ilo0-9]{3}.?[ilo0-9]{4}',
-                          '\+?([ilo0-9]{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}[ilo0-9]{3}[\s\.\-⋅]{0,5}[ilo0-9]{4}'
+      and length(body.previous_threads) == 0
+      and any(ml.nlu_classifier(body.current_thread.text).intents,
+              .name == "callback_scam"
       )
     )
     or any(attachments,


### PR DESCRIPTION
# Description

Updating logic to tag samples that start with `PayPal` and contain the NLU intent `callback_scam` with no previous threads

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50bdd3ab9268092babcd73ae8a2f662e2a8c02f5bd6262f1d4acddb5798fb1da?preview_id=019fcd0a-f98a-7082-8daf-df035b9e5a64)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019fdc42-4d93-7a36-b16a-a246f67ccaab)