### PR TITLE
Update generic_zip.yar

### DIFF
--- a/yara/generic_zip.yar
+++ b/yara/generic_zip.yar
@@ -62,3 +62,20 @@ rule zip_excel_dll {
 		)
 
 }
+
+rule zip_pklfh_cd_mismatch_fname {
+    meta:
+        author      = "kyle eaton"
+        date        = "2026-08-18"
+        description = "zip file with a mismatch file name between the local file header and the central directory entry"
+    strings:
+        $pklfh = { 50 4B 03 04 }
+        $pkcd  = { 50 4B 01 02 }
+    condition:
+        for any i in (1..100): (
+            uint16(@pklfh[i] + 26) < 100
+            and for any j in (1..uint16(@pklfh[i] + 26)): (
+                uint8(@pklfh[i] + 30 + j - 1) != uint8(@pkcd[i] + 46 + j - 1)
+            )
+        )
+}


### PR DESCRIPTION
## Description
yara rule to match zip files which contain different file names in the same-index local file header and central directory records. Could be an indicator of modified or malformed files. 

## Associated samples

- [Sample 1](https://platform.sublime.security/messages/50ca0e589d58e21ad4531735463b2e9d144dde21e8b471f8e4d4463a59a73da9)

