### PR TITLE
Create bec_wealth_management_new_sender_domain.yml

### DIFF
--- a/detection-rules/bec_wealth_management_new_sender_domain.yml
+++ b/detection-rules/bec_wealth_management_new_sender_domain.yml
@@ -1,0 +1,26 @@
+name: "BEC: Wealth management lure from newly registered domain"
+description: "Detects inbound messages sent from domains registered within the last 90 days that reference wealth management, estate planning, or offshore financial themes such as Luxembourg or licensed intermediaries. The rule combine these thematic keyword matches with an NLU classifier that flags advance fee or business email compromise intent, surfacing messages that closely resemble financial fraud or advance-fee scams."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and network.whois(sender.email.domain).days_old < 90
+  and 2 of (
+    strings.icontains(body.current_thread.text, "luxembourg"),
+    strings.icontains(body.current_thread.text, "wealth management"),
+    strings.icontains(body.current_thread.text, "estate planning"),
+    strings.icontains(body.current_thread.text, "full disclosure"),
+    strings.icontains(body.current_thread.text, "licensed intermediary")
+  )
+  and any(ml.nlu_classifier(body.current_thread.text).intents,
+          .name in ("advance_fee", "bec") and .confidence != "low"
+  )
+  
+attack_types:
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Social engineering"
+detection_methods:
+  - "Whois"
+  - "Content analysis"
+  - "Natural Language Understanding"

--- a/detection-rules/bec_wealth_management_new_sender_domain.yml
+++ b/detection-rules/bec_wealth_management_new_sender_domain.yml
@@ -24,3 +24,4 @@ detection_methods:
   - "Whois"
   - "Content analysis"
   - "Natural Language Understanding"
+id: "4120e4bc-2bd9-589c-8c99-1089a92137d3"


### PR DESCRIPTION
# Description

Detects inbound messages sent from domains registered within the last 90 days that reference wealth management, estate planning, or offshore financial themes such as Luxembourg or licensed intermediaries. The rule combine these thematic keyword matches with an NLU classifier that flags advance fee or business email compromise intent, surfacing messages that closely resemble financial fraud or advance-fee scams.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50da860a7fcafd5ea66571751446dfabbd960314349e7491713a74216425899e?preview_id=01a063b2-df72-7db5-a7cb-99222d8fa241)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Hunt](https://platform.sublime.security/messages/hunt?huntId=01a0811e-b772-7355-9948-eab222a71c5f)
- [L30D 95 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/aa46757d-1625-456b-a0f7-0948fd7bfb72)
