### PR TITLE
Update link_screenconnect_access_guest.yml

### DIFF
--- a/detection-rules/link_screenconnect_access_guest.yml
+++ b/detection-rules/link_screenconnect_access_guest.yml
@@ -5,20 +5,15 @@ severity: "high"
 source: |
   type.inbound
   // at least one link to screenconnect
-  and length(filter(body.links,
-                    .href_url.domain.root_domain == "screenconnect.com"
-                    // exclude tenant_domains (if the customer users screenconnect and has their own subdomain)
-                    and .href_url.domain.domain not in $tenant_domains
-             )
-  ) > 0
-  // all the screenconnect links include an msi/exe with Guesst Access
-  and all(filter(body.links, .href_url.domain.root_domain == "screenconnect.com"),
+  and any(body.links,
           strings.iends_with(.href_url.path, '.msi', '.exe')
           // https://docs.connectwise.com/ScreenConnect_Documentation/Developers/Integration_guide
           // e = SessionType. Support, Meet, or Access
           and strings.icontains(.href_url.query_params, "e=Access")
           // y = ProcessType (host vs guest)
           and strings.icontains(.href_url.query_params, "y=Guest")
+          // exclude tenant_domains (if the customer users screenconnect and has their own subdomain)
+          and .href_url.domain.domain not in $tenant_domains
   )
 attack_types:
   - "Malware/Ransomware"


### PR DESCRIPTION
# Description

Allow the screenconnect rule to match on non-screenconnect root domains.  The rule know keys in on the ProcessType and SessionType without considering the domain. 

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50c8480665f578a7d7b9fbcff2ad31ac0b1751f90093591efbcd2e38a3a2e030?preview_id=01a00588-e310-726b-8e70-a0c2b8bed5c2)

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Net new](https://hunt.limeseed.email/hunts/9c6199d0-b7f4-4f38-92f0-20469ec6ef79)
- [net new multihunt](https://platform.sublime.security/messages/hunt?huntId=01a08cb3-fb27-79e2-ba47-77df8ae8a25b)

