### PR TITLE
Update vip_impersonation_fake_thread_with_invoice_handoff_display_nam…

### DIFF
--- a/detection-rules/vip_impersonation_fake_thread_with_invoice_handoff_display_name.yml
+++ b/detection-rules/vip_impersonation_fake_thread_with_invoice_handoff_display_name.yml
@@ -24,7 +24,7 @@ source: |
                      // payment "handoff" phrasing.
                      and regex.icontains(.text,
                                          'accounts? payable',
-                                         '(?:forward|send|rout|direct|remit|submit|issue) it (?:directly )?to',
+                                         '(?:forward|send|rout|direct|remit|submit|issue) (?:it|a copy) (?:directly )?to',
                                          '(?:forward|send|direct|remit|submit|route) (?:the |all |related |for )?(?:invoice|correspondence|payment|billing|processing)',
                                          'for payment processing,? please contact',
                                          '(?:please )?direct (?:it|all|the)[^\n]{0,60}\bto\b',

--- a/detection-rules/vip_impersonation_fake_thread_with_invoice_handoff_display_name.yml
+++ b/detection-rules/vip_impersonation_fake_thread_with_invoice_handoff_display_name.yml
@@ -3,6 +3,10 @@ description: "Detects inbound messages where an external sender, absent from the
 type: "rule"
 severity: "high"
 source: |
+  // note to rule writers
+  // this rule has a related rule which covers the same logic, but handles the "email address" but no display name in preivous threads
+  // very likely the logic will need updated in the corresponding rule
+  // see vip_impersonation_fake_thread_with_invoice_handoff_email.yml
   type.inbound
   and any(map(filter(body.previous_threads,
                      .sender.email.email == ""
@@ -17,31 +21,36 @@ source: |
                              .email.domain.root_domain in $org_domains
                              and strings.icontains(..text, .email.email)
                      )
+                     // payment "handoff" phrasing.
                      and regex.icontains(.text,
                                          'accounts? payable',
-                                         '(?:forward|send|rout|direct|remit|submit|issue) (?:it|a copy) (?:directly )?to',
-                                         '(?:forward|send|direct|remit|submit|route) (?:the |all |related )?(?:invoice|correspondence|payment|billing)',
+                                         '(?:forward|send|rout|direct|remit|submit|issue) it (?:directly )?to',
+                                         '(?:forward|send|direct|remit|submit|route) (?:the |all |related |for )?(?:invoice|correspondence|payment|billing|processing)',
                                          'for payment processing,? please contact',
                                          '(?:please )?direct (?:it|all|the)[^\n]{0,60}\bto\b',
-                                         'directed to (?:our |the )?[^\n]{0,40}(?:team|processing)',
                                          '(?:as follows|provided below|find below|details are|contact is)[^\n]{0,10}:',
-                                         'billing (?:contact|correspondence|team|department|statements?)'
+                                         'billing (?:contact|correspondence|team|department)',
+                                         'a copy.{0,20}sent to',
                      )
               ),
               .sender.display_name
           ),
           . != ""
-          and any(filter(body.previous_threads, .sender.display_name == ..),
-                  any(ml.nlu_classifier(.text, subject=.subject.base).tags,
-                      .name in ("invoice", "payment") and .confidence != "low"
-                  )
-                  or any(ml.nlu_classifier(.text, subject=.subject.base).topics,
-                         .name in (
-                           "Request to View Invoice",
-                           "Payment Information"
-                         )
-                         and .confidence != "low"
-                  )
+          // any previous thread authored by the "VIP" has invoice/payment
+          and (
+            any(filter(body.previous_threads, .sender.email.email == ..),
+                any(ml.nlu_classifier(.text, subject=.subject.base).tags,
+                    .name in ("invoice", "payment") and .confidence != "low"
+                )
+                or any(ml.nlu_classifier(.text, subject=.subject.base).topics,
+                       .name in ("Request to View Invoice", "Payment Information")
+                       and .confidence != "low"
+                )
+            )
+            // if we don't get NLU but there is a W9 or Inv attached, we can assume it's invoice related
+            or any(attachments,
+                   strings.istarts_with(.file_name, 'INV', "W-9", 'W9')
+            )
           )
           and not any(flatten([recipients.to, recipients.cc, recipients.bcc]),
                       any($org_vips,


### PR DESCRIPTION
…e.yml

# Description

Update the rule to include observed hand off wording and allow for invoice themed attachments to match when NLU doesnt.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b6aea325022ad7f079cd06d4d3bee50166991f453fc1759a9ccca592f63b0c?preview_id=019fa94f-0b02-7623-a242-feeb1c6a51b1)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Multihunt](https://hunt.limeseed.email/hunts/cd51f136-e607-49df-a53d-3c1b06febb3b)
