### PR TITLE
Update impersonation_usps.yml

### DIFF
--- a/detection-rules/impersonation_usps.yml
+++ b/detection-rules/impersonation_usps.yml
@@ -64,6 +64,12 @@ source: |
       )
     ),
     any(body.links, regex.icontains(.href_url.url, 'https?://[0-9]{7,12}/.+')),
+    (
+      any(body.links,
+          strings.icontains(.display_url.domain.root_domain, 'usps')
+          and .mismatched
+      )
+    )
   )
   and (
     sender.email.domain.root_domain not in (
@@ -82,7 +88,7 @@ source: |
   )
   // negate newsletters
   and not (
-    length(body.links) > 20
+    length(filter(body.links, .visible == true)) > 20
     or any(ml.nlu_classifier(body.html.display_text).topics,
            .name == "Newsletters and Digests"
     )


### PR DESCRIPTION
# Description

Updating link negation logic to exclude non visible links, also added another condition for mismatched links with a display text root domain that contains `usps`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50bf95f530c3253282922859523a5731b3a32cca2ff094c0dc4d48f7b6ff41ae?preview_id=019fd7a9-420d-7b44-8901-d6eac828bdc3)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019fec1b-c524-7b47-b83a-92bd450dc0d7)
- [L7D 112 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/6fc11517-f9ad-45bc-807c-f81d77e1fe90)