### PR TITLE
Create link_short_message_with_generic_subdomain_matching_sender_domain.yml

### DIFF
--- a/detection-rules/link_short_message_with_generic_subdomain_matching_sender_domain.yml
+++ b/detection-rules/link_short_message_with_generic_subdomain_matching_sender_domain.yml
@@ -41,3 +41,4 @@ detection_methods:
   - "Whois"
   - "Sender analysis"
   - "Content analysis"
+id: "f5024ab8-2d82-5bb0-bc71-c3494f7bea6c"

--- a/detection-rules/link_short_message_with_generic_subdomain_matching_sender_domain.yml
+++ b/detection-rules/link_short_message_with_generic_subdomain_matching_sender_domain.yml
@@ -16,25 +16,24 @@ source: |
     // only one link is present
     length(body.links) == 1
     // link is a generic subdomain landing page of sender root domain
-    and (
-      any(body.links,
-          .parser == "hyperlink"
-          and .href_url.domain.root_domain == sender.email.domain.root_domain
-          and .href_url.domain.subdomain is not null
-          and .href_url.domain.subdomain != "www"
-          and .href_url.path is null
-          // short display text hyperlink
-          and length(.display_text) < 20
-          // single word only
-          and not strings.icontains(.display_text, " ")
-      )
-  
-      // action link is always third word from the end
-      or any(regex.extract(body.html.raw,
-                           "<a.*?>[\r\n]{0,2}[a-zA-Z0-9-''%()]*?[.,?!]?</a>\\s([0-9a-zA-Z-''%]+[.,?!:]?\\s[0-9a-zA-Z-''%]+[.,?!']?)"
-             ),
-             strings.ends_with(body.html.display_text, .groups[0])
-      )
+    and any(body.links,
+            .parser == "hyperlink"
+            and .href_url.domain.root_domain == sender.email.domain.root_domain
+            and .href_url.domain.subdomain is not null
+            and .href_url.domain.subdomain != "www"
+            and .href_url.path is null
+            // short display text hyperlink
+            and length(.display_text) < 20
+            and (
+              // single word action link
+              not strings.icontains(.display_text, " ")
+              // action link is third word from the end of body
+              and any(regex.extract(body.html.raw,
+                                    "<a.*?>[\r\n]{0,2}[a-zA-Z0-9-''%()]*?[.,?!]?</a>\\s([0-9a-zA-Z-''%]+[.,?!:]?\\s[0-9a-zA-Z-''%]+[.,?!']?)"
+                      ),
+                      strings.ends_with(body.html.display_text, .groups[0])
+              )
+            )
     )
   )
   

--- a/detection-rules/link_short_message_with_generic_subdomain_matching_sender_domain.yml
+++ b/detection-rules/link_short_message_with_generic_subdomain_matching_sender_domain.yml
@@ -1,0 +1,43 @@
+name: "Link: Generic subdomain link from newly registered domain"
+description: "Detects short, single-threaded inbound messages that contain exactly one hyperlink pointing to a generic subdomain landing page on the sender's own root domain, with no path and brief display text. The sender's domain is also newly registered, being less than 365 days old, a strong indicator of infrastructure set up for spam, reconnoissance or malicious use."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // only one short thread is present
+  and length(body.previous_threads) == 0
+  and length(body.current_thread.text) < 250
+  
+  // negate attachments
+  and length(attachments) == 0
+  
+  // generic link
+  and (
+    // only one link is present
+    length(body.links) == 1
+    // link is a generic subdomain landing page of sender root domain
+    and any(body.links,
+            .parser == "hyperlink"
+            and .href_url.domain.root_domain == sender.email.domain.root_domain
+            and .href_url.domain.subdomain is not null
+            and .href_url.domain.subdomain != "www"
+            and .href_url.path is null
+            // short display text hyperlink
+            and length(.display_text) < 20
+    )
+  )
+  
+  // newly created sender domain
+  and network.whois(sender.email.domain).days_old < 365
+  
+attack_types:
+  - "Credential Phishing"
+  - "Spam"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "URL analysis"
+  - "Whois"
+  - "Sender analysis"
+  - "Content analysis"

