### PR TITLE
Update abuse_fliphtml5 rule replace zero attachment logic

### DIFF
--- a/detection-rules/abuse_fliphtml5.yml
+++ b/detection-rules/abuse_fliphtml5.yml
@@ -9,7 +9,7 @@ source: |
     regex.icontains(body.current_thread.text,
                     "attached|see.*attached|find.*attached|please{0,10}attached"
     )
-    and length(attachments) == 0
+    and length(filter(attachments, .sha256 not in $file_hashes_image_warning_banners)) == 0
   )
   // and the link goes to fliphtml5 and contains suspect "click me" language
   and any(body.links, .href_url.domain.root_domain == "fliphtml5.com")

--- a/detection-rules/abuse_fliphtml5.yml
+++ b/detection-rules/abuse_fliphtml5.yml
@@ -9,7 +9,10 @@ source: |
     regex.icontains(body.current_thread.text,
                     "attached|see.*attached|find.*attached|please{0,10}attached"
     )
-    and length(filter(attachments, .sha256 not in $file_hashes_image_warning_banners)) == 0
+    and length(filter(attachments,
+                      .sha256 not in $file_hashes_image_warning_banners
+               )
+    ) == 0
   )
   // and the link goes to fliphtml5 and contains suspect "click me" language
   and any(body.links, .href_url.domain.root_domain == "fliphtml5.com")


### PR DESCRIPTION
# Description

3rd party tools adding warning banners as images rather than text mess with rules that have "zero attachments" logic by adding an attached image warning banner that wasn't part of the original message. This uses a new list of warning banner image SHA256 hashes to exclude those.

