### PR TITLE
Fix undisclosed-recipients handling in body_advance_fee_new_sender.yml

### DIFF
--- a/detection-rules/body_advance_fee_new_sender.yml
+++ b/detection-rules/body_advance_fee_new_sender.yml
@@ -28,7 +28,13 @@ source: |
     or sender.email.domain.tld in $suspicious_tlds
     or any(["jp", "jo"], strings.iends_with(sender.email.domain.tld, .))
     or (
-      length(recipients.to) == 0
+      // an "undisclosed-recipients" placeholder is parsed as a To entry with an
+      // empty address, so it must be treated as equivalent to no disclosed
+      // recipients — otherwise all-bcc mailings evade this branch entirely
+      (
+        length(recipients.to) == 0
+        or all(recipients.to, .email.email == "")
+      )
       and any(headers.reply_to,
               .email.domain.root_domain != sender.email.domain.root_domain
       )

--- a/detection-rules/body_advance_fee_new_sender.yml
+++ b/detection-rules/body_advance_fee_new_sender.yml
@@ -32,8 +32,7 @@ source: |
       // empty address, so it must be treated as equivalent to no disclosed
       // recipients — otherwise all-bcc mailings evade this branch entirely
       (
-        length(recipients.to) == 0
-        or all(recipients.to, .email.email == "")
+        length(recipients.to) == 0 or all(recipients.to, .email.email == "")
       )
       and any(headers.reply_to,
               .email.domain.root_domain != sender.email.domain.root_domain


### PR DESCRIPTION
# Description

The all-bcc branch of this rule gates on `length(recipients.to) == 0`. An "undisclosed-recipients" mailing is parsed as a **single To entry with an empty address**, not an empty array — so that check is false for exactly the population the branch was written to catch. All-bcc advance fee mailings were evading the branch entirely.

```mql
// before
length(recipients.to) == 0
and any(headers.reply_to, ...)

// after
(
  length(recipients.to) == 0
  or all(recipients.to, .email.email == "")
)
and any(headers.reply_to, ...)
```

This was found while investigating an FBI-impersonation AFF false negative. The message satisfied every other condition in the rule; only this parsing gap kept it from firing. Worth noting it's a DMARC-passing compromised `.edu.ng` account, so the usual freemail/suspicious-TLD sender branches don't apply either — the all-bcc branch was the one that should have caught it.

# Associated samples

- [Sample — FBI impersonation AFF, all-bcc, DMARC-passing compromised account](https://platform.sublime.security/messages/50034a3d5d020b7101bec850ba01046def544a185f18911ab18db0f4fb24b233) — now matches; previously flagged by only one rule
- [Sample — regression check](https://platform.sublime.security/messages/50b7517dfbdef4048d1ddf3f0e80e9f2b4059e8a2761ffefdf2c2d87994e7868) — still matches, no regression

## Associated hunts

- [Isolated delta hunt](https://platform.sublime.security/messages/hunt?huntId=019fde04-eaff-7914-8f22-f1bea155d863) — messages the patched rule newly catches that the current one does not

The delta hunt is scoped to *only* the new coverage (patched branch matches AND current rule does not), so it measures the change's blast radius directly rather than total rule volume. **10 results over 30 days, all recognizably AFF:** "We provide loans on any viable business/project", "Access Capital", "Congratulations on Your Grant Award", "Project Financing Opportunity". No benign traffic in the delta.

`validateRule` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)