### PR TITLE
Update: body_fake_safe_sender

### DIFF
--- a/detection-rules/body_fake_safe_sender.yml
+++ b/detection-rules/body_fake_safe_sender.yml
@@ -49,7 +49,7 @@ source: |
                             "*safe content*",
                             "*safe sender*",
                             "*trusted sender*",
-                            "secure share"
+                            "secure share" // strict match to avoid FPs
           )
           and not regex.icontains(.full_match,
                                   "add.{0,50} to.{0,50}(address book|safe senders? list)"

--- a/detection-rules/body_fake_safe_sender.yml
+++ b/detection-rules/body_fake_safe_sender.yml
@@ -48,7 +48,8 @@ source: |
           and strings.ilike(strings.replace_confusables(.full_match),
                             "*safe content*",
                             "*safe sender*",
-                            "*trusted sender*"
+                            "*trusted sender*",
+                            "secure share*"
           )
           and not regex.icontains(.full_match,
                                   "add.{0,50} to.{0,50}(address book|safe senders? list)"

--- a/detection-rules/body_fake_safe_sender.yml
+++ b/detection-rules/body_fake_safe_sender.yml
@@ -49,7 +49,7 @@ source: |
                             "*safe content*",
                             "*safe sender*",
                             "*trusted sender*",
-                            "secure share*"
+                            "secure share"
           )
           and not regex.icontains(.full_match,
                                   "add.{0,50} to.{0,50}(address book|safe senders? list)"


### PR DESCRIPTION
# Description

Added 'secure share' to the list of fake safe sender patterns.

# Associated samples
- https://platform.sublime.security/messages/50b9592de249bb5fb5b8c03f0bc859cdc827a94074a01e5d91e0d3f053902d17
## Associated hunts
- https://hunt.limeseed.email/hunts/3c94dc81-0f94-40ec-a26b-5363eb6b15ac