### PR TITLE
CI: map rule validation diagnostics to their real file line

### DIFF
--- a/.github/workflows/rule-validate.yml
+++ b/.github/workflows/rule-validate.yml
@@ -191,6 +191,37 @@ jobs:
             printf '%s' "$s"
           }
 
+          # Locates a rule's MQL `source` scalar within its YAML file. Prints
+          # "<first_source_line> <indent>": the 1-indexed file line holding source line 0, and
+          # the number of characters in the file that precede each line of source. Fails if the
+          # file has no top-level source key.
+          # The key is located by text because yq's `line` operator is off by one on files that
+          # open with a comment.
+          source_anchor() {
+            local file="$1" key key_line key_text content rest value ws
+            local block_re='^source:[[:space:]]*[|>]'
+
+            key=$(grep -n -m1 '^source:' "$file") || return 1
+            key_line="${key%%:*}"
+            key_text="${key#*:}"
+
+            if [[ "$key_text" =~ $block_re ]]; then
+              # Block scalar: source starts on the next line, and every line is indented by the
+              # same amount, which the block's first non-blank line establishes.
+              key_line=$((key_line + 1))
+              while IFS= read -r content; do
+                [[ -n "${content//[[:space:]]/}" ]] && break
+              done < <(tail -n "+${key_line}" "$file")
+              ws="${content%%[![:space:]]*}"
+              printf '%s %s' "$key_line" "${#ws}"
+            else
+              # Inline scalar: source is the remainder of the key line.
+              rest="${key_text#source:}"
+              value="${rest#"${rest%%[![:space:]]*}"}"
+              printf '%s %s' "$key_line" "$((${#key_text} - ${#value}))"
+            fi
+          }
+
           # Emits one GitHub annotation per diagnostic in a bulk_validate response.
           # $1: response file. Remaining args: the files submitted in that response, in order
           # (bulk_validate returns validation_responses in the same order as the request).
@@ -207,8 +238,29 @@ jobs:
               file="${files[$idx]}"
               severity=$(jq -r '.severity' <<<"$diag_json")
               message=$(jq -r '.message' <<<"$diag_json")
-              line=$(( $(jq -r '.line' <<<"$diag_json") + 1 ))
-              col=$(( $(jq -r '.col' <<<"$diag_json") + 1 ))
+              src_line=$(jq -r '.line' <<<"$diag_json")
+              src_col=$(jq -r '.col' <<<"$diag_json")
+
+              if [[ "$file" == insights/* ]]; then
+                # build_request wraps insight sources in "length([\n\n" + source, which pushes
+                # every line of source down by two.
+                src_line=$((src_line - 2))
+                if (( src_line < 0 )); then
+                  src_line=0
+                fi
+              fi
+
+              # Diagnostic positions are 0-indexed and relative to the rule's `source` scalar,
+              # not to the YAML file, so shift them onto the file's own coordinates. Without
+              # this the annotation lands on whatever happens to be at that line of the file.
+              if anchor=$(source_anchor "$file"); then
+                read -r first_line indent <<<"$anchor"
+                line=$((first_line + src_line))
+                col=$((indent + src_col + 1))
+              else
+                line=1
+                col=1
+              fi
 
               gh_level="notice"
               if [[ "$severity" == "error" ]]; then


### PR DESCRIPTION
## Summary

Annotations from the "Validate Rules" step point at the wrong line. `bulk_validate` reports diagnostic positions **0-indexed and relative to the rule's MQL `source` scalar**, not to the YAML file, and the step added in #5209 only added 1 to each — so every annotation landed however far `source:` sits into the file.

Seen on #5315: the raw diagnostic is `line: 3, column: 2`, which got annotated as **line 4**. The actual offender is `impersonation_social_SA.yml:9`:

```
9:    regex.contains(sender.display_name, '^SSA\b')
```

Insight sources were off by a further 2, because `build_request` prepends `length([\n\n` to them.

## Changes

- Add `source_anchor()`, which reports `<first_source_line> <indent>` for a rule file: the 1-indexed file line holding source line 0, and the number of characters preceding each line of source.
- `emit_diagnostics` now shifts each diagnostic onto the file's own coordinates: `line = first_source_line + diag_line`, `col = indent + diag_col + 1`, applying `diag_line - 2` first for `insights/*`. Falls back to line 1 if the `source` key can't be found.

Two notes on the approach:

- The `source:` key is located **by text, not with `yq`**. `yq '.source | line'` is silently off by one on any file whose first line is a comment (go-yaml head-comment attachment) — currently `insights/headers/suspicious_recipient_pattern.yml`, which is the same wrong-line failure mode this PR fixes. `mql_format.py` already locates the block by text for the same reason.
- No new dependencies or languages; 54 insertions, 2 deletions.

## Test plan

- [x] For **all 1,484 rule/insight/exclusion files (62,372 source lines)**: asserted that stripping `indent` from file line `first_source_line + i` yields source line `i` exactly. Zero line failures, zero column failures.
- [x] End-to-end against #5315's real `bulk_validate` response: now emits `line=9,col=5`, the `r` of `regex.contains` (was `line=4,col=3`).
- [x] End-to-end against all 133 insights: 10 annotations, each landing on the exact token named in its message (`ilike` at 5:10, `beta.scan_base64` at 9:50, `regex.icontains` at 5:9), confirming the `-2` wrapper offset.
- [x] 100 detection rules: 77 annotations, none out of range.
- [x] Edge cases: no `source` key → clean fallback to line 1; missing file → clean fallback; an indented `source:` nested under another key is correctly ignored.
- [x] `bash -n` on the extracted step; YAML parses.

Note: `shellcheck` and `actionlint` were not available in the environment I tested in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)