### PR TITLE
Fix null handling for nlu_classifier language checks

### DIFF
--- a/detection-rules/credential_phishing_nifty.com_domain_abuse.yml
+++ b/detection-rules/credential_phishing_nifty.com_domain_abuse.yml
@@ -9,7 +9,7 @@ source: |
     sender.email.local_part in map(recipients.to, .email.local_part)
     or sender.email.local_part in $org_slds
   )
-  and ml.nlu_classifier(body.current_thread.text).language != "japanese"
+  and coalesce(ml.nlu_classifier(body.current_thread.text).language != "japanese", true)
   
   // and no false positives and not solicited
   and not profile.by_sender_email().any_messages_benign

--- a/detection-rules/credential_phishing_nifty.com_domain_abuse.yml
+++ b/detection-rules/credential_phishing_nifty.com_domain_abuse.yml
@@ -9,7 +9,9 @@ source: |
     sender.email.local_part in map(recipients.to, .email.local_part)
     or sender.email.local_part in $org_slds
   )
-  and coalesce(ml.nlu_classifier(body.current_thread.text).language != "japanese", true)
+  and coalesce(ml.nlu_classifier(body.current_thread.text).language != "japanese",
+               true
+  )
   
   // and no false positives and not solicited
   and not profile.by_sender_email().any_messages_benign

--- a/detection-rules/credential_phishing_reauthentication.yml
+++ b/detection-rules/credential_phishing_reauthentication.yml
@@ -10,7 +10,7 @@ source: |
     any(ml.nlu_classifier(body.current_thread.text).intents,
         .name == "cred_theft" and .confidence == "high"
     )
-    or ml.nlu_classifier(body.current_thread.text).language != "english"
+    or coalesce(ml.nlu_classifier(body.current_thread.text).language != "english", true)
   )
   and any(ml.nlu_classifier(body.current_thread.text).topics,
           .name == "Security and Authentication" and .confidence == "high"

--- a/detection-rules/credential_phishing_reauthentication.yml
+++ b/detection-rules/credential_phishing_reauthentication.yml
@@ -10,7 +10,9 @@ source: |
     any(ml.nlu_classifier(body.current_thread.text).intents,
         .name == "cred_theft" and .confidence == "high"
     )
-    or coalesce(ml.nlu_classifier(body.current_thread.text).language != "english", true)
+    or coalesce(ml.nlu_classifier(body.current_thread.text).language != "english",
+                true
+    )
   )
   and any(ml.nlu_classifier(body.current_thread.text).topics,
           .name == "Security and Authentication" and .confidence == "high"
@@ -155,7 +157,6 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:


### PR DESCRIPTION
# Description

Wrap `ml.nlu_classifier(body.current_thread.text).language` comparisons with `coalesce(..., true)` in two rules so they don't fall back to `null` when `body.current_thread.text` is `null` and the classifier returns no output. Using `coalesce` will make these rules behave the same as if `unknown` was returned by `ml.nlu_classifier`.

Rules updated:
- `credential_phishing_nifty.com_domain_abuse.yml` — `!= "japanese"` check
- `credential_phishing_reauthentication.yml` — `!= "english"` check