### PR TITLE
Create link_rtl_text_contains_email.yml

### DIFF
--- a/detection-rules/link_rtl_text_contains_email.yml
+++ b/detection-rules/link_rtl_text_contains_email.yml
@@ -10,8 +10,8 @@ source: |
                   strings.contains(.href_url.url, recipients.to[0].email.email)
                   // exclude common RTL languages
                   and not regex.icontains(.display_text,
-                                        '[\x{0590}-\x{08FF}\x{FB1D}-\x{FDFF}\x{FE70}-\x{FEFF}]'
-                )
+                                          '[\x{0590}-\x{08FF}\x{FB1D}-\x{FDFF}\x{FE70}-\x{FEFF}]'
+                  )
           )
   )
 attack_types:

--- a/detection-rules/link_rtl_text_contains_email.yml
+++ b/detection-rules/link_rtl_text_contains_email.yml
@@ -1,0 +1,20 @@
+name: "Link: RTL text reversal with recipient email in URL"
+description: "Flags inbound messages containing anchor tags styled with 'direction:rtl' to visually reverse displayed text—an evasion tactic against text-based scanning—where the underlying link URL also contains the recipient's email address, a common personalization technique used to track or validate targets in phishing links."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(html.xpath(body.html, '//a').nodes,
+          strings.icontains(.raw, 'direction:rtl')
+          and any(.links,
+                  strings.contains(.href_url.url, recipients.to[0].email.email)
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "HTML analysis"
+  - "URL analysis"

--- a/detection-rules/link_rtl_text_contains_email.yml
+++ b/detection-rules/link_rtl_text_contains_email.yml
@@ -8,6 +8,10 @@ source: |
           strings.icontains(.raw, 'direction:rtl')
           and any(.links,
                   strings.contains(.href_url.url, recipients.to[0].email.email)
+                  // exclude common RTL languages
+                  and not regex.icontains(.display_text,
+                                        '[\x{0590}-\x{08FF}\x{FB1D}-\x{FDFF}\x{FE70}-\x{FEFF}]'
+                )
           )
   )
 attack_types:

--- a/detection-rules/link_rtl_text_contains_email.yml
+++ b/detection-rules/link_rtl_text_contains_email.yml
@@ -18,3 +18,4 @@ tactics_and_techniques:
 detection_methods:
   - "HTML analysis"
   - "URL analysis"
+id: "dbf5de4c-e105-5ca8-aa28-429fbdb61df4"

--- a/detection-rules/link_rtl_text_contains_email.yml
+++ b/detection-rules/link_rtl_text_contains_email.yml
@@ -4,6 +4,7 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
+  and recipients.to[0].email.domain.valid
   and any(html.xpath(body.html, '//a').nodes,
           strings.icontains(.raw, 'direction:rtl')
           and any(.links,


### PR DESCRIPTION
# Description
Display text is reversed and link contains recipients email. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50ca323abd6a5699fe0e661b49adb49f52449625436fe6346856eaca5c91e445)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [95 customer multi-hunt](https://hunt.limeseed.email/hunts/09ee2073-0e85-4fc7-b754-ac04dc8e2261)
- [SWS Hunt
](https://platform.sublime.security/messages/hunt?huntId=01a0167f-e7cc-7620-92b7-57ec77d0951a)

### Aug 20 Hunts
- [SWS regression hunt](https://platform.sublime.security/messages/hunt?huntId=01a01f6a-fefa-7162-a74d-26d0bf26cd7e)
- [95 customer multi-hunt](https://hunt.limeseed.email/hunts/21182022-9755-41af-b3cc-01b70a72d433)
- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=01a01f96-01d4-794c-8f17-c3eff396fb26)