### PR TITLE
Optimize three more rules slowing down one env

### DIFF
--- a/detection-rules/body_html_class_name_placeholder_rcpt.yml
+++ b/detection-rules/body_html_class_name_placeholder_rcpt.yml
@@ -7,8 +7,10 @@ source: |
   and (
     // observed unpopulated template variables in class names
     any(html.xpath(body.html, "//*/@class").nodes,
-        regex.icontains(.raw,
-                        '\{\s*(?:domain|email|(?:RECIPIENT|SENDER)[_\s]?EMAIL)\s*\}'
+        strings.contains(.raw, '{')
+        and strings.contains(.raw, '}')
+        and regex.icontains(.raw,
+                            '\{\s*(?:domain|email|(?:RECIPIENT|SENDER)[_\s]?EMAIL)\s*\}'
         )
     )
   

--- a/detection-rules/headers_anonymousfox.yml
+++ b/detection-rules/headers_anonymousfox.yml
@@ -12,14 +12,10 @@ source: |
     any(headers.hops,
         any(.fields,
             strings.istarts_with(.name, "X-Authenticated-Sender", "X-Sender")
-            and (
-              strings.icontains(.value, "anonymousfox-")
-              or strings.icontains(.value, "smtpfox-")
-            )
+            and strings.icontains(.value, "anonymousfox-", "smtpfox-")
         )
     )
-    or strings.icontains(sender.email.email, "anonymousfox-")
-    or strings.icontains(sender.email.email, "smtpfox-")
+    or strings.icontains(sender.email.email, "anonymousfox-", "smtpfox-")
   )
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/headers_anonymousfox.yml
+++ b/detection-rules/headers_anonymousfox.yml
@@ -11,11 +11,14 @@ source: |
   and (
     any(headers.hops,
         any(.fields,
-            regex.icontains(.name, "^(X-Authenticated-Sender|X-Sender)")
-            and regex.icontains(.value, "(anonymous|smtp)fox-")
+            (strings.icontains(.name, "X-Authenticated-Sender")
+             or strings.icontains(.name, "X-Sender"))
+            and (strings.icontains(.value, "anonymousfox-")
+                 or strings.icontains(.value, "smtpfox-"))
         )
     )
-    or regex.icontains(sender.email.email, "(anonymous|smtp)fox-")
+    or strings.icontains(sender.email.email, "anonymousfox-")
+    or strings.icontains(sender.email.email, "smtpfox-")
   )
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/headers_anonymousfox.yml
+++ b/detection-rules/headers_anonymousfox.yml
@@ -12,10 +12,10 @@ source: |
     any(headers.hops,
         any(.fields,
             strings.istarts_with(.name, "X-Authenticated-Sender", "X-Sender")
-            and strings.icontains(.value, "anonymousfox-", "smtpfox-")
+            and regex.icontains(.value, "(anonymous|smtp)fox-")
         )
     )
-    or strings.icontains(sender.email.email, "anonymousfox-", "smtpfox-")
+    or regex.icontains(sender.email.email, "(anonymous|smtp)fox-")
   )
 attack_types:
   - "BEC/Fraud"

