### PR TITLE
Update spam_fake_photo_share.yml

### DIFF
--- a/detection-rules/spam_fake_photo_share.yml
+++ b/detection-rules/spam_fake_photo_share.yml
@@ -84,19 +84,24 @@ source: |
         )
         or (
           length(body.current_thread.text) < 500
-          and strings.ilike(body.current_thread.text,
-                            "*picture*",
-                            "*photo*",
-                            "*image*",
-                            "*sad news*",
-                            "*sad announcement*",
-                            "*sad update*",
-                            "*new pics*",
-                            "*back memories*",
-                            "*any memories*",
-                            "*old memories*",
-                            "*evoke memories*",
-                            "*bittersweet memories*"
+          and (
+            strings.ilike(body.current_thread.text,
+                          "*picture*",
+                          "*photo*",
+                          "*image*",
+                          "*sad news*",
+                          "*sad announcement*",
+                          "*sad update*",
+                          "*new pics*",
+                          "*back memories*",
+                          "*any memories*",
+                          "*old memories*",
+                          "*evoke memories*",
+                          "*bittersweet memories*"
+            )
+            or regex.icontains(body.current_thread.text,
+                               '\bpics?\b.{0,40}https?://[a-z]+\.[a-z]+\.com'
+            )
           )
         )
       )


### PR DESCRIPTION
# Description

Adding logic that tags samples with `pics` followed by a link with a subdomain

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50daab6a9cd24c415df5fc0578dacd0999e5e1e11abc6793d4589a96fed8b794?preview_id=01a06263-0793-7eba-8dce-b2ac077dd77c)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=01a08105-c560-72d2-96f2-a5464ba33a7f)
- [L30D Net New Multi-Hunt](https://hunt.limeseed.email/hunts/29b2dd7d-a40a-4f79-8c6b-0fd20eb85a56)
