### PR TITLE
Create attachment_ics_base64_query_parameter.yml

### DIFF
--- a/detection-rules/attachment_ics_base64_query_parameter.yml
+++ b/detection-rules/attachment_ics_base64_query_parameter.yml
@@ -17,8 +17,8 @@ source: |
           and any(beta.file.parse_ics(.).events,
                   any(.links,
                       .href_url.path == '/'
-                      and regex.icontains(.href_url.query_params,
-                                          '^[A-Za-z0-9+/]{8}$'
+                      and regex.imatch(.href_url.query_params,
+                                          '[A-Za-z0-9+/]{8}'
                       )
                       and length(.href_url.query_params_decoded) == 1
                       and all(flatten(values(.href_url.query_params_decoded)),

--- a/detection-rules/attachment_ics_base64_query_parameter.yml
+++ b/detection-rules/attachment_ics_base64_query_parameter.yml
@@ -17,9 +17,7 @@ source: |
           and any(beta.file.parse_ics(.).events,
                   any(.links,
                       .href_url.path == '/'
-                      and regex.imatch(.href_url.query_params,
-                                          '[A-Za-z0-9+/]{8}'
-                      )
+                      and regex.imatch(.href_url.query_params, '[A-Za-z0-9+/]{8}')
                       and length(.href_url.query_params_decoded) == 1
                       and all(flatten(values(.href_url.query_params_decoded)),
                               . == ''

--- a/detection-rules/attachment_ics_base64_query_parameter.yml
+++ b/detection-rules/attachment_ics_base64_query_parameter.yml
@@ -36,3 +36,4 @@ detection_methods:
   - "File analysis"
   - "URL analysis"
   - "Header analysis"
+id: "d5ce3bc3-9771-541c-a5e5-aedf94cc9e8f"

--- a/detection-rules/attachment_ics_base64_query_parameter.yml
+++ b/detection-rules/attachment_ics_base64_query_parameter.yml
@@ -12,7 +12,8 @@ source: |
           )
           and any(beta.file.parse_ics(.).events,
                   any(.links,
-                      regex.icontains(.href_url.query_params,
+                      .href_url.path == '/'
+                      and regex.icontains(.href_url.query_params,
                                       '^[A-Za-z0-9+/]{8}$'
                       )
                       and length(.href_url.query_params_decoded) == 1

--- a/detection-rules/attachment_ics_base64_query_parameter.yml
+++ b/detection-rules/attachment_ics_base64_query_parameter.yml
@@ -14,7 +14,7 @@ source: |
                   any(.links,
                       .href_url.path == '/'
                       and regex.icontains(.href_url.query_params,
-                                      '^[A-Za-z0-9+/]{8}$'
+                                          '^[A-Za-z0-9+/]{8}$'
                       )
                       and length(.href_url.query_params_decoded) == 1
                       and all(flatten(values(.href_url.query_params_decoded)),

--- a/detection-rules/attachment_ics_base64_query_parameter.yml
+++ b/detection-rules/attachment_ics_base64_query_parameter.yml
@@ -1,0 +1,38 @@
+name: "Attachment: ICS Link With Valueless Base64 Query Parameter"
+description: "Detects inbound emails containing ICS calendar attachments where embedded event links include a randomized 8-character base64 query parameter with no assigned value. The rule excludes messages from high-trust sender domains that pass DMARC authentication."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(attachments,
+          (
+            .file_type == "ics"
+            or .file_extension == "ics"
+            or .content_type in ("application/ics", "text/calendar")
+          )
+          and any(beta.file.parse_ics(.).events,
+                  any(.links,
+                      regex.icontains(.href_url.query_params,
+                                      '^[A-Za-z0-9+/]{8}$'
+                      )
+                      and length(.href_url.query_params_decoded) == 1
+                      and all(flatten(values(.href_url.query_params_decoded)),
+                              . == ''
+                      )
+                  )
+          )
+  )
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+attack_types:
+  - "ICS Phishing"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Evasion"
+  - "Social engineering"
+detection_methods:
+  - "File analysis"
+  - "URL analysis"
+  - "Header analysis"

--- a/detection-rules/attachment_ics_base64_query_parameter.yml
+++ b/detection-rules/attachment_ics_base64_query_parameter.yml
@@ -10,6 +10,10 @@ source: |
             or .file_extension == "ics"
             or .content_type in ("application/ics", "text/calendar")
           )
+          //
+          // This rule makes use of a beta feature and is subject to change without notice
+          // using the beta feature in custom rules is not suggested until it has been formally released
+          //
           and any(beta.file.parse_ics(.).events,
                   any(.links,
                       .href_url.path == '/'


### PR DESCRIPTION
# Description
Detects inbound emails containing ICS calendar attachments where embedded event links include a randomized 8-character base64 query parameter with no assigned value.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50d2c7552bb50cb9032d5cbd2d9e5739a69d24f13a9ca38f787179dd88dc8677)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [95 customer multi-hunt](https://hunt.limeseed.email/hunts/8801c34c-f00e-4d4d-9be2-45661bd5f2dd)
- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=01a068b7-4674-7388-bc07-03a7494107ee)
