### PR TITLE
Update evasion_excessive_image_padding_cred_theft.yml

### DIFF
--- a/detection-rules/evasion_excessive_image_padding_cred_theft.yml
+++ b/detection-rules/evasion_excessive_image_padding_cred_theft.yml
@@ -7,7 +7,7 @@ source: |
   // CTA link with action-oriented display text pointing to a different domain than the sender
   and any(body.current_thread.links,
           regex.icontains(.display_text,
-                          '(?:open|sign.?in|log.?in|retain|credential|secure|confirm|accept|release|review|document)'
+                          '(?:open|sign.?in|log.?in|retain|credential|secure|confirm|accept|release|review|document|deliver)'
           )
           and .href_url.domain.root_domain != sender.email.domain.root_domain
           and not regex.icontains(.display_text, 'open source')
@@ -41,16 +41,16 @@ source: |
     or regex.icontains(body.html.raw,
                        '(?:<p>\s*(?:&nbsp;|&#160;)\s*</p>\s*){25,}'
     )
-    // css margin-top pushdown >= 1500px
+    // css margin-top or padding-top pushdown >= 1500px
     or (
       regex.icontains(body.html.raw,
-                      'margin-top\s*:\s*(?:1[5-9]\d{2}|[2-9]\d{3}|\d{5,})px'
+                      '(?:margin|padding)-top\s*:\s*(?:1[5-9]\d{2}|[2-9]\d{3}|\d{5,})px'
       )
       and not regex.icontains(body.html.raw,
-                              'position\s*:\s*absolute[^"]*margin-top\s*:\s*(?:1[5-9]\d{2}|[2-9]\d{3}|\d{5,})px'
+                              'position\s*:\s*absolute[^"]*(?:margin|padding)-top\s*:\s*(?:1[5-9]\d{2}|[2-9]\d{3}|\d{5,})px'
       )
       and not regex.icontains(body.html.raw,
-                              'margin-left\s*:\s*\d{3,}px[^"]*margin-top\s*:\s*(?:1[5-9]\d{2}|[2-9]\d{3}|\d{5,})px'
+                              'margin-left\s*:\s*\d{3,}px[^"]*(?:margin|padding)-top\s*:\s*(?:1[5-9]\d{2}|[2-9]\d{3}|\d{5,})px'
       )
     )
   )


### PR DESCRIPTION
# Description

Updating regex logic to include `padding-top` as an evasion technique. Also updating `display_text` logic to include the keyword `deliver`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50cca11ae419c9c0260750d2015d6a5e3641978d9ebbbdbf966bf2a84c9ae354?preview_id=01a01b32-0d2b-7a44-bb9b-315e372af63a)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=01a03902-ae37-7f3e-8479-bc055de5bcfb)
- [L7D 95 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/4027cad6-9f0b-435e-b979-238f57971683)