### PR TITLE
Update impersonation_sharepoint_body_credential_theft.yml

### DIFF
--- a/detection-rules/impersonation_sharepoint_body_credential_theft.yml
+++ b/detection-rules/impersonation_sharepoint_body_credential_theft.yml
@@ -51,10 +51,12 @@ source: |
              .name == "cred_theft" and .confidence == "high"
       )
       or any(attachments,
-             any(file.explode(.),
-                 any(ml.nlu_classifier(.scan.ocr.raw).intents,
-                     .name == "cred_theft" and .confidence == "high"
-                 )
+             .file_type == "pdf"
+             and beta.parse_exif(.).page_count == 1
+             and any(file.explode(.),
+                     any(ml.nlu_classifier(.scan.ocr.raw).intents,
+                         .name == "cred_theft" and .confidence == "high"
+                     )
              )
       )
     )

--- a/detection-rules/impersonation_sharepoint_body_credential_theft.yml
+++ b/detection-rules/impersonation_sharepoint_body_credential_theft.yml
@@ -50,6 +50,13 @@ source: |
       or any(ml.nlu_classifier(beta.ocr(file.message_screenshot()).text).intents,
              .name == "cred_theft" and .confidence == "high"
       )
+      or any(attachments,
+             any(file.explode(.),
+                 any(ml.nlu_classifier(.scan.ocr.raw).intents,
+                     .name == "cred_theft" and .confidence == "high"
+                 )
+             )
+      )
     )
     or any(ml.nlu_classifier(body.current_thread.text).entities,
            .name == "urgency" and strings.ilike(.text, "*encrypted*")


### PR DESCRIPTION
# Description

Updating logic to get the NLU intent of the attachments and tag samples with `cred_theft` intent and `high` confidence

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50c4288031345b20dc38645609fa9d05975bbb0c9e6a72fd008b6bb5eb628c50?preview_id=019ff0d5-e667-70f2-84cc-5a4e625d5f89)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019ffddd-5f5a-7584-9db2-cae6cba68286)
- [L7D 95 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/400393fa-0e35-44b7-8683-cc16c5aa6370)