### PR TITLE
Create bec_fraud_unrealted_link_and_previous_threads.yml

### DIFF
--- a/detection-rules/bec_fraud_unrealted_link_and_previous_threads.yml
+++ b/detection-rules/bec_fraud_unrealted_link_and_previous_threads.yml
@@ -15,7 +15,6 @@ source: |
   and all(headers.reply_to,
           filter(body.current_thread.links, .href_url.scheme != "mailto")[0].href_url.domain.root_domain != .email.domain.root_domain
   )
-  
   and length(body.previous_threads) > 1
   
   // the first link's  domain does not appears in a previous thread's links
@@ -87,8 +86,6 @@ source: |
              // we are left with all the entries that are unrelated to the sender, there should be more than 0
              )
   ) > 0
-  
-  
 tags:
   - "Attack surface reduction"
 attack_types:
@@ -102,3 +99,4 @@ detection_methods:
   - "Header analysis"
   - "Sender analysis"
   - "Content analysis"
+id: "7d8cd472-97b1-5088-92fe-5174c19719d7"

--- a/detection-rules/bec_fraud_unrealted_link_and_previous_threads.yml
+++ b/detection-rules/bec_fraud_unrealted_link_and_previous_threads.yml
@@ -1,0 +1,104 @@
+name: "BEC/Fraud: Self-addressed reply with unrelated link in ongoing thread"
+description: "Flags messages where the sender appears to be replying to themselves within an established thread, but the first non-mailto link in the current message points to a domain unrelated to the sender and to any links seen in the previous thread history (accounting for Mimecast link wrapping). The rule confirms the sender was a genuine participant in prior thread messages and that no organizational recipients or domain matches exist in the earlier history, indicating a likely compromised external account being used to redirect the conversation via a newly introduced, unrelated link."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  // self sender behavior
+  and length(recipients.to) == 1
+  and length(recipients.cc) == 0
+  and sender.email.email == recipients.to[0].email.email
+  
+  // the first link is not related to the sender
+  and filter(body.current_thread.links, .href_url.scheme != "mailto")[0].href_url.domain.root_domain != sender.email.domain.root_domain
+  // reply-to address (if present) is not related
+  and all(headers.reply_to,
+          filter(body.current_thread.links, .href_url.scheme != "mailto")[0].href_url.domain.root_domain != .email.domain.root_domain
+  )
+  
+  and length(body.previous_threads) > 1
+  
+  // the first link's  domain does not appears in a previous thread's links
+  and not any(body.previous_threads,
+              any(.links,
+                  // current link IS mimecast rewritten
+                  (
+                    filter(body.current_thread.links,
+                           .href_url.scheme != "mailto"
+                    )[0].href_url.domain.root_domain in (
+                      "mimecastprotect.com",
+                      "mimecast.com"
+                    )
+                    and (
+                      // the previous thread is also rewritten
+                      strings.parse_domain(.href_url.query_params_decoded['domain'][0]
+                      ).root_domain == strings.parse_domain(filter(body.current_thread.links,
+                                                                   .href_url.scheme != "mailto"
+                                                            )[0].href_url.query_params_decoded['domain'][0]
+                      ).root_domain
+                      // or the preiovus thread is not rewritten
+                      or .href_url.domain.root_domain == strings.parse_domain(filter(body.current_thread.links,
+                                                                                     .href_url.scheme != "mailto"
+                                                                              )[0].href_url.query_params_decoded['domain'][0]
+                      ).root_domain
+                    )
+                  )
+                  // current link is NOT mimecast rewritten
+                  or (
+                    // but the previous thread is mimecast rewritten
+                    strings.parse_domain(.href_url.query_params_decoded['domain'][0]
+                    ).root_domain == filter(body.current_thread.links,
+                                            .href_url.scheme != "mailto"
+                    )[0].href_url.domain.root_domain
+                    // neither are mimecast rewritten
+                    or .href_url.domain.root_domain == filter(body.current_thread.links,
+                                                              .href_url.scheme != "mailto"
+                    )[0].href_url.domain.root_domain
+                  )
+              )
+  )
+  
+  // none of the previous threads
+  and not any(body.previous_threads,
+              // the subjet has been changed
+              .subject.base =~ subject.base
+              // none of the previous corrispondents are in the org_domains
+              or any(flatten([.recipients.to, .recipients.bcc, .recipients.cc]),
+                     .email.domain.domain in $org_domains
+              )
+              or .sender.email.domain.domain in $org_domains
+  )
+  
+  // there is more than a single particiapte in the previous threads (by email and display_name)
+  and length(filter(flatten([
+                              // pull all the sender emails from previous threads
+                              map(body.previous_threads, .sender),
+                              // get all the recipients from the previous threads
+                              flatten(map(body.previous_threads, .recipients.to, )
+                              )
+                            ]
+                    ),
+                    // remove entries that have no email or display name
+                    .email.email != ""
+                    // remove enties that match the sender display name
+                    and not strings.icontains(sender.display_name, .display_name)
+                    // remove entires that match the sender email
+                    and sender.email.email != .email.email
+             // we are left with all the entries that are unrelated to the sender, there should be more than 0
+             )
+  ) > 0
+  
+  
+tags:
+  - "Attack surface reduction"
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Out of band pivot"
+detection_methods:
+  - "URL analysis"
+  - "Header analysis"
+  - "Sender analysis"
+  - "Content analysis"


### PR DESCRIPTION
# Description

Creating ASR rule for coverage on a general attack pattern related to turning a benign thread into malicious. 

There are some benign matches of this (commonly observed in mailing list) thus making it an ASR rule. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50ae5a8cea026d074c4c745ab1c6044f6ee8c9c9d0fdaccd2b128722688f8980?preview_id=019f812a-95d8-7c16-b988-5989ac68f199)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01a03b40-0f9c-74a0-bb55-f4e823710f8c)
- [Multihunt](https://hunt.limeseed.email/hunts/75c50b10-026b-46cc-aeca-7527f02d6795)

