### PR TITLE
service_abuse_notion_free_tier_impersonating_vip.yml

### DIFF
--- a/detection-rules/service_abuse_notion_free_tier_impersonating_vip.yml
+++ b/detection-rules/service_abuse_notion_free_tier_impersonating_vip.yml
@@ -1,5 +1,5 @@
 name: "Service abuse: Notion free-tier account impersonating VIP"
-description: "Detects messages sent from Notion's legitimate notification address (notify@mail.notion.so) that pass SPF and DMARC checks, but where the sender's display name matches an internal VIP, and the embedded links resolve to a Notion workspace associated with a free-tier subscription. This pattern indicates abuse of Notion's free tier to craft convincing internal impersonation lures."
+description: "Detects messages sent from Notion's legitimate notification address (notify@mail.notion.so), but where the sender's display name matches an internal VIP, and the embedded links resolve to a Notion workspace associated with a free-tier subscription. This pattern indicates abuse of Notion's free tier to craft convincing internal impersonation lures."
 type: "rule"
 severity: "medium"
 source: |


### PR DESCRIPTION
# Description

Remove `that pass SPF and DMARC checks` from the description since it is no longer in the rule logic. 

