### PR TITLE
Update link_content_credential_phishing.yml

### DIFF
--- a/detection-rules/link_content_credential_phishing.yml
+++ b/detection-rules/link_content_credential_phishing.yml
@@ -69,16 +69,13 @@ source: |
   
   // negate docusign originated emails
   and not any(headers.hops,
-              regex.imatch(.received.server.raw, ".+.docusign.(net|com)")
+              regex.imatch(.received.server.raw, '.+\.docusign.(?:net|com)')
   )
   
   // negate highly trusted sender domains unless they fail DMARC authentication
-  and (
-    (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and not headers.auth_summary.dmarc.pass
-    )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
 attack_types:
   - "Credential Phishing"


### PR DESCRIPTION
# Description
update regex to match literal dot, add non-capturing group, and update high trust negation to latest and greatest 


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019fd79f-3bb9-7b52-b76b-c6f99f3c45a9) - showing no cases where the any character regex is needed

