### PR TITLE
Update link_multistage_adobe_acrobat_hosted_pdf.yml

### DIFF
--- a/detection-rules/link_multistage_adobe_acrobat_hosted_pdf.yml
+++ b/detection-rules/link_multistage_adobe_acrobat_hosted_pdf.yml
@@ -49,15 +49,15 @@ source: |
                       length(beta.ocr(.file).text) < 750
                       and (
                         regex.icontains(beta.ocr(.file).text, 'e-sign(?:ature)?')
-                        or strings.icontains(beta.ocr(.file).text,
-                                             'shared a document',
-                                             'review and sign',
-                                             'PDF viewer',
-                                             "display this type of document",
-                                             'please wait...',
-                                             'New PDF Document',
-                                             'view document',
-                                             'open the secure review session'
+                        or regex.icontains(beta.ocr(.file).text,
+                                           'shared\s*a\s*document',
+                                           'review\s*and\s*sign',
+                                           'PDF\s*viewer',
+                                           'display\s*this\s*type\s*of\s*document',
+                                           'please\s*wait\.\.\.',
+                                           'New\s*PDF\s*Document',
+                                           'view\s*document',
+                                           'open\s*the\s*secure\s*review\s*session'
                         )
                       )
                     )


### PR DESCRIPTION
# Description
found while sharing IOC results, missing these samples due to the newline in the OCR output, regex seems to solve this short term while longer term eng work is focused on it

# Associated samples
<!-- 
Link to samples that are affected by your change. 

For example, samples you are negating, samples you are including, or samples your new insight should fire on.
-->

- [Sample 1](https://platform.sublime.security/messages/50e28a190495fbdbcda3993c4daf1861f9882fea563ab584d7a16242a5723355?preview_id=01a090d8-90de-7ae4-b5e1-6c46879c5661)
- Sample 2

## Associated hunts
<!-- 

If you ran any hunts with your rule, please link them here.
-->

- [Hunt 1](https://platform.sublime.security/messages/hunt?huntId=01a0910a-d6b9-71fd-9e2e-e755aae4423d) - net new
- [large multi](https://hunt.limeseed.email/hunts/bd22ec52-33cd-4536-a924-ac3749439e7b)
