### PR TITLE
Update brand_impersonation_sendgrid.yml

### DIFF
--- a/detection-rules/brand_impersonation_sendgrid.yml
+++ b/detection-rules/brand_impersonation_sendgrid.yml
@@ -13,6 +13,9 @@ source: |
       or strings.ilevenshtein(strings.replace_confusables(sender.display_name),
                               'sendgrid'
       ) <= 1
+      or regex.icontains(sender.display_name,
+                         's[\x{2063}\x{200B}]+e[\x{2063}\x{200B}]+n[\x{2063}\x{200B}]+d[\x{2063}\x{200B}]+g[\x{2063}\x{200B}]+r[\x{2063}\x{200B}]+i[\x{2063}\x{200B}]+d'
+      )
       or (
         strings.ilike(strings.replace_confusables(sender.email.local_part),
                       '*sendgrid*'
@@ -142,13 +145,10 @@ source: |
     )
     and headers.auth_summary.dmarc.pass
   )
-  // Exclude high trust domains with valid auth and solicited senders
-  and (
-    (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and not headers.auth_summary.dmarc.pass
-    )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
   and not profile.by_sender().solicited
 attack_types:


### PR DESCRIPTION
# Description

Adding logic to capture samples with `Sendgrid` as the `sender.display_name` where each character is separated by Unicode characters

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50bc001965da24deedcc460e139b67a1a1c593a4e465f3ac6ba25ac04d4a3741?preview_id=019fcdfd-e417-79e0-839f-b7263cc96a3d)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019fdc8e-cbd9-7d53-88c9-59a9bcc3d1a5)