### PR TITLE
Update impersonation_brand_wix.yml regex anchors

### DIFF
--- a/detection-rules/impersonation_brand_wix.yml
+++ b/detection-rules/impersonation_brand_wix.yml
@@ -6,7 +6,7 @@ source: |
   type.inbound
   and (
     (
-      regex.icontains(sender.display_name, '^WIX\b')
+      regex.icontains(sender.display_name, '\AWIX\b')
       or strings.ilike(sender.email.domain.domain, 'WIX')
     )
     or (
@@ -25,7 +25,7 @@ source: |
     )
     or (
       any(ml.nlu_classifier(body.current_thread.text).entities,
-          .name in ("sender", "org") and regex.icontains(.text, '^wix\b')
+          .name in ("sender", "org") and regex.icontains(.text, '\Awix\b')
       )
       and any(ml.nlu_classifier(body.current_thread.text).intents,
               .name == "cred_theft" and .confidence != "low"


### PR DESCRIPTION
# Description

Instead of anchoring to the beginning of the line, we should probably anchor to the beginning of the text instead. This prevents us from having to search the entire input for a newline that won't exist.
