### PR TITLE
Update attachment_suspicious_message_unscannable_cloudflare.yml

### DIFF
--- a/detection-rules/attachment_suspicious_message_unscannable_cloudflare.yml
+++ b/detection-rules/attachment_suspicious_message_unscannable_cloudflare.yml
@@ -16,8 +16,11 @@ source: |
                   0 < length(.scan.url.urls) < 20
                   // fewer unique root domain links
                   and length(distinct(.scan.url.urls, .domain.root_domain)) < 10
-                  // sender domain matches no body domains
-                  and all(.scan.url.urls,
+                  // at least one link points off the sender's own domain
+                  // (a self-domain footer url shouldn't defeat the off-domain
+                  // signal — `all` previously missed lures whose payload link
+                  // sits on a third-party domain alongside the sender's own)
+                  and any(.scan.url.urls,
                           .domain.root_domain != sender.email.domain.root_domain
                   )
           )


### PR DESCRIPTION
# Description

Loosens the attachment URL clause from `all(.scan.url.urls, .domain.root_domain != sender.email.domain.root_domain)` to `any(...)`.

The `all` form required that **no** URL in the attachment point back to the sender's own domain. In practice a sender's own domain often appears as a parsed URL in the attachment (e.g. a footer contact block), which flips `all` to false and causes the rule to miss image-only lures whose Cloudflare-turnstile payload link sits on a third-party domain alongside the sender's own. `any(... != sender domain)` preserves the intended "at least one link goes off the sender's domain" signal without being defeated by a single self-domain URL. Same self-domain-URL bug class as #5165.

The rule's precision is carried by the downstream live Cloudflare-turnstile-interstitial gate (+ suspicious subject/display-name + sender-profile gates), so this loosening only changes which messages reach that gate — validated as strictly additive below (+7 net-new, 0 regressions / 30d).

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/50cd021719ec3fbcf4473d11b27c8d67c528e9e5657bd9d56f2c76d0d5673946?preview_id=01a03436-7c52-7933-bd13-b58621e71f22)

## Associated hunts

- [New catches (any AND NOT all, 30d)](https://platform.sublime.security/messages/hunt?huntId=01a03514-6c49-7c4f-a162-96792890c5a2)
- [Regressions (all AND NOT any, 30d)](https://platform.sublime.security/messages/hunt?huntId=01a03515-3330-7cc6-8b1f-0e1524e08129)

🤖 Generated with [Claude Code](https://claude.com/claude-code)