### PR TITLE
Create link_telegraph.yml

### DIFF
--- a/detection-rules/link_telegraph.yml
+++ b/detection-rules/link_telegraph.yml
@@ -16,3 +16,4 @@ tactics_and_techniques:
   - "Free file host"
 detection_methods:
   - "URL analysis"
+id: "a1ccdfa2-4945-545f-a90c-08f9ac1bf458"

--- a/detection-rules/link_telegraph.yml
+++ b/detection-rules/link_telegraph.yml
@@ -1,0 +1,18 @@
+name: "Link: Telegraph-hosted content"
+description: "Inbound messages containing links that point to telegra.ph or graph.org, the free Telegram-run publishing platform, which is abused to host redirect pages for spam and low-effort social engineering lures. Observed samples span dating/flirting pitches, pharmacy and medication marketing, generic curiosity-bait subject lines, and other unsolicited outreach, with senders coming from free webmail providers, questionable domains, or spoofed corporate addresses. The shared trait is use of a legitimate, free content-hosting service to mask the true destination and improve deliverability."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(body.links, .href_url.domain.root_domain in ("telegra.ph", "graph.org"))
+  
+tags:
+  - "Attack surface reduction"
+attack_types:
+  - "Spam"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Free file host"
+detection_methods:
+  - "URL analysis"


### PR DESCRIPTION
# Description

Add ASR coverage for direct links to telegraph (a minimal "blog" platform) that is heavily abused for landing pages in a variety of attack types (AFF via dating and online pharmacy, crypto scam and cred theft observed)

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50c3e6ecdde0cb8302d68056355d7b9e71c10062671beca038722a6523beef38?preview_id=019fe9d6-abc6-7dd3-a8cd-3de3c1bfd807)
- [Sample 2](https://platform.sublime.security/messages/50c8c0f0ffd15819c09007abae70bd6f0590dcbde70f8d33bff55d8278c2fb68?preview_id=01a0045d-5bf5-71e2-a560-6f58def5760c)
- [sample 3](https://platform.sublime.security/messages/50cab744094f32e53fb983b3d7a3740fbde129711ae58eb4bf4c4e20c4698fea?preview_id=01a01757-23eb-766a-9c77-d4c6a747d557)
- [sample 4](https://platform.sublime.security/messages/50687353e017578167c18eb60e7bf934bf012debaa62e16d70d4e81e1fe3e04f?preview_id=019e48da-8f77-773f-9a31-335f0d81f70c)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/hunts/01a01a0a-2d93-72f8-9317-eace064fc4c0)
- [Multihunt](https://hunt.limeseed.email/hunts/2eabdad5-c478-4250-b35c-5db54cc77fb8) (for not soliticed, i removed that from the rule to be see the inverse see [challenge](https://hunt.limeseed.email/hunts/b910ca78-bcba-4af0-ae04-3c65b1ea996d)
