### PR TITLE
Create link_url_fragmeneted_hidden_spans.yml

### DIFF
--- a/detection-rules/link_url_fragmeneted_hidden_spans.yml
+++ b/detection-rules/link_url_fragmeneted_hidden_spans.yml
@@ -17,7 +17,7 @@ source: |
   
   // A URL appears in the rendered/visible text but is NOT present
   // in the raw HTML because hidden spans fragmented it.
-  and any(regex.extract(body.html.display_text, 'https?://\S+'),
+  and any(regex.extract(body.html.display_text, 'https?://[a-zA-Z0-9.\-/%?=&#:@_~]{1,1000}[a-zA-Z0-9/]'),
           strings.parse_url(.full_match, strict=false).domain.valid
           and not strings.icontains(body.html.raw, .full_match)
   )

--- a/detection-rules/link_url_fragmeneted_hidden_spans.yml
+++ b/detection-rules/link_url_fragmeneted_hidden_spans.yml
@@ -8,7 +8,7 @@ source: |
   // a tag contains spans indicating it's not visable
   // the random tokens the kit uses to fragment the URL are longer than 4
   and length(filter(html.xpath(body.html,
-                               '//a//span[contains(@style,"display:none") or contains(@style,"display: none") or contains(@style,"visibility:hidden") or contains(@style,"font-size:0") or  contains(@style,"opacity:0")]'
+                               "//a//span[(contains(@style,'display:none') or contains(@style,'display: none') or contains(@style,'visibility:hidden') or contains(@style,'font-size:0') or contains(@style,'opacity:0')) and not(.//img)]"
                     ).nodes,
                     // the node contains at least 4 word chars
                     regex.contains(.inner_text, '\w{4,}')
@@ -22,7 +22,7 @@ source: |
           and not strings.icontains(body.html.raw, .full_match)
   )
   and not (
-    sender.email.domain.root_domain not in $high_trust_sender_root_domains
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
 attack_types:

--- a/detection-rules/link_url_fragmeneted_hidden_spans.yml
+++ b/detection-rules/link_url_fragmeneted_hidden_spans.yml
@@ -17,7 +17,9 @@ source: |
   
   // A URL appears in the rendered/visible text but is NOT present
   // in the raw HTML because hidden spans fragmented it.
-  and any(regex.extract(body.html.display_text, 'https?://[a-zA-Z0-9.\-/%?=&#:@_~]{1,1000}[a-zA-Z0-9/]'),
+  and any(regex.extract(body.html.display_text,
+                        'https?://[a-zA-Z0-9.\-/%?=&#:@_~]{1,1000}[a-zA-Z0-9/]'
+          ),
           strings.parse_url(.full_match, strict=false).domain.valid
           and not strings.icontains(body.html.raw, .full_match)
   )

--- a/detection-rules/link_url_fragmeneted_hidden_spans.yml
+++ b/detection-rules/link_url_fragmeneted_hidden_spans.yml
@@ -1,0 +1,38 @@
+name: "Link: URL fragmented by hidden spans"
+description: "Detects messages where a link's URL is broken into multiple pieces using anchor tags containing hidden spans (via CSS such as display:none, visibility:hidden, font-size:0, or opacity:0). This technique reconstructs a visible URL in the rendered text while keeping the full URL absent from the raw HTML, evading scanners that inspect raw content. The rule confirms this by finding a URL in the displayed text that does not appear in the raw HTML, and further exempts messages from high-trust sending domains that pass DMARC."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  
+  // a tag contains spans indicating it's not visable
+  // the random tokens the kit uses to fragment the URL are longer than 4
+  and length(filter(html.xpath(body.html,
+                               '//a//span[contains(@style,"display:none") or contains(@style,"display: none") or contains(@style,"visibility:hidden") or contains(@style,"font-size:0") or  contains(@style,"opacity:0")]'
+                    ).nodes,
+                    // the node contains at least 4 word chars
+                    regex.contains(.inner_text, '\w{4,}')
+             )
+  ) >= 2
+  
+  // A URL appears in the rendered/visible text but is NOT present
+  // in the raw HTML because hidden spans fragmented it.
+  and any(regex.extract(body.html.display_text, 'https?://\S+'),
+          strings.parse_url(.full_match, strict=false).domain.valid
+          and not strings.icontains(body.html.raw, .full_match)
+  )
+  
+  and not (
+         sender.email.domain.root_domain not in $high_trust_sender_root_domains
+         and coalesce(headers.auth_summary.dmarc.pass, fasle)
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "HTML smuggling"
+  - "Social engineering"
+detection_methods:
+  - "HTML analysis"
+  - "URL analysis"
+  - "Content analysis"

--- a/detection-rules/link_url_fragmeneted_hidden_spans.yml
+++ b/detection-rules/link_url_fragmeneted_hidden_spans.yml
@@ -24,7 +24,7 @@ source: |
   
   and not (
          sender.email.domain.root_domain not in $high_trust_sender_root_domains
-         and coalesce(headers.auth_summary.dmarc.pass, fasle)
+         and coalesce(headers.auth_summary.dmarc.pass, false)
   )
 attack_types:
   - "Credential Phishing"

--- a/detection-rules/link_url_fragmeneted_hidden_spans.yml
+++ b/detection-rules/link_url_fragmeneted_hidden_spans.yml
@@ -21,10 +21,9 @@ source: |
           strings.parse_url(.full_match, strict=false).domain.valid
           and not strings.icontains(body.html.raw, .full_match)
   )
-  
   and not (
-         sender.email.domain.root_domain not in $high_trust_sender_root_domains
-         and coalesce(headers.auth_summary.dmarc.pass, false)
+    sender.email.domain.root_domain not in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
 attack_types:
   - "Credential Phishing"
@@ -36,3 +35,4 @@ detection_methods:
   - "HTML analysis"
   - "URL analysis"
   - "Content analysis"
+id: "c7baf090-3cab-5b9f-86cf-a71777aba30c"


### PR DESCRIPTION
# Description

Add detection of observed technique that splits a url up via hidden spans.  The url is detected in body.links via the plain text parser. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50bfb1b48a7ff91ae34608ee9bde3c685343c640323cda496a179275cff0a727)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=019fed42-a51f-72d4-b1d2-cc6da68427ef)
