### PR TITLE
Create sender_suspicious_cc_display_name.yml

### DIFF
--- a/detection-rules/sender_suspicious_cc_display_name.yml
+++ b/detection-rules/sender_suspicious_cc_display_name.yml
@@ -13,3 +13,4 @@ tactics_and_techniques:
   - "Spoofing"
 detection_methods:
   - "Sender analysis"
+id: "c656f255-8929-5c8f-a3ee-00193a1c1fb7"

--- a/detection-rules/sender_suspicious_cc_display_name.yml
+++ b/detection-rules/sender_suspicious_cc_display_name.yml
@@ -1,0 +1,15 @@
+name: "Sender: Suspicious CC suffix in sender display name"
+description: "Detects inbound messages where the sender's display name ends with a 'cc:' or 'CC:' suffix, a tactic often used to appear as though they're recipients rather than part of the attacker's sender identity."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and strings.ends_with(sender.display_name, 'cc:', 'CC:')
+attack_types:
+  - "BEC/Fraud"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Social engineering"
+  - "Spoofing"
+detection_methods:
+  - "Sender analysis"


### PR DESCRIPTION
# Description
Detects inbound messages where the sender's display name ends with a 'cc:' or 'CC:' suffix.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50cb7957a04bc07ff4bcd6fbf879e5d17a4b833fbc18a114c04677a1b0b92640?preview_id=01a08835-331f-7548-bca0-b0ccf1738cb8)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [SWS Hunt](https://platform.sublime.security/messages/hunt?huntId=01a08c6f-b226-72c4-afcf-127df6ff7473)
- [95 customer multi-hunt](https://hunt.limeseed.email/hunts/a1ae0582-a55d-4f65-bca9-c5883248cbcb)
- [10 customer multi-hunt](https://hunt.limeseed.email/hunts/e737665b-0bbc-4606-a435-fdd4f92ea2e3)