### PR TITLE
Create service_abuse_domain_the_net_new_sender_domain.yml

### DIFF
--- a/detection-rules/service_abuse_domain_the_net_new_sender_domain.yml
+++ b/detection-rules/service_abuse_domain_the_net_new_sender_domain.yml
@@ -11,10 +11,8 @@ source: |
   // there are 3 name servers which have subdomains containing .ns
   and length(network.whois(sender.email.domain).name_servers) == 3
   and all(network.whois(sender.email.domain).name_servers,
-          strings.istarts_with(.subdomain, 'ns')
-          and .root_domain == 'dtnt.info'
+          strings.istarts_with(.subdomain, 'ns') and .root_domain == 'dtnt.info'
   )
-
 attack_types:
   - "Spam"
   - "Credential Phishing"
@@ -25,3 +23,4 @@ tactics_and_techniques:
 detection_methods:
   - "Whois"
   - "Sender analysis"
+id: "23cc8de2-1c76-50d9-9ec0-11d4acb004e0"

--- a/detection-rules/service_abuse_domain_the_net_new_sender_domain.yml
+++ b/detection-rules/service_abuse_domain_the_net_new_sender_domain.yml
@@ -1,0 +1,27 @@
+name: "Service abuse: Newly registered domain from dtnt.info (Domain the Net)"
+description: "Detects inbound messages where the sender's domain was registered within the last 365 days and uses exactly three name servers, with subdomains starting with 'ns' under dtnt.info (Domain the Net). This pattern has been observed in both spam & malicious campaigns."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  
+  // newly registered sender domain
+  and network.whois(sender.email.domain).days_old < 365
+  
+  // there are 3 name servers which have subdomains containing .ns
+  and length(network.whois(sender.email.domain).name_servers) == 3
+  and all(network.whois(sender.email.domain).name_servers,
+          strings.istarts_with(.subdomain, 'ns')
+          and .root_domain == 'dtnt.info'
+  )
+
+attack_types:
+  - "Spam"
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "Whois"
+  - "Sender analysis"


### PR DESCRIPTION
Creating new rule for newly registered senders from suspicious DNS servers.

# Description

Rule flags inbound messages where the sender's domain was registered within the last 365 days and uses exactly three name servers, with subdomains starting with 'ns' under dtnt.info (Domain the Net). This pattern has been observed in both spam & malicious campaigns.

# Associated samples

[- Sample 1](https://platform.sublime.security/messages/50c377b6796a591c80f2750717d4c9abf746a56a07a628a9ae7863ed9af2ea91?preview_id=019feca6-96bd-7d8c-bef6-e5a3db383f26)
[- Sample 2](https://platform.sublime.security/messages/508d35b3ae17dc693469e0f9bcc5c301e475ee0d772a40a32a45e209b89ab1e9?preview_id=019ed7aa-398e-78de-9146-b943be013c73)

## Associated hunts

WILL UPDATE

- Hunt 1 (Shared samples) - L180D
- Hunt 2 (Multi) - L30D