### PR TITLE
Update impersonation_usps.yml

### DIFF
--- a/detection-rules/impersonation_usps.yml
+++ b/detection-rules/impersonation_usps.yml
@@ -87,11 +87,14 @@ source: |
     )
   )
   // negate newsletters
-  and not (
-    length(filter(body.current_thread.links, .visible == true)) > 20
-    or any(ml.nlu_classifier(body.html.display_text).topics,
-           .name == "Newsletters and Digests"
+  and (
+    not (
+      length(filter(body.links, .visible == true)) > 20
+      or any(ml.nlu_classifier(body.html.display_text).topics,
+             .name == "Newsletters and Digests"
+      )
     )
+    or length(body.links) > length(body.current_thread.links) + 20
   )
   // not all links to usps.com
   and not all(body.links, .href_url.domain.root_domain == "usps.com")

--- a/detection-rules/impersonation_usps.yml
+++ b/detection-rules/impersonation_usps.yml
@@ -88,7 +88,7 @@ source: |
   )
   // negate newsletters
   and not (
-    length(filter(body.links, .visible == true)) > 20
+    length(filter(body.current_thread.links, .visible == true)) > 20
     or any(ml.nlu_classifier(body.html.display_text).topics,
            .name == "Newsletters and Digests"
     )


### PR DESCRIPTION
# Description

Adding an exception to existing newsletter negations by tagging samples where the length of body.links is far greater than body.current_thread.links

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50c2778aa8400bd76267a617620eb2997c091122e8e155f5b8f257e8a667ec26?preview_id=019fe7c1-c4b7-71a9-a24e-2ebbdc25e062)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=01a06357-e348-71da-9f55-e20d43f155ad)
- [L30D 95 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/b9222031-5171-4bd0-99c2-678656348584)
