### PR TITLE
Add pdf_eof_md5_hash

### DIFF
--- a/yara/generic_pdf.yar
+++ b/yara/generic_pdf.yar
@@ -188,6 +188,22 @@ rule SAI_Global_ISO9001_Logo_PDF_Fuzzy
         )
 }
 
+rule pdf_eof_md5_hash
+{
+    meta:
+        author      = "brandon murphy"
+        date        = "2026-09-09"
+        description = "PDF with a 32-char hex hash appended as a PDF comment after %%EOF and at the end of the file"
+
+    strings:
+        $header   = { 25 50 44 46 2D }
+        $eof_hash = /%%EOF\s{1,4}%[0-9a-f]{32}\s{0,2}$/
+
+    condition:
+        $header at 0
+        and $eof_hash in (filesize - 50..filesize)
+}
+
 rule pdf_jsfck_ratio {
     meta:
         author      = "kyle eaton"

--- a/yara/generic_pdf.yar
+++ b/yara/generic_pdf.yar
@@ -197,7 +197,7 @@ rule pdf_eof_md5_hash
 
     strings:
         $header   = { 25 50 44 46 2D }
-        $eof_hash = /%%EOF\s{1,4}%[0-9a-f]{32}\s{0,2}$/
+        $eof_hash = /%%EOF\s{0,4}%[0-9a-f]{32}\s{0,4}$/
 
     condition:
         $header at 0


### PR DESCRIPTION
# Description

Adds a yara rule to detect an 32 char hex string after the EOF comment at the end of the file with optional new lines 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50e0ffefef63d7f1c7a06f0bb0b48da86478908ea477aef5ab73bcca059e5e9f)

## Associated hunts
N/A