### PR TITLE
Update knowbe4_phishing_simulation.yml

### DIFF
--- a/exclusions/knowbe4_phishing_simulation.yml
+++ b/exclusions/knowbe4_phishing_simulation.yml
@@ -14,7 +14,7 @@ source: |
     or (
       length(headers.ips) == 0
       and length(headers.hops) == 1
-      and any(headers.hops, any(.fields, strings.ilike(.name, "x-phish%")))
+      and any(headers.hops, any(.fields, strings.istarts_with(.name, "x-phish")))
       and (
         (
           headers.return_path.domain.root_domain == "knowbe4.com"

--- a/exclusions/knowbe4_phishing_simulation.yml
+++ b/exclusions/knowbe4_phishing_simulation.yml
@@ -14,7 +14,7 @@ source: |
     or (
       length(headers.ips) == 0
       and length(headers.hops) == 1
-      and any(headers.hops, any(.fields, strings.starts_with(.name, "X-PHISH")))
+      and any(headers.hops, any(.fields, strings.ilike(.name, "x-phish%")))
       and (
         (
           headers.return_path.domain.root_domain == "knowbe4.com"


### PR DESCRIPTION
strings.ilike with the % glob wildcard replaces starts_with, making the prefix match case-insensitive. X-PHISHTEST, x-phishtest, X-Phish-Test etc. 

All match now.


knowb4 have some updates to their whitelisting guide that includes some potential updates to their headers.
<!-- 
Explain your change and why. For example, "negating legitimate replies," or "adding additional credential theft keywords."

If it's a new rule or insight, explain what the rule is designed to catch/what the insight should fire on.
-->

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b8ac165a622c286d63aef2da3d876ace6b53dff641027ab644f00ccc8912d9?preview_id=019fc94f-bbfc-7a9d-9c9e-982a8953e5b7)
- [Sample 2](https://platform.sublime.security/messages/50bc84e6279b02c5065a85f59488dbe654809821d1c1151bab6ff44d9baffb64?preview_id=019fcd7a-625e-7519-8251-f8253f6a3aac)

## Associated hunts


https://platform.sublime.security/messages/hunt?huntId=019fd73d-5ccd-715a-8f40-3f7ca9b739ae
This hunt includes an exclusion for the existing rule


# Screenshot (insights)
<!-- 
**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
-->
