### PR TITLE
Create link_hidden_span_split_url.yml

### DIFF
--- a/detection-rules/link_hidden_span_split_url.yml
+++ b/detection-rules/link_hidden_span_split_url.yml
@@ -1,5 +1,5 @@
 name: "Link: URL fragmented by hidden spans"
-description: "Detects messages containing HTML links that are broken up with inline <span> elements styled with display:none, injecting random alphanumeric strings inside the URL to defeat text-based scanning while rendering a clean clickable link to the recipient. Observed lures impersonate HR or payroll communications, such as fake 401K enrollment notices and PTO balance alerts, sent from unrelated or spoofed domains to drive clicks on the obfuscated link."
+description: "Detects messages containing HTML links that are broken up with inline <span> elements styled with display:none, injecting random alphanumeric strings inside the URL to defeat text-based scanning while rendering strings that looks like a link to the recipient. Observed lures impersonate HR or payroll communications, such as fake 401K enrollment notices and PTO balance alerts, sent from unrelated or spoofed domains to drive clicks on the obfuscated link."
 type: "rule"
 severity: "high"
 source: |

--- a/detection-rules/link_hidden_span_split_url.yml
+++ b/detection-rules/link_hidden_span_split_url.yml
@@ -13,7 +13,6 @@ attack_types:
 tactics_and_techniques:
   - "Evasion"
   - "Social engineering"
-  - "Impersonation: Brand"
 detection_methods:
   - "HTML analysis"
   - "Content analysis"

--- a/detection-rules/link_hidden_span_split_url.yml
+++ b/detection-rules/link_hidden_span_split_url.yml
@@ -1,0 +1,20 @@
+name: "Link: Hidden span tags embedded in links"
+description: "Detects messages containing HTML links that are broken up with inline <span> elements styled with display:none, injecting random alphanumeric strings inside the URL to defeat text-based scanning while rendering a clean clickable link to the recipient. Observed lures impersonate HR or payroll communications, such as fake 401K enrollment notices and PTO balance alerts, sent from unrelated or spoofed domains to drive clicks on the obfuscated link."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and strings.icontains(body.html.raw, 'https:/<span')
+  and regex.icontains(body.html.raw,
+                     'https:/<span[^>]{0,300}display:\s*none[^>]{0,300}>[A-Z0-9]{6,}\s*</span>/'
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+  - "Impersonation: Brand"
+detection_methods:
+  - "HTML analysis"
+  - "Content analysis"
+  - "URL analysis"

--- a/detection-rules/link_hidden_span_split_url.yml
+++ b/detection-rules/link_hidden_span_split_url.yml
@@ -1,4 +1,4 @@
-name: "Link: Hidden span tags embedded in links"
+name: "Link: URL fragmented by hidden spans"
 description: "Detects messages containing HTML links that are broken up with inline <span> elements styled with display:none, injecting random alphanumeric strings inside the URL to defeat text-based scanning while rendering a clean clickable link to the recipient. Observed lures impersonate HR or payroll communications, such as fake 401K enrollment notices and PTO balance alerts, sent from unrelated or spoofed domains to drive clicks on the obfuscated link."
 type: "rule"
 severity: "high"

--- a/detection-rules/link_hidden_span_split_url.yml
+++ b/detection-rules/link_hidden_span_split_url.yml
@@ -6,7 +6,7 @@ source: |
   type.inbound
   and strings.icontains(body.html.raw, 'https:/<span')
   and regex.icontains(body.html.raw,
-                     'https:/<span[^>]{0,300}display:\s*none[^>]{0,300}>[A-Z0-9]{6,}\s*</span>/'
+                      'https:/<span[^>]{0,300}display:\s*none[^>]{0,300}>[A-Z0-9]{6,}\s*</span>/'
   )
 attack_types:
   - "Credential Phishing"
@@ -18,3 +18,4 @@ detection_methods:
   - "HTML analysis"
   - "Content analysis"
   - "URL analysis"
+id: "9c7f6db1-2e4e-50db-ab74-eaa29822189e"


### PR DESCRIPTION
# Description

Add coverage for observed technique that is using hidden text to break up a url and only make it display in text (not clickable)

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50bfb1b48a7ff91ae34608ee9bde3c685343c640323cda496a179275cff0a727?preview_id=019fd7bf-70d6-77b7-a4ee-e4a6c4aa9f04)


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Multi  1](https://hunt.limeseed.email/hunts/999a0aae-adc1-45c4-89a7-fda3e9e1f1d6)
- [Hunt](https://platform.sublime.security/messages/hunt?huntId=019ffba0-a2cb-77db-91d4-d43e05dbd4b9)