### PR TITLE
Create body_prompt_injection_llm_instructions_new_sender.yml

### DIFF
--- a/detection-rules/body_prompt_injection_llm_instructions_new_sender.yml
+++ b/detection-rules/body_prompt_injection_llm_instructions_new_sender.yml
@@ -1,0 +1,50 @@
+name: "Prompt injection: Body instructions directed at an LLM from a new sender"
+description: "Detects messages whose plaintext body contains instructions directed at an LLM (prompt injection), sent from a sender with no established, benign relationship. Targets attacks that attempt to manipulate downstream AI assistants that process email on the recipient's behalf."
+type: "rule"
+severity: "high"
+source: |
+  //
+  // This rule makes use of a beta feature and is subject to change without notice.
+  // Using the beta feature in custom rules is not suggested until it has been formally released.
+  //
+  type.inbound
+  and beta.prompt_injection_detection(body.plain.raw).detection == "injection"
+  and profile.by_sender().prevalence in ("new", "outlier", "rare")
+  and not profile.by_sender().any_messages_benign
+
+  // Graymail exclusion (Fuzzy Attack Score)
+  and beta.fuzzy_attack_score().verdict != "graymail"
+
+  // TEMPORARY
+  and not (
+    headers.auth_summary.dmarc.pass
+    and (
+      sender.email.domain.root_domain in (
+        "linkedin.com",
+        "brighttalk.com",
+        "docusign.net",
+        "facebookmail.com",
+        "substack.com",
+        "glassdoor.com",
+        "divenewsletter.com"
+      )
+      or sender.email.domain.domain in (
+        "mail.beehiiv.com",
+        "mail.grammarly.com",
+        "rs.email.nextdoor.com",
+        "campaign.eventbrite.com",
+        "engage.canva.com",
+        "mail.zillow.com"
+      )
+    )
+  )
+attack_types:
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Evasion"
+detection_methods:
+  - "Content analysis"
+  - "Natural Language Understanding"
+  - "Sender analysis"

--- a/detection-rules/body_prompt_injection_llm_instructions_new_sender.yml
+++ b/detection-rules/body_prompt_injection_llm_instructions_new_sender.yml
@@ -12,32 +12,12 @@ source: |
   and profile.by_sender().prevalence in ("new", "outlier", "rare")
   and not profile.by_sender().any_messages_benign
 
-  // Graymail exclusion (Fuzzy Attack Score)
-  and beta.fuzzy_attack_score().verdict != "graymail"
-
-  // TEMPORARY
+  // Graymail exclusion (Fuzzy Attack Score), limited to authenticated senders
   and not (
-    headers.auth_summary.dmarc.pass
-    and (
-      sender.email.domain.root_domain in (
-        "linkedin.com",
-        "brighttalk.com",
-        "docusign.net",
-        "facebookmail.com",
-        "substack.com",
-        "glassdoor.com",
-        "divenewsletter.com"
-      )
-      or sender.email.domain.domain in (
-        "mail.beehiiv.com",
-        "mail.grammarly.com",
-        "rs.email.nextdoor.com",
-        "campaign.eventbrite.com",
-        "engage.canva.com",
-        "mail.zillow.com"
-      )
-    )
+    beta.fuzzy_attack_score().verdict == "graymail"
+    and headers.auth_summary.dmarc.pass
   )
+
 attack_types:
   - "Credential Phishing"
   - "BEC/Fraud"

--- a/detection-rules/body_prompt_injection_llm_instructions_new_sender.yml
+++ b/detection-rules/body_prompt_injection_llm_instructions_new_sender.yml
@@ -48,3 +48,4 @@ detection_methods:
   - "Content analysis"
   - "Natural Language Understanding"
   - "Sender analysis"
+id: "eeba0baa-be61-55af-833b-9e2282119270"

--- a/detection-rules/body_prompt_injection_llm_instructions_new_sender.yml
+++ b/detection-rules/body_prompt_injection_llm_instructions_new_sender.yml
@@ -18,6 +18,8 @@ source: |
     and headers.auth_summary.dmarc.pass
   )
 
+tags:
+  - "Prompt injection"
 attack_types:
   - "Credential Phishing"
   - "BEC/Fraud"

--- a/detection-rules/body_prompt_injection_llm_instructions_new_sender.yml
+++ b/detection-rules/body_prompt_injection_llm_instructions_new_sender.yml
@@ -19,7 +19,7 @@ source: |
   )
 
 tags:
-  - "Prompt injection"
+  - "Email prompt injection"
 attack_types:
   - "Credential Phishing"
   - "BEC/Fraud"

