### PR TITLE
Create impersonation_law_enforcement_agency_advance_fee.yml

### DIFF
--- a/detection-rules/impersonation_law_enforcement_agency_advance_fee.yml
+++ b/detection-rules/impersonation_law_enforcement_agency_advance_fee.yml
@@ -14,7 +14,7 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-
+  
   // the sender ASSERTS the agency's identity rather than merely mentioning it
   and (
     // a display name bearing the agency is itself the identity claim
@@ -50,11 +50,12 @@ source: |
     // pasted FBI headquarters letterhead address
     or strings.icontains(body.current_thread.text, '935 Pennsylvania Avenue')
   )
-
+  
   // the fraud mechanism — the ask, not merely the theme
   and (
     any(ml.nlu_classifier(body.current_thread.text).intents,
-        .name in ("advance_fee", "extortion") and .confidence in ("medium", "high")
+        .name in ("advance_fee", "extortion")
+        and .confidence in ("medium", "high")
     )
     or 2 of (
       // PII harvesting form
@@ -77,7 +78,7 @@ source: |
       )
     )
   )
-
+  
   // the sender is not the authenticated government agency it claims to be. Scoped to
   // gov/mil TLDs — a general DMARC pass is deliberately NOT an exclusion, since these
   // campaigns routinely relay through compromised authenticated .edu and .ac accounts.
@@ -87,19 +88,15 @@ source: |
     )
     and headers.auth_summary.dmarc.pass
   )
-
+  
   // reporting and commentary about these agencies rather than correspondence from them
   and not any(ml.nlu_classifier(body.current_thread.text).topics,
               .name in ("Newsletters and Digests", "Marketing and Promotions")
               and .confidence in ("medium", "high")
   )
   // established conversations
-  and not (
-    length(headers.references) > 0
-    or length(body.previous_threads) > 0
-  )
+  and not (length(headers.references) > 0 or length(body.previous_threads) > 0)
   and not profile.by_sender().any_messages_benign
-
 attack_types:
   - "BEC/Fraud"
 tactics_and_techniques:

