### PR TITLE
Update body_whitespace_stuffing_short_lure.yml

### DIFF
--- a/detection-rules/body_whitespace_stuffing_short_lure.yml
+++ b/detection-rules/body_whitespace_stuffing_short_lure.yml
@@ -31,8 +31,13 @@ source: |
                       '(?:<p[^>]*>\s*<o:p>\s*(?:&nbsp;|&#160;)\s*</o:p>\s*</p>\s*){10,}',
                       '(?:<p[^>]*>\s*(?:&nbsp;|&#160;)\s*</p>\s*){30,}'
       )
-      and any(ml.nlu_classifier(body.current_thread.text).intents,
-              .name in ("cred_theft", "bec")
+      and (
+        any(ml.nlu_classifier(body.current_thread.text).intents,
+            .name in ("cred_theft", "bec")
+        )
+        or any(body.current_thread.links,
+               strings.ends_with(.href_url.path, 'php')
+        )
       )
     )
   )


### PR DESCRIPTION
# Description

We miss this because NLU thinks this full message is in spanish, but also we can totally make this php url path a malicious indicator, hunts indicate that this has earned its stay. 

<!-- 
Explain your change and why. For example, "negating legitimate replies," or "adding additional credential theft keywords."

If it's a new rule or insight, explain what the rule is designed to catch/what the insight should fire on.
-->

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50cc3b6e1f8b9981cf49d7413e5031137589d518ff14a8e654cb55c7c60e03c1?preview_id=01a01c4d-8a27-7a04-8576-e8194a928f15)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [net-new multihunt](https://hunt.limeseed.email/hunts/b570f77d-79c0-4d46-b535-c8a78ff61659)
- [shared samples hunt](https://platform.sublime.security/messages/hunt?huntId=01a04323-83e9-71a4-b630-8940737c66b1)