### PR TITLE
Fix double nesting of body.links in Microsoft Planner rule

### DIFF
--- a/detection-rules/brand_impersonation_ms_planner.yml
+++ b/detection-rules/brand_impersonation_ms_planner.yml
@@ -14,10 +14,9 @@ source: |
              or .href_url.domain.domain in $url_shorteners
              or .href_url.domain.domain in $social_landing_hosts
              or .href_url.domain.root_domain in $social_landing_hosts
-             or 
    
              // mass mailer link, masks the actual URL
-             .href_url.domain.root_domain in (
+             or .href_url.domain.root_domain in (
                "hubspotlinks.com",
                "mandrillapp.com",
                "sendgrid.net",
@@ -31,11 +30,9 @@ source: |
              )
    
              // Recipient email address in link
-             or any(body.links,
-                    any(recipients.to,
-                        strings.icontains(..href_url.url, .email.email)
-                        and .email.domain.valid
-                    )
+             or any(recipients.to,
+                    strings.icontains(..href_url.url, .email.email)
+                    and .email.domain.valid
              )
              or .href_url.domain.root_domain == "beehiiv.com"
            )


### PR DESCRIPTION
# Description

Noticed this rule could be improved and I was confused why links were checked twice. Seems like a pretty unobjectionable change, but I would like some eyes!

# Associated samples
None

## Associated hunts
None

# Screenshot (insights)
None
