### PR TITLE
Update body_whitespace_stuffing_short_lure.yml

### DIFF
--- a/detection-rules/body_whitespace_stuffing_short_lure.yml
+++ b/detection-rules/body_whitespace_stuffing_short_lure.yml
@@ -23,7 +23,7 @@ source: |
   and (
     regex.icontains(body.html.raw, '(?:<br\s*/?\s*>\s*){30,}')
     or regex.icontains(body.html.raw,
-                       '(?:<p>\s*(?:&nbsp;|&#160;)\s*</p>\s*){10,}'
+                       '(?:<p[^>]*>\s*(?:&nbsp;|&#160;)\s*</p>\s*){10,}'
     )
     or regex.icontains(body.html.raw,
                        '(?:<div[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}'

--- a/detection-rules/body_whitespace_stuffing_short_lure.yml
+++ b/detection-rules/body_whitespace_stuffing_short_lure.yml
@@ -21,16 +21,15 @@ source: |
   and length(body.current_thread.text) < 2000
   // HTML whitespace stuffing
   and (
-    regex.icontains(body.html.raw, '(?:<br\s*/?\s*>\s*){30,}')
-    or regex.icontains(body.html.raw,
-                       '(?:<p[^>]*>\s*(?:&nbsp;|&#160;)\s*</p>\s*){10,}'
-    )
-    or regex.icontains(body.html.raw,
-                       '(?:<div[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}'
+    regex.icontains(body.html.raw,
+                    '(?:<br\s*/?\s*>\s*){30,}',
+                    '(?:<p>\s*(?:&nbsp;|&#160;)\s*</p>\s*){10,}',
+                    '(?:<div[^>]*>\s*<br\s*/?\s*>\s*</div>\s*){20,}'
     )
     or (
       regex.icontains(body.html.raw,
-                      '(?:<p[^>]*>\s*<o:p>\s*(?:&nbsp;|&#160;)\s*</o:p>\s*</p>\s*){10,}'
+                      '(?:<p[^>]*>\s*<o:p>\s*(?:&nbsp;|&#160;)\s*</o:p>\s*</p>\s*){10,}',
+                      '(?:<p[^>]*>\s*(?:&nbsp;|&#160;)\s*</p>\s*){30,}'
       )
       and any(ml.nlu_classifier(body.current_thread.text).intents,
               .name in ("cred_theft", "bec")


### PR DESCRIPTION
# Description

Updating `body.html.raw` regex to allow styling in the `<p>` tag before the empty `&nbsp;` or `&#160;`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b504ad8251d902d04759ecaa973c0dd5e7e0161236689910f024f3353c0532?preview_id=019fc9b8-10bf-7622-a2c5-05bece5857e6)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019ff7a2-37cd-74df-9964-865fbff5c2a9)
- [L7D 97 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/624495f8-1f7e-41c7-b2b9-f5c91d0f594d)