### PR TITLE
Update attachment_invoice_w9_pdfs.yml

### DIFF
--- a/detection-rules/attachment_invoice_w9_pdfs.yml
+++ b/detection-rules/attachment_invoice_w9_pdfs.yml
@@ -17,6 +17,10 @@ source: |
                     .key == "Producer" and .value == ""
             )
           )
+          or any(beta.parse_exif(.).fields,
+                 .key in ("Producer", "CreatorTool")
+                 and regex.icontains(.value, '(?:pdfium|mpdf)')
+          )
   )
   and any(attachments,
           strings.istarts_with(.file_name, 'lnv')


### PR DESCRIPTION
# Description

Updating logic to tag samples that have the values of `pdfium` or `mpdf` in the `Producer` or `CreatorTool` fields

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50c5ad851622f2ae57a07154029a71f5cbdd2a115f8adec85ee23bf30df6356c?preview_id=019ff7a2-c116-75b5-9ee8-876f75a0d03d)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=019ffdb1-c512-7e89-9af0-926ddc1c07b6)
- [L7D 95 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/a3ae23d3-68b4-4a93-af3f-942ded8066f2)