### PR TITLE
Update brand_impersonation_survey.yml

### DIFF
--- a/detection-rules/brand_impersonation_survey.yml
+++ b/detection-rules/brand_impersonation_survey.yml
@@ -9,7 +9,14 @@ source: |
         .name == "cred_theft" and .confidence == "high"
     )
     or any(ml.nlu_classifier(body.current_thread.text).entities,
-           .name == "org" and .text in ("AAA", "Medicare Kit", "Kobalt", "DeWalt")
+           .name == "org" and .text in ("AAA", "Medicare Kit")
+    )
+    or any(ml.nlu_classifier(body.current_thread.text).entities,
+           .name == "sender"
+           and (
+             strings.icontains(.text, "Sam's Club", "Kobalt")
+             or regex.icontains(.text, "lowe\'s.{0,10}reward")
+           )
     )
     or any(ml.nlu_classifier(body.current_thread.text).entities,
            .name == "request"

--- a/detection-rules/brand_impersonation_survey.yml
+++ b/detection-rules/brand_impersonation_survey.yml
@@ -9,7 +9,7 @@ source: |
         .name == "cred_theft" and .confidence == "high"
     )
     or any(ml.nlu_classifier(body.current_thread.text).entities,
-           .name == "org" and .text in ('AAA', 'Medicare Kit')
+           .name == "org" and .text in ("AAA", "Medicare Kit", "Kobalt", "DeWalt")
     )
     or any(ml.nlu_classifier(body.current_thread.text).entities,
            .name == "request"


### PR DESCRIPTION
# Description

Adding the `NLU` sender entities of `Sam's Club`, `Kobalt`, and `Lowe's`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50d9d2c7d7db1f7bf852151338a9a4d64bd3b73a4f42dc1f542ae8410c9467fb?preview_id=01a05e8a-877c-777f-a149-95805fef3cba)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=01a081dc-8431-729d-b679-3b3ad5d366c1)
- [L30D Net New Multi-Hunt](https://hunt.limeseed.email/hunts/ee1b2228-4578-452d-861e-2544e5d62925)