--- a/dlp-discovery-rules/beta_dlp_at_vat.yml
+++ b/dlp-discovery-rules/beta_dlp_at_vat.yml
@@ -15,22 +15,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "at_vat" and .confidence in ("medium", "high")
+        .type == "at_vat" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "at_vat" and .confidence in ("medium", "high")
+           .type == "at_vat" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "at_vat" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "at_vat" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "at_vat" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "at_vat" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_au_abn.yml
+++ b/dlp-discovery-rules/beta_dlp_au_abn.yml
@@ -15,22 +15,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "au_abn" and .confidence in ("medium", "high")
+        .type == "au_abn" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "au_abn" and .confidence in ("medium", "high")
+           .type == "au_abn" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "au_abn" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "au_abn" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "au_abn" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "au_abn" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_au_bank_account.yml
+++ b/dlp-discovery-rules/beta_dlp_au_bank_account.yml
@@ -15,22 +15,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "au_bank_account" and .confidence in ("medium", "high")
+        .type == "au_bank_account" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "au_bank_account" and .confidence in ("medium", "high")
+           .type == "au_bank_account" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "au_bank_account" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "au_bank_account" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "au_bank_account"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "au_bank_account"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_au_driver_license.yml
+++ b/dlp-discovery-rules/beta_dlp_au_driver_license.yml
@@ -15,22 +15,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "au_driver_license" and .confidence in ("medium", "high")
+        .type == "au_driver_license" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "au_driver_license" and .confidence in ("medium", "high")
+           .type == "au_driver_license" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "au_driver_license" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "au_driver_license" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "au_driver_license"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "au_driver_license"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_au_medicare.yml
+++ b/dlp-discovery-rules/beta_dlp_au_medicare.yml
@@ -15,22 +15,23 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "au_medicare" and .confidence in ("medium", "high")
+        .type == "au_medicare" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "au_medicare" and .confidence in ("medium", "high")
+           .type == "au_medicare" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "au_medicare" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "au_medicare" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "au_medicare" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "au_medicare"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_au_passport.yml
+++ b/dlp-discovery-rules/beta_dlp_au_passport.yml
@@ -15,22 +15,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "au_passport_number" and .confidence in ("medium", "high")
+        .type == "au_passport_number" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "au_passport_number" and .confidence in ("medium", "high")
+           .type == "au_passport_number" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "au_passport_number" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "au_passport_number" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "au_passport_number"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "au_passport_number"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_au_tfn.yml
+++ b/dlp-discovery-rules/beta_dlp_au_tfn.yml
@@ -16,22 +16,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "au_tfn" and .confidence in ("medium", "high")
+        .type == "au_tfn" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "au_tfn" and .confidence in ("medium", "high")
+           .type == "au_tfn" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "au_tfn" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "au_tfn" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "au_tfn" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "au_tfn" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_aws_access_key.yml
+++ b/dlp-discovery-rules/beta_dlp_aws_access_key.yml
@@ -6,23 +6,25 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "aws_access_key" and .confidence in ("medium", "high")
+        .type == "aws_access_key" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "aws_access_key" and .confidence in ("medium", "high")
+           .type == "aws_access_key" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "aws_access_key" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "aws_access_key" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "aws_access_key"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "aws_access_key"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "Credentials"

--- a/dlp-discovery-rules/beta_dlp_be_vat.yml
+++ b/dlp-discovery-rules/beta_dlp_be_vat.yml
@@ -15,22 +15,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "be_vat" and .confidence in ("medium", "high")
+        .type == "be_vat" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "be_vat" and .confidence in ("medium", "high")
+           .type == "be_vat" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "be_vat" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "be_vat" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "be_vat" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "be_vat" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_ca_bank_account.yml
+++ b/dlp-discovery-rules/beta_dlp_ca_bank_account.yml
@@ -15,22 +15,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "ca_bank_account" and .confidence in ("medium", "high")
+        .type == "ca_bank_account" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "ca_bank_account" and .confidence in ("medium", "high")
+           .type == "ca_bank_account" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "ca_bank_account" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "ca_bank_account" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "ca_bank_account"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "ca_bank_account"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_ca_driver_license.yml
+++ b/dlp-discovery-rules/beta_dlp_ca_driver_license.yml
@@ -16,22 +16,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "ca_driver_license" and .confidence in ("medium", "high")
+        .type == "ca_driver_license" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "ca_driver_license" and .confidence in ("medium", "high")
+           .type == "ca_driver_license" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "ca_driver_license" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "ca_driver_license" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "ca_driver_license"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "ca_driver_license"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_ca_health_service.yml
+++ b/dlp-discovery-rules/beta_dlp_ca_health_service.yml
@@ -15,22 +15,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "ca_health_service" and .confidence in ("medium", "high")
+        .type == "ca_health_service" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "ca_health_service" and .confidence in ("medium", "high")
+           .type == "ca_health_service" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "ca_health_service" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "ca_health_service" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "ca_health_service"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "ca_health_service"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_ca_passport.yml
+++ b/dlp-discovery-rules/beta_dlp_ca_passport.yml
@@ -16,22 +16,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "ca_passport_number" and .confidence in ("medium", "high")
+        .type == "ca_passport_number" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "ca_passport_number" and .confidence in ("medium", "high")
+           .type == "ca_passport_number" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "ca_passport_number" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "ca_passport_number" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "ca_passport_number"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "ca_passport_number"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_ca_phin.yml
+++ b/dlp-discovery-rules/beta_dlp_ca_phin.yml
@@ -15,22 +15,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "ca_phin" and .confidence in ("medium", "high")
+        .type == "ca_phin" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "ca_phin" and .confidence in ("medium", "high")
+           .type == "ca_phin" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "ca_phin" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "ca_phin" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "ca_phin" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "ca_phin" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_canadian_sin.yml
+++ b/dlp-discovery-rules/beta_dlp_canadian_sin.yml
@@ -6,23 +6,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "canadian_sin" and .confidence in ("medium", "high")
+        .type == "canadian_sin" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "canadian_sin" and .confidence in ("medium", "high")
+           .type == "canadian_sin" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "canadian_sin" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "canadian_sin" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "canadian_sin" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "canadian_sin"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "PII"

