### PR TITLE
Create link_google_share_google.yml

### DIFF
--- a/detection-rules/link_google_share_google.yml
+++ b/detection-rules/link_google_share_google.yml
@@ -1,0 +1,58 @@
+name: "Link: Undocumented share.google link shortener"
+description: "Detects inbound messages that abuse Google's undocumented share.google URL shortener as an open redirect, either directly in message body links or embedded within email attachments and ICS calendar invites. These links carry a 'q' query parameter used to redirect recipients to attacker-controlled destinations while masquerading as a trusted Google domain. Observed lures include fake photo-sharing notifications, dating/adult content teasers, and generic 'message received' hooks designed to entice clicks."
+type: "rule"
+severity: "medium"
+source: |
+  type.inbound
+  and (
+    // within body.links
+    any(body.links,
+        .href_url.domain.root_domain == "google.com"
+        and strings.istarts_with(.href_url.path, '/share.google')
+        and 'q' in keys(.href_url.query_params_decoded)
+    )
+    // within attachments
+    or any(attachments,
+           // file explode for non ICS
+           (
+             not (
+               .file_type == "ics"
+               or .file_extension == "ics"
+               or .content_type in ("application/ics", "text/calendar")
+             )
+             and any(file.explode(.),
+                     any(.scan.url.urls,
+                         .domain.root_domain == "google.com"
+                         and strings.istarts_with(.path, '/share.google')
+                         and 'q' in keys(.query_params_decoded)
+                     )
+             )
+           )
+           // use parse_ics for ics eents
+           or (
+             (
+               .file_type == "ics"
+               or .file_extension == "ics"
+               or .content_type in ("application/ics", "text/calendar")
+             )
+             and any(beta.file.parse_ics(.).events,
+                     any(.links,
+                         .href_url.domain.root_domain == "google.com"
+                         and strings.istarts_with(.href_url.path, '/share.google')
+                         and 'q' in keys(.href_url.query_params_decoded)
+                     )
+             )
+           )
+    )
+  )
+
+attack_types:
+  - "Spam"
+  - "Credential Phishing"
+tactics_and_techniques:
+  - "Open redirect"
+  - "Social engineering"
+detection_methods:
+  - "URL analysis"
+  - "Content analysis"
+  - "File analysis"

--- a/detection-rules/link_google_share_google.yml
+++ b/detection-rules/link_google_share_google.yml
@@ -56,3 +56,4 @@ detection_methods:
   - "URL analysis"
   - "Content analysis"
   - "File analysis"
+id: "e29cd002-1624-5ff7-b05f-386ae5e4d115"


### PR DESCRIPTION
# Description

Add rule for matching on an unusual format of the Google URL shortener: links shaped like `google.<tld>/share.google?q=<code>`, where the host is any Google top-level domain and the code is a per-share alphanumeric string — as opposed to the more familiar `share.google/<code>` link on the standalone share.google domain. Served from a `google.<tld>` domain, it inherits Google's reputation and is frequently allow-listed. The form is undocumented: Google publishes the share.google shortener, but not this on-Google-domain form or its `q` parameter.

Covers `body.links`. Attachments in #5341, ICS in #5342.


# Associated samples

- [Sample 1](https://platform.sublime.security/messages/50d36a39fef574237e7b6142a8d5b3905c521c3863571fba3a399f51a66dc891?preview_id=01a0593d-71c7-782f-ba70-96c04cafe38c)
- [non .com tld sample](https://platform.sublime.security/messages/50e44d5339da185081264a38f1e1a4714a2d4eac7892374a2caa770acc0c9cc1?preview_id=01a09d70-a98c-7a73-9430-23b16f7f832d)
- [additional non .com tld samples](https://platform.sublime.security/hunts/01a0a0ab-7c12-713a-90ad-ee1ff025f62f)

## Associated hunts

- [Hunt](https://platform.sublime.security/messages/hunt?huntId=01a0a0be-797e-74ef-962d-33c9a5a91ea2)
- [Multihunt](https://hunt.limeseed.email/hunts/62b1523b-3f2c-4aae-81fd-0d2d5d92288a) - includes all 3 forms of the rule
 
