### PR TITLE
Create spam_spoofed_outlook_reference_id_footer.yml

### DIFF
--- a/detection-rules/spam_spoofed_outlook_reference_id_footer.yml
+++ b/detection-rules/spam_spoofed_outlook_reference_id_footer.yml
@@ -1,7 +1,7 @@
 name: "Spam: Spoofed Outlook mailer with unsubscribe and reference ID footer"
 description: "Flags inbound messages that spoof the Microsoft Outlook mailer header while containing an 'unsubscribe here' link followed by an alphanumeric reference ID pattern in the body text, a common tactic used to lend spam messages an air of legitimacy. Highly trusted sender domains are excluded from this rule when they pass DMARC authentication."
 type: "rule"
-severity: "medium"
+severity: "low"
 source: |
   type.inbound
   and strings.istarts_with(headers.mailer, 'Microsoft Outlook')

--- a/detection-rules/spam_spoofed_outlook_reference_id_footer.yml
+++ b/detection-rules/spam_spoofed_outlook_reference_id_footer.yml
@@ -1,0 +1,24 @@
+name: "Spam: Spoofed Outlook mailer with unsubscribe and reference ID footer"
+description: "Flags inbound messages that spoof the Microsoft Outlook mailer header while containing an 'unsubscribe here' link followed by an alphanumeric reference ID pattern in the body text, a common tactic used to lend spam messages an air of legitimacy. Highly trusted sender domains are excluded from this rule when they pass DMARC authentication."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and strings.istarts_with(headers.mailer, 'Microsoft Outlook')
+  and regex.icontains(body.current_thread.text,
+                      'unsubscribe here[\s\S]{0,120}?reference\s?id:\s*[a-z0-9]{6,}'
+  )
+  
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+attack_types:
+  - "Spam"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Spoofing"
+detection_methods:
+  - "Content analysis"
+  - "Header analysis"

--- a/detection-rules/spam_spoofed_outlook_reference_id_footer.yml
+++ b/detection-rules/spam_spoofed_outlook_reference_id_footer.yml
@@ -22,3 +22,4 @@ tactics_and_techniques:
 detection_methods:
   - "Content analysis"
   - "Header analysis"
+id: "5257f3dd-8c5f-50c7-a987-89379dfc4e40"


### PR DESCRIPTION
# Description

<!-- 
Explain your change and why. For example, "negating legitimate replies," or "adding additional credential theft keywords."

If it's a new rule or insight, explain what the rule is designed to catch/what the insight should fire on.
-->

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50c384350f6a0f8b7efba18b8adc1e8aed42e6532c6cae8817b2abfb716982c3?preview_id=019fec4d-bfee-7274-a5b5-57d119968149)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [latest hunt post-multihunt](https://platform.sublime.security/messages/hunt?huntId=01a02515-0362-7aad-8551-d7912232407d)
- [mega big multihunt](https://hunt.limeseed.email/hunts/836e830c-aa43-45e5-93fc-291db2387c61)
- [This logic, and not 5149 or 5150](https://platform.sublime.security/messages/hunt?huntId=01a02505-8324-73fc-9430-25b1c4cfaf76)