### PR TITLE
Update brand_impersonation_paperlesspost.yml

### DIFF
--- a/detection-rules/brand_impersonation_paperlesspost.yml
+++ b/detection-rules/brand_impersonation_paperlesspost.yml
@@ -32,7 +32,10 @@ source: |
     )
   )
   and not (
-    sender.email.domain.root_domain == "paperlesspost.com"
+    (
+       sender.email.domain.root_domain == "paperlesspost.com"
+    or sender.email.domain.domain == 'paperlesspost.zendesk.com'
+  )
     and headers.auth_summary.dmarc.pass
   )
 

--- a/detection-rules/brand_impersonation_paperlesspost.yml
+++ b/detection-rules/brand_impersonation_paperlesspost.yml
@@ -33,12 +33,11 @@ source: |
   )
   and not (
     (
-       sender.email.domain.root_domain == "paperlesspost.com"
-    or sender.email.domain.domain == 'paperlesspost.zendesk.com'
-  )
+      sender.email.domain.root_domain == "paperlesspost.com"
+      or sender.email.domain.domain == 'paperlesspost.zendesk.com'
+    )
     and headers.auth_summary.dmarc.pass
   )
-
 attack_types:
   - "Credential Phishing"
   - "Malware/Ransomware"

--- a/detection-rules/brand_impersonation_paperlesspost.yml
+++ b/detection-rules/brand_impersonation_paperlesspost.yml
@@ -9,7 +9,7 @@ source: |
                     // calling parse_url allows url decoding to help us
                     strings.parse_url(.raw).domain.root_domain == 'ppassets.com'
              )
-  ) >= 2
+  ) >= 1
   and (
     length(filter(body.links,
                   .href_url.domain.domain == "links.paperlesspost.com"


### PR DESCRIPTION
# Description

Require at least 1 ppassets image in the html instead of two or more. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50ce82348fb5d51c0a62088294f283a7aba08d3c330ff58ffeb56bd6ca456c29?preview_id=01a03459-b09f-70e1-b784-4b7515434322)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Net new multi-hunt ](https://hunt.limeseed.email/hunts/a385a903-e674-4f60-bc9d-c111e032e500)
- [SWS hunt](https://platform.sublime.security/messages/hunt?huntId=01a0589f-77fe-7e99-a785-63a38f9ddb89)