### PR TITLE
Update credential_phishing_esign_document_notification.yml

### DIFF
--- a/detection-rules/credential_phishing_esign_document_notification.yml
+++ b/detection-rules/credential_phishing_esign_document_notification.yml
@@ -92,6 +92,25 @@ source: |
       and not any(attachments,
                   .file_extension in~ ("pdf", "doc", "docx", "xls", "xlsx", "rtf")
       )
+      // legit notification platforms (e.g. ParentSquare, Panopto) self-host their
+      // "review/sign/view" CTA on the sender's own root domain; this campaign points
+      // the CTA at an off-domain credential page. require a suspicious link whose
+      // display text is a document CTA AND that leaves the sender domain, so
+      // self-hosted legit notifications (and incidental links like the aka.ms
+      // first-contact banner, which carries no CTA verb) don't match.
+      and any(body.links,
+              .href_url.domain.root_domain is not null
+              and .href_url.domain.root_domain != sender.email.domain.root_domain
+              and regex.icontains(strings.replace_confusables(.display_text),
+                                  "view",
+                                  "review",
+                                  "sign",
+                                  "document",
+                                  "download",
+                                  "open",
+                                  "complete"
+              )
+      )
     )
   )
   and (

--- a/detection-rules/credential_phishing_esign_document_notification.yml
+++ b/detection-rules/credential_phishing_esign_document_notification.yml
@@ -146,29 +146,28 @@ source: |
     or regex.count(body.html.raw,
                    'mailto:[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
     ) > 50
-
+  
     // High count of empty elements (padding)
     or regex.count(body.html.raw,
                    '<(?:p|div|span|td)[^>]*>\s*(?:&nbsp;|\s)*\s*</(?:p|div|span|td)>'
     ) > 30
-
+  
     // HR impersonation
     or strings.ilike(sender.display_name, "HR", "H?R", "*Human Resources*")
-
+  
     // Sender display name contains a phone number
     or regex.icontains(sender.display_name,
                        '\+?([ilo0-9]{1}.)?\(?[ilo0-9]{3}?\)?.[ilo0-9]{3}.?[ilo0-9]{4}'
     )
-
+  
     // short CTA grafted above a forwarded legitimate thread to borrow its credibility
     or (
-      length(body.previous_threads) > 0
-      and length(body.current_thread.text) < 600
+      length(body.previous_threads) > 0 and length(body.current_thread.text) < 600
     )
   )
   and (
     any(body.links,
-
+  
         // suspicious content within link display_text
         regex.icontains(strings.replace_confusables(.display_text),
                         "activate",
@@ -208,10 +207,10 @@ source: |
           )
           and regex.match(.display_text, "^[^a-z]*[A-Z][^a-z]*$")
         )
-
+  
         // the display text is _exactly_
         or .display_text in~ ("Open")
-
+  
         // URL fragment containing recipient's address
         or .href_url.fragment in map(recipients.to, .email.email)
     )
@@ -285,10 +284,10 @@ source: |
       )
     )
   )
-
+  
   // negate replies/fowards containing legitimate docs
   and not (length(headers.references) > 0 or headers.in_reply_to is not null)
