### PR TITLE
Create open_redirect_fragment_link_html.yml

### DIFF
--- a/detection-rules/open_redirect_fragment_link_html.yml
+++ b/detection-rules/open_redirect_fragment_link_html.yml
@@ -23,3 +23,4 @@ tactics_and_techniques:
 detection_methods:
   - "URL analysis"
   - "Content analysis"
+id: "9b715c35-6c35-5a41-a1a0-bb26ee1ade78"

--- a/detection-rules/open_redirect_fragment_link_html.yml
+++ b/detection-rules/open_redirect_fragment_link_html.yml
@@ -1,0 +1,25 @@
+name: "Open redirect: Generic link.html redirector abuse"
+description: "Detects messages that route recipients through a generic '/link.html' redirect path carrying an encoded destination in the URL fragment, then confirms via redirect-chain analysis that the link actually resolves to that embedded destination. This pattern is commonly abused in bulk spam and scam lures—such as fake storage-deletion warnings, loan offers, and discounted warranty plans—to disguise the true landing page behind a benign-looking tracking link."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(filter(body.links,
+                 strings.iends_with(.href_url.path, '/link.html')
+                 and .href_url.fragment is not null
+          ),
+          ml.link_analysis(.).submitted
+          and length(ml.link_analysis(.).redirect_history) > 1
+          and any(ml.link_analysis(.).redirect_history,
+                  strings.contains(.path, ..href_url.fragment)
+          )
+  )
+attack_types:
+  - "Spam"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Open redirect"
+  - "Social engineering"
+detection_methods:
+  - "URL analysis"
+  - "Content analysis"


### PR DESCRIPTION
# Description

Detects messages that route recipients through a generic '/link.html' redirect path carrying an encoded destination in the URL fragment, then confirms via redirect-chain analysis that the link actually resolves to that embedded destination. This pattern is commonly abused in bulk spam and scam lures—such as fake storage-deletion warnings, loan offers, and discounted warranty plans—to disguise the true landing page behind a benign-looking tracking link.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50d1eb52410e890a8e17ac1f27a85f59ab8aa49fe0393310bb78f25c412a58df?preview_id=01a05d14-56a6-7b77-b37b-75cd40533daf)
- [Sample 2](https://platform.sublime.security/messages/50d9ba264b300efcb3538d304b8c543c083d309920587f409ae3d01d30d127a0?preview_id=01a05d50-f726-77cf-846f-884bb2c0b2b0)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=01a05e6f-5850-7f13-9c08-f1d193ded42b)
- [L30D 95 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/4a3ff59c-44d1-4549-aff9-b097d1aa6717)