### PR TITLE
Update brand_impersonation_state_farm.yml

### DIFF
--- a/detection-rules/brand_impersonation_state_farm.yml
+++ b/detection-rules/brand_impersonation_state_farm.yml
@@ -39,7 +39,8 @@ source: |
         "statefarmclaims.com",
         "statefarmfeedback.com", // legit survey
         "statefarmsurveys.com", // legit survey
-        "nationalesurvey.com"
+        "nationalesurvey.com",
+        "sfdividend.com" // dividend payout email from State Farm
       )
     )
   )


### PR DESCRIPTION
# Description

Adding negation to `sfdividend.com` based on a Detection ping. This domain was used by State Farm to send out dividend payments. 

Sources: 
[State Farm Is Issuing $5 Billion to Car Insurance Customers. Here’s How To Claim Your Payment
](https://www.usnews.com/insurance/auto/state-farm-is-issuing-5-billion-to-car-insurance-customers-heres-how-to-claim-your-payment)

[State Farm is sending dividend payments to auto policyholders—why the email might look like spam
](https://www.9news.com/article/money/consumer/steve-on-your-side/state-farm-dividend-email/73-c5a07c60-8368-4835-b70a-3eb35821d6e6)

[Dividend payments underscore State Farm Mutual’s customer-first focus and ability to provide value directly to customers](https://newsroom.statefarm.com/state-farm-mutual-begins-issuing-dividend-payments/)


## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L365D Regression Hunt](https://platform.sublime.security/messages/hunt?huntId=01a044a6-524c-7016-bbb6-f191b8aadc59)