--- a/dlp-discovery-rules/beta_dlp_clear_text_credentials_outbound.yml
+++ b/dlp-discovery-rules/beta_dlp_clear_text_credentials_outbound.yml
@@ -14,43 +14,72 @@ severity: critical
 source: |
   type.outbound
   and (
-      // ── ML extraction: body ────────────────────────────────────────────────
-
-      any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-          .type in ("private_key", "aws_access_key", "github_token", "http_authorization_header", "oauth_client_secret")
-          and .confidence in ("medium", "high")
-      )
-
-      // ── ML extraction: subject ─────────────────────────────────────────────
-
-      or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-          .type in ("private_key", "aws_access_key", "github_token", "http_authorization_header", "oauth_client_secret")
-          and .confidence in ("medium", "high")
-      )
-
-      // ── Credential-bearing file types by extension and name ────────────────
-
-      or any(attachments,
-          .file_extension in~ ("env", "pem", "key", "p12", "pfx", "jks", "keystore", "ovpn")
-          or strings.icontains(.file_name, "credential")
-          or strings.icontains(.file_name, "secret")
-          or strings.icontains(.file_name, "password")
-      )
-
-      // ── ML extraction: attachments (raw text + OCR) ────────────────────────
-
-      or any(attachments,
-          any(file.explode(.),
-              any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-                  .type in ("private_key", "aws_access_key", "github_token", "http_authorization_header", "oauth_client_secret")
-                  and .confidence in ("medium", "high")
-              )
-              or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-                  .type in ("private_key", "aws_access_key", "github_token", "http_authorization_header", "oauth_client_secret")
-                  and .confidence in ("medium", "high")
-              )
-          )
-      )
+    // ── ML extraction: body ────────────────────────────────────────────────
+    any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
+        .type in (
+          "private_key",
+          "aws_access_key",
+          "github_token",
+          "http_authorization_header",
+          "oauth_client_secret"
+        )
+        and .confidence in ("medium", "high")
+    )
+  
+    // ── ML extraction: subject ─────────────────────────────────────────────
+    or any(beta.ml_extract_sensitive_information(subject.subject).elements,
+           .type in (
+             "private_key",
+             "aws_access_key",
+             "github_token",
+             "http_authorization_header",
+             "oauth_client_secret"
+           )
+           and .confidence in ("medium", "high")
+    )
+  
+    // ── Credential-bearing file types by extension and name ────────────────
+    or any(attachments,
+           .file_extension in~ (
+             "env",
+             "pem",
+             "key",
+             "p12",
+             "pfx",
+             "jks",
+             "keystore",
+             "ovpn"
+           )
+           or strings.icontains(.file_name, "credential")
+           or strings.icontains(.file_name, "secret")
+           or strings.icontains(.file_name, "password")
+    )
+  
+    // ── ML extraction: attachments (raw text + OCR) ────────────────────────
+    or any(attachments,
+           any(file.explode(.),
+               any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                   .type in (
+                     "private_key",
+                     "aws_access_key",
+                     "github_token",
+                     "http_authorization_header",
+                     "oauth_client_secret"
+                   )
+                   and .confidence in ("medium", "high")
+               )
+               or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                      .type in (
+                        "private_key",
+                        "aws_access_key",
+                        "github_token",
+                        "http_authorization_header",
+                        "oauth_client_secret"
+                      )
+                      and .confidence in ("medium", "high")
+               )
+           )
+    )
   )
 tags:
   - "Credentials"

--- a/dlp-discovery-rules/beta_dlp_cn_prc_id.yml
+++ b/dlp-discovery-rules/beta_dlp_cn_prc_id.yml
@@ -16,22 +16,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "cn_prc_id" and .confidence in ("medium", "high")
+        .type == "cn_prc_id" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "cn_prc_id" and .confidence in ("medium", "high")
+           .type == "cn_prc_id" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "cn_prc_id" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "cn_prc_id" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "cn_prc_id" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "cn_prc_id" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_crypto_wallet_address.yml
+++ b/dlp-discovery-rules/beta_dlp_crypto_wallet_address.yml
@@ -6,23 +6,25 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "crypto_wallet_address" and .confidence in ("medium", "high")
+        .type == "crypto_wallet_address" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "crypto_wallet_address" and .confidence in ("medium", "high")
+           .type == "crypto_wallet_address" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "crypto_wallet_address" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "crypto_wallet_address" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "crypto_wallet_address"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "crypto_wallet_address"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "Financial data"

