### PR TITLE
Create attachment_pdf_susp_domain_globalsign.yml

### DIFF
--- a/detection-rules/attachment_pdf_susp_domain_globalsign.yml
+++ b/detection-rules/attachment_pdf_susp_domain_globalsign.yml
@@ -1,0 +1,26 @@
+name: "Attachment: PDF with suspicious domain and globalsign link"
+description: "Detects PDF attachments containing exactly two unique linked domains, where one is globalsign.com and the other is a suspicious domain absent from the Tranco 10k list with a high-risk top-level domain."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(filter(attachments, .file_type == "pdf"),
+      any(file.explode(.),
+          length(distinct(.scan.pdf.urls, .domain.root_domain)) == 2
+          and any(distinct(.scan.pdf.urls, .domain.root_domain),
+              .domain.root_domain == "globalsign.com"
+          )
+          and any(distinct(.scan.pdf.urls, .domain.root_domain),
+              not .domain.root_domain in $tranco_10k
+              and .domain.tld in $suspicious_tlds
+          )
+      )
+  )
+attack_types:
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "PDF"
+  - "Social engineering"
+detection_methods:
+  - "File analysis"
+  - "URL analysis"

--- a/detection-rules/attachment_pdf_susp_domain_globalsign.yml
+++ b/detection-rules/attachment_pdf_susp_domain_globalsign.yml
@@ -5,16 +5,16 @@ severity: "medium"
 source: |
   type.inbound
   and any(filter(attachments, .file_type == "pdf"),
-      any(file.explode(.),
-          length(distinct(.scan.pdf.urls, .domain.root_domain)) == 2
-          and any(distinct(.scan.pdf.urls, .domain.root_domain),
-              .domain.root_domain == "globalsign.com"
+          any(file.explode(.),
+              length(distinct(.scan.pdf.urls, .domain.root_domain)) == 2
+              and any(distinct(.scan.pdf.urls, .domain.root_domain),
+                      .domain.root_domain == "globalsign.com"
+              )
+              and any(distinct(.scan.pdf.urls, .domain.root_domain),
+                      not .domain.root_domain in $tranco_10k
+                      and .domain.tld in $suspicious_tlds
+              )
           )
-          and any(distinct(.scan.pdf.urls, .domain.root_domain),
-              not .domain.root_domain in $tranco_10k
-              and .domain.tld in $suspicious_tlds
-          )
-      )
   )
 attack_types:
   - "Credential Phishing"
@@ -24,3 +24,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "URL analysis"
+id: "f5e26068-8cb8-57a0-902c-d6e29960e7ba"


### PR DESCRIPTION
## Description
Matching messages with attached PDFs which contain links to two unique domains where one of them is not present in the tranco 10k list and uses a suspicious TLD, and the other is a link to globalsign. This has been observed in fake "sign here" documents. 

## Associated samples

- [Sample 1](https://platform.sublime.security/messages/50da83658b72617f16be1fe8c2ac501d6bcb6cfe4e03342b71584fd5229ba4f3?preview_id=01a06350-9c81-70b4-ad39-47fb026cb30b)


## Associated hunts
- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01a0675d-2c95-745a-a7a2-32d09345a56b)
- [Multi-Hunt](https://hunt.limeseed.email/hunts/d57c06e1-85bd-4110-ad66-a5341c4088b6)
