### PR TITLE
Create link_fake_video_new_domain.yml

### DIFF
--- a/detection-rules/link_fake_video_new_domain.yml
+++ b/detection-rules/link_fake_video_new_domain.yml
@@ -1,0 +1,19 @@
+name: "Link: Fake video link from newly registered domain"
+description: "Detects inbound messages from a sender using the local part "support" whose domain was registered less than 30 days ago, containing a link with a path resembling a video file URL structure (".mp4/views/")."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and sender.email.local_part == "support"
+  and network.whois(sender.email.domain).days_old < 30
+  and any(body.current_thread.links, 
+      strings.contains(.href_url.path, ".mp4/views/")
+  )
+attack_types:
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Whois"
+  - "URL analysis"
+  - "Sender analysis"

--- a/detection-rules/link_fake_video_new_domain.yml
+++ b/detection-rules/link_fake_video_new_domain.yml
@@ -6,8 +6,8 @@ source: |
   type.inbound
   and sender.email.local_part == "support"
   and network.whois(sender.email.domain).days_old < 30
-  and any(body.current_thread.links, 
-      strings.contains(.href_url.path, ".mp4/views/")
+  and any(body.current_thread.links,
+          strings.contains(.href_url.path, ".mp4/views/")
   )
 attack_types:
   - "Malware/Ransomware"
@@ -17,3 +17,4 @@ detection_methods:
   - "Whois"
   - "URL analysis"
   - "Sender analysis"
+id: "dc1f5d72-233b-5c20-8573-bdebf23552ce"

--- a/detection-rules/link_fake_video_new_domain.yml
+++ b/detection-rules/link_fake_video_new_domain.yml
@@ -1,5 +1,5 @@
 name: "Link: Fake video link from newly registered domain"
-description: "Detects inbound messages from a sender using the local part "support" whose domain was registered less than 30 days ago, containing a link with a path resembling a video file URL structure (".mp4/views/")."
+description: "Detects inbound messages from a sender using the local part 'support' whose domain was registered less than 30 days ago, containing a link with a path resembling a video file URL structure ('.mp4/views/')."
 type: "rule"
 severity: "medium"
 source: |


### PR DESCRIPTION
## Description
Matches messages with a recently registered domain sent from a fake "support" address, where the link that references a hosted video.

## Associated samples
- [Sample 1](https://platform.sublime.security/messages/50d122e11ba6963a55adbb3cf5c33fa555dcc70667abd2a3feed0b84a7b2e3af?preview_id=01a0447b-c090-72a2-9690-55ec4e44cf1a)
- [Sample 2](https://platform.sublime.security/messages/50cb6e645191291f663e92d613e89712b2daf46e377a727b262219838504b1b2?preview_id=01a013eb-af95-7929-bb54-b7952eea82e5)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01a04970-fdc4-734d-b160-968e4d173a03)
- [Multi-hunt](https://hunt.limeseed.email/hunts/27294ac3-a2fa-4cd1-9c67-cebbf469c48e)
- [updated multi-hunt (aug 31)](https://hunt.limeseed.email/hunts/656b7e48-20e8-4972-8c70-354d869dd836)