### PR TITLE
Create attachment_callback_phish_via_image_only_office_document.yml

### DIFF
--- a/detection-rules/attachment_callback_phish_via_image_only_office_document.yml
+++ b/detection-rules/attachment_callback_phish_via_image_only_office_document.yml
@@ -1,0 +1,63 @@
+name: "Attachment: Image-only docx/pptx callback phishing"
+description: "Detects inbound emails with docx or pptx attachments that contain no text but exactly one embedded image, a common tactic to evade text-based scanning by presenting content as a picture. The rule then inspects any extracted text from the image for a combination of callback phishing lures—such as references to subscriptions, invoices, refunds, or antivirus renewals alongside phone numbers or dollar amounts—paired with impersonation of well-known brands like PayPal, McAfee, Norton, or Best Buy, indicating a fraudulent phone-based scam attempt."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+    and any(attachments,
+            .file_type in ("docx", "pptx")
+            and any(file.explode(.),
+                    (.scan.docx.word_count == 0 and .scan.docx.image_count == 1)
+                    or (
+                      .scan.pptx.word_count == 0 and .scan.pptx.image_count == 1
+                    )
+            )
+            and any(file.explode(.),
+                    (.depth == 0 or .flavors.mime == "text/plain")
+                    // 4 of the following strings are found
+                    and 4 of (
+                      // this section is synced with attachment_callback_phish_with_pdf.yml and body_callback_phishing_no_attachment.yml
+                      strings.icontains(.scan.strings.raw, "purchase"),
+                      strings.icontains(.scan.strings.raw, "payment"),
+                      strings.icontains(.scan.strings.raw, "transaction"),
+                      strings.icontains(.scan.strings.raw, "subscription"),
+                      strings.icontains(.scan.strings.raw, "antivirus"),
+                      strings.icontains(.scan.strings.raw, "order"),
+                      strings.icontains(.scan.strings.raw, "support"),
+                      strings.icontains(.scan.strings.raw, "help line"),
+                      strings.icontains(.scan.strings.raw, "receipt"),
+                      strings.icontains(.scan.strings.raw, "invoice"),
+                      strings.icontains(.scan.strings.raw, "call"),
+                      strings.icontains(.scan.strings.raw, "helpdesk"),
+                      strings.icontains(.scan.strings.raw, "cancel"),
+                      strings.icontains(.scan.strings.raw, "renew"),
+                      strings.icontains(.scan.strings.raw, "refund"),
+                      regex.icontains(.scan.strings.raw,
+                                      "(?:reach|contact) us at"
+                      ),
+                      strings.icontains(.scan.strings.raw, "+1"),
+                      strings.icontains(.scan.strings.raw, "amount"),
+                      strings.icontains(.scan.strings.raw, "charged"),
+                      strings.icontains(.scan.strings.raw, "crypto"),
+                      strings.icontains(.scan.strings.raw, "wallet address"),
+                      regex.icontains(.scan.strings.raw, '\$\d{3}\.\d{2}\b'),
+                      regex.icontains(.scan.strings.raw,
+                                      '\+?([ilo0-9]{1}.)?\(?[ilo0-9]{3}?\)?.[ilo0-9]{3}.?[ilo0-9]{4}',
+                                      '\+?([ilo0-9]{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}[ilo0-9]{3}[\s\.\-⋅]{0,5}[ilo0-9]{4}'
+                      ),
+                    )
+                    and regex.icontains(.scan.strings.raw,
+                                        '(p.{0,3}a.{0,3}y.{0,3}p.{0,3}a.{0,3}l|ma?c.?fee|n[o0]rt[o0]n|geek.{0,5}squad|ebay|symantec|best buy|lifel[o0]c|secure anywhere|starz|utilities premium|pc security|at&t|quickbooks|amazon)'
+                    )
+            )
+    )
+attack_types:
+  - "Callback Phishing"
+tactics_and_techniques:
+  - "Image as content"
+  - "Impersonation: Brand"
+  - "Social engineering"
+detection_methods:
+  - "File analysis"
+  - "Optical Character Recognition"
+  - "Content analysis"

