### PR TITLE
Create impersonation_mychart.yml

### DIFF
--- a/detection-rules/impersonation_mychart.yml
+++ b/detection-rules/impersonation_mychart.yml
@@ -4,21 +4,24 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
+  and strings.icontains(sender.display_name, "mychart")
   and (
-    regex.icontains(sender.display_name, '^mychart\s\w+')
-    or strings.iends_with(sender.display_name, "from mychart")
-    or (
+    (
       strings.icontains(body.current_thread.text, "mychart")
-      and strings.icontains(body.current_thread.text,
-                            "feedback survey",
-                            "claim your reward"
+      and 2 of (
+        strings.icontains(body.current_thread.text, "claim your reward"),
+        strings.icontains(body.current_thread.text, "feedback survey"),
+        strings.icontains(body.current_thread.text, "invited to participate"),
+        strings.icontains(body.current_thread.text, "medicare kit"),
+        strings.icontains(body.current_thread.text, "member rewards"),
+        strings.icontains(body.current_thread.text, "member appreciation"),
+        strings.icontains(body.current_thread.text, "log in to mychart"),
+        regex.icontains(body.current_thread.text, '©\s*(?:\d+)\s*mychart')
       )
     )
+    or strings.icontains(subject.base, "medicare kit")
+    or network.whois(sender.email.domain).days_old < 365
   )
-  and not any(ml.nlu_classifier(body.current_thread.text).topics,
-              .name in ("Newsletters and Digests", "Out of Band Pivot")
-  )
-  and not strings.contains(subject.base, "Quarantine")
   // negate highly trusted sender domains unless they fail DMARC authentication
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains

--- a/detection-rules/impersonation_mychart.yml
+++ b/detection-rules/impersonation_mychart.yml
@@ -36,3 +36,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Header analysis"
   - "Sender analysis"
+id: "8be6743d-8d17-53ef-97c7-cb00f2b27374"

--- a/detection-rules/impersonation_mychart.yml
+++ b/detection-rules/impersonation_mychart.yml
@@ -22,6 +22,13 @@ source: |
     or strings.icontains(subject.base, "medicare kit")
     or network.whois(sender.email.domain).days_old < 365
   )
+  and not (
+    sender.email.domain.root_domain in (
+      "epic-notification.com",
+      "myhealthconnect.org"
+    )
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
   // negate highly trusted sender domains unless they fail DMARC authentication
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains

--- a/detection-rules/impersonation_mychart.yml
+++ b/detection-rules/impersonation_mychart.yml
@@ -1,5 +1,5 @@
 name: "Brand impersonation: MyChart"
-description: "Detects inbound messages impersonating MyChart through spoofed display names or body content referencing MyChart alongside common lure phrases like feedback surveys or reward claims. Excludes newsletters, out-of-band pivots, quarantine notices, and messages from highly trusted sender domains that pass DMARC authentication."
+description: "Detects inbound messages impersonating MyChart, the patient portal brand, by using a display name containing 'mychart' combined with common lure phrases such as 'claim your reward', 'member rewards', 'feedback survey', or 'medicare kit'. The rule also flags messages sent from recently registered domains. Legitimate senders from trusted MyChart-related domains that pass DMARC authentication, as well as designated high-trust sender domains, are excluded."
 type: "rule"
 severity: "medium"
 source: |

--- a/detection-rules/impersonation_mychart.yml
+++ b/detection-rules/impersonation_mychart.yml
@@ -1,0 +1,38 @@
+name: "Brand impersonation: MyChart"
+description: "Detects inbound messages impersonating MyChart through spoofed display names or body content referencing MyChart alongside common lure phrases like feedback surveys or reward claims. Excludes newsletters, out-of-band pivots, quarantine notices, and messages from highly trusted sender domains that pass DMARC authentication."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+    regex.icontains(sender.display_name, '^mychart\s\w+')
+    or strings.iends_with(sender.display_name, "from mychart")
+    or (
+      strings.icontains(body.current_thread.text, "mychart")
+      and strings.icontains(body.current_thread.text,
+                            "feedback survey",
+                            "claim your reward"
+      )
+    )
+  )
+  and not any(ml.nlu_classifier(body.current_thread.text).topics,
+              .name in ("Newsletters and Digests", "Out of Band Pivot")
+  )
+  and not strings.contains(subject.base, "Quarantine")
+  // negate highly trusted sender domains unless they fail DMARC authentication
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+attack_types:
+  - "Credential Phishing"
+  - "Spam"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+  - "Spoofing"
+detection_methods:
+  - "Content analysis"
+  - "Natural Language Understanding"
+  - "Header analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

Detects inbound messages impersonating MyChart, the patient portal brand, by using a display name containing 'mychart' combined with common lure phrases such as 'claim your reward', 'member rewards', 'feedback survey', or 'medicare kit'. The rule also flags messages sent from recently registered domains. Legitimate senders from trusted MyChart-related domains that pass DMARC authentication, as well as designated high-trust sender domains, are excluded.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50cefa2845ac5456f8eebdc8da0663b6847951e2c64a239d434fff7f37cfffbc?preview_id=01a025dc-235a-7f24-87cc-37a5a4652f3a)
- [Sample 2](https://platform.sublime.security/messages/509aa1049c710109baea802941e13cff1fd53437107fc14785c4f33977b4dfab?preview_id=019f1adf-6c99-71d4-9b23-f12e76e46cca)
- [Sample 3](https://platform.sublime.security/messages/50cff77c6bfc8ff67f4818874c36803b7ee4ed4c3fa487334e5428cbbac109ff?preview_id=01a028c4-24ed-7501-a631-43b89fc9be95)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=01a0435d-542c-7d40-a9cb-6b5c55ce2fc5)
- [L7D 95 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/667c52c6-cd38-4472-bd93-b727e163c840)