### PR TITLE
Update service_abuse_facebook_mail_callback.yml

### DIFF
--- a/detection-rules/service_abuse_facebook_mail_callback.yml
+++ b/detection-rules/service_abuse_facebook_mail_callback.yml
@@ -37,7 +37,7 @@ source: |
       )
       // phone number regex
       and any([body.current_thread.text, subject.subject],
-              regex.icontains(.,
+              regex.icontains(strings.replace_confusables(.),
                               '\+?([ilo0-9]{1}.)?\(?[ilo0-9]{3}?\)?.[ilo0-9]{3}.?[ilo0-9]{4}',
                               '\+?([ilo0-9]{1,2})?\s?\(?\d{3}\)?[\s\.\-⋅]{0,5}[ilo0-9]{3}[\s\.\-⋅]{0,5}[ilo0-9]{4}',
                               '[\+\x{FF0B}]?(?:[0-9\x{FF10}-\x{FF19}][^0-9\x{FF10}-\x{FF19}]{0,3}){10,11}'


### PR DESCRIPTION
# Description

The phone number contained confusables. We need to use replace_confusables before calling icontains. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50c57c0120026162de72a566f8f6e9bdad7989c407668829cb16f951872f0532)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=01a00226-cb2d-7c27-ab56-177f5a3ebb31)
- [Net new SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=01a00228-1ce7-7b16-bf39-80d9806ca939)
- [Net new Multi-hunt](https://hunt.limeseed.email/hunts/da508b30-3dde-4bf5-8060-e2d0319e472f)
