### PR TITLE
Create body_css_zero_dimension_table_column.yml

### DIFF
--- a/detection-rules/body_css_zero_dimension_table_column.yml
+++ b/detection-rules/body_css_zero_dimension_table_column.yml
@@ -1,0 +1,22 @@
+name: "Body: CSS Hidden text via table-column"
+description: "Detects inbound HTML emails containing elements styled with 'display: table-column' combined with a height or width of zero, effectively hiding the element from visual rendering. The rule flags cases where the hidden element contains more than 100 non-whitespace characters of inner text, a technique commonly used to conceal content from human recipients while still embedding it in the DOM to evade text-based or visual detection systems."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(html.xpath(body.html, '//*[contains(@style,"table-column")]').nodes,
+          regex.icontains(.raw, 'display\s*:\s*table-column')
+          and (
+            regex.icontains(.raw, '[;"\s]height\s*:\s*0')
+            or regex.icontains(.raw, '[;"\s]width\s*:\s*0')
+          )
+          and regex.icount(.inner_text, '\S') > 100
+  )
+attack_types:
+  - "Credential Phishing"
+  - "Spam"
+tactics_and_techniques:
+  - "Evasion"
+detection_methods:
+  - "HTML analysis"
+  - "Content analysis"

--- a/detection-rules/body_css_zero_dimension_table_column.yml
+++ b/detection-rules/body_css_zero_dimension_table_column.yml
@@ -20,3 +20,4 @@ tactics_and_techniques:
 detection_methods:
   - "HTML analysis"
   - "Content analysis"
+id: "a2b8ef87-89d9-5ebb-9be4-9d4db8571e57"

--- a/detection-rules/body_css_zero_dimension_table_column.yml
+++ b/detection-rules/body_css_zero_dimension_table_column.yml
@@ -1,5 +1,5 @@
 name: "Body: CSS Hidden text via table-column"
-description: "Detects inbound HTML emails containing elements styled with 'display: table-column' combined with a height or width of zero, effectively hiding the element from visual rendering. The rule flags cases where the hidden element contains more than 100 non-whitespace characters of inner text, a technique commonly used to conceal content from human recipients while still embedding it in the DOM to evade text-based or visual detection systems."
+description: "Detects inbound messages containing elements styled with 'display: table-column' combined with a height or width of zero, effectively hiding the element from visual rendering. The rule flags cases where the hidden element contains more than 100 non-whitespace characters of inner text, a technique commonly used to conceal content from human recipients while still embedding it in the DOM to evade text-based or visual detection systems."
 type: "rule"
 severity: "medium"
 source: |


### PR DESCRIPTION
# Description

Observed CSS evasion technique

Detects inbound messages containing elements styled with 'display: table-column' combined with a height or width of zero, effectively hiding the element from visual rendering. The rule flags cases where the hidden element contains more than 100 non-whitespace characters of inner text, a technique commonly used to conceal content from human recipients while still embedding it in the DOM to evade text-based or visual detection systems.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50c2778aa8400bd76267a617620eb2997c091122e8e155f5b8f257e8a667ec26?preview_id=019fe7c1-c4b7-71a9-a24e-2ebbdc25e062)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=01a05e81-9ea2-7559-adf6-83511c9c213d)
- [L30D 101 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/9e43373f-49f9-4f79-a151-b665163c4480)