### PR TITLE
Use regex.imatch for certain URL regexes

### DIFF
--- a/detection-rules/body_unicode_slashes_in_url.yml
+++ b/detection-rules/body_unicode_slashes_in_url.yml
@@ -14,8 +14,8 @@ source: |
                     'https?:\/\/[^\s⁄∕]+(?:\/[^\s⁄∕]+)*[⁄∕][^\s⁄∕]+'
     )
     or any(body.links,
-           regex.icontains(.href_url.url,
-                           'https?:\/\/[^\s⁄∕]+(?:\/[^\s⁄∕]+)*[⁄∕][^\s⁄∕]+'
+           regex.imatch(.href_url.url,
+                        'https?:\/\/[^\s⁄∕]+(?:\/[^\s⁄∕]+)*[⁄∕][^\s⁄∕]+.*'
            )
     )
   )

--- a/detection-rules/link_numeric_ip_obfuscation.yml
+++ b/detection-rules/link_numeric_ip_obfuscation.yml
@@ -4,7 +4,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and any(body.links, regex.icontains(.href_url.url, 'https?://[0-9]{7,12}/.+'))
+  and any(body.links, regex.imatch(.href_url.url, 'https?://[0-9]{7,12}/.+'))
 attack_types:
   - "Credential Phishing"
   - "Malware/Ransomware"

--- a/detection-rules/link_numeric_ip_obfuscation.yml
+++ b/detection-rules/link_numeric_ip_obfuscation.yml
@@ -4,7 +4,11 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and any(body.links, regex.imatch(.href_url.url, 'https?://[0-9]{7,12}/.+'))
+  and any(body.links,
+          any(.href_url.ip.translation.encoders,
+              . in ('octal', 'decimal_integer')
+          )
+  )
 attack_types:
   - "Credential Phishing"
   - "Malware/Ransomware"

--- a/detection-rules/link_numeric_ip_obfuscation.yml
+++ b/detection-rules/link_numeric_ip_obfuscation.yml
@@ -6,7 +6,7 @@ source: |
   type.inbound
   and any(body.links,
           any(.href_url.ip.translation.encoders,
-              . in ('octal', 'decimal_integer' )
+              . in ('octal', 'decimal_integer')
           )
   )
 attack_types:

--- a/detection-rules/link_numeric_ip_obfuscation.yml
+++ b/detection-rules/link_numeric_ip_obfuscation.yml
@@ -6,7 +6,7 @@ source: |
   type.inbound
   and any(body.links,
           any(.href_url.ip.translation.encoders,
-              . in ('octal', 'decimal_integer')
+              . in ('octal', 'decimal_integer' )
           )
   )
 attack_types:


### PR DESCRIPTION
# Description

These URL regexes should be applied to the entire URL instead of seeing if the URL contains this regex. This does have some performance improvements and is probably closer to the original intention of the rule.
