### PR TITLE
Update impersonation_social_SA.yml

### DIFF
--- a/detection-rules/impersonation_social_SA.yml
+++ b/detection-rules/impersonation_social_SA.yml
@@ -91,7 +91,10 @@ source: |
   )
   
   // Not from a .gov domain
-  and not (sender.email.domain.tld == "gov" and headers.auth_summary.dmarc.pass)
+  and not (
+    sender.email.domain.tld == "gov"
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
   
   // Additional suspicious indicator
   and (


### PR DESCRIPTION
# Description

Adding `coalesce` to DMARC check for the `.gov` TLD negation

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50e227fbe461ffd79ccf38d37da7938db5ffc8a7df5cc568c1f69bf776c00886?preview_id=01a08aed-1fbf-71ac-bd82-ecb33d51744b)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L30D Net New Hunt](https://platform.sublime.security/messages/hunt?huntId=01a08cf8-fef1-7bd0-a507-5651f99cae0f)
- [L7D Net New Multi-Hunt](https://hunt.limeseed.email/hunts/71a9040f-18c6-4089-8ae9-2432876dd923)