### PR TITLE
Create brand_impersonation_bill.yml

### DIFF
--- a/detection-rules/brand_impersonation_bill.yml
+++ b/detection-rules/brand_impersonation_bill.yml
@@ -1,0 +1,43 @@
+name: "Brand impersonation: Bill.com"
+description: "Detects inbound messages containing text and branding elements characteristic of Bill.com or BILL Operations, LLC communications—such as copyright notices, registered office addresses, or signature phrases—while excluding legitimate newsletters/webinars (via NLU classification) and messages that authenticate via DMARC from trusted or verified Bill.com/Divvy domains, indicating potential brand impersonation."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+    strings.icontains(body.current_thread.text,
+                      "Registered office: Bill.com, LLC"
+    )
+    or strings.icontains(body.current_thread.text, "From the Bill.com Team")
+    or strings.icontains(body.current_thread.text, "BILL Operations, LLC")
+    or regex.icontains(body.current_thread.text, '©\\s*20[0-9]{2}\\s*BILL')
+    or 2 of (
+      strings.icontains(body.current_thread.text, "Bill.com"),
+      strings.icontains(body.current_thread.text, '6220 America Center Dr'),
+      strings.icontains(body.current_thread.text, "San Jose, CA"),
+    )
+  )
+  and not any(ml.nlu_classifier(body.current_thread.text).topics,
+              .name in ("Newsletters and Digests", "Events and Webinars")
+              and .confidence == "high"
+  )
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+  and not (
+    sender.email.domain.root_domain in ("bill.com", "getdivvy.com")
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+  
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Spoofing"
+detection_methods:
+  - "Content analysis"
+  - "Natural Language Understanding"
+  - "Header analysis"
+  - "Sender analysis"

--- a/detection-rules/brand_impersonation_bill.yml
+++ b/detection-rules/brand_impersonation_bill.yml
@@ -55,13 +55,17 @@ source: |
     )
   )
   and not any(ml.nlu_classifier(body.current_thread.text).topics,
-              .name in ("Newsletters and Digests", "Events and Webinars", "Advertising and Promotions")
+              .name in (
+                "Newsletters and Digests",
+                "Events and Webinars",
+                "Advertising and Promotions"
+              )
               and .confidence == "high"
   )
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
-  ) 
+  )
 attack_types:
   - "BEC/Fraud"
   - "Credential Phishing"

--- a/detection-rules/brand_impersonation_bill.yml
+++ b/detection-rules/brand_impersonation_bill.yml
@@ -41,3 +41,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "Header analysis"
   - "Sender analysis"
+id: "3ac8a2a8-b43a-5219-bd6f-2f91ca07d03a"

--- a/detection-rules/brand_impersonation_bill.yml
+++ b/detection-rules/brand_impersonation_bill.yml
@@ -10,26 +10,58 @@ source: |
     )
     or strings.icontains(body.current_thread.text, "From the Bill.com Team")
     or strings.icontains(body.current_thread.text, "BILL Operations, LLC")
-    or regex.icontains(body.current_thread.text, '©\\s*20[0-9]{2}\\s*BILL')
-    or 2 of (
-      strings.icontains(body.current_thread.text, "Bill.com"),
-      strings.icontains(body.current_thread.text, '6220 America Center Dr'),
-      strings.icontains(body.current_thread.text, "San Jose, CA"),
+    or regex.icontains(body.current_thread.text, '©\s*20[0-9]{2}\s*BILL')
+    or (
+      strings.icontains(body.current_thread.text, "Bill.com")
+      and strings.icontains(body.current_thread.text, '6220 America Center Dr')
+      and strings.icontains(body.current_thread.text, "San Jose, CA")
+      and not strings.icontains(body.current_thread.text, "billing address")
+    )
+  )
+  
+  // not sent from bill.com or through bill.com infra
+  and not (
+    sender.email.domain.root_domain in ("bill.com", "getdivvy.com")
+    or any(headers.domains, .root_domain == "bill.com")
+    or any(headers.hops,
+           .authentication_results.dmarc_details.from.root_domain == "bill.com"
+           or any(.authentication_results.dkim_details,
+                  .domain == "bill.com"
+                  or strings.iends_with(.domain, ".bill.com")
+           )
+    )
+  )
+  // external link that isn't bill.com
+  and any(body.current_thread.links,
+          .href_url.domain.root_domain not in ("bill.com", "aka.ms", "app.link")
+          and .href_url.domain.valid
+  )
+  and not (
+    (
+      any(headers.reply_to, .email.domain.root_domain == "bill.com")
+      and strings.icontains(body.current_thread.text,
+                            "You received this message because you are subscribed"
+      )
+    )
+    or regex.icontains(subject.subject, 'ticket\s+[0-9]+')
+    or regex.icontains(body.current_thread.text,
+                       'assigned to this ticket|new ticket has been assigned'
+    )
+    or (
+      strings.icontains(body.current_thread.text, "This email is a service from")
+      and any(body.current_thread.links,
+              .href_url.domain.root_domain == "zendesk.com"
+      )
     )
   )
   and not any(ml.nlu_classifier(body.current_thread.text).topics,
-              .name in ("Newsletters and Digests", "Events and Webinars")
+              .name in ("Newsletters and Digests", "Events and Webinars", "Advertising and Promotions")
               and .confidence == "high"
   )
   and not (
     sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
-  )
-  and not (
-    sender.email.domain.root_domain in ("bill.com", "getdivvy.com")
-    and coalesce(headers.auth_summary.dmarc.pass, false)
-  )
-  
+  ) 
 attack_types:
   - "BEC/Fraud"
   - "Credential Phishing"


### PR DESCRIPTION
# Description
Detects inbound messages containing text and branding elements characteristic of Bill.com or BILL Operations, LLC communications—such as copyright notices, registered office addresses, or signature phrases—while excluding legitimate newsletters/webinars (via NLU classification) and messages that authenticate via DMARC from trusted or verified Bill.com/Divvy domains, indicating potential brand impersonation.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50c6e99be5507a2ea7128b382b6677e5138d8dcdc142051ba476a2b9a8dc22f0)


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01a062ed-ddd7-7287-ba56-c59e73061e30)

