### PR TITLE
Create attachment_ics_financial_lure.yml

### DIFF
--- a/detection-rules/attachment_ics_financial_lure.yml
+++ b/detection-rules/attachment_ics_financial_lure.yml
@@ -4,38 +4,38 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-    and any(attachments,
-            (
-              .file_type == "ics"
-              or .file_extension == "ics"
-              or .content_type in ("application/ics", "text/calendar")
-            )
-            and any(beta.file.parse_ics(.).events,
-                    regex.icontains(.description,
-                                    'credit\s+note.{0,30}CN-[0-9]{8}',
-                                    '(?:review|issued?).{0,30}credit\s+note',
-                                    'credit.{0,20}(?:has\s+been\s+)?issued.{0,30}(?:invoice|billing|pricing\s+adjustment)',
-                                    '(?:billing|accounting)\s+(?:review|adjustment|reconciliation).{0,30}credit'
-                    )
-            )
-    )
-    and any(body.links,
-            .href_url.domain.root_domain != sender.email.domain.root_domain
-            and (
-              .href_url.domain.domain in $url_shorteners
-              or .href_url.domain.root_domain in $url_shorteners
-              or .href_url.domain.tld in $suspicious_tlds
-              or network.whois(.href_url.domain).days_old < 90
-              or .href_url.domain.root_domain in $free_file_hosts
-              or .href_url.domain.domain in $free_file_hosts
-              or .href_url.domain.root_domain in $self_service_creation_platform_domains
-              or .href_url.domain.domain in $self_service_creation_platform_domains
-            )
-    )
-    and not (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and coalesce(headers.auth_summary.dmarc.pass, false)
-    )
+  and any(attachments,
+          (
+            .file_type == "ics"
+            or .file_extension == "ics"
+            or .content_type in ("application/ics", "text/calendar")
+          )
+          and any(beta.file.parse_ics(.).events,
+                  regex.icontains(.description,
+                                  'credit\s+note.{0,30}CN-[0-9]{8}',
+                                  '(?:review|issued?).{0,30}credit\s+note',
+                                  'credit.{0,20}(?:has\s+been\s+)?issued.{0,30}(?:invoice|billing|pricing\s+adjustment)',
+                                  '(?:billing|accounting)\s+(?:review|adjustment|reconciliation).{0,30}credit'
+                  )
+          )
+  )
+  and any(body.links,
+          .href_url.domain.root_domain != sender.email.domain.root_domain
+          and (
+            .href_url.domain.domain in $url_shorteners
+            or .href_url.domain.root_domain in $url_shorteners
+            or .href_url.domain.tld in $suspicious_tlds
+            or network.whois(.href_url.domain).days_old < 90
+            or .href_url.domain.root_domain in $free_file_hosts
+            or .href_url.domain.domain in $free_file_hosts
+            or .href_url.domain.root_domain in $self_service_creation_platform_domains
+            or .href_url.domain.domain in $self_service_creation_platform_domains
+          )
+  )
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
 attack_types:
   - "Credential Phishing"
   - "BEC/Fraud"

