### PR TITLE
Update vip_impersonation_fake_thread_with_invoice_handoff_display_nam…

### DIFF
--- a/detection-rules/vip_impersonation_fake_thread_with_invoice_handoff_display_name.yml
+++ b/detection-rules/vip_impersonation_fake_thread_with_invoice_handoff_display_name.yml
@@ -38,7 +38,7 @@ source: |
           . != ""
           // any previous thread authored by the "VIP" has invoice/payment
           and (
-            any(filter(body.previous_threads, .sender.email.email == ..),
+            any(filter(body.previous_threads, .sender.display_name == ..),
                 any(ml.nlu_classifier(.text, subject=.subject.base).tags,
                     .name in ("invoice", "payment") and .confidence != "low"
                 )


### PR DESCRIPTION
…e.yml

# Description

fix copy/paste error that resulted in rule not matching

looks like logic was copied from `vip_impersonation_fake_thread_with_invoice_handoff_email` and not updated to handle this display_name format that this rule is intended to match. 
