### PR TITLE
Update impersonation_chase.yml

### DIFF
--- a/detection-rules/impersonation_chase.yml
+++ b/detection-rules/impersonation_chase.yml
@@ -15,7 +15,8 @@ source: |
                   '*chase card services*',
                   '*united mileageplus*',
                   "echase*",
-                  "*freedom unlimited*"
+                  "*freedom unlimited*",
+                  "*chase bank*"
     )
     or strings.ilevenshtein(sender.display_name, 'chase sapphire') <= 2
     or strings.ilevenshtein(sender.display_name, 'chase card services') <= 2


### PR DESCRIPTION
# Description

Minor change, accounting for `chase bank` in the sender display name

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50d21bfdb56560be55db0221b7b6e9edb154eeb6b3d2d27f353e2d3e023ff200?preview_id=01a039b8-8ecf-72c0-9113-1bf313768047)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=01a0443c-ceee-7ec9-880c-5681e5d4372a)
- [L7D 95 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/76440729-182d-496b-abc5-5c247e70a57c)