### PR TITLE
Update link_numeric_ip_obfuscation.yml

### DIFF
--- a/detection-rules/link_numeric_ip_obfuscation.yml
+++ b/detection-rules/link_numeric_ip_obfuscation.yml
@@ -7,7 +7,7 @@ source: |
   and any(body.links,
           .href_url.scheme == "http"
           and any(.href_url.ip.translation.encoders,
-              . in ('octal', 'decimal_integer')
+                  . in ('octal', 'decimal_integer')
           )
   )
 attack_types:

--- a/detection-rules/link_numeric_ip_obfuscation.yml
+++ b/detection-rules/link_numeric_ip_obfuscation.yml
@@ -5,7 +5,8 @@ severity: "medium"
 source: |
   type.inbound
   and any(body.links,
-          any(.href_url.ip.translation.encoders,
+          .href_url.scheme != "http"
+          and any(.href_url.ip.translation.encoders,
               . in ('octal', 'decimal_integer')
           )
   )

--- a/detection-rules/link_numeric_ip_obfuscation.yml
+++ b/detection-rules/link_numeric_ip_obfuscation.yml
@@ -5,7 +5,7 @@ severity: "medium"
 source: |
   type.inbound
   and any(body.links,
-          .href_url.scheme != "http"
+          .href_url.scheme == "http"
           and any(.href_url.ip.translation.encoders,
               . in ('octal', 'decimal_integer')
           )


### PR DESCRIPTION
# Description

Address FPs by ensuring scheme is http

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50c0c9146df8338ecc8c5b9628caaa4e096f8762335c652ddb38d984028da6b2?preview_id=019fdb1f-3bcf-7614-a85a-7b0efce8f9a2)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Samples that will no longer match](https://platform.sublime.security/messages/hunt?huntId=01a06ebe-6c38-70d5-abea-e0d5ad2b911f)
There are some non-benign messages here, but the link with the obfuscation is not malicious in them.