--- a/detection-rules/attachment_ics_financial_lure.yml
+++ b/detection-rules/attachment_ics_financial_lure.yml
@@ -1,0 +1,50 @@
+name: "Attachment: ICS calendar invite with financial lure and suspicious link
+description: "Detects inbound emails containing ICS calendar attachments whose event descriptions reference credit notes, billing adjustments, or invoice reconciliation language, combined with body links pointing to URL shorteners, suspicious TLDs, newly registered domains, free file hosts, or self-service platforms that do not match the sender's domain. Excludes messages from high-trust sender domains that pass DMARC authentication."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+    and any(attachments,
+            (
+              .file_type == "ics"
+              or .file_extension == "ics"
+              or .content_type in ("application/ics", "text/calendar")
+            )
+            and any(beta.file.parse_ics(.).events,
+                    regex.icontains(.description,
+                                    'credit\s+note.{0,30}CN-[0-9]{8}',
+                                    '(?:review|issued?).{0,30}credit\s+note',
+                                    'credit.{0,20}(?:has\s+been\s+)?issued.{0,30}(?:invoice|billing|pricing\s+adjustment)',
+                                    '(?:billing|accounting)\s+(?:review|adjustment|reconciliation).{0,30}credit'
+                    )
+            )
+    )
+    and any(body.links,
+            .href_url.domain.root_domain != sender.email.domain.root_domain
+            and (
+              .href_url.domain.domain in $url_shorteners
+              or .href_url.domain.root_domain in $url_shorteners
+              or .href_url.domain.tld in $suspicious_tlds
+              or network.whois(.href_url.domain).days_old < 90
+              or .href_url.domain.root_domain in $free_file_hosts
+              or .href_url.domain.domain in $free_file_hosts
+              or .href_url.domain.root_domain in $self_service_creation_platform_domains
+              or .href_url.domain.domain in $self_service_creation_platform_domains
+            )
+    )
+    and not (
+      sender.email.domain.root_domain in $high_trust_sender_root_domains
+      and coalesce(headers.auth_summary.dmarc.pass, false)
+    )
+attack_types:
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Evasion"
+detection_methods:
+  - "File analysis"
+  - "Content analysis"
+  - "URL analysis"
+  - "Whois"
+  - "Header analysis"

--- a/detection-rules/attachment_ics_financial_lure.yml
+++ b/detection-rules/attachment_ics_financial_lure.yml
@@ -10,6 +10,11 @@ source: |
             or .file_extension == "ics"
             or .content_type in ("application/ics", "text/calendar")
           )
+          //
+          // This rule makes use of a beta feature and is subject to change without notice
+          // using the beta feature in custom rules is not suggested until it has been formally released
+          //
+          // bid/rfp/proposal language in the meeting description
           and any(beta.file.parse_ics(.).events,
                   regex.icontains(.description,
                                   'credit\s+note.{0,30}CN-[0-9]{8}',

--- a/detection-rules/attachment_ics_financial_lure.yml
+++ b/detection-rules/attachment_ics_financial_lure.yml
@@ -1,4 +1,4 @@
-name: "Attachment: ICS calendar invite with financial lure and suspicious link
+name: "Attachment: ICS calendar invite with financial lure and suspicious link"
 description: "Detects inbound emails containing ICS calendar attachments whose event descriptions reference credit notes, billing adjustments, or invoice reconciliation language, combined with body links pointing to URL shorteners, suspicious TLDs, newly registered domains, free file hosts, or self-service platforms that do not match the sender's domain. Excludes messages from high-trust sender domains that pass DMARC authentication."
 type: "rule"
 severity: "medium"

--- a/detection-rules/attachment_ics_financial_lure.yml
+++ b/detection-rules/attachment_ics_financial_lure.yml
@@ -14,7 +14,6 @@ source: |
           // This rule makes use of a beta feature and is subject to change without notice
           // using the beta feature in custom rules is not suggested until it has been formally released
           //
-          // bid/rfp/proposal language in the meeting description
           and any(beta.file.parse_ics(.).events,
                   regex.icontains(.description,
                                   'credit\s+note.{0,30}CN-[0-9]{8}',

--- a/detection-rules/attachment_ics_financial_lure.yml
+++ b/detection-rules/attachment_ics_financial_lure.yml
@@ -48,3 +48,4 @@ detection_methods:
   - "URL analysis"
   - "Whois"
   - "Header analysis"
+id: "30cf1a7f-76d7-518a-bbd7-5308b87a1730"


### PR DESCRIPTION
# Description

Detects inbound emails containing ICS calendar attachments whose event descriptions reference credit notes, billing adjustments, or invoice reconciliation language, combined with body links pointing to URL shorteners, suspicious TLDs, newly registered domains, free file hosts, or self-service platforms that do not match the sender's domain. Excludes messages from high-trust sender domains that pass DMARC authentication.


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01a02708-2452-7446-b490-8f3cbd640f4d)
- [big multi ](https://hunt.limeseed.email/hunts/62f08e8e-067d-4ce3-9f7b-136490d068cd)

