### PR TITLE
Update: link_credential_phishing_intent_and_other_indicators

### DIFF
--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -56,6 +56,7 @@ source: |
                     "e-?ma[il1]{2}.*up.?grade",
                     "e.?ma[il1]{2}.*server",
                     "e.?ma[il1]{2}.*suspend",
+                    "electronic advisory",
                     "email.update",
                     "faxed you",
                     "fraud(ulent)?.*charge",


### PR DESCRIPTION
# Description

adding `electronic advisory` as a suspicious subject keyword

# Associated samples
- https://platform.sublime.security/messages/50b9592de249bb5fb5b8c03f0bc859cdc827a94074a01e5d91e0d3f053902d17

## Associated hunts
- https://platform.sublime.security/messages/hunt?huntId=01a00289-162f-705c-8970-20a223201c6c