### PR TITLE
Skip MQL mimic tests for observed IOC rules

### DIFF
--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -367,12 +367,20 @@ jobs:
         run: |
           for file in detection-rules/*.yml; do
             rule_id=$(yq '.id' "$file")
-          
+
+            # Skip observed IOC rules from MQL mimic testing
+            # These rules have large IOC lists that change frequently (adds/removes)
+            # which causes MQL mimic tests to fail on legitimate IOC updates
+            if [[ "$file" == detection-rules/observed_*.yml ]]; then
+              echo "$file ($rule_id) is an observed IOC rule, skipping MQL mimic"
+              continue
+            fi
+
             if [[ "${STEPS_GET_BASE_REF_OUTPUTS_RUN_ALL}" == "true" ]]; then
               altered_rule_ids="${rule_id} ${altered_rule_ids}"
               continue
             fi
-          
+
             new_source=$(yq '.source' "$file")
             old_file="sr-main/detection-rules/$rule_id.yml"
             if [[ ! -f "$old_file" ]]; then
@@ -388,13 +396,19 @@ jobs:
               altered_rule_ids="${rule_id} ${altered_rule_ids}"
             fi
           done
-          
+
           for file in ${STEPS_CHANGED_FILES_OUTPUTS_DELETED_FILES}; do
+            # Skip observed IOC rules from MQL mimic testing for deleted files too
+            if [[ "$file" == detection-rules/observed_*.yml ]]; then
+              echo "$file is a deleted observed IOC rule, skipping MQL mimic"
+              continue
+            fi
+
             rule_id=$(yq '.id' "$file")
             echo "$file ($rule_id) was deleted"
             altered_rule_ids="${rule_id} ${altered_rule_ids}"
           done
-          
+
           echo "Altered Ruled IDs: [$altered_rule_ids]"
           echo "##[set-output name=rule_ids;]${altered_rule_ids}"
           # TODO: This doesn't solve for a modified rule_id. We could merge with any files known on 'main', but changing


### PR DESCRIPTION
## Problem

Observed IOC rules are failing MQL mimic tests on legitimate IOC updates (e.g., PR #5214). These rules contain large IOC lists that are automatically managed by the IOC pipeline from the private threat intelligence feed.

When IOCs are added or removed from these lists, MQL mimic tests fail because:
- Test samples that previously matched the IOC list may no longer match after IOCs are removed
- New IOCs added to the list may cause previously passing samples to now match

This creates CI failures on routine IOC updates that are otherwise valid and necessary.

## Solution

This PR modifies the CI workflow to automatically skip MQL mimic testing for all `observed_*.yml` rules in both scenarios:
1. When the rules are modified (IOCs added/removed)
2. When the rules are deleted

The check uses a simple pattern match: `detection-rules/observed_*.yml`

## Affected Rules

This exemption applies to all 14 observed IOC rules:
- `observed_malicious_attachment_sha256.yml`
- `observed_malicious_body_link_domains.yml`
- `observed_malicious_body_link_root_domains.yml`
- `observed_malicious_body_link_urls.yml`
- `observed_malicious_headers_ips_aeza_group.yml`
- `observed_malicious_headers_ips_smartape.yml`
- `observed_malicious_headers_ips_spamhaus_asndrop.yml`
- `observed_malicious_headers_ips_spamhaus_drop.yml`
- `observed_malicious_reply_to_domains.yml`
- `observed_malicious_reply_to_emails.yml`
- `observed_malicious_reply_to_root_domains.yml`
- `observed_malicious_sender_domains.yml`
- `observed_malicious_sender_emails.yml`
- `observed_malicious_sender_root_domains.yml`

## Testing Strategy

These rules are IOC-based rather than behavioral, so MQL mimic testing provides less value:
- The IOCs are already validated by the automated IOC pipeline
- The rule logic is simple hash/domain matching (low risk of regressions)
- The IOC lists are curated from real threat intelligence, not test samples

## Implementation

The change is in `.github/workflows/rule-validate.yml` in the "Find updated rule IDs" step. It adds pattern matching to skip any file matching `detection-rules/observed_*.yml` before adding rule IDs to the MQL mimic test queue.

This eliminates the need for manual `/mql-mimic-exempt` comments on every IOC update PR.

## References

- Example failing PR: #5214