### PR TITLE
Create spam_godaddy_domaincontrol_newly_registered_domain.yml

### DIFF
--- a/detection-rules/spam_godaddy_domaincontrol_newly_registered_domain.yml
+++ b/detection-rules/spam_godaddy_domaincontrol_newly_registered_domain.yml
@@ -1,4 +1,4 @@
-name: "Spam: Cold outreach from newly registered domain"
+name: "Spam: Cold outreach from newly registered sender with default name servers"
 description: "Detects inbound messages from domains registered less than 365 days ago using GoDaddy (domaincontrol.com) nameservers, where the message content is classified as B2B cold outreach by NLU analysis. The rule excludes legitimate reply threads and auto-replies, and only flags senders who are either unsolicited or have a history of malicious/spam activity without any benign messages."
 type: "rule"
 severity: "low"

--- a/detection-rules/spam_godaddy_domaincontrol_newly_registered_domain.yml
+++ b/detection-rules/spam_godaddy_domaincontrol_newly_registered_domain.yml
@@ -22,3 +22,4 @@ tactics_and_techniques:
 detection_methods:
   - "Whois"
   - "Sender analysis"
+id: "9645ef3c-27d2-5891-b77b-38c8f06a5964"

--- a/detection-rules/spam_godaddy_domaincontrol_newly_registered_domain.yml
+++ b/detection-rules/spam_godaddy_domaincontrol_newly_registered_domain.yml
@@ -27,7 +27,7 @@ source: |
     )
     and (
       (
-        (subject.is_forward or subject.is_auto_reply or subject.is_reply)
+        (subject.is_forward or subject.is_reply)
         and length(body.previous_threads) >= 1
       )
       // auto replies may not always have a previous thread

--- a/detection-rules/spam_godaddy_domaincontrol_newly_registered_domain.yml
+++ b/detection-rules/spam_godaddy_domaincontrol_newly_registered_domain.yml
@@ -1,4 +1,4 @@
-name: "Spam: Cold outreach from newly registered sender with default name servers"
+name: "Spam: Cold outreach from GoDaddy-hosted newly registered domain"
 description: "Detects inbound messages from domains registered less than 365 days ago using GoDaddy (domaincontrol.com) nameservers, where the message content is classified as B2B cold outreach by NLU analysis. The rule excludes legitimate reply threads and auto-replies, and only flags senders who are either unsolicited or have a history of malicious/spam activity without any benign messages."
 type: "rule"
 severity: "low"

--- a/detection-rules/spam_godaddy_domaincontrol_newly_registered_domain.yml
+++ b/detection-rules/spam_godaddy_domaincontrol_newly_registered_domain.yml
@@ -1,5 +1,5 @@
-name: "Spam: Newly registered domain with default GoDaddy name servers"
-description: "Detects inbound messages where the sender's domain was registered within the past year and uses exactly two name servers, both with subdomains starting with 'ns' under domaincontrol.com. This pattern reflects unconfigured, default GoDaddy DNS settings indicating abuse of GoDaddy's DNS infrastructure to rapidly stand up new domains"
+name: "Spam: Cold outreach from newly registered domain"
+description: "Detects inbound messages from domains registered less than 365 days ago using GoDaddy (domaincontrol.com) nameservers, where the message content is classified as B2B cold outreach by NLU analysis. The rule excludes legitimate reply threads and auto-replies, and only flags senders who are either unsolicited or have a history of malicious/spam activity without any benign messages."
 type: "rule"
 severity: "low"
 source: |
@@ -14,12 +14,45 @@ source: |
           and .root_domain == 'domaincontrol.com'
   )
   
+  // nlu logic
+  and any(ml.nlu_classifier(body.current_thread.text).topics,
+          .name in ('B2B Cold Outreach')
+  )
+  
+  // negate legitimate replies
+  and not (
+    (
+      length(headers.references) > 0
+      or (headers.in_reply_to is not null and headers.in_reply_to != "")
+    )
+    and (
+      (
+        (subject.is_forward or subject.is_auto_reply or subject.is_reply)
+        and length(body.previous_threads) >= 1
+      )
+      // auto replies may not always have a previous thread
+      or subject.is_auto_reply
+    )
+  )
+  
+  // sender profiles
+  and (
+    not profile.by_sender_email().solicited
+    or (
+      profile.by_sender_email().any_messages_malicious_or_spam
+      and not profile.by_sender_email().any_messages_benign
+    )
+  )
+  
+tags:
+  - "Attack surface reduction"
 attack_types:
   - "Spam"
 tactics_and_techniques:
-  - "Evasion"
   - "Social engineering"
 detection_methods:
   - "Whois"
+  - "Natural Language Understanding"
+  - "Header analysis"
   - "Sender analysis"
 id: "9645ef3c-27d2-5891-b77b-38c8f06a5964"

--- a/detection-rules/spam_godaddy_domaincontrol_newly_registered_domain.yml
+++ b/detection-rules/spam_godaddy_domaincontrol_newly_registered_domain.yml
@@ -1,0 +1,24 @@
+name: "Spam: Newly registered domain with default GoDaddy name servers"
+description: "Detects inbound messages where the sender's domain was registered within the past year and uses exactly two name servers, both with subdomains starting with 'ns' under domaincontrol.com. This pattern reflects unconfigured, default GoDaddy DNS settings indicating abuse of GoDaddy's DNS infrastructure to rapidly stand up new domains"
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  // newly registered sender domain
+  and network.whois(sender.email.domain).days_old < 365
+  
+  // there are 2 name servers which have subdomains containing .ns
+  and length(network.whois(sender.email.domain).name_servers) == 2
+  and all(network.whois(sender.email.domain).name_servers,
+          strings.istarts_with(.subdomain, 'ns')
+          and .root_domain == 'domaincontrol.com'
+  )
+  
+attack_types:
+  - "Spam"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "Whois"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

Rule flags on newly registered sender domains less than 365 days old, using GoDaddy's default DNS name servers.

# Associated samples

[- Sample 1](https://platform.sublime.security/messages/50c3a14a9eb826f37971359baf892fbb93344530c94f23863afde44f0cc9b977?preview_id=019feca6-95a3-793c-a8d3-673f9b84a1de)
[- Sample 2](https://platform.sublime.security/messages/50c29ea3368802d800e3697f45e92bd93c92c189fca2b2bad8fca7ce526815c2?from_canonical_id=50c2c153d8894c5e7476eb034a0ef2e3d5144ecb6e473f127818d15589c4f5d3&preview_id=019feca6-e0e3-74a2-a947-8c08e74b7648)

## Associated hunts

- [Hunt 1 (Shared Samples) - L180D](https://platform.sublime.security/messages/hunt?huntId=01a059b1-3e66-704e-a429-269bfc0a0e6d)
- [Hunt 2 (Multi) - L30D](https://hunt.limeseed.email/hunts/1250fea4-6927-49e2-a075-e55725f7bf36)