--- a/detection-rules/link_short_message_with_generic_subdomain_matching_sender_domain.yml
+++ b/detection-rules/link_short_message_with_generic_subdomain_matching_sender_domain.yml
@@ -24,6 +24,8 @@ source: |
             and .href_url.path is null
             // short display text hyperlink
             and length(.display_text) < 20
+            // single word only
+            and not strings.icontains(.display_text, " ")
     )
   )
   

--- a/detection-rules/link_short_message_with_generic_subdomain_matching_sender_domain.yml
+++ b/detection-rules/link_short_message_with_generic_subdomain_matching_sender_domain.yml
@@ -6,7 +6,7 @@ source: |
   type.inbound
   // only one short thread is present
   and length(body.previous_threads) == 0
-  and length(body.current_thread.text) < 250
+  and length(body.current_thread.text) < 300
   
   // negate attachments
   and length(attachments) == 0
@@ -16,21 +16,27 @@ source: |
     // only one link is present
     length(body.links) == 1
     // link is a generic subdomain landing page of sender root domain
-    and any(body.links,
-            .parser == "hyperlink"
-            and .href_url.domain.root_domain == sender.email.domain.root_domain
-            and .href_url.domain.subdomain is not null
-            and .href_url.domain.subdomain != "www"
-            and .href_url.path is null
-            // short display text hyperlink
-            and length(.display_text) < 20
-            // single word only
-            and not strings.icontains(.display_text, " ")
+    and (
+      any(body.links,
+          .parser == "hyperlink"
+          and .href_url.domain.root_domain == sender.email.domain.root_domain
+          and .href_url.domain.subdomain is not null
+          and .href_url.domain.subdomain != "www"
+          and .href_url.path is null
+          // short display text hyperlink
+          and length(.display_text) < 20
+          // single word only
+          and not strings.icontains(.display_text, " ")
+      )
+  
+      // action link is always third word from the end
+      or any(regex.extract(body.html.raw,
+                           "<a.*?>[\r\n]{0,2}[a-zA-Z0-9-''%()]*?[.,?!]?</a>\\s([0-9a-zA-Z-''%]+[.,?!:]?\\s[0-9a-zA-Z-''%]+[.,?!']?)"
+             ),
+             strings.ends_with(body.html.display_text, .groups[0])
+      )
     )
   )
-  
-  // newly created sender domain
-  and network.whois(sender.email.domain).days_old < 365
   
 attack_types:
   - "Credential Phishing"


### PR DESCRIPTION
# Description

Campaign discovered while scoping hostinger dns abuse.

Logic:

- Sub 365d sender
- Only ONE link, which is a generic subdomain matching the sender domain
- Link is inline with short display text
- Short body, sub 250 characters
-  Only one thread present
- Negate attachments for FP's

# Associated samples

[- Sample 1](https://platform.sublime.security/messages/50afa9375655e53552835354917413f31f4372024f53d805bef80a020a5ed0fb?preview_id=019ffc20-b918-7b33-bae4-fdfe90219620)
[- Sample 2](https://platform.sublime.security/messages/50b2413d88ec52117b540dda10d5087c5525881a38a7cc38a2a11412a71c432f?preview_id=019ffc1f-ca9c-75ab-8af7-111fcdd39125)

## Associated hunts

[- Hunt 1 - Shared Samples (L180D)](https://platform.sublime.security/messages/hunt?huntId=01a03588-4292-7949-942c-6698b8ab6b5b)
[- Hunt 2 - Multi (L30D)](https://hunt.limeseed.email/hunts/a08ba892-5050-4d5a-94ec-4a9809ca3552)