### PR TITLE
Update cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml

### DIFF
--- a/detection-rules/cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml
+++ b/detection-rules/cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml
@@ -4,21 +4,24 @@ type: "rule"
 severity: "high"
 source: |
   type.inbound
-  
+
   // more than 0 but less than 20 links
   and 0 < length(body.links) < 20
   
   // all attachments are images or there are 0 attachments
   and (
-    length(attachments) > 0 and all(attachments, .file_type in $file_types_images)
-    or length(attachments) == 0
+    length(attachments) > 0
+    and (
+      all(attachments, .file_type in $file_types_images)
+      or length(attachments) == 0
+    )
   )
   
   // subject contains payment/invoice language
   and (
     any(ml.nlu_classifier(subject.subject).tags, .name in ("payment", "invoice"))
     or regex.contains(subject.subject,
-                      '(?:\binv(?:oice|o)\b|in_v|in-voice|pay(?:ment|mnt)|pymt|\brec(?:eipt|pt|iept)\b|rcpt|confirm(?:ation)|cnfrm|cnf|po\b|p\.o\.|purch(?:ase)?-?order|\bord(?:er)?\b|bill(?:ing)|billing-info|transact(?:ion)|txn|trx|\bstmt\b|\bstmnt\b|remit(?:tance)|rmt|remndr|remind|\bdue(?:-date)\b|ovrdue|overdue|\bbal(?:ance)\b|\bpaid(?:-invoice)\b|requires\s+your\s+a(?:ttention|ction)|\b[fF]inal\s+(?:[nN]otice|[uU]npaid).{0,20}[iI]nvoice)',
+                      '(?:\binv(?:oice|o)\b|outstanding\s+inv\b|in_v|in-voice|pay(?:ment|mnt)|pymt|\brec(?:eipt|pt|iept)\b|rcpt|confirm(?:ation)|cnfrm|cnf|po\b|p\.o\.|purch(?:ase)?-?order|\bord(?:er)?\b|bill(?:ing)|billing-info|transact(?:ion)|txn|trx|\bstmt\b|\bstmnt\b|remit(?:tance)|rmt|remndr|remind|\bdue(?:-date)\b|ovrdue|overdue|\bbal(?:ance)\b|\bpaid(?:-invoice)\b|requires\s+your\s+a(?:ttention|ction)|\b[fF]inal\s+(?:[nN]otice|[uU]npaid).{0,20}[iI]nvoice)',
                       // suspicious invoice format
                       '\d{6}\b.{10,30}(\d{2}\.){3}pdf'
     )
@@ -48,9 +51,9 @@ source: |
     )
   )
   
-  // the body references an attachment 
+  // the body references an attachment
   and (
-    strings.contains(body.current_thread.text, "attach")
+    strings.contains(body.current_thread.text, "attach", "download")
     // negate warning banners warning about the attachment(s)
     and (
       not (
@@ -83,7 +86,8 @@ source: |
           .name == "cred_theft"
       )
       or any(ml.nlu_classifier(body.current_thread.text).entities,
-             .name == "request" and (strings.icontains(.text, "kindly"))
+             .name == "request" and strings.icontains(.text, "kindly")
+             or .name == "financial" and regex.match(.text, '(?:INVOICE|Inv)')
       )
     )
   )
@@ -95,7 +99,10 @@ source: |
     )
     or sender.email.domain.root_domain not in $high_trust_sender_root_domains
   )
-  and not profile.by_sender().solicited
+  and (
+    not profile.by_sender().solicited
+    or profile.by_sender().days_since.last_outbound > 280
+  )
 attack_types:
   - "Credential Phishing"
 tactics_and_techniques:

--- a/detection-rules/cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml
+++ b/detection-rules/cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml
@@ -10,11 +10,8 @@ source: |
   
   // all attachments are images or there are 0 attachments
   and (
-    length(attachments) > 0
-    and (
-      all(attachments, .file_type in $file_types_images)
-      or length(attachments) == 0
-    )
+    length(attachments) > 0 and all(attachments, .file_type in $file_types_images)
+    or length(attachments) == 0
   )
   
   // subject contains payment/invoice language

--- a/detection-rules/cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml
+++ b/detection-rules/cred_theft_suspicious_invoice_w_missing_or_image_only_attachments.yml
@@ -50,23 +50,29 @@ source: |
   
   // the body references an attachment
   and (
-    strings.contains(body.current_thread.text, "attach", "download")
-    // negate warning banners warning about the attachment(s)
-    and (
-      not (
-        (
-          regex.count(body.current_thread.text, "attach") == 1
-          and regex.icontains(body.current_thread.text,
-                              "(caution|warning).{0,30}attach"
+    (
+      strings.contains(body.current_thread.text, "attach")
+      // negate warning banners warning about the attachment(s)
+      and (
+        not (
+          (
+            regex.count(body.current_thread.text, "attach") == 1
+            and regex.icontains(body.current_thread.text,
+                                "(caution|warning).{0,30}attach"
+            )
           )
-        )
-        or ( // WeTransfer expiry warning notification
-          sender.email.email == "noreply@wetransfer.com"
-          and any(body.links,
-                  .display_text == "Don't send me these expiry reminders anymore"
+          or ( // WeTransfer expiry warning notification
+            sender.email.email == "noreply@wetransfer.com"
+            and any(body.links,
+                    .display_text == "Don't send me these expiry reminders anymore"
+            )
           )
         )
       )
+    )
+    or strings.contains(body.current_thread.text,
+                        "download the invoice",
+                        "see below"
     )
   )
   
@@ -84,7 +90,7 @@ source: |
       )
       or any(ml.nlu_classifier(body.current_thread.text).entities,
              .name == "request" and strings.icontains(.text, "kindly")
-             or .name == "financial" and regex.match(.text, '(?:INVOICE|Inv)')
+             or .name == "financial" and regex.match(.text, 'Inv')
       )
     )
   )


### PR DESCRIPTION

# Description

Updating logic to include `regex.match` logic on `financial` NLU matching on `INVOICE` or `Inv`, also `download` in the body, and updating the `sender.profile()` logic for last outbound > 280 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50b146f160b15c65bfeb1d18e97af2d50579928ddb176fa92c692f09b589b7d5?preview_id=019fc9ba-128e-7dea-b6b2-0e0649ee95fd)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019ff6b7-2197-7379-a5aa-8bd7c58d16c7)