### PR TITLE
Update link_file_sharing_cred_theft.yml

### DIFF
--- a/detection-rules/link_file_sharing_cred_theft.yml
+++ b/detection-rules/link_file_sharing_cred_theft.yml
@@ -26,6 +26,9 @@ source: |
       length(recipients.to) == 1
       and recipients.to[0].email.email == sender.email.email
     ),
+    any(recipients.to,
+        .email.domain.root_domain != headers.delivered_to.domain.root_domain
+    ),
     any(headers.reply_to,
         .email.domain.domain in $free_email_providers
         and .email.domain.domain != sender.email.domain.domain


### PR DESCRIPTION
# Description

Updating `1 of` logic to account for when any of the recipients do not match the `delivered_to` header field

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b504ad8251d902d04759ecaa973c0dd5e7e0161236689910f024f3353c0532?preview_id=019fc9b8-10bf-7622-a2c5-05bece5857e6)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019ff5d1-3e88-7b28-9fe3-eb01d35d47cf)