--- a/detection-rules/headers_anonymousfox.yml
+++ b/detection-rules/headers_anonymousfox.yml
@@ -11,10 +11,7 @@ source: |
   and (
     any(headers.hops,
         any(.fields,
-            (
-              strings.istarts_with(.name, "X-Authenticated-Sender")
-              or strings.istarts_with(.name, "X-Sender")
-            )
+            strings.istarts_with(.name, "X-Authenticated-Sender", "X-Sender")
             and (
               strings.icontains(.value, "anonymousfox-")
               or strings.icontains(.value, "smtpfox-")

--- a/detection-rules/headers_anonymousfox.yml
+++ b/detection-rules/headers_anonymousfox.yml
@@ -11,10 +11,14 @@ source: |
   and (
     any(headers.hops,
         any(.fields,
-            (strings.icontains(.name, "X-Authenticated-Sender")
-             or strings.icontains(.name, "X-Sender"))
-            and (strings.icontains(.value, "anonymousfox-")
-                 or strings.icontains(.value, "smtpfox-"))
+            (
+              strings.icontains(.name, "X-Authenticated-Sender")
+              or strings.icontains(.name, "X-Sender")
+            )
+            and (
+              strings.icontains(.value, "anonymousfox-")
+              or strings.icontains(.value, "smtpfox-")
+            )
         )
     )
     or strings.icontains(sender.email.email, "anonymousfox-")

--- a/detection-rules/headers_anonymousfox.yml
+++ b/detection-rules/headers_anonymousfox.yml
@@ -12,8 +12,8 @@ source: |
     any(headers.hops,
         any(.fields,
             (
-              strings.icontains(.name, "X-Authenticated-Sender")
-              or strings.icontains(.name, "X-Sender")
+              strings.istarts_with(.name, "X-Authenticated-Sender")
+              or strings.istarts_with(.name, "X-Sender")
             )
             and (
               strings.icontains(.value, "anonymousfox-")

--- a/detection-rules/impersonation_google_groups_suspicious.yml
+++ b/detection-rules/impersonation_google_groups_suspicious.yml
@@ -16,9 +16,7 @@ source: |
   )
   and any(headers.hops,
           any(.fields,
-              strings.istarts_with(.name, "X-Authenticated-Sender")
-              or strings.istarts_with(.name, "X-Sender")
-              or strings.istarts_with(.name, "X-Original-Sender")
+              strings.istarts_with(.name, "X-Authenticated-Sender", "X-Sender", "X-Original-Sender")
           )
   )
   

--- a/detection-rules/impersonation_google_groups_suspicious.yml
+++ b/detection-rules/impersonation_google_groups_suspicious.yml
@@ -16,7 +16,11 @@ source: |
   )
   and any(headers.hops,
           any(.fields,
-              strings.istarts_with(.name, "X-Authenticated-Sender", "X-Sender", "X-Original-Sender")
+              strings.istarts_with(.name,
+                                   "X-Authenticated-Sender",
+                                   "X-Sender",
+                                   "X-Original-Sender"
+              )
           )
   )
   
@@ -49,7 +53,7 @@ source: |
       )
     ),
   
-    // reply-to is freemail 
+    // reply-to is freemail
     any(headers.reply_to, .email.domain.domain in $free_email_providers),
   
     // reply-to is not in $recipient_emails

--- a/detection-rules/impersonation_google_groups_suspicious.yml
+++ b/detection-rules/impersonation_google_groups_suspicious.yml
@@ -16,9 +16,9 @@ source: |
   )
   and any(headers.hops,
           any(.fields,
-              strings.icontains(.name, "X-Authenticated-Sender")
-              or strings.icontains(.name, "X-Sender")
-              or strings.icontains(.name, "X-Original-Sender")
+              strings.istarts_with(.name, "X-Authenticated-Sender")
+              or strings.istarts_with(.name, "X-Sender")
+              or strings.istarts_with(.name, "X-Original-Sender")
           )
   )
   

--- a/detection-rules/impersonation_google_groups_suspicious.yml
+++ b/detection-rules/impersonation_google_groups_suspicious.yml
@@ -16,9 +16,9 @@ source: |
   )
   and any(headers.hops,
           any(.fields,
-              regex.icontains(.name,
-                              "X-Authenticated-Sender|X-Sender|X-Original-Sender"
-              )
+              strings.icontains(.name, "X-Authenticated-Sender")
+              or strings.icontains(.name, "X-Sender")
+              or strings.icontains(.name, "X-Original-Sender")
           )
   )
   


### PR DESCRIPTION
# Description
* `body_html_class_name_placeholder_rcpt.yml` gets a similar `{}` pre-filter like the one added in #5006. This is on HTML node attributes, not emails, but the same idea applies.
* `headers_anonymousfox.yml` and `impersonation_google_groups_suspicious.yml` have their `regex.icontains` turned into plain `strings.istarts_with` for header matching and `strings.icontains` for the rest.

# Associated samples
n/a

## Associated hunts
n/a

# Screenshot (insights)
n/a