### PR TITLE
Create brand_impersonation_ms_image_link_free_host.yml

### DIFF
--- a/detection-rules/brand_impersonation_ms_image_link_free_host.yml
+++ b/detection-rules/brand_impersonation_ms_image_link_free_host.yml
@@ -49,3 +49,4 @@ detection_methods:
   - "Exif analysis"
   - "HTML analysis"
   - "URL analysis"
+id: "b929c2fc-6328-5314-ade2-16b8fb19b321"

--- a/detection-rules/brand_impersonation_ms_image_link_free_host.yml
+++ b/detection-rules/brand_impersonation_ms_image_link_free_host.yml
@@ -1,0 +1,51 @@
+name: "Brand impersonation: Microsoft logo image linking to free file host"
+description: "Detects inline images that display a Microsoft logo and contain text, used as clickable links within the message body. The link behind the image redirects to a self-service site creation platform or free file hosting domain rather than a legitimate Microsoft or tenant domain, a common technique for disguising credential phishing or malware delivery links as trusted Microsoft branded content."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(map(filter(attachments,
+                     .file_type in $file_types_images
+                     and .content_disposition =~ "inline"
+                     and any(ml.logo_detect(.).brands,
+                             strings.istarts_with(.name, "Microsoft")
+                             and .confidence == "high"
+                     )
+                     // big image
+                     and beta.parse_exif(.).image_height > 96
+                     and beta.parse_exif(.).image_width > 96
+                     // and there is text on the image
+                     and regex.icount(beta.ocr(.).text, '\w+\W') > 5
+              ),
+              .content_id
+          ),
+          // that image is used a a link in the body
+          any(html.xpath(body.html, '//a[.//img[@src]]').nodes,
+              strings.icontains(.raw, ..)
+              and any(.links,
+                      // the link goes to self_service for free_file_hosts
+                      (
+                        .href_url.domain.domain in $self_service_creation_platform_domains
+                        or .href_url.domain.root_domain in $self_service_creation_platform_domains
+                        or .href_url.domain.domain in $free_file_hosts
+                        or .href_url.domain.root_domain in $free_file_hosts
+                      )
+                      // but not sharepoint
+                      and not .href_url.domain.domain in $tenant_domains
+              )
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Image as content"
+  - "Free file host"
+  - "Social engineering"
+detection_methods:
+  - "Computer Vision"
+  - "Optical Character Recognition"
+  - "Exif analysis"
+  - "HTML analysis"
+  - "URL analysis"


### PR DESCRIPTION
# Description

Add coverage for messages using image as content with MS brand impersonation that links to free_file_hosts or self_service_creation_platform_domains

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/508b196ca03e69a4c2c471e031117504a5ae70edd9820615ae3269e942b28f69?preview_id=019fdd7b-e645-7055-8ed1-ad658ad59803)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Multihunt 1](https://hunt.limeseed.email/hunts/592142ae-e48c-4fbd-97ef-56112c2d389b)
- [L365](https://platform.sublime.security/messages/hunt?huntId=01a024f8-4124-7b60-b5fb-f0ed6756bcfe)
