### PR TITLE
Update vip_impersonation_fake_thread.yml

### DIFF
--- a/detection-rules/vip_impersonation_fake_thread.yml
+++ b/detection-rules/vip_impersonation_fake_thread.yml
@@ -4,28 +4,11 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and any($org_vips,
-          strings.icontains(body.html.display_text,
-                            strings.concat("From: ", .display_name, " <")
-          )
-          and not strings.icontains(body.html.display_text,
-                                    strings.concat("From: ",
-                                                   .display_name,
-                                                   " <",
-                                                   .email,
-                                                   ">"
-                                    )
-          )
-  )
-  and any([body.current_thread.text, body.html.display_text, body.plain.raw],
-          3 of (
-            strings.icontains(., "from:"),
-            strings.icontains(., "to:"),
-            strings.icontains(., "sent:"),
-            strings.icontains(., "date:"),
-            strings.icontains(., "cc:"),
-            strings.icontains(., "subject:")
-          )
+  and any(body.previous_threads,
+          any($org_vips, ..sender.display_name =~ .display_name)
+          and not any($org_vips,
+                      ..sender.display_name =~ .display_name
+                      and ..sender.email.email =~ .email)
   )
   and (length(headers.references) == 0 or headers.in_reply_to is null)
 attack_types:

--- a/detection-rules/vip_impersonation_fake_thread.yml
+++ b/detection-rules/vip_impersonation_fake_thread.yml
@@ -8,7 +8,8 @@ source: |
           any($org_vips, ..sender.display_name =~ .display_name)
           and not any($org_vips,
                       ..sender.display_name =~ .display_name
-                      and ..sender.email.email =~ .email)
+                      and ..sender.email.email =~ .email
+          )
   )
   and (length(headers.references) == 0 or headers.in_reply_to is null)
 attack_types:


### PR DESCRIPTION
# Description

Found an FP due to two VIP's having the same display name BUT different email addresses. 

This change updates the rule to use body.previous_thread.sender details AND does a second check to ensure that no org_vips match the previous thread's author details

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b9b409d051178a231953a60f9393cb84d0c8532ea49a352a8d9af1eac08229)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Multihunt- Net New](https://hunt.limeseed.email/hunts/750ee659-8bcb-49d0-9b8c-336ee21fb18d)
