### PR TITLE
Update attachment_ics_base64_query_parameter.yml

### DIFF
--- a/detection-rules/attachment_ics_base64_query_parameter.yml
+++ b/detection-rules/attachment_ics_base64_query_parameter.yml
@@ -29,7 +29,7 @@ source: |
                       or (
                         ml.link_analysis(.).effective_url.path == '/'
                         and regex.imatch(ml.link_analysis(.).effective_url.query_params,
-                                     '[A-Za-z0-9+/]{8}'
+                                         '[A-Za-z0-9+/]{8}'
                         )
                         and length(ml.link_analysis(.).effective_url.query_params_decoded
                         ) == 1

--- a/detection-rules/attachment_ics_base64_query_parameter.yml
+++ b/detection-rules/attachment_ics_base64_query_parameter.yml
@@ -16,11 +16,27 @@ source: |
           //
           and any(beta.file.parse_ics(.).events,
                   any(.links,
-                      .href_url.path == '/'
-                      and regex.imatch(.href_url.query_params, '[A-Za-z0-9+/]{8}')
-                      and length(.href_url.query_params_decoded) == 1
-                      and all(flatten(values(.href_url.query_params_decoded)),
-                              . == ''
+                      (
+                        .href_url.path == '/'
+                        and regex.imatch(.href_url.query_params,
+                                         '[A-Za-z0-9+/]{8}'
+                        )
+                        and length(.href_url.query_params_decoded) == 1
+                        and all(flatten(values(.href_url.query_params_decoded)),
+                                . == ''
+                        )
+                      )
+                      or (
+                        regex.imatch(ml.link_analysis(.).effective_url.query_params,
+                                     '[A-Za-z0-9+/]{8}'
+                        )
+                        and length(ml.link_analysis(.).effective_url.query_params_decoded
+                        ) == 1
+                        and all(flatten(values(ml.link_analysis(.).effective_url.query_params_decoded
+                                        )
+                                ),
+                                . == ''
+                        )
                       )
                   )
           )

--- a/detection-rules/attachment_ics_base64_query_parameter.yml
+++ b/detection-rules/attachment_ics_base64_query_parameter.yml
@@ -27,7 +27,8 @@ source: |
                         )
                       )
                       or (
-                        regex.imatch(ml.link_analysis(.).effective_url.query_params,
+                        ml.link_analysis(.).effective_url.path == '/'
+                        and regex.imatch(ml.link_analysis(.).effective_url.query_params,
                                      '[A-Za-z0-9+/]{8}'
                         )
                         and length(ml.link_analysis(.).effective_url.query_params_decoded


### PR DESCRIPTION
# Description
Also check for the base64 query parameter in the effective_url. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50cc44d86b68778c91da65b6ae1834f9487eb4949383d2ecf9ee4af082c44ccd)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [95 customer multi-hunt net new](https://hunt.limeseed.email/hunts/9a611198-9446-4395-a1f6-35df554b0283)
- [SWS Hunt net new](https://platform.sublime.security/hunts/01a06cbe-8f4d-79b1-8079-9f52aca37609)
