### PR TITLE
Update link_credential_phishing_intent_and_other_indicators.yml

### DIFF
--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -68,7 +68,6 @@ source: |
                     "heipdesk",
                     "i[il]iega[il]",
                     "ii[il]ega[il]",
-                    "important \\w+ update",
                     "incoming e?mail",
                     "incoming.*fax",
                     "lock.*security",
@@ -92,12 +91,14 @@ source: |
                     "office365",
                     "on google docs with you",
                     "online doc",
+                    "outstanding inv\\b",
                     "password.*compromised",
                     "(?:payroll|salary|bonus).*Distribution",
                     "periodic maintenance",
                     "potential(ly)? unauthorized",
                     "refund not approved",
                     "report",
+                    "\\brfq\\s_",
                     "revised.*policy",
                     "scam",
                     "scanned.?invoice",
@@ -166,6 +167,7 @@ source: |
                     "freefax",
                     "fwd: due invoice paid",
                     "has shared",
+                    "important community update",
                     "inbox is full",
                     "invitation to comment",
                     "invitation to edit",
@@ -312,6 +314,23 @@ source: |
       any(ml.nlu_classifier(body.current_thread.text).entities,
           .name == "request"
       ),
+      (
+        any(ml.nlu_classifier(body.current_thread.text).topics,
+            .name == "Government Services" and .confidence == "high"
+        )
+        and any(ml.nlu_classifier(body.current_thread.text).topics,
+                .name == "Emergency Alerts" and .confidence == "high"
+        )
+        and not any(ml.nlu_classifier(body.current_thread.text).topics,
+                    .name == "News and Current Events"
+        )
+      ),
+      (
+        any(body.current_thread.links,
+            strings.iends_with(.display_text, ".pdf")
+            and strings.istarts_with(.display_text, "view")
+        )
+      ),
       // recipient email address base64 encoded in link
       any(body.links,
           any(recipients.to,
@@ -371,6 +390,9 @@ source: |
       strings.contains(body.current_thread.text,
                        "Your mailbox can no longer send or receive messages."
       ),
+      strings.contains(body.current_thread.text,
+                       "this invoice has been overlooked"
+      ),
       any(body.links,
           strings.icontains(.href_url.query_params, 'redirect')
           or any(.href_url.rewrite.encoders,
@@ -388,11 +410,15 @@ source: |
               any(ml.nlu_classifier(.display_text).entities, .name == "request")
       ),
       any(body.links,
-          strings.icontains(.href_url.path, mailbox.email.domain.root_domain)
-          and not .href_url.domain.domain in ("groups.google.com")
+          .href_url.domain.tld in ("xyz") and .href_url.scheme != "mailto"
       ),
-      any(body.links,
-          regex.contains(.href_url.path, '/[a-z]{6,8}/[a-z]{6,8}/[a-z]{6,8}/')
+      (
+        any(body.links,
+            .href_url.domain.root_domain in $self_service_creation_platform_domains
+        )
+        and any(ml.nlu_classifier(body.current_thread.text).tags,
+                .name == "invoice" and .confidence == "high"
+        )
       ),
       any(body.links,
           // display text contains a request

--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -68,6 +68,7 @@ source: |
                     "heipdesk",
                     "i[il]iega[il]",
                     "ii[il]ega[il]",
+                    "important \\w+ update",
                     "incoming e?mail",
                     "incoming.*fax",
                     "lock.*security",
@@ -314,9 +315,9 @@ source: |
       // recipient email address base64 encoded in link
       any(body.links,
           any(recipients.to,
-              any(beta.scan_base64(..href_url.url,
-                                   ignore_padding=true,
-                                   format="url"
+              any(strings.scan_base64(..href_url.url,
+                                      ignore_padding=true,
+                                      format="url"
                   ),
                   strings.icontains(., ..email.email)
               )
@@ -385,6 +386,13 @@ source: |
       and any(body.links,
               // display text contains a request
               any(ml.nlu_classifier(.display_text).entities, .name == "request")
+      ),
+      any(body.links,
+          strings.icontains(.href_url.path, mailbox.email.domain.root_domain)
+          and not .href_url.domain.domain in ("groups.google.com")
+      ),
+      any(body.links,
+          regex.contains(.href_url.path, '/[a-z]{6,8}/[a-z]{6,8}/[a-z]{6,8}/')
       ),
       any(body.links,
           // display text contains a request
@@ -543,7 +551,7 @@ source: |
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
   // FP avoidance
-  and not any(beta.ml_topic(body.current_thread.text).topics,
+  and not any(ml.nlu_classifier(body.current_thread.text).topics,
               .name in (
                 "Advertising and Promotions",
                 "Political Mail",

--- a/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
+++ b/detection-rules/link_credential_phishing_intent_and_other_indicators.yml
@@ -167,7 +167,6 @@ source: |
                     "freefax",
                     "fwd: due invoice paid",
                     "has shared",
-                    "important community update",
                     "inbox is full",
                     "invitation to comment",
                     "invitation to edit",
@@ -315,17 +314,6 @@ source: |
           .name == "request"
       ),
       (
-        any(ml.nlu_classifier(body.current_thread.text).topics,
-            .name == "Government Services" and .confidence == "high"
-        )
-        and any(ml.nlu_classifier(body.current_thread.text).topics,
-                .name == "Emergency Alerts" and .confidence == "high"
-        )
-        and not any(ml.nlu_classifier(body.current_thread.text).topics,
-                    .name == "News and Current Events"
-        )
-      ),
-      (
         any(body.current_thread.links,
             strings.iends_with(.display_text, ".pdf")
             and strings.istarts_with(.display_text, "view")
@@ -408,9 +396,6 @@ source: |
       and any(body.links,
               // display text contains a request
               any(ml.nlu_classifier(.display_text).entities, .name == "request")
-      ),
-      any(body.links,
-          .href_url.domain.tld in ("xyz") and .href_url.scheme != "mailto"
       ),
       (
         any(body.links,


### PR DESCRIPTION
# Description

Adding logic to tag samples with links to `self_service_creation_platforms` and links with `display_text` that starts with `view` and end with `.pdf`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b504ad8251d902d04759ecaa973c0dd5e7e0161236689910f024f3353c0532?preview_id=019fc9b8-10bf-7622-a2c5-05bece5857e6)
- [Sample 2](https://platform.sublime.security/messages/50b146f160b15c65bfeb1d18e97af2d50579928ddb176fa92c692f09b589b7d5?preview_id=019fc9ba-128e-7dea-b6b2-0e0649ee95fd)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=01a034e3-4fd5-7a98-b2e3-263deb24c816)
- [L7D 95 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/8ae575f6-1865-41c2-be09-57cb4a5cf065)