--- a/dlp-discovery-rules/beta_dlp_de_passport.yml
+++ b/dlp-discovery-rules/beta_dlp_de_passport.yml
@@ -16,22 +16,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "de_passport_number" and .confidence in ("medium", "high")
+        .type == "de_passport_number" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "de_passport_number" and .confidence in ("medium", "high")
+           .type == "de_passport_number" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "de_passport_number" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "de_passport_number" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "de_passport_number"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "de_passport_number"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_de_personalausweis.yml
+++ b/dlp-discovery-rules/beta_dlp_de_personalausweis.yml
@@ -16,22 +16,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "de_personalausweis" and .confidence in ("medium", "high")
+        .type == "de_personalausweis" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "de_personalausweis" and .confidence in ("medium", "high")
+           .type == "de_personalausweis" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "de_personalausweis" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "de_personalausweis" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "de_personalausweis"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "de_personalausweis"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_de_tax_id.yml
+++ b/dlp-discovery-rules/beta_dlp_de_tax_id.yml
@@ -16,22 +16,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "de_tax_id" and .confidence in ("medium", "high")
+        .type == "de_tax_id" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "de_tax_id" and .confidence in ("medium", "high")
+           .type == "de_tax_id" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "de_tax_id" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "de_tax_id" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "de_tax_id" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "de_tax_id" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_de_vat.yml
+++ b/dlp-discovery-rules/beta_dlp_de_vat.yml
@@ -15,22 +15,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "de_vat" and .confidence in ("medium", "high")
+        .type == "de_vat" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "de_vat" and .confidence in ("medium", "high")
+           .type == "de_vat" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "de_vat" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "de_vat" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "de_vat" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "de_vat" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_es_bank_account.yml
+++ b/dlp-discovery-rules/beta_dlp_es_bank_account.yml
@@ -15,22 +15,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "es_bank_account" and .confidence in ("medium", "high")
+        .type == "es_bank_account" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "es_bank_account" and .confidence in ("medium", "high")
+           .type == "es_bank_account" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "es_bank_account" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "es_bank_account" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "es_bank_account"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "es_bank_account"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_es_id.yml
+++ b/dlp-discovery-rules/beta_dlp_es_id.yml
@@ -16,22 +16,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "es_dni_nie_nif" and .confidence in ("medium", "high")
+        .type == "es_dni_nie_nif" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "es_dni_nie_nif" and .confidence in ("medium", "high")
+           .type == "es_dni_nie_nif" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "es_dni_nie_nif" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "es_dni_nie_nif" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "es_dni_nie_nif"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "es_dni_nie_nif"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_es_passport.yml
+++ b/dlp-discovery-rules/beta_dlp_es_passport.yml
@@ -16,22 +16,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "es_passport_number" and .confidence in ("medium", "high")
+        .type == "es_passport_number" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "es_passport_number" and .confidence in ("medium", "high")
+           .type == "es_passport_number" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "es_passport_number" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "es_passport_number" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "es_passport_number"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "es_passport_number"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_fi_european_health_insurance.yml
+++ b/dlp-discovery-rules/beta_dlp_fi_european_health_insurance.yml
@@ -15,22 +15,26 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "fi_european_health_insurance" and .confidence in ("medium", "high")
+        .type == "fi_european_health_insurance"
+        and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "fi_european_health_insurance" and .confidence in ("medium", "high")
+           .type == "fi_european_health_insurance"
+           and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "fi_european_health_insurance" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "fi_european_health_insurance" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "fi_european_health_insurance"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "fi_european_health_insurance"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_fr_bank_account.yml
+++ b/dlp-discovery-rules/beta_dlp_fr_bank_account.yml
@@ -15,22 +15,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "fr_bank_account" and .confidence in ("medium", "high")
+        .type == "fr_bank_account" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "fr_bank_account" and .confidence in ("medium", "high")
+           .type == "fr_bank_account" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "fr_bank_account" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "fr_bank_account" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "fr_bank_account"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "fr_bank_account"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_fr_cni.yml
+++ b/dlp-discovery-rules/beta_dlp_fr_cni.yml
@@ -16,22 +16,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "fr_cni" and .confidence in ("medium", "high")
+        .type == "fr_cni" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "fr_cni" and .confidence in ("medium", "high")
+           .type == "fr_cni" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "fr_cni" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "fr_cni" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "fr_cni" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "fr_cni" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_fr_driver_license.yml
+++ b/dlp-discovery-rules/beta_dlp_fr_driver_license.yml
@@ -16,22 +16,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "fr_driver_license" and .confidence in ("medium", "high")
+        .type == "fr_driver_license" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "fr_driver_license" and .confidence in ("medium", "high")
+           .type == "fr_driver_license" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "fr_driver_license" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "fr_driver_license" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "fr_driver_license"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "fr_driver_license"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_fr_insee.yml
+++ b/dlp-discovery-rules/beta_dlp_fr_insee.yml
@@ -16,22 +16,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "fr_insee" and .confidence in ("medium", "high")
+        .type == "fr_insee" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "fr_insee" and .confidence in ("medium", "high")
+           .type == "fr_insee" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "fr_insee" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "fr_insee" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "fr_insee" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "fr_insee" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_fr_passport.yml
+++ b/dlp-discovery-rules/beta_dlp_fr_passport.yml
@@ -16,22 +16,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "fr_passport_number" and .confidence in ("medium", "high")
+        .type == "fr_passport_number" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "fr_passport_number" and .confidence in ("medium", "high")
+           .type == "fr_passport_number" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "fr_passport_number" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "fr_passport_number" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "fr_passport_number"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "fr_passport_number"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_fr_vat.yml
+++ b/dlp-discovery-rules/beta_dlp_fr_vat.yml
@@ -15,22 +15,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "fr_vat" and .confidence in ("medium", "high")
+        .type == "fr_vat" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "fr_vat" and .confidence in ("medium", "high")
+           .type == "fr_vat" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "fr_vat" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "fr_vat" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "fr_vat" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "fr_vat" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_github_token.yml
+++ b/dlp-discovery-rules/beta_dlp_github_token.yml
@@ -6,23 +6,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "github_token" and .confidence in ("medium", "high")
+        .type == "github_token" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "github_token" and .confidence in ("medium", "high")
+           .type == "github_token" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "github_token" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "github_token" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "github_token" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "github_token"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "Credentials"

--- a/dlp-discovery-rules/beta_dlp_google_api_key.yml
+++ b/dlp-discovery-rules/beta_dlp_google_api_key.yml
@@ -15,22 +15,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "google_api_key" and .confidence in ("medium", "high")
+        .type == "google_api_key" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "google_api_key" and .confidence in ("medium", "high")
+           .type == "google_api_key" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "google_api_key" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "google_api_key" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "google_api_key"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "google_api_key"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_http_authorization_header.yml
+++ b/dlp-discovery-rules/beta_dlp_http_authorization_header.yml
@@ -6,23 +6,26 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "http_authorization_header" and .confidence in ("medium", "high")
+        .type == "http_authorization_header" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "http_authorization_header" and .confidence in ("medium", "high")
+           .type == "http_authorization_header"
+           and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "http_authorization_header" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "http_authorization_header" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "http_authorization_header"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "http_authorization_header"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "Credentials"

