### PR TITLE
Create callback_phishing_zero_width_obfuscation.yml

### DIFF
--- a/detection-rules/callback_phishing_zero_width_obfuscation.yml
+++ b/detection-rules/callback_phishing_zero_width_obfuscation.yml
@@ -1,0 +1,23 @@
+name: "Callback phishing: Zero-width character obfuscation from freemail sender"
+description: "Detects inbound messages sent from free email providers that contain a high volume of zero-width no-break space characters inserted before closing HTML tags, a technique used to break up and obfuscate text from content scanners. The rule also requires the presence of a phone number pattern in the message thread, consistent with callback phishing lures that rely on victims dialing a number rather than clicking a link."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and sender.email.domain.root_domain in $free_email_providers
+  and regex.icount(body.html.raw, '\x{FEFF}+</[^>]*>[a-z0-9]') >= 20
+  and regex.icontains(body.current_thread.text,
+                      '\+?([ilo0-9]{1}.)?\(?[ilo0-9]{3}?\)?.[ilo0-9]{3}.?[ilo0-9]{4}',
+                      '\+?([ilo0-9]{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}[ilo0-9]{3}[\s\.\-⋅]{0,5}[ilo0-9]{4}'
+  )
+  
+attack_types:
+  - "Callback Phishing"
+tactics_and_techniques:
+  - "Free email provider"
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "HTML analysis"
+  - "Content analysis"
+  - "Sender analysis"

--- a/detection-rules/callback_phishing_zero_width_obfuscation.yml
+++ b/detection-rules/callback_phishing_zero_width_obfuscation.yml
@@ -21,3 +21,4 @@ detection_methods:
   - "HTML analysis"
   - "Content analysis"
   - "Sender analysis"
+id: "6a6149e0-b4f1-5bee-81e4-96d9e6449db0"


### PR DESCRIPTION
# Description

Based on samples seen in Mode report

Detects inbound messages sent from free email providers that contain a high volume of zero-width no-break space characters inserted before closing HTML tags, a technique used to break up and obfuscate text from content scanners. The rule also requires the presence of a phone number pattern in the message thread, consistent with callback phishing lures that rely on victims dialing a number rather than clicking a link.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50bdc995a371a3593ded879a0b708933ead09dd24a6dc7c92cd82d85a29c5b3e?preview_id=019fce3c-fab0-72dc-b131-dbeb6cecb248)
- [Sample 2](https://platform.sublime.security/messages/50bc2ed3bb4c661557e7f81a5784bb4f8b277d56e2d5710c13e0b9ccc336ecfd?preview_id=019fce49-40d2-7df9-8768-fd0823fcc639)
- [Sample 3](https://platform.sublime.security/messages/50bc6962ecb595cb0e37965ed5ebb6c966a1bdee69e53f6a38f1b2771f2da870?preview_id=019fcdfb-b3e8-703b-908e-72a24ddb6ce9)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=019fd3ba-d8cc-77cf-978b-5a01b700b448)
- [97 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/847e90d9-9fad-4cb5-83eb-856420c2aad9)