### PR TITLE
Create nsfw_google_drive_share.yml

### DIFF
--- a/detection-rules/nsfw_google_drive_share.yml
+++ b/detection-rules/nsfw_google_drive_share.yml
@@ -1,0 +1,36 @@
+name: "Brand impersonation: Romantic google drive share notification"
+description: "Detects freemail senders spoofing Google Drive sharing notifications by using drive in the display name, attaching calendar .ics files, and mimicking the standard Drive sharing email template with indication of an NSFW or romantic google share."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // freemail sender impersonating Google Drive
+  and sender.email.domain.root_domain in $free_email_providers
+  and strings.icontains(sender.display_name, "drive")
+  // ICS calendar attachment unusual for real Google Drive share notifications
+  and any(attachments,
+          .file_type == "ics"
+          or .content_type in ("application/ics", "text/calendar")
+  )
+  // body matches Google Drive sharing notification template
+  and regex.icontains(body.current_thread.text,
+                      "shared a folder with you",
+                      'private\walbum\w+',
+                      "access may expire after the first view"
+  )
+  // credential theft intent confirmed by NLU
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "cred_theft" and .confidence == "high"
+  ) 
+attack_types:
+  - "Credential Phishing"
+  - "ICS Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Free email provider"
+  - "Social engineering"
+detection_methods:
+  - "Sender analysis"
+  - "Content analysis"
+  - "File analysis"
+  - "Natural Language Understanding"

--- a/detection-rules/nsfw_google_drive_share.yml
+++ b/detection-rules/nsfw_google_drive_share.yml
@@ -34,3 +34,4 @@ detection_methods:
   - "Content analysis"
   - "File analysis"
   - "Natural Language Understanding"
+id: "771a72d3-4672-5c03-b09f-4552d4a0ccdf"


### PR DESCRIPTION
# Description
Detects freemail senders spoofing Google Drive sharing notifications by using drive in the display name, attaching calendar .ics files, and mimicking the standard Drive sharing email template with indication of an NSFW or romantic google share.

# Associated samples
- [Sample 1](https://platform.sublime.security/messages/50ced60b31caf6a6887a7f300b6ba230d685623c8d234eca0f935f56bf334235)
- [Sample 2](https://platform.sublime.security/messages/50cec5a4cd18e7fecfba898115465fb26f954379a2c21ce93fbd31eda0e1a5a7?preview_id=01a02680-9d2c-762f-bc99-bb80cae647e3)

## Associated hunts
- [Hunt 365D](https://platform.sublime.security/messages/hunt?huntId=01a03540-562b-76ee-b572-2cf36cd248b4)
- [Multi-hunt 30D](https://hunt.limeseed.email/hunts/0dbd3add-23ec-4db1-b70e-fadc30bf40e6)

