### PR TITLE
Create credential_phishing_btc_portfolio_confirmation.yml

### DIFF
--- a/detection-rules/credential_phishing_btc_portfolio_confirmation.yml
+++ b/detection-rules/credential_phishing_btc_portfolio_confirmation.yml
@@ -1,0 +1,35 @@
+name: "Credential Phishing: Bitcoin portfolio confirmation"
+description: "Detects inbound messages that combine bitcoin/BTC terminology with portfolio or balance confirmation language, alongside at least two credential-harvesting indicators such as references to a web portal, customer ID, or password. The rule further requires the NLU classifier to flag the message with credential theft, advance fee, or BEC intent, and excludes messages from senders on high trust root domains that pass DMARC authentication."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+    strings.icontains(body.current_thread.text, "btc", "bitcoin")
+    and strings.icontains(body.current_thread.text,
+                          "portfolio",
+                          "confirm your balance"
+    )
+  )
+  and 2 of (
+    strings.icontains(body.current_thread.text, "web portal"),
+    strings.icontains(body.current_thread.text, "customer id"),
+    regex.icontains(body.current_thread.text, 'pass[\s-]?word')
+  )
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name in ("cred_theft", "advance_fee", "bec")
+  )
+  // and the sender is not from high trust sender root domains
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+attack_types:
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Content analysis"
+  - "Natural Language Understanding"
+  - "Header analysis"

--- a/detection-rules/credential_phishing_btc_portfolio_confirmation.yml
+++ b/detection-rules/credential_phishing_btc_portfolio_confirmation.yml
@@ -33,3 +33,4 @@ detection_methods:
   - "Content analysis"
   - "Natural Language Understanding"
   - "Header analysis"
+id: "64920d24-04c8-5afc-9f99-2948142a985a"


### PR DESCRIPTION
# Description

Noticed this type of activity ramping up in the FN queue within the last 24 hours:

Detects inbound messages that combine bitcoin/BTC terminology with portfolio or balance confirmation language, alongside at least two credential-harvesting indicators such as references to a web portal, customer ID, or password. The rule further requires the NLU classifier to flag the message with credential theft, advance fee, or BEC intent, and excludes messages from senders on high trust root domains that pass DMARC authentication.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50d0b8852c27bb82890c924aa27ac7493febbf87528f50caa2a659a9e549f237?preview_id=01a0310d-875f-78a5-8a67-3f4fbfcfddb2)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=01a034fc-aa83-7567-a8f0-1822b6a90524)
- [L14D 95 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/209eefb9-6970-4062-b76b-2f03582c1571)