### PR TITLE
Update attachment_google_image_lure_qr_code.yml

### DIFF
--- a/detection-rules/attachment_google_image_lure_qr_code.yml
+++ b/detection-rules/attachment_google_image_lure_qr_code.yml
@@ -7,7 +7,7 @@ source: |
   and length(body.current_thread.text) < 1000
   and any([subject.subject, sender.display_name, body.current_thread.text],
           regex.icontains(.,
-                          '(\b2fa\b|\bQ.?R\.?\s?\b|MFA|Muti[ -]?Factor|(Auth(enticat|e|or|ion))?)'
+                          '(?:\b2fa\b|\bQ.?R\.?\s?\b|MFA|Muti[ -]?Factor|(?:Auth(enticat|e|or|ion)?))'
           )
   )
   and (

--- a/detection-rules/attachment_google_image_lure_qr_code.yml
+++ b/detection-rules/attachment_google_image_lure_qr_code.yml
@@ -7,7 +7,7 @@ source: |
   and length(body.current_thread.text) < 1000
   and any([subject.subject, sender.display_name, body.current_thread.text],
           regex.icontains(.,
-                          '(?:\b2fa\b|\bQ.?R\.?\s?\b|MFA|Muti[ -]?Factor|(?:Auth(enticat|e|or|ion)?))'
+                          '(?:\b2fa\b|\bQ.?R\.?\s?\b|MFA|Muti[ -]?Factor|Auth(?:enticat|e|or|ion)?)'
           )
   )
   and (


### PR DESCRIPTION
# Description

1. make the alteration of `(enticat|e|or|ion)` optional instead of the entire `Auth(enticat|e|or|ion)` alteration.
2. convert to non-capture groups
3. remove unnecessary group