--- a/dlp-discovery-rules/beta_dlp_hu_taj.yml
+++ b/dlp-discovery-rules/beta_dlp_hu_taj.yml
@@ -15,22 +15,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "hu_taj" and .confidence in ("medium", "high")
+        .type == "hu_taj" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "hu_taj" and .confidence in ("medium", "high")
+           .type == "hu_taj" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "hu_taj" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "hu_taj" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "hu_taj" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "hu_taj" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_hu_vat.yml
+++ b/dlp-discovery-rules/beta_dlp_hu_vat.yml
@@ -15,22 +15,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "hu_vat" and .confidence in ("medium", "high")
+        .type == "hu_vat" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "hu_vat" and .confidence in ("medium", "high")
+           .type == "hu_vat" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "hu_vat" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "hu_vat" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "hu_vat" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "hu_vat" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_iban_code.yml
+++ b/dlp-discovery-rules/beta_dlp_iban_code.yml
@@ -6,23 +6,23 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "iban_code" and .confidence in ("medium", "high")
+        .type == "iban_code" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "iban_code" and .confidence in ("medium", "high")
+           .type == "iban_code" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "iban_code" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "iban_code" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "iban_code" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "iban_code" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "Financial data"

--- a/dlp-discovery-rules/beta_dlp_jp_driver_license.yml
+++ b/dlp-discovery-rules/beta_dlp_jp_driver_license.yml
@@ -16,22 +16,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "jp_driver_license" and .confidence in ("medium", "high")
+        .type == "jp_driver_license" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "jp_driver_license" and .confidence in ("medium", "high")
+           .type == "jp_driver_license" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "jp_driver_license" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "jp_driver_license" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "jp_driver_license"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "jp_driver_license"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_jp_my_number.yml
+++ b/dlp-discovery-rules/beta_dlp_jp_my_number.yml
@@ -16,22 +16,23 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "jp_my_number" and .confidence in ("medium", "high")
+        .type == "jp_my_number" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "jp_my_number" and .confidence in ("medium", "high")
+           .type == "jp_my_number" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "jp_my_number" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "jp_my_number" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "jp_my_number" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "jp_my_number"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_jp_passport.yml
+++ b/dlp-discovery-rules/beta_dlp_jp_passport.yml
@@ -16,22 +16,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "jp_passport_number" and .confidence in ("medium", "high")
+        .type == "jp_passport_number" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "jp_passport_number" and .confidence in ("medium", "high")
+           .type == "jp_passport_number" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "jp_passport_number" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "jp_passport_number" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "jp_passport_number"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "jp_passport_number"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_jwt.yml
+++ b/dlp-discovery-rules/beta_dlp_jwt.yml
@@ -15,22 +15,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "jwt" and .confidence in ("medium", "high")
+        .type == "jwt" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "jwt" and .confidence in ("medium", "high")
+           .type == "jwt" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "jwt" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "jwt" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "jwt" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "jwt" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_kr_rrn.yml
+++ b/dlp-discovery-rules/beta_dlp_kr_rrn.yml
@@ -16,22 +16,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "kr_rrn" and .confidence in ("medium", "high")
+        .type == "kr_rrn" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "kr_rrn" and .confidence in ("medium", "high")
+           .type == "kr_rrn" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "kr_rrn" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "kr_rrn" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "kr_rrn" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "kr_rrn" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_luxembourg_nonnatural_id.yml
+++ b/dlp-discovery-rules/beta_dlp_luxembourg_nonnatural_id.yml
@@ -15,22 +15,25 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "luxembourg_nonnatural_id" and .confidence in ("medium", "high")
+        .type == "luxembourg_nonnatural_id" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "luxembourg_nonnatural_id" and .confidence in ("medium", "high")
+           .type == "luxembourg_nonnatural_id"
+           and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "luxembourg_nonnatural_id" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "luxembourg_nonnatural_id" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "luxembourg_nonnatural_id"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "luxembourg_nonnatural_id"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_mac_address.yml
+++ b/dlp-discovery-rules/beta_dlp_mac_address.yml
@@ -15,22 +15,23 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "mac_address" and .confidence in ("medium", "high")
+        .type == "mac_address" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "mac_address" and .confidence in ("medium", "high")
+           .type == "mac_address" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "mac_address" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "mac_address" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "mac_address" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "mac_address"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_nhs_number.yml
+++ b/dlp-discovery-rules/beta_dlp_nhs_number.yml
@@ -6,23 +6,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "nhs_number" and .confidence in ("medium", "high")
+        .type == "nhs_number" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "nhs_number" and .confidence in ("medium", "high")
+           .type == "nhs_number" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "nhs_number" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "nhs_number" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "nhs_number" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "nhs_number"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "PII"

