### PR TITLE
Create attachment_pdf_obj_hash_cred_phish.yml

### DIFF
--- a/detection-rules/attachment_pdf_obj_hash_cred_phish.yml
+++ b/detection-rules/attachment_pdf_obj_hash_cred_phish.yml
@@ -1,0 +1,21 @@
+name: "Attachment: PDF object hash cred phish"
+description: "Detects inbound emails containing PDF attachments whose embedded objects match known malicious object hashes observed in cred phish PDFs."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and any(filter(attachments, .file_type == "pdf"),
+          any(file.explode(.),
+              .scan.pdf_obj_hash.object_hash in (
+                "c515d2cb8f93b87bc4891a411ab37e6d",
+                "a67f29d92dd43a924218dc6a437c13d6"
+              )
+          )
+  )
+attack_types:
+  - "Malware/Ransomware"
+tactics_and_techniques:
+  - "PDF"
+detection_methods:
+  - "File analysis"
+  - "Threat intelligence"

--- a/detection-rules/attachment_pdf_obj_hash_cred_phish.yml
+++ b/detection-rules/attachment_pdf_obj_hash_cred_phish.yml
@@ -19,3 +19,4 @@ tactics_and_techniques:
 detection_methods:
   - "File analysis"
   - "Threat intelligence"
+id: "93572816-27f2-5d36-9388-da090a7635bc"


### PR DESCRIPTION
## Description
Matches PDFs with one of two object hashes observed in cred phish campaigns where pw protected PDFs are attached and the password is embedded in the message.
## Associated samples

- [Sample 1](https://platform.sublime.security/messages/50da8c8d0427e741f96546226d5cea6d8a6175662733495ed8ab51c477f2adbe?preview_id=01a08692-e397-70b6-a45b-3bb0ed98eee8)
- [Sample 2](https://platform.sublime.security/messages/50da677ea3798df1da9e65e09de526612c8841b7c6d9fc34cb7e8e97b34f9c0a?preview_id=01a08692-e3c2-710c-add8-f59f410633f8)

## Associated hunts

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01a0869f-702e-7821-b12c-6b99d2de3ea8)

