### PR TITLE
Create attachment_pdf_wkhtmltopdf_sus_link_cred_theft.yml

### DIFF
--- a/detection-rules/attachment_pdf_wkhtmltopdf_sus_link_cred_theft.yml
+++ b/detection-rules/attachment_pdf_wkhtmltopdf_sus_link_cred_theft.yml
@@ -44,3 +44,4 @@ detection_methods:
   - "Natural Language Understanding"
   - "URL analysis"
   - "File analysis"
+id: "63977bda-8d15-543a-8308-6c2ba7884402"

--- a/detection-rules/attachment_pdf_wkhtmltopdf_sus_link_cred_theft.yml
+++ b/detection-rules/attachment_pdf_wkhtmltopdf_sus_link_cred_theft.yml
@@ -15,7 +15,7 @@ source: |
           any(filter(file.explode(.), .scan.ocr.raw is not null),
               (
                 any(ml.nlu_classifier(.scan.ocr.raw).intents,
-                    .name == 'cred_theft' and .confidence != 'low'
+                    .name in ('cred_theft', 'bec') and .confidence != 'low'
                 )
               )
           )

--- a/detection-rules/attachment_pdf_wkhtmltopdf_sus_link_cred_theft.yml
+++ b/detection-rules/attachment_pdf_wkhtmltopdf_sus_link_cred_theft.yml
@@ -1,0 +1,46 @@
+name: "Attachment: PDF credential phishing via wkhtmltopdf/Qt with suspicious link"
+description: "Detects inbound emails containing PDF attachments whose embedded metadata (creator/producer fields) indicates generation by wkhtmltopdf or Qt-based tools, both commonly used in malicious PDF creation. The rule extracts and OCRs the PDF content, then applies NLU classification to confirm credential theft intent. It further inspects URLs embedded in the PDF for suspicious patterns, such as very short paths or OAuth redirect parameters, which are often abused for credential phishing redirection."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  and any(filter(attachments,
+                 .file_type == "pdf"
+                 // creator and producer of PDF seen in malicious content
+                 and (
+                   strings.starts_with(beta.parse_exif(.).creator, "wkhtmltopdf")
+                   or strings.starts_with(beta.parse_exif(.).producer, "Qt ")
+                 )
+          ),
+          any(filter(file.explode(.), .scan.ocr.raw is not null),
+              (
+                any(ml.nlu_classifier(.scan.ocr.raw).intents,
+                    .name == 'cred_theft' and .confidence != 'low'
+                )
+              )
+          )
+          // suspicious link
+          and any(file.explode(.),
+                  any(.scan.pdf.urls,
+                      // short 1 char path
+                      length(.path) == 2
+                      // oauth redirect
+                      or (
+                        strings.istarts_with(.path, '/oauth/')
+                        and strings.icontains(.query_params, 'redirect_uri=')
+                      )
+                  )
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "PDF"
+  - "Open redirect"
+  - "Social engineering"
+detection_methods:
+  - "Exif analysis"
+  - "Optical Character Recognition"
+  - "Natural Language Understanding"
+  - "URL analysis"
+  - "File analysis"


### PR DESCRIPTION
# Description

This rule detects wkhtmltopdf generated pdfs that contain cred_theft language and a suspicious link. I want to add more suspicious link indicators to this rule in the future. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50ceff4fea6c9d270f151dbb574558e81138aaf3ecb77a22744f8f74bf7ae9fd?preview_id=01a023b4-bca6-7f27-b770-42a8b487db6c)
- [Sample 2](https://platform.sublime.security/messages/50d11628d414c45dca5a5a2b7140661b34272665d30998ecf6fc99808f13f547?preview_id=01a04458-f352-715b-ac71-ef3afd3aff97)
- [Sample 3](https://platform.sublime.security/messages/50bcc34cbd3e89bbc74a930de0f69e372d3a1e25cc6de5055393ce3cfbae67e3?preview_id=01a04458-eb81-7286-9b6b-01a231db21c2)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [95 customer multi-hunt](https://hunt.limeseed.email/hunts/3c700292-a91e-4225-a224-9f5be2182816)
- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=01a0447b-39e7-7e84-a4bd-c1a375e31eef)

[With BEC](https://hunt.limeseed.email/hunts/f6a985b6-c75e-428d-95b2-90f5237422c4)
