### PR TITLE
Create spam_porkbun_newly_registered_domain.yml

### DIFF
--- a/detection-rules/spam_porkbun_newly_registered_domain.yml
+++ b/detection-rules/spam_porkbun_newly_registered_domain.yml
@@ -1,4 +1,4 @@
-name: "Spam: Cold outreach from PorkBun-hosted newly registered domain""
+name: "Spam: Cold outreach from PorkBun-hosted newly registered domain"
 description: "Detects inbound messages from domains registered less than 365 days ago using PorkBun (porkbun.com) nameservers, where the message content is classified as B2B cold outreach by NLU analysis. The rule only flags senders who are either unsolicited or have a history of malicious/spam activity without any benign messages."
 type: "rule"
 severity: "low"

--- a/detection-rules/spam_porkbun_newly_registered_domain.yml
+++ b/detection-rules/spam_porkbun_newly_registered_domain.yml
@@ -1,0 +1,39 @@
+name: "Spam: Cold outreach from PorkBun-hosted newly registered domain""
+description: "Detects inbound messages from domains registered less than 365 days ago using PorkBun (porkbun.com) nameservers, where the message content is classified as B2B cold outreach by NLU analysis. The rule only flags senders who are either unsolicited or have a history of malicious/spam activity without any benign messages."
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  // newly registered sender domain
+  and network.whois(sender.email.domain).days_old < 365
+  
+  // there are 4 name servers which have subdomains containing .ns
+  and length(network.whois(sender.email.domain).name_servers) == 4
+  and all(network.whois(sender.email.domain).name_servers,
+          strings.iends_with(.subdomain, 'ns') and .root_domain == 'porkbun.com'
+  )
+  
+  // nlu topic
+  and any(ml.nlu_classifier(body.current_thread.text).topics,
+          .name == 'B2B Cold Outreach'
+  )
+  
+  // sender profiles
+  and (
+    not profile.by_sender_email().solicited
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and not profile.by_sender().any_messages_benign
+    )
+  )
+  
+tags:
+  - "Attack surface reduction"
+attack_types:
+  - "Spam"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Whois"
+  - "Natural Language Understanding"
+  - "Sender analysis"

--- a/detection-rules/spam_porkbun_newly_registered_domain.yml
+++ b/detection-rules/spam_porkbun_newly_registered_domain.yml
@@ -37,3 +37,4 @@ detection_methods:
   - "Whois"
   - "Natural Language Understanding"
   - "Sender analysis"
+id: "985ac6a6-1dfd-5330-9bda-36da0da45f27"


### PR DESCRIPTION
# Description

Rule flags on newly registered sender domains less than 365 days old, using PorkBun's default DNS name servers.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/50d79ee4b19f0b4475914d8f168b85d328c9094f74ebbf43fd77f2b7581f8d4c?preview_id=01a0689f-ba19-7bfc-a9cc-0321716aa483)
- [Sample 2](https://platform.sublime.security/messages/50d84815e29a739fa51eef043643d55ae1f4a87f969692b7e4c5879e396033a4?preview_id=01a0689f-be2f-7146-818d-bba5f0263438)

## Associated hunts

- [Hunt 1 (Shared Samples) - L180d](https://platform.sublime.security/messages/hunt?huntId=01a068a0-3813-72f5-8fae-199d5f2ffdd6)
- [Hunt 2 (Multi) - L30d](https://hunt.limeseed.email/hunts/39a8a71a-9f3a-4bb1-934a-f051a65334ab)