--- a/detection-rules/impersonation_law_enforcement_agency_advance_fee.yml
+++ b/detection-rules/impersonation_law_enforcement_agency_advance_fee.yml
@@ -1,0 +1,114 @@
+name: "Impersonation: Law enforcement agency with advance fee fraud"
+description: |
+  Detects advance fee fraud in which the sender asserts the identity of a federal law
+  enforcement agency (FBI, Interpol, EFCC, CBP) to lend authority to a fabricated payout,
+  restitution, or compensation claim. Requires both an identity assertion (agency in the
+  display name, agency letterhead, an agency rank in the signature block, or impersonation
+  of named agency leadership) and a fraud mechanism (advance fee/extortion intent, or two
+  of: PII harvesting form, unearned windfall language, out-of-band pivot to an
+  agency-themed mailbox on a non-government domain, disbursement method menu).
+
+  Agency mentions alone are deliberately insufficient — news commentary and personal
+  narratives referencing the FBI will not match without an accompanying identity assertion.
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+
+  // the sender ASSERTS the agency's identity rather than merely mentioning it
+  and (
+    // a display name bearing the agency is itself the identity claim
+    regex.icontains(strings.replace_confusables(sender.display_name),
+                    '\b(?:f\.?b\.?i|federal bureau of investigation|interpol|international criminal police|scotland yard|cyber ?crimes? commission|economic and financial crimes commission|efcc)\b'
+    )
+    // a subject naming the agency in full reads as agency-authored correspondence
+    or regex.icontains(strings.replace_confusables(subject.subject),
+                       '\b(?:federal bureau of investigation|interpol|international criminal police|scotland yard|economic and financial crimes commission)\b'
+    )
+    // a bare acronym only counts when framed as official correspondence, which
+    // keeps narrative mentions ("FBI found out that...") out of the rule
+    or (
+      regex.icontains(strings.replace_confusables(subject.subject),
+                      '\b(?:f\.?b\.?i|efcc|interpol)\b'
+      )
+      and regex.icontains(strings.replace_confusables(subject.subject),
+                          '\b(?:notice|notification|memo|payment|compensation|beneficiar|director|office|department|funds?|claim|approv(?:al|ed)|award)'
+      )
+    )
+    // agency letterhead opening the message
+    or regex.icontains(body.current_thread.text,
+                       '^\s*\W{0,5}(?:federal bureau of investigation|fbi\b|interpol|international criminal police)'
+    )
+    // signature block asserting an agency rank
+    or regex.icontains(body.current_thread.text,
+                       '(?:special agent|deputy director|assistant director|director)[\s,.]{1,30}(?:of the )?(?:federal bureau of investigation|fbi)\b'
+    )
+    // impersonating named agency leadership
+    or regex.icontains(body.current_thread.text,
+                       '\b(?:i am|this is)\b.{0,40}\b(?:k[ae]sh patel|dan bongino|christopher wray)\b'
+    )
+    // pasted FBI headquarters letterhead address
+    or strings.icontains(body.current_thread.text, '935 Pennsylvania Avenue')
+  )
+
+  // the fraud mechanism — the ask, not merely the theme
+  and (
+    any(ml.nlu_classifier(body.current_thread.text).intents,
+        .name in ("advance_fee", "extortion") and .confidence in ("medium", "high")
+    )
+    or 2 of (
+      // PII harvesting form
+      regex.icontains(body.current_thread.text,
+                      '(?:full|residential|delivery)\s+(?:name|address)s?\s*:'
+      ),
+      // unearned windfall
+      regex.icontains(body.current_thread.text,
+                      '\b(?:compensation|compensated|beneficiar(?:y|ies)|inheritance|lottery|winning|unclaimed funds?|atm card)\b'
+      ),
+      // out-of-band pivot to an agency-themed mailbox on any non-government domain.
+      // The TLD alternation is an inverted "not gov/mil" — RE2 forbids lookahead, so
+      // the exclusion is spelled out via first-character classes rather than (?!gov).
+      regex.icontains(body.current_thread.text,
+                      '[\w.+-]*(?:fbi|interpol|agent|deputy)[\w.+-]*@(?:[\w-]+\.)+(?:[a-fh-ln-z][a-z]+|g[a-np-z][a-z]*|go[a-uw-z][a-z]*|m[a-hj-z][a-z]*|mi[a-km-z][a-z]*)'
+      ),
+      // disbursement method menu
+      regex.icontains(body.current_thread.text,
+                      '\b(?:bank transfer|cashier(?:''s)? che(?:ck|que)|cash delivery|digital wallet|wire transfer)\b'
+      )
+    )
+  )
+
+  // the sender is not the authenticated government agency it claims to be. Scoped to
+  // gov/mil TLDs — a general DMARC pass is deliberately NOT an exclusion, since these
+  // campaigns routinely relay through compromised authenticated .edu and .ac accounts.
+  and not (
+    any(["gov", "gov.uk", "gov.au", "mil"],
+        strings.iends_with(sender.email.domain.tld, .)
+    )
+    and headers.auth_summary.dmarc.pass
+  )
+
+  // reporting and commentary about these agencies rather than correspondence from them
+  and not any(ml.nlu_classifier(body.current_thread.text).topics,
+              .name in ("Newsletters and Digests", "Marketing and Promotions")
+              and .confidence in ("medium", "high")
+  )
+  // established conversations
+  and not (
+    length(headers.references) > 0
+    or length(body.previous_threads) > 0
+  )
+  and not profile.by_sender().any_messages_benign
+
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+  - "Out of band pivot"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"
+id: "3b3ad7af-7034-559e-b938-d286ace72768"


### PR DESCRIPTION
# Description

Detects advance fee fraud where the sender **asserts the identity of** a federal law enforcement agency (FBI, Interpol, EFCC) to lend authority to a fabricated payout or compensation claim.