--- a/detection-rules/attachment_callback_phish_via_image_only_office_document.yml
+++ b/detection-rules/attachment_callback_phish_via_image_only_office_document.yml
@@ -4,6 +4,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
+  and sender.email.domain.root_domain in $free_email_providers
   and any(attachments,
           .file_type in ("docx", "pptx")
           and any(file.explode(.),

--- a/detection-rules/attachment_callback_phish_via_image_only_office_document.yml
+++ b/detection-rules/attachment_callback_phish_via_image_only_office_document.yml
@@ -4,53 +4,49 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-    and any(attachments,
-            .file_type in ("docx", "pptx")
-            and any(file.explode(.),
-                    (.scan.docx.word_count == 0 and .scan.docx.image_count == 1)
-                    or (
-                      .scan.pptx.word_count == 0 and .scan.pptx.image_count == 1
-                    )
-            )
-            and any(file.explode(.),
-                    (.depth == 0 or .flavors.mime == "text/plain")
-                    // 4 of the following strings are found
-                    and 4 of (
-                      // this section is synced with attachment_callback_phish_with_pdf.yml and body_callback_phishing_no_attachment.yml
-                      strings.icontains(.scan.strings.raw, "purchase"),
-                      strings.icontains(.scan.strings.raw, "payment"),
-                      strings.icontains(.scan.strings.raw, "transaction"),
-                      strings.icontains(.scan.strings.raw, "subscription"),
-                      strings.icontains(.scan.strings.raw, "antivirus"),
-                      strings.icontains(.scan.strings.raw, "order"),
-                      strings.icontains(.scan.strings.raw, "support"),
-                      strings.icontains(.scan.strings.raw, "help line"),
-                      strings.icontains(.scan.strings.raw, "receipt"),
-                      strings.icontains(.scan.strings.raw, "invoice"),
-                      strings.icontains(.scan.strings.raw, "call"),
-                      strings.icontains(.scan.strings.raw, "helpdesk"),
-                      strings.icontains(.scan.strings.raw, "cancel"),
-                      strings.icontains(.scan.strings.raw, "renew"),
-                      strings.icontains(.scan.strings.raw, "refund"),
-                      regex.icontains(.scan.strings.raw,
-                                      "(?:reach|contact) us at"
-                      ),
-                      strings.icontains(.scan.strings.raw, "+1"),
-                      strings.icontains(.scan.strings.raw, "amount"),
-                      strings.icontains(.scan.strings.raw, "charged"),
-                      strings.icontains(.scan.strings.raw, "crypto"),
-                      strings.icontains(.scan.strings.raw, "wallet address"),
-                      regex.icontains(.scan.strings.raw, '\$\d{3}\.\d{2}\b'),
-                      regex.icontains(.scan.strings.raw,
-                                      '\+?([ilo0-9]{1}.)?\(?[ilo0-9]{3}?\)?.[ilo0-9]{3}.?[ilo0-9]{4}',
-                                      '\+?([ilo0-9]{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}[ilo0-9]{3}[\s\.\-⋅]{0,5}[ilo0-9]{4}'
-                      ),
-                    )
-                    and regex.icontains(.scan.strings.raw,
-                                        '(p.{0,3}a.{0,3}y.{0,3}p.{0,3}a.{0,3}l|ma?c.?fee|n[o0]rt[o0]n|geek.{0,5}squad|ebay|symantec|best buy|lifel[o0]c|secure anywhere|starz|utilities premium|pc security|at&t|quickbooks|amazon)'
-                    )
-            )
-    )
+  and any(attachments,
+          .file_type in ("docx", "pptx")
+          and any(file.explode(.),
+                  (.scan.docx.word_count == 0 and .scan.docx.image_count == 1)
+                  or (.scan.pptx.word_count == 0 and .scan.pptx.image_count == 1)
+          )
+          and any(file.explode(.),
+                  (.depth == 0 or .flavors.mime == "text/plain")
+                  // 4 of the following strings are found
+                  and 4 of (
+                    // this section is synced with attachment_callback_phish_with_pdf.yml and body_callback_phishing_no_attachment.yml
+                    strings.icontains(.scan.strings.raw, "purchase"),
+                    strings.icontains(.scan.strings.raw, "payment"),
+                    strings.icontains(.scan.strings.raw, "transaction"),
+                    strings.icontains(.scan.strings.raw, "subscription"),
+                    strings.icontains(.scan.strings.raw, "antivirus"),
+                    strings.icontains(.scan.strings.raw, "order"),
+                    strings.icontains(.scan.strings.raw, "support"),
+                    strings.icontains(.scan.strings.raw, "help line"),
+                    strings.icontains(.scan.strings.raw, "receipt"),
+                    strings.icontains(.scan.strings.raw, "invoice"),
+                    strings.icontains(.scan.strings.raw, "call"),
+                    strings.icontains(.scan.strings.raw, "helpdesk"),
+                    strings.icontains(.scan.strings.raw, "cancel"),
+                    strings.icontains(.scan.strings.raw, "renew"),
+                    strings.icontains(.scan.strings.raw, "refund"),
+                    regex.icontains(.scan.strings.raw, "(?:reach|contact) us at"),
+                    strings.icontains(.scan.strings.raw, "+1"),
+                    strings.icontains(.scan.strings.raw, "amount"),
+                    strings.icontains(.scan.strings.raw, "charged"),
+                    strings.icontains(.scan.strings.raw, "crypto"),
+                    strings.icontains(.scan.strings.raw, "wallet address"),
+                    regex.icontains(.scan.strings.raw, '\$\d{3}\.\d{2}\b'),
+                    regex.icontains(.scan.strings.raw,
+                                    '\+?([ilo0-9]{1}.)?\(?[ilo0-9]{3}?\)?.[ilo0-9]{3}.?[ilo0-9]{4}',
+                                    '\+?([ilo0-9]{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}[ilo0-9]{3}[\s\.\-⋅]{0,5}[ilo0-9]{4}'
+                    ),
+                  )
+                  and regex.icontains(.scan.strings.raw,
+                                      '(p.{0,3}a.{0,3}y.{0,3}p.{0,3}a.{0,3}l|ma?c.?fee|n[o0]rt[o0]n|geek.{0,5}squad|ebay|symantec|best buy|lifel[o0]c|secure anywhere|starz|utilities premium|pc security|at&t|quickbooks|amazon)'
+                  )
+          )
+  )
 attack_types:
   - "Callback Phishing"
 tactics_and_techniques:
@@ -61,3 +57,4 @@ detection_methods:
   - "File analysis"
   - "Optical Character Recognition"
   - "Content analysis"
+id: "7d6bf731-af14-5ce6-9e0d-a792cbde6fa8"


### PR DESCRIPTION
# Description
Detects inbound emails with docx or pptx attachments that contain no text but exactly one embedded image. The image text contains callback language. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50c54d81309e299f0d9bba78d27636d08014d641bbb2e7c765cce9b1f1c07068?preview_id=019ff671-8b02-7274-afb1-c11a4788447c)
- [Sample 2](https://platform.sublime.security/messages/50c69991b3b8e9ebae8086e2e679cb4c1ff0beff85c172278f625dc4cbceada6?preview_id=019ffc90-1227-775a-b028-815647acb158)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=01a00192-03b6-7dbf-b2f7-53f1e359e881)
- [96 customer multi-hunt](https://hunt.limeseed.email/hunts/0138daf3-1afc-42c7-98f9-3e127a99804e)
