### PR TITLE
Update link_undisclosed_recipients_credphish.yml

### DIFF
--- a/detection-rules/link_undisclosed_recipients_credphish.yml
+++ b/detection-rules/link_undisclosed_recipients_credphish.yml
@@ -12,17 +12,20 @@ source: |
   )
   and length(recipients.cc) == 0
   and length(recipients.bcc) == 0
-  and any(body.links,
-          ml.link_analysis(.).credphish.disposition == "phishing"
-          and ml.link_analysis(.).credphish.confidence in ("medium", "high")
+  and (
+    any(body.links,
+        ml.link_analysis(.).credphish.disposition == "phishing"
+        and ml.link_analysis(.).credphish.confidence in ("medium", "high")
+    )
+    or any(body.current_thread.links,
+           regex.icount(.href_url.path, '\.[a-z]{2,}/') >= 2
+           and not strings.icontains(.href_url.path, .href_url.domain.root_domain)
+    )
   )
   // negate highly trusted sender domains unless they fail DMARC authentication
-  and (
-    (
-      sender.email.domain.root_domain in $high_trust_sender_root_domains
-      and not headers.auth_summary.dmarc.pass
-    )
-    or sender.email.domain.root_domain not in $high_trust_sender_root_domains
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
   )
   and not profile.by_sender().solicited
   and not profile.by_sender().any_messages_benign


### PR DESCRIPTION
# Description

For a runner ping, updating logic to account for links that contain two or more domains in the href path

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50c1bc211d55b7ae42727466bf2de9f49a2ac70722110a79304b0018c291f7f4?preview_id=019fece6-7c03-7173-b9d6-fb7254e7d32c)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=01a03438-e9ba-7212-8124-07b4109e1fcb)
- [L7D 95 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/0bb14d4a-0eee-4d4f-9d16-767e6eef329d)