--- a/dlp-discovery-rules/beta_dlp_nl_bsn.yml
+++ b/dlp-discovery-rules/beta_dlp_nl_bsn.yml
@@ -16,22 +16,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "nl_bsn" and .confidence in ("medium", "high")
+        .type == "nl_bsn" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "nl_bsn" and .confidence in ("medium", "high")
+           .type == "nl_bsn" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "nl_bsn" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "nl_bsn" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "nl_bsn" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "nl_bsn" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_nl_vat.yml
+++ b/dlp-discovery-rules/beta_dlp_nl_vat.yml
@@ -15,22 +15,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "nl_vat" and .confidence in ("medium", "high")
+        .type == "nl_vat" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "nl_vat" and .confidence in ("medium", "high")
+           .type == "nl_vat" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "nl_vat" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "nl_vat" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "nl_vat" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "nl_vat" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_nz_bank_account.yml
+++ b/dlp-discovery-rules/beta_dlp_nz_bank_account.yml
@@ -15,22 +15,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "nz_bank_account" and .confidence in ("medium", "high")
+        .type == "nz_bank_account" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "nz_bank_account" and .confidence in ("medium", "high")
+           .type == "nz_bank_account" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "nz_bank_account" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "nz_bank_account" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "nz_bank_account"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "nz_bank_account"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_nz_moh.yml
+++ b/dlp-discovery-rules/beta_dlp_nz_moh.yml
@@ -15,22 +15,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "nz_moh" and .confidence in ("medium", "high")
+        .type == "nz_moh" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "nz_moh" and .confidence in ("medium", "high")
+           .type == "nz_moh" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "nz_moh" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "nz_moh" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "nz_moh" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "nz_moh" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_oauth_client_secret.yml
+++ b/dlp-discovery-rules/beta_dlp_oauth_client_secret.yml
@@ -6,22 +6,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "oauth_client_secret" and .confidence in ("medium", "high")
+        .type == "oauth_client_secret" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "oauth_client_secret" and .confidence in ("medium", "high")
+           .type == "oauth_client_secret" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "oauth_client_secret" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "oauth_client_secret" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "oauth_client_secret"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "oauth_client_secret"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 tags:

--- a/dlp-discovery-rules/beta_dlp_pci_us_credit_card_any.yml
+++ b/dlp-discovery-rules/beta_dlp_pci_us_credit_card_any.yml
@@ -6,23 +6,25 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "credit_card_number" and .confidence in ("medium", "high")
+        .type == "credit_card_number" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "credit_card_number" and .confidence in ("medium", "high")
+           .type == "credit_card_number" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "credit_card_number" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "credit_card_number" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "credit_card_number"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "credit_card_number"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "Financial data"

--- a/dlp-discovery-rules/beta_dlp_pl_regon.yml
+++ b/dlp-discovery-rules/beta_dlp_pl_regon.yml
@@ -15,22 +15,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "pl_regon" and .confidence in ("medium", "high")
+        .type == "pl_regon" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "pl_regon" and .confidence in ("medium", "high")
+           .type == "pl_regon" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "pl_regon" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "pl_regon" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "pl_regon" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "pl_regon" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_private_key.yml
+++ b/dlp-discovery-rules/beta_dlp_private_key.yml
@@ -6,22 +6,23 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "private_key" and .confidence in ("medium", "high")
+        .type == "private_key" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "private_key" and .confidence in ("medium", "high")
+           .type == "private_key" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "private_key" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "private_key" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "private_key" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "private_key"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 tags:

--- a/dlp-discovery-rules/beta_dlp_se_personnummer.yml
+++ b/dlp-discovery-rules/beta_dlp_se_personnummer.yml
@@ -16,22 +16,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "se_personnummer" and .confidence in ("medium", "high")
+        .type == "se_personnummer" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "se_personnummer" and .confidence in ("medium", "high")
+           .type == "se_personnummer" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "se_personnummer" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "se_personnummer" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "se_personnummer"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "se_personnummer"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_sg_nric.yml
+++ b/dlp-discovery-rules/beta_dlp_sg_nric.yml
@@ -16,22 +16,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "sg_nric" and .confidence in ("medium", "high")
+        .type == "sg_nric" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "sg_nric" and .confidence in ("medium", "high")
+           .type == "sg_nric" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "sg_nric" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "sg_nric" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "sg_nric" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "sg_nric" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_sg_uen.yml
+++ b/dlp-discovery-rules/beta_dlp_sg_uen.yml
@@ -15,22 +15,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "sg_uen" and .confidence in ("medium", "high")
+        .type == "sg_uen" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "sg_uen" and .confidence in ("medium", "high")
+           .type == "sg_uen" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "sg_uen" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "sg_uen" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "sg_uen" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "sg_uen" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_slack_access_token.yml
+++ b/dlp-discovery-rules/beta_dlp_slack_access_token.yml
@@ -15,22 +15,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "slack_access_token" and .confidence in ("medium", "high")
+        .type == "slack_access_token" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "slack_access_token" and .confidence in ("medium", "high")
+           .type == "slack_access_token" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "slack_access_token" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "slack_access_token" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "slack_access_token"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "slack_access_token"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_ssl_certificate.yml
+++ b/dlp-discovery-rules/beta_dlp_ssl_certificate.yml
@@ -6,23 +6,25 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "ssl_certificate" and .confidence in ("medium", "high")
+        .type == "ssl_certificate" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "ssl_certificate" and .confidence in ("medium", "high")
+           .type == "ssl_certificate" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "ssl_certificate" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "ssl_certificate" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "ssl_certificate"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "ssl_certificate"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "Credentials"

--- a/dlp-discovery-rules/beta_dlp_swift_bic.yml
+++ b/dlp-discovery-rules/beta_dlp_swift_bic.yml
@@ -10,22 +10,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "swift_bic" and .confidence in ("medium", "high")
+        .type == "swift_bic" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "swift_bic" and .confidence in ("medium", "high")
+           .type == "swift_bic" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "swift_bic" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "swift_bic" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "swift_bic" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "swift_bic" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 tags:

