### PR TITLE
Update link_wordress_recipient_email.yml

### DIFF
--- a/detection-rules/link_wordress_recipient_email.yml
+++ b/detection-rules/link_wordress_recipient_email.yml
@@ -7,7 +7,7 @@ source: |
   and recipients.to[0].email.domain.valid
   and any(body.links,
           regex.icontains(.href_url.path,
-                          '^\/(?:wp-(?:admin|includes|content|login|json|signup|activate|cron|mail)|xmlrpc\.php)'
+                          '\/(?:wp-(?:admin|includes|content|login|json|signup|activate|cron|mail)|xmlrpc\.php)'
           )
           and (
             // fragments base64 encoded


### PR DESCRIPTION
# Description
Removed the start-of-string anchor (^) to allow the regex to match WordPress paths at any position in the URL path.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50c5d5ecb19e90924741d56fc078c0ef45af3ea8bcc1ceb097dc6065cc31e455?preview_id=019ff5ce-895a-7465-b893-ab365a6125fd)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [96 customer multi-hunt net new](https://hunt.limeseed.email/hunts/95b24340-8dd1-49e1-a33c-c827927ac0ba)
- [SWS net new hunt](https://platform.sublime.security/hunts/019ff687-c5ea-7592-bba0-5b44b6ed8718)