-
+  
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (

--- a/detection-rules/credential_phishing_esign_document_notification.yml
+++ b/detection-rules/credential_phishing_esign_document_notification.yml
@@ -4,79 +4,95 @@ type: "rule"
 severity: "medium"
 source: |
   type.inbound
-  and any([subject.subject, sender.display_name],
-          regex.icontains(strings.replace_confusables(.),
-                          "D[0o]cuLink",
-                          "Agreement",
-                          "Access.&.Appr[0o]ved",
-                          "Agreement.{0,5}Review",
-                          "Attend.and.Review",
-                          "action.re?quired",
-                          "AuthentiSign",
-                          "Completed.File",
-                          "D[0o]chsared",
-                          "D[0o]cshared",
-                          "D[0o]csPoint",
-                          "D[0o]cument.Shared",
-                          "D[0o]cuCentre",
-                          "D[0o]cuCenter",
-                          "D[0o]cCenter",
-                          "D[0o]csOnline",
-                          "D[0o]cSend",
-                          "D[0o]cu?Send",
-                          "d[0o]csign",
-                          "D[0o]cu-eSin",
-                          "D[0o]cu-management",
-                          "\\beSign",
-                          "e\\.sign",
-                          "esign.[0o]nline",
-                          "[SsZz][lL][GgSs][Nn].*D[0o]c",
-                          "e-d[0o]c",
-                          "e-signature",
-                          "e-Verify Doc",
-                          "eSignature",
-                          "eSign&Return",
-                          "eSign[0o]nline",
-                          "Fileshare",
-                          "Review.and.C[0o]mplete",
-                          "Review.&.Sign",
-                          "Sign[0o]nline",
-                          "Signature.Request",
-                          "Shared.C[0o]mpleted",
-                          "Sign.and.Seal",
-                          "viaSign",
-                          "D[0o]cuSign",
-                          "D[0o]csID",
-                          "Complete.{0,10}D[0o]cuSign",
-                          "Enroll & Sign",
-                          "Review and Sign",
-                          "Sign(?:Report|Now)",
-                          "SignD[0o]c",
-                          "D[0o]cxxx",
-                          "d[0o]cufile",
-                          'E\x{00AD}-\x{00AD}S\x{00AD}i\x{00AD}g\x{00AD}n\x{00AD}&Return',
-                          "d[0o]cument.signature",
-                          "Electr[0o]nic.?Signature",
-                          "Complete: ",
-                          "Please (?:Review|Sign)",
-                          "^REVIEW$",
-                          "requests your signature",
-                          "signature on.*contract",
-                          "Independent Contract",
-                          "Contract.*signature",
-                          "add your signature",
-                          "signature needed",
-                          "attn_task",
-                          "DocReq\\b"
+  and (
+    any([subject.subject, sender.display_name],
+        regex.icontains(strings.replace_confusables(.),
+                        "D[0o]cuLink",
+                        "Agreement",
+                        "Access.&.Appr[0o]ved",
+                        "Agreement.{0,5}Review",
+                        "Attend.and.Review",
+                        "action.re?quired",
+                        "AuthentiSign",
+                        "Completed.File",
+                        "D[0o]chsared",
+                        "D[0o]cshared",
+                        "D[0o]csPoint",
+                        "D[0o]cument.Shared",
+                        "D[0o]cuCentre",
+                        "D[0o]cuCenter",
+                        "D[0o]cCenter",
+                        "D[0o]csOnline",
+                        "D[0o]cSend",
+                        "D[0o]cu?Send",
+                        "d[0o]csign",
+                        "D[0o]cu-eSin",
+                        "D[0o]cu-management",
+                        "\\beSign",
+                        "e\\.sign",
+                        "esign.[0o]nline",
+                        "[SsZz][lL][GgSs][Nn].*D[0o]c",
+                        "e-d[0o]c",
+                        "e-signature",
+                        "e-Verify Doc",
+                        "eSignature",
+                        "eSign&Return",
+                        "eSign[0o]nline",
+                        "Fileshare",
+                        "Review.and.C[0o]mplete",
+                        "Review.&.Sign",
+                        "Sign[0o]nline",
+                        "Signature.Request",
+                        "Shared.C[0o]mpleted",
+                        "Sign.and.Seal",
+                        "viaSign",
+                        "D[0o]cuSign",
+                        "D[0o]csID",
+                        "Complete.{0,10}D[0o]cuSign",
+                        "Enroll & Sign",
+                        "Review and Sign",
+                        "Sign(?:Report|Now)",
+                        "SignD[0o]c",
+                        "D[0o]cxxx",
+                        "d[0o]cufile",
+                        'E\x{00AD}-\x{00AD}S\x{00AD}i\x{00AD}g\x{00AD}n\x{00AD}&Return',
+                        "d[0o]cument.signature",
+                        "Electr[0o]nic.?Signature",
+                        "Complete: ",
+                        "Please (?:Review|Sign)",
+                        "^REVIEW$",
+                        "requests your signature",
+                        "signature on.*contract",
+                        "Independent Contract",
+                        "Contract.*signature",
+                        "add your signature",
+                        "signature needed",
+                        "attn_task",
+                        "DocReq\\b"
+        )
+        or (
+          regex.icontains(strings.replace_confusables(.), "action.re?quired")
+          and not (
+            sender.email.domain.root_domain == "sharepointonline.com"
+            and headers.auth_summary.dmarc.pass
+            and strings.icontains(subject.subject, "asked to edit")
           )
-          or (
-            regex.icontains(strings.replace_confusables(.), "action.re?quired")
-            and not (
-              sender.email.domain.root_domain == "sharepointonline.com"
-              and headers.auth_summary.dmarc.pass
-              and strings.icontains(subject.subject, "asked to edit")
-            )
-          )
+        )
+    )
+    // lure CTA injected into the body (not subject/display) above a forwarded thread
+    or (
+      regex.icontains(strings.replace_confusables(body.current_thread.text),
+                      "requests? your signature",
+                      "review, sign, and return",
+                      "signature on the attached"
+      )
+      // legit "please sign & return" mail attaches the actual document; this
+      // campaign references an "attached" doc but delivers a fake one via an
+      // off-domain link, with no real document attached
+      and not any(attachments,
+                  .file_extension in~ ("pdf", "doc", "docx", "xls", "xlsx", "rtf")
+      )
+    )
   )
   and (
     // unusual repeated patterns in HTML
@@ -130,23 +146,29 @@ source: |
     or regex.count(body.html.raw,
                    'mailto:[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
     ) > 50
-  
+
     // High count of empty elements (padding)
     or regex.count(body.html.raw,
                    '<(?:p|div|span|td)[^>]*>\s*(?:&nbsp;|\s)*\s*</(?:p|div|span|td)>'
     ) > 30
-  
+
     // HR impersonation
     or strings.ilike(sender.display_name, "HR", "H?R", "*Human Resources*")
-  
+
     // Sender display name contains a phone number
     or regex.icontains(sender.display_name,
                        '\+?([ilo0-9]{1}.)?\(?[ilo0-9]{3}?\)?.[ilo0-9]{3}.?[ilo0-9]{4}'
     )
+
+    // short CTA grafted above a forwarded legitimate thread to borrow its credibility
+    or (
+      length(body.previous_threads) > 0
+      and length(body.current_thread.text) < 600
+    )
   )
   and (
     any(body.links,
-  
+
         // suspicious content within link display_text
         regex.icontains(strings.replace_confusables(.display_text),
                         "activate",
@@ -186,18 +208,10 @@ source: |
           )
           and regex.match(.display_text, "^[^a-z]*[A-Z][^a-z]*$")
         )
-  
+
         // the display text is _exactly_
         or .display_text in~ ("Open")
-  
-        // the display text is "go to documents" with the local part of recipient email in body
-        or (
-          strings.icontains(.display_text, "go to documents")
-          and any(recipients.to,
-                  strings.contains(body.current_thread.text, .email.local_part)
-          )
-        )
-  
+
         // URL fragment containing recipient's address
         or .href_url.fragment in map(recipients.to, .email.email)
     )
@@ -271,10 +285,10 @@ source: |
       )
     )
   )
-  
+
   // negate replies/fowards containing legitimate docs
   and not (length(headers.references) > 0 or headers.in_reply_to is not null)
-  
+
   // negate highly trusted sender domains unless they fail DMARC authentication
   and (
     (


### PR DESCRIPTION
# Description

Refactoring and updating this rule to account for a few FNs that were slipping through. Adding a few "or" statements to the initial and which is why the diff is so big... sorry whoever reviews this. 

<!-- 
Explain your change and why. For example, "negating legitimate replies," or "adding additional credential theft keywords."

If it's a new rule or insight, explain what the rule is designed to catch/what the insight should fire on.
-->

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50cc3b6e1f8b9981cf49d7413e5031137589d518ff14a8e654cb55c7c60e03c1?preview_id=01a01c4d-8a27-7a04-8576-e8194a928f15)
- Sample 2

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://hunt.limeseed.email/hunts/7f3d23da-97a9-47d9-aa0c-c6d1ac15a448)