Supersedes closed PR #3991 (reuses its rule ID). That PR was closed with "need to figure out where to improve to remove LBs" — the root cause was structural: it paired an agency-keyword check against the body with a second agency-keyword check against subject/display_name/**body**, so both halves were satisfied by any message merely *containing* "fbi". There was no fraud-mechanism requirement at all.

Restructured into three genuinely independent signals:

1. **Identity assertion** — agency in display name, letterhead opening, agency rank in signature block, named leadership impersonation, or pasted HQ address
2. **Fraud mechanism** — `advance_fee`/`extortion` intent, or 2-of: PII harvesting form, unearned windfall language, out-of-band pivot to an agency-themed mailbox on a non-gov domain, disbursement method menu
3. **Sender is not an authenticated gov/mil domain**

The key distinction: *mentioning* an agency is not *claiming to be* one. A bare acronym in the subject only counts when paired with official-correspondence framing, which keeps news commentary and personal narratives out.

Also fixes two defects carried from #3991:
- `strings.ends_with(sender.email.domain.root_domain, ".gov")` never matched (`root_domain` is `fbi.gov`, not `.gov`-suffixed) and ignored authentication entirely, so a spoofed `.gov` display domain bypassed it
- bare `"fbi"` via `strings.icontains` matched inside unrelated words

## Design notes for reviewers

**Auth exclusion is scoped to gov/mil TLDs, not a blanket DMARC pass.** These campaigns routinely relay through compromised authenticated accounts — one of the samples below passes DMARC via a compromised `.edu.ng` account. A general auth exclusion would re-miss it.

**RE2 has no lookahead**, so the "agency mailbox on a non-government domain" exclusion is spelled out via first-character classes rather than `(?!gov)`. An earlier draft used a TLD allowlist (`com|net|org|...`) which silently capped coverage — `.us`, `.co.uk`, `.me` were trivial evasions.

**Known limitation:** named leadership (Patel/Bongino/Wray) is hardcoded and needs maintenance across administrations. The other identity-assertion branches don't depend on it.

# Associated samples

- [Sample — FBI "Special Agent" compensation lure, PII form + disbursement menu](https://platform.sublime.security/messages/50b7517dfbdef4048d1ddf3f0e80e9f2b4059e8a2761ffefdf2c2d87994e7868)
- [Sample — FBI director impersonation, all-bcc, DMARC-passing compromised account](https://platform.sublime.security/messages/50034a3d5d020b7101bec850ba01046def544a185f18911ab18db0f4fb24b233) (the FN from #3991)

## Associated hunts

- [Hunt — 90 day, full rule](https://platform.sublime.security/messages/hunt?huntId=019fddc7-7480-7415-940a-d0adb621a0a4) — 25 results, all reading as agency-impersonation AFF
- [Hunt — 60 day confirmation](https://platform.sublime.security/messages/hunt?huntId=019fddf9-a14f-76a2-9197-c773406a986b) — 24 results, no likely-benigns

`validateRule` passes; both samples verified matching via `runMqlByCanonicalId`.

**Tuning done from hunt evidence:** an earlier draft matched a personal YouTube-share rant because "FBI" appeared narratively in its subject — the same failure mode that sank #3991. Tightening the acronym branch dropped it while retaining both true positives. `customs and border protection` and `homeland security` were also removed from the display-name branch: hunting the identity-assertion signal in isolation showed they generated the largest block of benign traffic (CBP newsletters and career alerts, DHS daily digests) and there were no impersonation samples for either.

**Overlap disclosure:** most hits also flag under "Advance Fee Fraud (AFF) from freemail provider or suspicious TLD". #5061 fixes an all-bcc parsing bug in that rule which narrows this rule's unique contribution further. Reviewers may reasonably conclude the AFF fix alone is sufficient and this rule isn't worth the maintenance cost — happy to close if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)