### PR TITLE
Create spam_hostinger_dns_parking_newly_registered_domain.yml

### DIFF
--- a/detection-rules/spam_hostinger_dns_parking_newly_registered_domain.yml
+++ b/detection-rules/spam_hostinger_dns_parking_newly_registered_domain.yml
@@ -38,3 +38,4 @@ detection_methods:
   - "Whois"
   - "Natural Language Understanding"
   - "Sender analysis"
+id: "d88e2669-e2f6-5b25-8fc0-4132f03b3c48"

--- a/detection-rules/spam_hostinger_dns_parking_newly_registered_domain.yml
+++ b/detection-rules/spam_hostinger_dns_parking_newly_registered_domain.yml
@@ -1,0 +1,40 @@
+name: "Spam: Cold outreach from Hostinger-hosted newly registered domain"
+description: "Detects inbound messages from domains registered less than 365 days ago using Hostinger (dns-parking.com) nameservers, where the message content is classified as B2B cold outreach by NLU analysis. The rule excludes legitimate reply threads, and only flags senders who are either unsolicited or have a history of malicious/spam activity without any benign messages."
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  // newly registered sender domain
+  and network.whois(sender.email.domain).days_old < 365
+  
+  // there are 2 name servers which have subdomains containing .ns
+  and length(network.whois(sender.email.domain).name_servers) == 2
+  and all(network.whois(sender.email.domain).name_servers,
+          strings.istarts_with(.subdomain, 'ns')
+          and .root_domain == 'dns-parking.com'
+  )
+  
+  // nlu logic
+  and any(ml.nlu_classifier(body.current_thread.text).topics,
+          .name == 'B2B Cold Outreach'
+  )
+  
+  // sender profiles
+  and (
+    not profile.by_sender_email().solicited
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and not profile.by_sender().any_messages_benign
+    )
+  )
+  
+tags:
+  - "Attack surface reduction"
+attack_types:
+  - "Spam"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Whois"
+  - "Natural Language Understanding"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

Rule flags on newly registered sender domains less than 365 days old, using Hostinger's default DNS name servers.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/50d99c278668310379926d23913cb22006b56613a16e7da77b9818589f7bfbf6?preview_id=01a05e92-86f0-79c5-9332-d5be89d9184a)
- [Sample 2](https://platform.sublime.security/messages/50c3b654aae70efcfa2478dcb4764b775c4902e157bfeb412e4f7eb7aab20cd9?preview_id=01a058a2-3184-7d00-8ab3-ca4e4877cd9b)

## Associated hunts

- [Hunt 1](https://hunt.limeseed.email/hunts/b3cc0ead-de10-4640-81dd-0e8f693fcb98)