### PR TITLE
Update uk dlp rules meta only

### DIFF
--- a/dlp-discovery-rules/beta_dlp_uk_drivers_license.yml
+++ b/dlp-discovery-rules/beta_dlp_uk_drivers_license.yml
@@ -31,7 +31,7 @@ tags:
   - "UK GDPR"
   - "UK"
 attack_types:
-  - "DLP: GDPR"
+  - "DLP: Personal data"
 detection_methods:
   - "Content analysis"
   - "Natural Language Understanding"

--- a/dlp-discovery-rules/beta_dlp_uk_drivers_license.yml
+++ b/dlp-discovery-rules/beta_dlp_uk_drivers_license.yml
@@ -27,9 +27,10 @@ source: |
     )
   )
 tags:
-  - "PII"
+  - "Personal data"
+  - "UK GDPR"
+  - "UK"
 attack_types:
-  - "DLP: PII"
   - "DLP: GDPR"
 detection_methods:
   - "Content analysis"

--- a/dlp-discovery-rules/beta_dlp_uk_nhs_number.yml
+++ b/dlp-discovery-rules/beta_dlp_uk_nhs_number.yml
@@ -26,11 +26,12 @@ source: |
     )
   )
 tags:
-  - "PII"
+  - "Personal data"
   - "Health data"
+  - "UK GDPR"
+  - "UK"
 attack_types:
-  - "DLP: PII"
-  - "DLP: GDPR"
+  - "DLP: Personal data"
 detection_methods:
   - "Content analysis"
   - "Natural Language Understanding"

--- a/dlp-discovery-rules/beta_dlp_uk_nino.yml
+++ b/dlp-discovery-rules/beta_dlp_uk_nino.yml
@@ -29,7 +29,7 @@ tags:
   - "UK GDPR"
   - "UK"
 attack_types:
-  - "DLP: PII"
+  - "DLP: Personal data"
 detection_methods:
   - "Content analysis"
   - "Natural Language Understanding"

--- a/dlp-discovery-rules/beta_dlp_uk_nino.yml
+++ b/dlp-discovery-rules/beta_dlp_uk_nino.yml
@@ -25,10 +25,11 @@ source: |
     )
   )
 tags:
-  - "PII"
+  - "Personal data"
+  - "UK GDPR"
+  - "UK"
 attack_types:
   - "DLP: PII"
-  - "DLP: GDPR"
 detection_methods:
   - "Content analysis"
   - "Natural Language Understanding"

--- a/dlp-discovery-rules/beta_dlp_uk_passport.yml
+++ b/dlp-discovery-rules/beta_dlp_uk_passport.yml
@@ -31,7 +31,7 @@ tags:
   - "UK GDPR"
   - "UK"
 attack_types:
-  - "DLP: PII"
+  - "DLP: Personal data"
 detection_methods:
   - "Content analysis"
   - "Natural Language Understanding"

--- a/dlp-discovery-rules/beta_dlp_uk_passport.yml
+++ b/dlp-discovery-rules/beta_dlp_uk_passport.yml
@@ -27,10 +27,11 @@ source: |
     )
   )
 tags:
-  - "PII"
+  - "Personal data"
+  - "UK GDPR"
+  - "UK"
 attack_types:
   - "DLP: PII"
-  - "DLP: GDPR"
 detection_methods:
   - "Content analysis"
   - "Natural Language Understanding"

--- a/dlp-discovery-rules/beta_dlp_uk_utr.yml
+++ b/dlp-discovery-rules/beta_dlp_uk_utr.yml
@@ -25,9 +25,11 @@ source: |
     )
   )
 tags:
-  - "PII"
+  - "Personal data"
+  - "UK GDPR"
+  - "UK"
 attack_types:
-  - "DLP: GDPR"
+  - "DLP: PII"
 detection_methods:
   - "Content analysis"
   - "Natural Language Understanding"

--- a/dlp-discovery-rules/beta_dlp_uk_utr.yml
+++ b/dlp-discovery-rules/beta_dlp_uk_utr.yml
@@ -29,7 +29,7 @@ tags:
   - "UK GDPR"
   - "UK"
 attack_types:
-  - "DLP: PII"
+  - "DLP: Personal data"
 detection_methods:
   - "Content analysis"
   - "Natural Language Understanding"


### PR DESCRIPTION
# Description

Changed metadata of all UK specific rules to be consistent with attack_types and tags of other DLP rules. 
- Replaced "DLP: PII" with "DLP: Personal data" in attack_types
- Moved "DLP: GDPR" from attack_types to "UK GDPR" in tags
- Added "UK" to tags

No change to any rule logic was made, metadata only.
