### PR TITLE
Update attachment_pdf_wkhtmltopdf_sus_link_cred_theft.yml

### DIFF
--- a/detection-rules/attachment_pdf_wkhtmltopdf_sus_link_cred_theft.yml
+++ b/detection-rules/attachment_pdf_wkhtmltopdf_sus_link_cred_theft.yml
@@ -30,29 +30,29 @@ source: |
                         and strings.icontains(.query_params, 'redirect_uri=')
                       )
                       // short 1 char path in redirect
-                    or any(.query_params_decoded['redirect'],
-                           length(strings.parse_url(.).path) == 2
-                    )
-                    // url param conatins recipeint domain
-                    or any(.query_params_decoded['url'],
-                           strings.contains(strings.parse_url(.).path,
-                                            recipients.to[0].email.domain.sld
-                           )
-                    )
-                    // multiple redirectUrl query_parms
-                    or length(.query_params_decoded['redirectUrl']) > 1
-                    // minimal js landing page
-                    or (
-                      length(ml.link_analysis(.).unique_urls_accessed) == 3
-                      and all(ml.link_analysis(.).unique_urls_accessed,
-                              .url == ..url
-                              or (
-                                strings.starts_with(.url, ..url)
-                                and strings.ends_with(.url, '.js')
-                              )
-                              or .url == strings.concat(..url, 'favicon.png')
+                      or any(.query_params_decoded['redirect'],
+                             length(strings.parse_url(.).path) == 2
                       )
-                    )
+                      // url param conatins recipeint domain
+                      or any(.query_params_decoded['url'],
+                             strings.contains(strings.parse_url(.).path,
+                                              recipients.to[0].email.domain.sld
+                             )
+                      )
+                      // multiple redirectUrl query_parms
+                      or length(.query_params_decoded['redirectUrl']) > 1
+                      // minimal js landing page
+                      or (
+                        length(ml.link_analysis(.).unique_urls_accessed) == 3
+                        and all(ml.link_analysis(.).unique_urls_accessed,
+                                .url == ..url
+                                or (
+                                  strings.starts_with(.url, ..url)
+                                  and strings.ends_with(.url, '.js')
+                                )
+                                or .url == strings.concat(..url, 'favicon.png')
+                        )
+                      )
                   )
           )
   )

--- a/detection-rules/attachment_pdf_wkhtmltopdf_sus_link_cred_theft.yml
+++ b/detection-rules/attachment_pdf_wkhtmltopdf_sus_link_cred_theft.yml
@@ -29,6 +29,30 @@ source: |
                         strings.istarts_with(.path, '/oauth/')
                         and strings.icontains(.query_params, 'redirect_uri=')
                       )
+                      // short 1 char path in redirect
+                    or any(.query_params_decoded['redirect'],
+                           length(strings.parse_url(.).path) == 2
+                    )
+                    // url param conatins recipeint domain
+                    or any(.query_params_decoded['url'],
+                           strings.contains(strings.parse_url(.).path,
+                                            recipients.to[0].email.domain.sld
+                           )
+                    )
+                    // multiple redirectUrl query_parms
+                    or length(.query_params_decoded['redirectUrl']) > 1
+                    // minimal js landing page
+                    or (
+                      length(ml.link_analysis(.).unique_urls_accessed) == 3
+                      and all(ml.link_analysis(.).unique_urls_accessed,
+                              .url == ..url
+                              or (
+                                strings.starts_with(.url, ..url)
+                                and strings.ends_with(.url, '.js')
+                              )
+                              or .url == strings.concat(..url, 'favicon.png')
+                      )
+                    )
                   )
           )
   )

--- a/detection-rules/attachment_pdf_wkhtmltopdf_sus_link_cred_theft.yml
+++ b/detection-rules/attachment_pdf_wkhtmltopdf_sus_link_cred_theft.yml
@@ -41,18 +41,6 @@ source: |
                       )
                       // multiple redirectUrl query_parms
                       or length(.query_params_decoded['redirectUrl']) > 1
-                      // minimal js landing page
-                      or (
-                        length(ml.link_analysis(.).unique_urls_accessed) == 3
-                        and all(ml.link_analysis(.).unique_urls_accessed,
-                                .url == ..url
-                                or (
-                                  strings.starts_with(.url, ..url)
-                                  and strings.ends_with(.url, '.js')
-                                )
-                                or .url == strings.concat(..url, 'favicon.png')
-                        )
-                      )
                   )
           )
   )


### PR DESCRIPTION
# Description
Add more suspicious link indicators to Attachment: PDF credential phishing via wkhtmltopdf/Qt with suspicious link.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50d1f0a1812079e63bdc13f4c9d74f687d60ab85a723b442a803858ba14f8189?preview_id=01a04480-877e-7949-962d-cb6a003b3aed)
- [Sample 2](https://platform.sublime.security/messages/50d2fb9e0fca79a7202fefc1d719c1330ca668b549608c9d659d325159c004cb?preview_id=01a04031-720f-7921-901c-21724f995bcf)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [SWS Hunt net new](https://platform.sublime.security/messages/hunt?huntId=01a05eab-28d3-7607-9a71-43d86b12df18)
- [95 customer multi-hunt net new](https://hunt.limeseed.email/hunts/9db69aaf-c1ff-4f17-a3d6-2e3f122e4f82)