### PR TITLE
Update impersonation_netflix.yml

### DIFF
--- a/detection-rules/impersonation_netflix.yml
+++ b/detection-rules/impersonation_netflix.yml
@@ -42,6 +42,12 @@ source: |
     or regex.icontains(strings.replace_confusables(sender.email.domain.domain),
                        '[nm]etf[li][il]x'
     )
+    or (
+      strings.istarts_with(body.current_thread.text, "netflix")
+      and any(ml.nlu_classifier(body.current_thread.text).intents,
+              .name == "cred_theft" and .confidence != "low"
+      )
+    )
     // logo detection on message screenshot (no link analysis)
     or (
       any(ml.logo_detect(file.message_screenshot()).brands,


### PR DESCRIPTION
# Description

Updating logic to tag samples that have a body that starts with `netflix` with `cred_theft` intent

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50e13ed693de180a55f0fbecf5113689357b9ffe121a633c4008ab230ec53789?preview_id=01a083f7-042c-7acc-bb8a-d7e4406c5bac)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=01a0875c-274a-7caa-8db9-14c5d163cac6)
- [L30D Net New Hunt - Latest](https://platform.sublime.security/messages/hunt?huntId=01a0916d-b69d-7e16-aee4-5c5fb837e74f)
- [L7D Net New Multi-Hunt](https://hunt.limeseed.email/hunts/8291ab1f-aa23-4df6-a7ec-3d67d283bdef)