--- a/dlp-discovery-rules/beta_dlp_uk_drivers_license.yml
+++ b/dlp-discovery-rules/beta_dlp_uk_drivers_license.yml
@@ -6,23 +6,25 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "uk_drivers_license" and .confidence in ("medium", "high")
+        .type == "uk_drivers_license" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "uk_drivers_license" and .confidence in ("medium", "high")
+           .type == "uk_drivers_license" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "uk_drivers_license" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "uk_drivers_license" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "uk_drivers_license"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "uk_drivers_license"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "PII"

--- a/dlp-discovery-rules/beta_dlp_uk_nino.yml
+++ b/dlp-discovery-rules/beta_dlp_uk_nino.yml
@@ -6,22 +6,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "uk_nino" and .confidence in ("medium", "high")
+        .type == "uk_nino" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "uk_nino" and .confidence in ("medium", "high")
+           .type == "uk_nino" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "uk_nino" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "uk_nino" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "uk_nino" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "uk_nino" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 tags:

--- a/dlp-discovery-rules/beta_dlp_uk_passport.yml
+++ b/dlp-discovery-rules/beta_dlp_uk_passport.yml
@@ -6,23 +6,25 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "uk_passport_number" and .confidence in ("medium", "high")
+        .type == "uk_passport_number" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "uk_passport_number" and .confidence in ("medium", "high")
+           .type == "uk_passport_number" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "uk_passport_number" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "uk_passport_number" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "uk_passport_number"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "uk_passport_number"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "PII"

--- a/dlp-discovery-rules/beta_dlp_uk_utr.yml
+++ b/dlp-discovery-rules/beta_dlp_uk_utr.yml
@@ -6,23 +6,23 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "uk_utr" and .confidence in ("medium", "high")
+        .type == "uk_utr" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "uk_utr" and .confidence in ("medium", "high")
+           .type == "uk_utr" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "uk_utr" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "uk_utr" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "uk_utr" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "uk_utr" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "PII"

--- a/dlp-discovery-rules/beta_dlp_us_aba_routing_number.yml
+++ b/dlp-discovery-rules/beta_dlp_us_aba_routing_number.yml
@@ -6,22 +6,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "us_aba_routing_number" and .confidence in ("medium", "high")
+        .type == "us_aba_routing_number" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "us_aba_routing_number" and .confidence in ("medium", "high")
+           .type == "us_aba_routing_number" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "us_aba_routing_number" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "us_aba_routing_number" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "us_aba_routing_number"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "us_aba_routing_number"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 tags:

--- a/dlp-discovery-rules/beta_dlp_us_bank_account.yml
+++ b/dlp-discovery-rules/beta_dlp_us_bank_account.yml
@@ -6,23 +6,25 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "us_bank_number" and .confidence in ("medium", "high")
+        .type == "us_bank_number" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "us_bank_number" and .confidence in ("medium", "high")
+           .type == "us_bank_number" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "us_bank_number" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "us_bank_number" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "us_bank_number"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "us_bank_number"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "Financial data"

--- a/dlp-discovery-rules/beta_dlp_us_dea_number.yml
+++ b/dlp-discovery-rules/beta_dlp_us_dea_number.yml
@@ -15,22 +15,24 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "us_dea_number" and .confidence in ("medium", "high")
+        .type == "us_dea_number" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "us_dea_number" and .confidence in ("medium", "high")
+           .type == "us_dea_number" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "us_dea_number" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "us_dea_number" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "us_dea_number"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "us_dea_number"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_us_driver_license.yml
+++ b/dlp-discovery-rules/beta_dlp_us_driver_license.yml
@@ -6,23 +6,25 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "us_driver_license" and .confidence in ("medium", "high")
+        .type == "us_driver_license" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "us_driver_license" and .confidence in ("medium", "high")
+           .type == "us_driver_license" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "us_driver_license" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "us_driver_license" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "us_driver_license"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "us_driver_license"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "PII"

--- a/dlp-discovery-rules/beta_dlp_us_icd10.yml
+++ b/dlp-discovery-rules/beta_dlp_us_icd10.yml
@@ -6,23 +6,23 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "us_icd10" and .confidence in ("medium", "high")
+        .type == "us_icd10" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "us_icd10" and .confidence in ("medium", "high")
+           .type == "us_icd10" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "us_icd10" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "us_icd10" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "us_icd10" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "us_icd10" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "Health data"

--- a/dlp-discovery-rules/beta_dlp_us_icd9.yml
+++ b/dlp-discovery-rules/beta_dlp_us_icd9.yml
@@ -6,23 +6,23 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "us_icd9" and .confidence in ("medium", "high")
+        .type == "us_icd9" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "us_icd9" and .confidence in ("medium", "high")
+           .type == "us_icd9" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "us_icd9" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "us_icd9" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "us_icd9" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "us_icd9" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "Health data"

--- a/dlp-discovery-rules/beta_dlp_us_itin.yml
+++ b/dlp-discovery-rules/beta_dlp_us_itin.yml
@@ -6,23 +6,23 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "us_itin" and .confidence in ("medium", "high")
+        .type == "us_itin" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "us_itin" and .confidence in ("medium", "high")
+           .type == "us_itin" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "us_itin" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "us_itin" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "us_itin" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "us_itin" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "PII"

