### PR TITLE
Create impersonation_sam_sba_federal_registration.yml

### DIFF
--- a/detection-rules/impersonation_sam_sba_federal_registration.yml
+++ b/detection-rules/impersonation_sam_sba_federal_registration.yml
@@ -40,3 +40,4 @@ detection_methods:
   - "Content analysis"
   - "HTML analysis"
   - "Header analysis"
+id: "057ad471-4564-584c-a700-bba6e0c6eea9"

--- a/detection-rules/impersonation_sam_sba_federal_registration.yml
+++ b/detection-rules/impersonation_sam_sba_federal_registration.yml
@@ -1,4 +1,4 @@
-name: "Impersonation: SAM.gov and SBA federal registration"
+name: "Impersonation: SAM/SBA federal registration"
 description: "Detects inbound messages impersonating SAM.gov or the Small Business Administration by matching sender display names against known spoofed naming patterns (e.g. sba-support, sam registration/renewal) or by identifying sam.gov references paired with an embedded 'renew entity' image lure. Legitimate senders from verified sba.gov, sam.gov, or other high-trust domains that pass DMARC authentication are excluded."
 type: "rule"
 severity: "high"
@@ -18,10 +18,6 @@ source: |
               strings.icontains(.raw, 'sam%20renew%20entity')
       )
     )
-  )
-  and not (
-    sender.email.domain.root_domain in~ ("sba.gov", "sam.gov")
-    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains

--- a/detection-rules/impersonation_sam_sba_federal_registration.yml
+++ b/detection-rules/impersonation_sam_sba_federal_registration.yml
@@ -6,12 +6,11 @@ source: |
   type.inbound
   and (
     regex.icontains(sender.display_name,
-                    '^sam\.gov\b',
+                    '^sam(?:\.gov\b|\s(?:renew|compliance))',
                     'final\ssam\.gov',
                     '^sba[\s-]?(?:e[fd]|\.gov)',
                     '^sba[\s-](?:connect|invoice|admin|eidl)\b',
-                    '^sba[\s-]support[\s-]\w+',
-                    '^sam\s(?:registration|renew|compliance)'
+                    '^sba[\s-]support[\s-]\w+'
     )
     or (
       strings.icontains(body.current_thread.text, 'sam.gov')

--- a/detection-rules/impersonation_sam_sba_federal_registration.yml
+++ b/detection-rules/impersonation_sam_sba_federal_registration.yml
@@ -1,0 +1,42 @@
+name: "Impersonation: SAM.gov and SBA federal registration"
+description: "Detects inbound messages impersonating SAM.gov or the Small Business Administration by matching sender display names against known spoofed naming patterns (e.g. sba-support, sam registration/renewal) or by identifying sam.gov references paired with an embedded 'renew entity' image lure. Legitimate senders from verified sba.gov, sam.gov, or other high-trust domains that pass DMARC authentication are excluded."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and (
+    regex.icontains(sender.display_name,
+                    '^sam\.gov\b',
+                    'final\ssam\.gov',
+                    '^sba[\s-]?(?:e[fd]|\.gov)',
+                    '^sba[\s-](?:connect|invoice|admin|eidl)\b',
+                    '^sba[\s-]support[\s-]\w+',
+                    '^sam\s(?:registration|renew|compliance)'
+    )
+    or (
+      strings.icontains(body.current_thread.text, 'sam.gov')
+      and any(html.xpath(body.html, '//img/@src').nodes,
+              strings.icontains(.raw, 'sam%20renew%20entity')
+      )
+    )
+  )
+  and not (
+    sender.email.domain.root_domain in~ ("sba.gov", "sam.gov")
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+attack_types:
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+  - "Image as content"
+detection_methods:
+  - "Sender analysis"
+  - "Content analysis"
+  - "HTML analysis"
+  - "Header analysis"


### PR DESCRIPTION
# Description

Detects inbound messages impersonating SAM.gov or the Small Business Administration by matching sender display names against known spoofed naming patterns (e.g. sba-support, sam registration/renewal) or by identifying sam.gov references paired with an embedded 'renew entity' image lure. Legitimate senders from verified sba.gov, sam.gov, or other high-trust domains that pass DMARC authentication are excluded.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50c0a374fcbb173d03539eaf0d9e48272635377f9d9dce889beffc92b8f95767?preview_id=019fdc7d-a284-704f-a99e-f12a8e1c42ab)
- [Sample 2](https://platform.sublime.security/messages/50b6e377bd5eb5740c09943df11a6439b200483c0280c17ee9da3233ea3356f8?preview_id=019fb968-3c84-746d-92ab-5edc982c3199)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=019fec34-58b3-7c4f-943a-8f4ea371ed05)
- [L7D 112 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/cf3aaa74-8334-428e-a7d0-0ce87c6a5b96)