### PR TITLE
Create link_gmail_phishkit_suspicious_recipient.yml

### DIFF
--- a/detection-rules/link_gmail_phishkit_suspicious_recipient.yml
+++ b/detection-rules/link_gmail_phishkit_suspicious_recipient.yml
@@ -24,13 +24,11 @@ source: |
   )
   and 0 < length(body.current_thread.links) < 10
   and any(body.current_thread.links,
-          (
-            strings.icontains(ml.link_analysis(., mode="aggressive").final_dom.raw,
-                              "aHR0cHM6Ly9nbWFpbC5jb20=" // https://gmail.com
-            )
-            and strings.icontains(ml.link_analysis(., mode="aggressive").final_dom.raw,
-                                  "/gmail/js/start.js"
-            )
+          strings.icontains(ml.link_analysis(., mode="aggressive").final_dom.raw,
+                            "aHR0cHM6Ly9nbWFpbC5jb20=" // https://gmail.com
+          )
+          and strings.icontains(ml.link_analysis(., mode="aggressive").final_dom.raw,
+                                "/gmail/js/start.js"
           )
   )
 attack_types:

--- a/detection-rules/link_gmail_phishkit_suspicious_recipient.yml
+++ b/detection-rules/link_gmail_phishkit_suspicious_recipient.yml
@@ -43,3 +43,4 @@ detection_methods:
   - "URL analysis"
   - "HTML analysis"
   - "Sender analysis"
+id: "39f3a5f3-e815-585d-bc31-9ca34c95f2c0"

--- a/detection-rules/link_gmail_phishkit_suspicious_recipient.yml
+++ b/detection-rules/link_gmail_phishkit_suspicious_recipient.yml
@@ -1,0 +1,45 @@
+name: "Link: Gmail phishkit with suspicious recipient"
+description: "Detects inbound messages where the recipient field is suspicious: the sender and recipient email addresses match, the recipient domain is invalid, or there are no valid recipients across to/cc/bcc fields. The rule further inspects the final rendered DOM of contained links using aggressive link analysis, flagging cases where the page impersonates Gmail's login flow by referencing an encoded 'gmail.com' string alongside the specific '/gmail/js/start.js' script path, a known indicator of a Gmail credential phishing kit."
+type: "rule"
+severity: "high"
+source: |
+  type.inbound
+  // Suspicious recipient
+  and (
+    (
+      length(recipients.to) == 1
+      and (
+        sender.email.email == recipients.to[0].email.email
+        or recipients.to[0].email.domain.valid == false
+      )
+    )
+    or (
+      (
+        length(recipients.to) == 0
+        or all(recipients.to, .email.domain.valid == false)
+      )
+      and length(recipients.cc) == 0
+      and length(recipients.bcc) == 0
+    )
+  )
+  and 0 < length(body.current_thread.links) < 10
+  and any(body.current_thread.links,
+          (
+            strings.icontains(ml.link_analysis(., mode="aggressive").final_dom.raw,
+                              "aHR0cHM6Ly9nbWFpbC5jb20=" // https://gmail.com
+            )
+            and strings.icontains(ml.link_analysis(., mode="aggressive").final_dom.raw,
+                                  "/gmail/js/start.js"
+            )
+          )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "URL analysis"
+  - "HTML analysis"
+  - "Sender analysis"


### PR DESCRIPTION
# Description
New rule for suspicious recipient with gmail phishkit indicators. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50ce82348fb5d51c0a62088294f283a7aba08d3c330ff58ffeb56bd6ca456c29?preview_id=01a03459-b09f-70e1-b784-4b7515434322)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [95 customer multi-hunt](https://hunt.limeseed.email/hunts/9c7ee8e3-caca-4980-982c-fa99e2a03865)
- [SWS hunt](https://platform.sublime.security/messages/hunt?huntId=01a05843-233f-7eca-b1f3-198b842de0d4)
