### PR TITLE
Update impersonation_brand_wix.yml

### DIFF
--- a/detection-rules/impersonation_brand_wix.yml
+++ b/detection-rules/impersonation_brand_wix.yml
@@ -6,7 +6,9 @@ source: |
   type.inbound
   and (
     (
-      regex.icontains(sender.display_name, '^WIX\b')
+      regex.icontains(strings.replace_confusables(sender.display_name),
+                      '^w[il1|]x\b'
+      )
       or strings.ilike(sender.email.domain.domain, 'WIX')
     )
     or (


### PR DESCRIPTION
# Description

Updating `sender.display_name` regex logic to use `strings.replace_confusables` and tag variations of `Wix` such as `w1x`, `wlx`, and `w|x`

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50e2c1546c9fe4397fa80274af76d35f298373a63fda42527372786db1983a9d?preview_id=01a08996-ef93-7144-bb22-5944818193e4)
- [Sample 2](https://platform.sublime.security/messages/50e2b572b144bd3a027b881b93ea2760a0efc2ef4a6da9a40bacb5c2cdebb5d1?preview_id=01a08ba3-0274-751b-bad6-d8efe4682cda)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=01a0a522-07e4-7550-abde-58a70c30ddab)