### PR TITLE
Create spam_dynadot_newly_registered_domain.yml

### DIFF
--- a/detection-rules/spam_dynadot_newly_registered_domain.yml
+++ b/detection-rules/spam_dynadot_newly_registered_domain.yml
@@ -37,3 +37,4 @@ detection_methods:
   - "Whois"
   - "Natural Language Understanding"
   - "Sender analysis"
+id: "90f144fc-50d2-5010-bfe1-06431d07791d"

--- a/detection-rules/spam_dynadot_newly_registered_domain.yml
+++ b/detection-rules/spam_dynadot_newly_registered_domain.yml
@@ -1,0 +1,39 @@
+name: "Rule flags on newly registered sender domains less than 365 days old, using Dynadot's default DNS name servers."
+description: "Detects inbound messages from domains registered less than 365 days ago using DynaDot (dyna-ns.net) nameservers, where the message content is classified as B2B cold outreach by NLU analysis. The rule only flags senders who are either unsolicited or have a history of malicious/spam activity without any benign messages."
+type: "rule"
+severity: "low"
+source: |
+  type.inbound
+  // newly registered sender domain
+  and network.whois(sender.email.domain).days_old < 365
+  
+  // there are 2 name servers which have subdomains containing .ns
+  and length(network.whois(sender.email.domain).name_servers) == 2
+  and all(network.whois(sender.email.domain).name_servers,
+          strings.istarts_with(.subdomain, 'ns') and .root_domain == 'dyna-ns.net'
+  )
+  
+  // nlu topic
+  and any(ml.nlu_classifier(body.current_thread.text).topics,
+          .name == 'B2B Cold Outreach'
+  )
+  
+  // sender profiles
+  and (
+    not profile.by_sender_email().solicited
+    or (
+      profile.by_sender().any_messages_malicious_or_spam
+      and not profile.by_sender().any_messages_benign
+    )
+  )
+  
+tags:
+  - "Attack surface reduction"
+attack_types:
+  - "Spam"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Whois"
+  - "Natural Language Understanding"
+  - "Sender analysis"


### PR DESCRIPTION
# Description

Rule flags on newly registered sender domains less than 365 days old, using DynaDot's default DNS name servers.

# Associated samples

- [Sample 1](https://platform.sublime.security/messages/50db259c1a70d2f35bda58e09ce538a517b4d3a8e6c0a2ec81543b02a78ca0ca?preview_id=01a06848-9d52-792c-9b36-35a78780c4ee)
- [Sample 2](https://platform.sublime.security/messages/50daca585fef60e26380db5ef142f3dc38b26bb8a5bfd7189e8800f6ee9de946?preview_id=01a062ea-62fb-7cc3-833a-081f9f5752c9)

## Associated hunts

- [Hunt 1 (Shared Samples) - L180d](https://platform.sublime.security/messages/hunt?huntId=01a0686f-c619-772b-82c6-3caea4d77241)
- [Hunt 2 (Multi) - L30d](https://hunt.limeseed.email/hunts/83f4d067-8045-4146-928a-807255ed2331)