### PR TITLE
Update vip_impersonation_fake_thread_with_invoice_handoff_email.yml

### DIFF
--- a/detection-rules/vip_impersonation_fake_thread_with_invoice_handoff_email.yml
+++ b/detection-rules/vip_impersonation_fake_thread_with_invoice_handoff_email.yml
@@ -3,6 +3,10 @@ description: "Detects inbound messages where an external sender, absent from the
 type: "rule"
 severity: "high"
 source: |
+  // note to rule writers
+  // this rule has a related rule which covers the same logic, but handles the display name but no email address in preivous threads
+  // very likely the logic will need updated in the corresponding rule
+  // see vip_impersonation_fake_thread_with_invoice_handoff_display_name.yml
   type.inbound
   and any(map(filter(body.previous_threads,
                      // VIP authored the segment: display_name OR real email (OR, not AND -- the actor guesses

--- a/detection-rules/vip_impersonation_fake_thread_with_invoice_handoff_email.yml
+++ b/detection-rules/vip_impersonation_fake_thread_with_invoice_handoff_email.yml
@@ -26,11 +26,12 @@ source: |
                      and regex.icontains(.text,
                                          'accounts? payable',
                                          '(?:forward|send|rout|direct|remit|submit|issue) it (?:directly )?to',
-                                         '(?:forward|send|direct|remit|submit|route) (?:the |all |related )?(?:invoice|correspondence|payment|billing)',
+                                         '(?:forward|send|direct|remit|submit|route) (?:the |all |related |for )?(?:invoice|correspondence|payment|billing|processing)',
                                          'for payment processing,? please contact',
                                          '(?:please )?direct (?:it|all|the)[^\n]{0,60}\bto\b',
                                          '(?:as follows|provided below|find below|details are|contact is)[^\n]{0,10}:',
-                                         'billing (?:contact|correspondence|team|department)'
+                                         'billing (?:contact|correspondence|team|department)',
+                                         'a copy.{0,20}sent to',
                      )
               ),
               .sender.email.email
@@ -42,17 +43,26 @@ source: |
                       strings.icontains(.email.email, ..)
           )
           // any previous thread authored by the "VIP" has invoice/payment
-          and any(filter(body.previous_threads, .sender.email.email == ..),
-                  any(ml.nlu_classifier(.text, subject=.subject.base).tags,
-                      .name in ("invoice", "payment") and .confidence != "low"
-                  )
-                  or any(ml.nlu_classifier(.text, subject=.subject.base).topics,
-                         .name in (
-                           "Request to View Invoice",
-                           "Payment Information"
-                         )
-                         and .confidence != "low"
-                  )
+          and (
+            any(filter(body.previous_threads,
+                       .sender.email.email == ..[0]
+                       or .sender.display_name == ..[1]
+                ),
+                any(ml.nlu_classifier(.text, subject=.subject.base).tags,
+                    .name in ("invoice", "payment") and .confidence != "low"
+                )
+                or any(ml.nlu_classifier(.text, subject=.subject.base).topics,
+                       .name in (
+                         "Request to View Invoice",
+                         "Payment Information"
+                       )
+                       and .confidence != "low"
+                )
+            )
+            // if we don't get NLU but there is a W9 or Inv attached, we can assume it's invoice related
+            or any(attachments,
+                   strings.istarts_with(.file_name, 'INV', "W-9", 'W9')
+            )
           )
   )
   // exactly one org-domain recipient (the payee); external sender.

--- a/detection-rules/vip_impersonation_fake_thread_with_invoice_handoff_email.yml
+++ b/detection-rules/vip_impersonation_fake_thread_with_invoice_handoff_email.yml
@@ -44,18 +44,12 @@ source: |
           )
           // any previous thread authored by the "VIP" has invoice/payment
           and (
-            any(filter(body.previous_threads,
-                       .sender.email.email == ..[0]
-                       or .sender.display_name == ..[1]
-                ),
+            any(filter(body.previous_threads, .sender.email.email == ..),
                 any(ml.nlu_classifier(.text, subject=.subject.base).tags,
                     .name in ("invoice", "payment") and .confidence != "low"
                 )
                 or any(ml.nlu_classifier(.text, subject=.subject.base).topics,
-                       .name in (
-                         "Request to View Invoice",
-                         "Payment Information"
-                       )
+                       .name in ("Request to View Invoice", "Payment Information")
                        and .confidence != "low"
                 )
             )

--- a/detection-rules/vip_impersonation_fake_thread_with_invoice_handoff_email.yml
+++ b/detection-rules/vip_impersonation_fake_thread_with_invoice_handoff_email.yml
@@ -29,7 +29,7 @@ source: |
                      // payment "handoff" phrasing.
                      and regex.icontains(.text,
                                          'accounts? payable',
-                                         '(?:forward|send|rout|direct|remit|submit|issue) it (?:directly )?to',
+                                         '(?:forward|send|rout|direct|remit|submit|issue) (?:it|a copy) (?:directly )?to',
                                          '(?:forward|send|direct|remit|submit|route) (?:the |all |related |for )?(?:invoice|correspondence|payment|billing|processing)',
                                          'for payment processing,? please contact',
                                          '(?:please )?direct (?:it|all|the)[^\n]{0,60}\bto\b',


### PR DESCRIPTION
# Description

Update the rule to include observed hand off wording and allow for invoice themed attachments to match when NLU doesnt.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b6aea325022ad7f079cd06d4d3bee50166991f453fc1759a9ccca592f63b0c?preview_id=019fa94f-0b02-7623-a242-feeb1c6a51b1)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Net New Multihunt](https://hunt.limeseed.email/hunts/a37a023c-cb06-4607-a151-979ef6bdb1eb)

# Screenshot (insights)
<!-- 
**For new insights only:** Insert a screenshot of the insight firing. Remove this section if not applicable.
-->
