### PR TITLE
Update impersonation_sam_sba_federal_registration.yml

### DIFF
--- a/detection-rules/impersonation_sam_sba_federal_registration.yml
+++ b/detection-rules/impersonation_sam_sba_federal_registration.yml
@@ -9,13 +9,14 @@ source: |
                     '^sam(?:\.gov\b|\s(?:renew|compliance))',
                     'final\ssam\.gov',
                     '^sba[\s-]?(?:e[fd]|[\.,]gov)',
-                    '^sba[\s-](?:connect|invoice|admin|eidl)\b',
+                    '^sba[\s-](?:connect|invoice|admin|eidl|profile)\b',
                     '^sba[\s-]support[\s-]\w+'
     )
     or (
       strings.icontains(body.current_thread.text, 'sam.gov')
       and any(html.xpath(body.html, '//img/@src').nodes,
               strings.icontains(.raw, 'sam%20renew%20entity')
+              or regex.icontains(.raw, '[./]sam[a-z]{3,}\.com')
       )
     )
   )


### PR DESCRIPTION
# Description

Updating logic to include `profile` after `SBA` in the sender display name. Also looking for `sam<word>.com` links via `xpath`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50d95a2e54f5ff543479a0537b5226a235e88e080ce8b06c8a71caf99b07dec0?preview_id=01a05d6a-9f21-78dd-9beb-948c3cf24b95)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=01a0682c-a98d-7652-b144-2b83924ca505)
- [L7D Net New Multi-Hunt](https://hunt.limeseed.email/hunts/111b28ea-4b42-4916-a937-5c47f0a39fc1)