### PR TITLE
Update BEC rule to match intent of no attachments other than banners

### DIFF
--- a/detection-rules/body_bec_mobile_solicitation_reply_thread.yml
+++ b/detection-rules/body_bec_mobile_solicitation_reply_thread.yml
@@ -6,7 +6,10 @@ source: |
   type.inbound
   and 0 < length(body.previous_threads) < 3
   // No attachments (other than 3rd party image warning banners)
-  and length(filter(attachments, .sha256 not in $file_hashes_image_warning_banners)) == 0
+  and length(filter(attachments,
+                    .sha256 not in $file_hashes_image_warning_banners
+             )
+  ) == 0
   // Check previous_threads for mobile solicitation patterns
   and any(body.previous_threads,
           (

--- a/detection-rules/body_bec_mobile_solicitation_reply_thread.yml
+++ b/detection-rules/body_bec_mobile_solicitation_reply_thread.yml
@@ -5,7 +5,8 @@ severity: "medium"
 source: |
   type.inbound
   and 0 < length(body.previous_threads) < 3
-  and length(filter(attachments, .file_type not in $file_types_images)) == 0
+  // No attachments (other than 3rd party image warning banners)
+  and length(filter(attachments, .sha256 not in $file_hashes_image_warning_banners)) == 0
   // Check previous_threads for mobile solicitation patterns
   and any(body.previous_threads,
           (


### PR DESCRIPTION
Replace strict zero attachments logic with "zero attachments but ignore image warning banners" logic.

# Description

3rd party tools adding warning banners as images rather than text mess with rules that have "zero attachments" logic by adding an attached image warning banner that wasn't part of the original message. This uses a new list of warning banner image SHA256 hashes to exclude those.

In a previous PR, @markmsublime  changed the logic from length(attachments) == 0 (which was causing FN) to checking for zero attachments other than images. This PR further refines that to only excluding known email warning banners.

