### PR TITLE
Create unsolicited_b2b_joboutreach.yml

### DIFF
--- a/detection-rules/unsolicited_b2b_outreach.yml
+++ b/detection-rules/unsolicited_b2b_outreach.yml
@@ -1,0 +1,34 @@
+name: "Spam: Unsolicited B2B job outreach"
+description: "Flags single-recipient messages claiming someone asked the sender to reach out or referencing an open role or task, where the body is classified as B2B cold outreach with medium or high confidence. Excludes senders the recipient has previously solicited and excludes highly trusted sender domains that pass DMARC authentication."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // direct outreach to sender
+  and length(recipients.to) == 1
+  // subject about a task or role
+  and regex.icontains(subject.base,
+                    '[a-zA-Z]{2,10}\s+asked me to reach out',
+                    '[Oo]pen.{0,10}role.{0,30}potential.{0,10}fit'
+    )
+  and any(ml.nlu_classifier(body.current_thread.text).topics,
+          .name == "B2B Cold Outreach" and .confidence != "low"
+  )
+  // not someone they have reached out to before
+  and not profile.by_sender().solicited
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+attack_types:
+  - "Spam"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Impersonation: Brand"
+  - "Lookalike domain"
+detection_methods:
+  - "Content analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"
+  - "Header analysis"

--- a/detection-rules/unsolicited_b2b_outreach.yml
+++ b/detection-rules/unsolicited_b2b_outreach.yml
@@ -8,9 +8,9 @@ source: |
   and length(recipients.to) == 1
   // subject about a task or role
   and regex.icontains(subject.base,
-                    '[a-zA-Z]{2,10}\s+asked me to reach out',
-                    '[Oo]pen.{0,10}role.{0,30}potential.{0,10}fit'
-    )
+                      '[a-zA-Z]{2,10}\s+asked me to reach out',
+                      '[Oo]pen.{0,10}role.{0,30}potential.{0,10}fit'
+  )
   and any(ml.nlu_classifier(body.current_thread.text).topics,
           .name == "B2B Cold Outreach" and .confidence != "low"
   )
@@ -32,3 +32,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Sender analysis"
   - "Header analysis"
+id: "f6a130d5-832e-56c2-8654-d4597009e3e3"

--- a/detection-rules/unsolicited_b2b_outreach.yml
+++ b/detection-rules/unsolicited_b2b_outreach.yml
@@ -14,8 +14,6 @@ source: |
   and any(ml.nlu_classifier(body.current_thread.text).topics,
           .name == "B2B Cold Outreach" and .confidence != "low"
   )
-  // not someone they have reached out to before
-  and not profile.by_sender().solicited
   // negate highly trusted sender domains unless they fail DMARC authentication
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains


### PR DESCRIPTION
# Description
Flags messages where the sender reaches out or referencing an open role or task, the body is classified as B2B cold outreach.

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/50465185c02f7ac7e0921f9ddfdb6600fd04e3489e711d8842abd5396c9c9e21?preview_id=019ed24c-5900-721f-a80e-0f18537f6680)
- [Sample 2](https://platform.sublime.security/messages/50caa51d9be79f625a403be833c10fbc41d9c939ad0a3f0d2f3f905a27b988b1?preview_id=01a01a54-5b7e-7bf1-ba52-194a379f93a3)

## Associated hunts
- [Hunt 365D](https://platform.sublime.security/messages/hunt?huntId=01a0211c-3790-7353-8af3-d2515de5b2b4)