### PR TITLE
Rename Fuzzy Attack Score on Graymail

### DIFF
--- a/detection-rules/attack_score_flash_graymail_rule.yml
+++ b/detection-rules/attack_score_flash_graymail_rule.yml
@@ -1,5 +1,5 @@
-name: "Fuzzy Attack Score: Advanced Graymail Detection"
-description: "Exercises the beta.fuzzy_attack_score() function. Flags on Graymail verdicts."
+name: "Attack Score Flash: Advanced Graymail Detection"
+description: "Exercises the beta.attack_score_flash() function. Flags on Graymail verdicts."
 type: "rule"
 severity: "medium"
 source: |
@@ -8,5 +8,5 @@ source: |
   // This rule makes use of a beta feature and is subject to change without notice
   // using the beta feature in custom rules is not suggested until it has been formally released
   //
-  and beta.fuzzy_attack_score().verdict == "graymail"
+  and beta.attack_score_flash().verdict == "graymail"
 id: "f83b83bc-039b-4025-be85-78a36ffabf6e"


### PR DESCRIPTION
# Description
Renames the fuzzy attack score graymail rule to use the new function name over the deprecated function name.
