### PR TITLE
Create callback_phishing_outlook_groups.yml

### DIFF
--- a/detection-rules/callback_phishing_outlook_groups.yml
+++ b/detection-rules/callback_phishing_outlook_groups.yml
@@ -1,0 +1,20 @@
+name: "Callback Scam: Outlook groups"
+description: "Detects inbound messages sent to Outlook group distribution lists (groups.outlook.com) where the body text is classified with high confidence as callback scam intent by an NLU model, while excluding cases where recipient lists are empty or entirely invalid."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and all(recipients.to, .email.domain.domain == "groups.outlook.com")
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name == "callback_scam" and .confidence == "high"
+  )
+  and not (
+    length(recipients.to) == 0 or all(recipients.to, .email.domain.valid == false)
+  )
+attack_types:
+  - "Callback Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Natural Language Understanding"
+  - "Header analysis"

--- a/detection-rules/callback_phishing_outlook_groups.yml
+++ b/detection-rules/callback_phishing_outlook_groups.yml
@@ -18,3 +18,4 @@ tactics_and_techniques:
 detection_methods:
   - "Natural Language Understanding"
   - "Header analysis"
+id: "e8775a29-c10d-5b02-825f-8baa5112e57f"


### PR DESCRIPTION
# Description

Detects inbound messages sent to Outlook group distribution lists (groups.outlook.com) where the body text is classified with high confidence as callback scam intent by an NLU model, while excluding cases where recipient lists are empty or entirely invalid.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50d28a210e55c3ce7b4fd7f94bb120d7914005992d1f927b284eca7c4927f4fc?preview_id=01a03947-0590-7638-a69a-ac1112c55522)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=01a03f68-297a-7294-960e-62b2928ecbef)
- [L7D 95 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/b4d3cde0-101a-4f2e-bcf9-adce986877e2)