### PR TITLE
Create impersonation_kroger.yml

### DIFF
--- a/detection-rules/impersonation_kroger.yml
+++ b/detection-rules/impersonation_kroger.yml
@@ -53,3 +53,4 @@ detection_methods:
   - "Optical Character Recognition"
   - "Natural Language Understanding"
   - "Header analysis"
+id: "23c90d6e-11bf-51a6-b34d-6de360f6f294"

--- a/detection-rules/impersonation_kroger.yml
+++ b/detection-rules/impersonation_kroger.yml
@@ -5,8 +5,8 @@ severity: "medium"
 source: |
   type.inbound
   and (
-    strings.icontains(sender.display_name, 'kroger')
-    or regex.icontains(sender.email.local_part, '^kroger\b')
+    regex.icontains(sender.display_name, 'kroger\b')
+    or strings.icontains(sender.email.local_part, 'kroger')
   )
   //
   // This rule makes use of a beta feature and is subject to change without notice
@@ -14,30 +14,36 @@ source: |
   //
   and any([body.current_thread.text, beta.ocr(file.message_screenshot()).text],
           strings.icontains(., 'kroger')
-          and strings.icontains(.,
-                                'boost membership',
-                                'renewal',
-                                'verification',
-                                'customer number:',
-                                'brief online survey',
-                                'points balance',
-                                'fuel savings',
-                                'expir',
-                                'loyalty member'
+          and (
+            strings.icontains(.,
+                              'boost membership',
+                              'renewal',
+                              'verification',
+                              'customer number',
+                              'brief online survey',
+                              'points balance',
+                              'fuel savings',
+                              'loyalty member',
+                              'start survey',
+                              'special member offer',
+                              'loyalty program'
+            )
+            or regex.icontains(., 'shopping\s?cart reward')
           )
   )
   and not any(ml.nlu_classifier(body.current_thread.text).topics,
               .name in ("Newsletters and Digests")
   )
   and not (
-    (
-      sender.email.domain.root_domain in (
-        "kroger.com",
-        "krogermail.com",
-        "thekrogerco.com"
-      )
-      or sender.email.domain.root_domain in $high_trust_sender_root_domains
+    sender.email.domain.root_domain in (
+      "kroger.com",
+      "krogermail.com",
+      "thekrogerco.com"
     )
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+  and not (
+    sender.email.domain.root_domain in $high_trust_sender_root_domains
     and coalesce(headers.auth_summary.dmarc.pass, false)
   )
 attack_types:

--- a/detection-rules/impersonation_kroger.yml
+++ b/detection-rules/impersonation_kroger.yml
@@ -1,0 +1,55 @@
+name: "Brand impersonation: Kroger"
+description: "Detects inbound messages that impersonate Kroger through a spoofed display name or local part while referencing loyalty program terms such as boost membership, renewal, verification, or points balance in the body or a rendered screenshot. Legitimate messages from verified Kroger domains or high trust senders that pass DMARC, as well as newsletters/digests, are excluded to reduce false positives."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+    strings.icontains(sender.display_name, 'kroger')
+    or regex.icontains(sender.email.local_part, '^kroger\b')
+  )
+  //
+  // This rule makes use of a beta feature and is subject to change without notice
+  // using the beta feature in custom rules is not suggested until it has been formally released
+  //
+  and any([body.current_thread.text, beta.ocr(file.message_screenshot()).text],
+          strings.icontains(., 'kroger')
+          and strings.icontains(.,
+                                'boost membership',
+                                'renewal',
+                                'verification',
+                                'customer number:',
+                                'brief online survey',
+                                'points balance',
+                                'fuel savings',
+                                'expir',
+                                'loyalty member'
+          )
+  )
+  and not any(ml.nlu_classifier(body.current_thread.text).topics,
+              .name in ("Newsletters and Digests")
+  )
+  and not (
+    (
+      sender.email.domain.root_domain in (
+        "kroger.com",
+        "krogermail.com",
+        "thekrogerco.com"
+      )
+      or sender.email.domain.root_domain in $high_trust_sender_root_domains
+    )
+    and coalesce(headers.auth_summary.dmarc.pass, false)
+  )
+attack_types:
+  - "Credential Phishing"
+  - "BEC/Fraud"
+tactics_and_techniques:
+  - "Impersonation: Brand"
+  - "Social engineering"
+  - "Image as content"
+detection_methods:
+  - "Sender analysis"
+  - "Content analysis"
+  - "Optical Character Recognition"
+  - "Natural Language Understanding"
+  - "Header analysis"


### PR DESCRIPTION
# Description

Detects inbound messages that impersonate Kroger through a spoofed display name or local part while referencing loyalty program terms such as boost membership, renewal, verification, or points balance in the body or a rendered screenshot. Legitimate messages from verified Kroger domains or high trust senders that pass DMARC, as well as newsletters/digests, are excluded to reduce false positives.

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50e22a7678fbce2feb02ebd73f1c7b0965a6bc9a13d0a859be7829d088ca0b23?preview_id=01a08bce-eea2-7477-87c8-72c50b6b989c)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [L365D Hunt](https://platform.sublime.security/messages/hunt?huntId=01a0a538-cdd5-74ca-9fec-4d277c9d2d35)
- [L7D 95 Customer Multi-Hunt](https://hunt.limeseed.email/hunts/1b8475da-2108-4bbb-877a-c06aec853b56)