### PR TITLE
Update link_rpmsg_self_addressed.yml

### DIFF
--- a/detection-rules/link_rpmsg_self_addressed.yml
+++ b/detection-rules/link_rpmsg_self_addressed.yml
@@ -17,9 +17,15 @@ source: |
             or strings.icontains(.href_url.path, '/Encryption/retrieve.ashx')
           )
   )
-  // the To and From headers are the same
-  and length(recipients.to) == 1
-  and all(recipients.to, .email.email == sender.email.email)
+  and (
+    // self sender 
+    (
+      length(recipients.to) == 1
+      and recipients.to[0].email.email == sender.email.email
+    )
+    // no recipients at all
+    or length(recipients.to) == 0
+  )
 tags:
  - "Attack surface reduction"
 attack_types:

--- a/detection-rules/link_rpmsg_self_addressed.yml
+++ b/detection-rules/link_rpmsg_self_addressed.yml
@@ -1,5 +1,5 @@
 name: "Link: Microsoft protected message with suspicious recipient patterns"
-description: "Detects when a user receives a protected message (RPMSG) with the to and from headers matching or there is no TO header at all."
+description: "Detects when a user receives a protected message (RPMSG) with the to and from headers matching or there is no TO header at all. Benign matches are possible, sender exclusions can be used to avoid matching on senders which commonly use Microsoft protected messages with suspicious recipient patterns"
 type: "rule"
 severity: "medium"
 source: |
@@ -26,6 +26,8 @@ source: |
     // no recipients at all
     or length(recipients.to) == 0
   )
+false_positives:
+  - "Some senders commonly send messages which match this behavior, sender exclusions should be used to avoid continued/repeat matching of benign messages"
 tags:
  - "Attack surface reduction"
 attack_types:

--- a/detection-rules/link_rpmsg_self_addressed.yml
+++ b/detection-rules/link_rpmsg_self_addressed.yml
@@ -1,5 +1,5 @@
-name: "Link: Microsoft protected message with matching sender and recipient addresses"
-description: "Detects when a user receives a protected message (RPMSG) with the to and from headers matching."
+name: "Link: Microsoft protected message with suspicious recipient patterns"
+description: "Detects when a user receives a protected message (RPMSG) with the to and from headers matching or there is no TO header at all."
 type: "rule"
 severity: "medium"
 source: |


### PR DESCRIPTION
# Description

Allow for rule to match when there are no recipients on the message

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50d342cd367a36adf8ba71f0dcb56f3157d5f1379ff99f2b76c38fa21e13b30a?preview_id=01a041fd-d415-752d-a4a5-0c057500d347)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Net New hunt](https://platform.sublime.security/messages/hunt?huntId=01a0434d-2b9d-7315-8424-a0a6e498ba3c)
- [Net new Multihunt](https://hunt.limeseed.email/hunts/7ff1d087-eecd-40e5-b7f5-ef8668d9a660)
