### PR TITLE
create evasion_suspicious_tld_redirecting_wikipedia.yml

### DIFF
--- a/detection-rules/evasion_suspicious_tld_redirecting_wikipedia.yml
+++ b/detection-rules/evasion_suspicious_tld_redirecting_wikipedia.yml
@@ -12,6 +12,7 @@ source: |
   )
 attack_types:
   - "Credential Phishing"
+  - "Spam"
 tactics_and_techniques:
   - "Evasion"
   - "Open redirect"

--- a/detection-rules/evasion_suspicious_tld_redirecting_wikipedia.yml
+++ b/detection-rules/evasion_suspicious_tld_redirecting_wikipedia.yml
@@ -1,0 +1,19 @@
+name: "Evasion: Suspicious TLD link redirecting to Wikipedia"
+description: "Flags inbound messages containing links with domains registered under suspicious top-level domains that redirect to Wikipedia when analyzed. This behavior indicates the link is detecting automated sandbox or security analysis tools and serving benign content to evade detection, while likely delivering malicious content to real users."
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  and any(body.current_thread.links,
+          .href_url.domain.tld in $suspicious_tlds
+          and ml.link_analysis(.).effective_url.url in (
+            'https://www.wikipedia.org/'
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Open redirect"
+detection_methods:
+  - "URL analysis"

--- a/detection-rules/evasion_suspicious_tld_redirecting_wikipedia.yml
+++ b/detection-rules/evasion_suspicious_tld_redirecting_wikipedia.yml
@@ -17,3 +17,4 @@ tactics_and_techniques:
   - "Open redirect"
 detection_methods:
   - "URL analysis"
+id: "c4567096-6e36-578e-b070-a51c01953287"


### PR DESCRIPTION
# Description
Flags inbound messages containing links with domains registered under suspicious top-level domains that redirect to Wikipedia when analyzed.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50c3d95e3b3e21401b8f7a0701ba839e004ce757f88a4c9d30d53e206997e6c0)

## Associated hunts
- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=019ff203-cc71-7b81-9cd2-c8fe6c52fd51)
- [15 customer multi-hunt](https://hunt.limeseed.email/hunts/22a629e3-9268-49c4-9d5f-acb8f04649fe)
- [80 customer multi-hunt](https://hunt.limeseed.email/hunts/80791fb8-3255-4e51-9d04-03e8c67ac9ff)

