### PR TITLE
Update service_abuse_aws_sns_callback.yml

### DIFF
--- a/detection-rules/service_abuse_aws_sns_callback.yml
+++ b/detection-rules/service_abuse_aws_sns_callback.yml
@@ -17,7 +17,7 @@ source: |
     or (
       regex.icontains(body.current_thread.text,
                       (
-                        "mcafee|n[o0]rt[o0]n|geek.{0,5}squad|paypal|\bebay\b|symantec|best buy|lifel[o0]ck"
+                        'mcafee|n[o0]rt[o0]n|geek.{0,5}squad|paypal|\bebay\b|symantec|best buy|lifel[o0]ck'
                       )
       )
       and (

--- a/detection-rules/service_abuse_aws_sns_callback.yml
+++ b/detection-rules/service_abuse_aws_sns_callback.yml
@@ -17,7 +17,7 @@ source: |
     or (
       regex.icontains(body.current_thread.text,
                       (
-                        "mcafee|n[o0]rt[o0]n|geek.{0,5}squad|paypal|ebay|symantec|best buy|lifel[o0]ck"
+                        "mcafee|n[o0]rt[o0]n|geek.{0,5}squad|paypal|\bebay\b|symantec|best buy|lifel[o0]ck"
                       )
       )
       and (


### PR DESCRIPTION
# Description

Add \b on both sides of the ebay to avoid matches on "thebay" 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50cb78d957ee6147f2bab8470420bc02997e1baa4ee4a17a764d71ca46288a7a)
(sample is incorrect as it was shared form a message group and only one message in the group matched)
EML of actual sample has been shared via private methods. Please reach out if required
## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Messages that will no longer match](https://platform.sublime.security/messages/hunt?huntId=01a02087-37b0-74f8-98f8-de3052ee56b1)
