### PR TITLE
Update impersonation_ups.yml

### DIFF
--- a/detection-rules/impersonation_ups.yml
+++ b/detection-rules/impersonation_ups.yml
@@ -14,7 +14,7 @@ source: |
     sender.display_name in~ ("UPS My Choice", "UPS Services", "Ups.com")
     or regex.icontains(sender.display_name, 'ups-\w+')
     // sender display name with weird delivery id
-    or regex.icontains(sender.display_name, 'ups.{0,20}deliver.{0,30}id.{0,5}\w+')
+    or regex.icontains(sender.display_name, '\bups\b.{0,40}id[\s-]?[a-z0-9]{6,}')
     or strings.ilike(sender.email.local_part, "*united*parcel*service*")
     or strings.ilike(sender.email.domain.domain, '*united*parcel*service*')
     or strings.icontains(subject.subject, 'UPS delivery')


### PR DESCRIPTION
# Description

Broadening up sender display name regex a bit to capture additional samples

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50cca11ae419c9c0260750d2015d6a5e3641978d9ebbbdbf966bf2a84c9ae354?preview_id=01a01b32-0d2b-7a44-bb9b-315e372af63a)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=01a03902-cae4-7110-ac12-64719566c3eb)
- [L7D 95 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/9f51acd5-c1a5-443b-9570-602fec851f60)