### PR TITLE
Added country and EU tag to each EU member state rule

### DIFF
--- a/dlp-discovery-rules/beta_dlp_at_vat.yml
+++ b/dlp-discovery-rules/beta_dlp_at_vat.yml
@@ -7,6 +7,8 @@ attack_types:
 tags:
   - "Financial data"
   - "GDPR"
+  - "Austria"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_be_vat.yml
+++ b/dlp-discovery-rules/beta_dlp_be_vat.yml
@@ -7,6 +7,8 @@ attack_types:
 tags:
   - "Financial data"
   - "GDPR"
+  - "Belgium"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_de_passport.yml
+++ b/dlp-discovery-rules/beta_dlp_de_passport.yml
@@ -8,6 +8,7 @@ tags:
   - "Personal data"
   - "GDPR"
   - "Germany"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_de_personalausweis.yml
+++ b/dlp-discovery-rules/beta_dlp_de_personalausweis.yml
@@ -8,6 +8,7 @@ tags:
   - "Personal data"
   - "GDPR"
   - "Germany"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_de_tax_id.yml
+++ b/dlp-discovery-rules/beta_dlp_de_tax_id.yml
@@ -8,6 +8,7 @@ tags:
   - "Personal data"
   - "GDPR"
   - "Germany"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_de_vat.yml
+++ b/dlp-discovery-rules/beta_dlp_de_vat.yml
@@ -7,6 +7,8 @@ attack_types:
 tags:
   - "Financial data"
   - "GDPR"
+  - "Germany"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_es_bank_account.yml
+++ b/dlp-discovery-rules/beta_dlp_es_bank_account.yml
@@ -7,6 +7,8 @@ attack_types:
 tags:
   - "Financial data"
   - "GDPR"
+  - "Spain"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_es_id.yml
+++ b/dlp-discovery-rules/beta_dlp_es_id.yml
@@ -8,6 +8,7 @@ tags:
   - "Personal data"
   - "GDPR"
   - "Spain"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_es_passport.yml
+++ b/dlp-discovery-rules/beta_dlp_es_passport.yml
@@ -8,6 +8,7 @@ tags:
   - "Personal data"
   - "GDPR"
   - "Spain"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_fi_european_health_insurance.yml
+++ b/dlp-discovery-rules/beta_dlp_fi_european_health_insurance.yml
@@ -7,6 +7,8 @@ attack_types:
 tags:
   - "Healthcare"
   - "GDPR"
+  - "Finland"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_fr_bank_account.yml
+++ b/dlp-discovery-rules/beta_dlp_fr_bank_account.yml
@@ -7,6 +7,8 @@ attack_types:
 tags:
   - "Financial data"
   - "GDPR"
+  - "France"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_fr_cni.yml
+++ b/dlp-discovery-rules/beta_dlp_fr_cni.yml
@@ -8,6 +8,7 @@ tags:
   - "Personal data"
   - "GDPR"
   - "France"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_fr_driver_license.yml
+++ b/dlp-discovery-rules/beta_dlp_fr_driver_license.yml
@@ -8,6 +8,7 @@ tags:
   - "Personal data"
   - "GDPR"
   - "France"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_fr_insee.yml
+++ b/dlp-discovery-rules/beta_dlp_fr_insee.yml
@@ -8,6 +8,7 @@ tags:
   - "Personal data"
   - "GDPR"
   - "France"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_fr_passport.yml
+++ b/dlp-discovery-rules/beta_dlp_fr_passport.yml
@@ -8,6 +8,7 @@ tags:
   - "Personal data"
   - "GDPR"
   - "France"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_fr_vat.yml
+++ b/dlp-discovery-rules/beta_dlp_fr_vat.yml
@@ -7,6 +7,8 @@ attack_types:
 tags:
   - "Financial data"
   - "GDPR"
+  - "France"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_hu_taj.yml
+++ b/dlp-discovery-rules/beta_dlp_hu_taj.yml
@@ -7,6 +7,8 @@ attack_types:
 tags:
   - "Healthcare"
   - "GDPR"
+  - "Hungary"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_hu_vat.yml
+++ b/dlp-discovery-rules/beta_dlp_hu_vat.yml
@@ -7,6 +7,8 @@ attack_types:
 tags:
   - "Financial data"
   - "GDPR"
+  - "Hungary"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_luxembourg_nonnatural_id.yml
+++ b/dlp-discovery-rules/beta_dlp_luxembourg_nonnatural_id.yml
@@ -7,6 +7,8 @@ attack_types:
 tags:
   - "Financial data"
   - "GDPR"
+  - "Luxembourg"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_nl_bsn.yml
+++ b/dlp-discovery-rules/beta_dlp_nl_bsn.yml
@@ -8,6 +8,7 @@ tags:
   - "Personal data"
   - "GDPR"
   - "Netherlands"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_nl_vat.yml
+++ b/dlp-discovery-rules/beta_dlp_nl_vat.yml
@@ -7,6 +7,8 @@ attack_types:
 tags:
   - "Financial data"
   - "GDPR"
+  - "Netherlands"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice

--- a/dlp-discovery-rules/beta_dlp_se_personnummer.yml
+++ b/dlp-discovery-rules/beta_dlp_se_personnummer.yml
@@ -8,6 +8,7 @@ tags:
   - "Personal data"
   - "GDPR"
   - "Sweden"
+  - "EU"
 source: |
   //
   // This rule makes use of a beta feature and is subject to change without notice


### PR DESCRIPTION
# Description

Changed metadata only, for EU member state specific rules only.
- Added tag "EU" to each
- For those that lacked a country tag, added the country name consistently