--- a/dlp-discovery-rules/beta_dlp_us_medicare_beneficiary_id.yml
+++ b/dlp-discovery-rules/beta_dlp_us_medicare_beneficiary_id.yml
@@ -15,22 +15,26 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "us_medicare_beneficiary_id" and .confidence in ("medium", "high")
+        .type == "us_medicare_beneficiary_id"
+        and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "us_medicare_beneficiary_id" and .confidence in ("medium", "high")
+           .type == "us_medicare_beneficiary_id"
+           and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "us_medicare_beneficiary_id" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "us_medicare_beneficiary_id" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "us_medicare_beneficiary_id"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "us_medicare_beneficiary_id"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_us_npi.yml
+++ b/dlp-discovery-rules/beta_dlp_us_npi.yml
@@ -15,22 +15,22 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "us_npi" and .confidence in ("medium", "high")
+        .type == "us_npi" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "us_npi" and .confidence in ("medium", "high")
+           .type == "us_npi" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "us_npi" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "us_npi" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "us_npi" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "us_npi" and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/beta_dlp_us_passport.yml
+++ b/dlp-discovery-rules/beta_dlp_us_passport.yml
@@ -6,23 +6,25 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "us_passport_number" and .confidence in ("medium", "high")
+        .type == "us_passport_number" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "us_passport_number" and .confidence in ("medium", "high")
+           .type == "us_passport_number" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "us_passport_number" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "us_passport_number" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "us_passport_number"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "us_passport_number"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "PII"

--- a/dlp-discovery-rules/beta_dlp_us_ssn.yml
+++ b/dlp-discovery-rules/beta_dlp_us_ssn.yml
@@ -6,23 +6,25 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "social_security_number" and .confidence in ("medium", "high")
+        .type == "social_security_number" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "social_security_number" and .confidence in ("medium", "high")
+           .type == "social_security_number" and .confidence in ("medium", "high")
     )
     or any(attachments,
-    any(file.explode(.),
-      (
-        any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-          .type == "social_security_number" and .confidence in ("medium", "high")
-        )
-        or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-          .type == "social_security_number" and .confidence in ("medium", "high")
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "social_security_number"
+                     and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "social_security_number"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
-  )
   )
 tags:
   - "PII"

--- a/dlp-discovery-rules/beta_dlp_vehicle_vin.yml
+++ b/dlp-discovery-rules/beta_dlp_vehicle_vin.yml
@@ -15,22 +15,23 @@ source: |
   type.outbound
   and (
     any(beta.ml_extract_sensitive_information(body.current_thread.text).elements,
-      .type == "vehicle_vin" and .confidence in ("medium", "high")
+        .type == "vehicle_vin" and .confidence in ("medium", "high")
     )
     or any(beta.ml_extract_sensitive_information(subject.subject).elements,
-      .type == "vehicle_vin" and .confidence in ("medium", "high")
+           .type == "vehicle_vin" and .confidence in ("medium", "high")
     )
     or any(attachments,
-      any(file.explode(.),
-        (
-          any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
-            .type == "vehicle_vin" and .confidence in ("medium", "high")
-          )
-          or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
-            .type == "vehicle_vin" and .confidence in ("medium", "high")
-          )
-        )
-      )
+           any(file.explode(.),
+               (
+                 any(beta.ml_extract_sensitive_information(.scan.strings.raw).elements,
+                     .type == "vehicle_vin" and .confidence in ("medium", "high")
+                 )
+                 or any(beta.ml_extract_sensitive_information(.scan.ocr.raw).elements,
+                        .type == "vehicle_vin"
+                        and .confidence in ("medium", "high")
+                 )
+               )
+           )
     )
   )
 detection_methods:

--- a/dlp-discovery-rules/dlp_slack_token.yml
+++ b/dlp-discovery-rules/dlp_slack_token.yml
@@ -6,11 +6,14 @@ source: |
   type.outbound
   and any([body.current_thread.text, subject.subject],
           // Slack tokens: xoxb-, xoxp-, xoxa-, xoxr-
-          regex.contains(., '\bxox[bpar]-[0-9]{10,13}-[0-9]{10,13}-[A-Za-z0-9]{24,}\b')
+          regex.contains(.,
+                         '\bxox[bpar]-[0-9]{10,13}-[0-9]{10,13}-[A-Za-z0-9]{24,}\b'
+          )
           // Slack webhook URLs
-          or regex.contains(., 'hooks\.slack\.com/services/T[A-Z0-9]+/B[A-Z0-9]+/[A-Za-z0-9]{24}')
+          or regex.contains(.,
+                            'hooks\.slack\.com/services/T[A-Z0-9]+/B[A-Z0-9]+/[A-Za-z0-9]{24}'
+          )
   )
-
 detection_methods:
   - "Content analysis"
 id: "99723c25-994d-59a5-ab4f-030415050c2e"


### PR DESCRIPTION
## Summary

New detection rule: **Prompt injection: Body instructions directed at an LLM from a new sender**.

Flags inbound messages whose plaintext body contains instructions aimed at an LLM (`beta.prompt_injection_detection`) when the sender has no established, benign relationship (`profile.by_sender()` prevalence of new/outlier/rare and no prior benign messages). Graymail is excluded via `beta.fuzzy_attack_score()`, and a temporary allowlist suppresses DMARC-authenticated mail from a set of high-volume legitimate newsletter/service domains.

## Notes

- The `// TEMPORARY` DMARC allowlist is a stopgap to suppress known-benign newsletter senders while the PI signal is tuned; expected to be removed once the model's false-positive rate on these senders drops.